### PR TITLE
{#design-shot}: Reword section to avoid putting requirements on how algorithms treat arguments

### DIFF
--- a/executors.bs
+++ b/executors.bs
@@ -390,7 +390,7 @@ Some senders may only support launching their operation a single time, while oth
 and support being launched multiple times. Executing the operation may consume resources owned by the
 sender.
 
-For example, a sender may contain a `unique_ptr` that it will be transferring ownership of to the
+For example, a sender may contain a `std::unique_ptr` that it will be transferring ownership of to the
 operation-state returned by a call to `execution::connect` so that the operation has access to
 this resource. In such a sender, calling `execution::connect` consumes the sender such that after
 the call the input sender is no longer valid. Such a sender will also typically be move-only so that
@@ -404,19 +404,18 @@ A <dfn>multi-shot sender</dfn> can be connected to multiple receivers and can be
 times. Mult-shot senders customise `execution::connect` to accept an lvalue reference to the
 sender. Callers can indicate that they want the sender to remain valid after the call to `execution::connect`
 by passing an lvalue reference to the sender to call these overloads. Multi-shot senders should also define
-overloads of `execution::connect` that accept rvalue-senders to allow the sender to be also used in places
+overloads of `execution::connect` that accept rvalue-qualified enders to allow the sender to be also used in places
 where only a single-shot sender is required.
 
-
-If the consumer of a sender does not require the sender to remain valid after connecting it to a
+If the user of a sender does not require the sender to remain valid after connecting it to a
 receiver then it can pass an rvalue-reference to the sender to the call to `execution::connect`.
 Such usages should be able to accept either single-shot or multi-shot senders.
 
-If the caller does wish for the sender to remain valid after the call then it can pass an lvalue sender
+If the caller does wish for the sender to remain valid after the call then it can pass an lvalue-qualified sender
 to the call to `execution::connect`. Such usages will only accept multi-shot senders.
 
 Algorithms that accept senders will typically either decay-copy an input sender and store it somewhere
-for later usage, for example as a data-member of the returned sender, or will immediately call
+for later usage (for example as a data-member of the returned sender) or will immediately call
 `execution::connect` on the input sender, such as in `this_thread::sync_wait` or `execution::start_detached`.
 
 Some multi-use sender algorithms may require that an input sender be copy-constructible but will only call
@@ -424,8 +423,7 @@ Some multi-use sender algorithms may require that an input sender be copy-constr
 Other multi-use sender algorithms may require that the sender is move-constructible but will invoke `execution::connect`
 on an lvalue reference to the sender.
 
-For a sender to be usable in both multi-use scenarios will generally require it to be both copy-constructible and
-lvalue-connectable.
+For a sender to be usable in both multi-use scenarios, it will generally be required to be both copy-constructible and lvalue-connectable.
 
 ## Senders are forkable ## {#design-forkable}
 


### PR DESCRIPTION
Talk about multi-shot senders solely in terms of lvalue-connectability.

Also talk about different kinds of multi-use algorithms:
* some copy-construct and call rvalue-connect
* others move-construct and call lvalue-connect