### PR TITLE
Fix some example code snippets in abstract

### DIFF
--- a/executors.bs
+++ b/executors.bs
@@ -155,7 +155,11 @@ sender auto async_inclusive_scan(scheduler auto sch,
 ### Asynchronous dynamically-sized read ### {#async-dynamically-sized-read}
 
 ```c++
-sender auto async_read(auto handle, std::span<std::byte> buffer);
+// `async_read` takes an input sender which sends a std::span<std::byte> buffer
+// to be filled, and returns a sender that completes when the buffer is filled
+// and sends the number of bytes. It's a pipeable sender adapter CPO with the
+// following signature:
+sender auto async_read(sender auto buffer, auto handle);
 
 struct dynamic_buffer {
   std::unique_ptr<std::byte[]> data;
@@ -163,22 +167,23 @@ struct dynamic_buffer {
 };
 
 sender auto async_read_array(auto handle) {
-  return
-    just(dynamic_buffer{})
-    | let_value([handle] (dynamic_buffer& buffer) {
-      return
-        async_read(handle, std::as_writable_bytes(std::span{&buffer.size, sizeof(buffer.size)}))
-        | let_value([&](std::size_t bytes_read) {
-          assert(bytes_read == sizeof(buffer.size));
-          buffer.data = std::make_unique<std::byte[]>(buffer.size);
-          return
-            async_read(handle, std::span{buffer.data.get(), buffer.size})
-            | then([&](std::size_t bytes_read) {
-              assert(bytes_read == buffer.size);
-              return std::move(buffer);
-            });
-        });
-    });
+  return let_value(just(dynamic_buffer{}),
+    [] (dynamic_buffer& buffer) {
+      return just(std::as_writeable_bytes(std::span(&buffer.size, 1))
+           | async_read(handle)
+           | then(
+               [&] (std::size_t bytes_read) {
+                 assert(bytes_read == sizeof(buffer.size));
+                 buffer.data = std::make_unique(new std::byte[buffer.size]);
+                 return std::span(buffer.data.get(), buffer.size);
+               }
+           | async_read(handle)
+           | then(
+               [&] (std::size_t bytes_read) {
+                 assert(bytes_read == buffer.size);
+                 return std::move(buffer.data);
+               }
+  });
 }
 ```
 


### PR DESCRIPTION
- Add missing parameters.
- Fix potential integer overload in calculation of tile-end offsets.
- Don't mutate input in-place in `async_inclusive_scan`
- Use `size_t` instead of `int` in bulk lambda parameter.
- Missing parentheses.
- Don't use pipe form of `async_read` as we don't declare it as a pipeable adapter
- Add missing capture of `handle`
