### PR TITLE
Add then and upon_* example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ def_example(example.retry "examples/retry.cpp")
 def_example(example.then "examples/then.cpp")
 def_example(example.server_theme.let_value "examples/server_theme/let_value.cpp")
 def_example(example.server_theme.on_transfer "examples/server_theme/on_transfer.cpp")
+def_example(example.server_theme.then_upon "examples/server_theme/then_upon.cpp")
 
 ##############################################################################
 # Install targets ------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ def_example(example.then "examples/then.cpp")
 def_example(example.server_theme.let_value "examples/server_theme/let_value.cpp")
 def_example(example.server_theme.on_transfer "examples/server_theme/on_transfer.cpp")
 def_example(example.server_theme.then_upon "examples/server_theme/then_upon.cpp")
+def_example(example.server_theme.split_bulk "examples/server_theme/split_bulk.cpp")
 
 ##############################################################################
 # Install targets ------------------------------------------------------------

--- a/examples/server_theme/.gitignore
+++ b/examples/server_theme/.gitignore
@@ -1,2 +1,3 @@
 let_value
 on_transfer
+then_upon

--- a/examples/server_theme/.gitignore
+++ b/examples/server_theme/.gitignore
@@ -1,3 +1,4 @@
 let_value
 on_transfer
 then_upon
+split_bulk

--- a/examples/server_theme/on_transfer.cpp
+++ b/examples/server_theme/on_transfer.cpp
@@ -101,8 +101,7 @@ int main() {
     // The entire flow
     auto snd =
         // start by reading data on the I/O thread
-        ex::on(io_sched, std::move(snd_read)) // TODO: doesn't work apple-clang-13
-        // ex::on(io_sched, ex::just(size_t(13)))
+        ex::on(io_sched, std::move(snd_read))
         // do the processing on the worker threads pool
         | ex::transfer(work_sched)
         // process the incoming data (on worker threads)

--- a/examples/server_theme/split_bulk.cpp
+++ b/examples/server_theme/split_bulk.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * General context:
+ * - server application that processes images
+ * - execution contexts:
+ *    - 1 dedicated thread for network I/O
+ *    - N worker threads used for CPU-intensive work
+ *    - M threads for auxiliary I/O
+ *    - optional GPU context that may be used on some types of servers
+ *
+ * Specific problem description:
+ * - implement the handler for applying 3 edge detection algorithms on one image
+ * - implement the handler for applying a blur filter over the given set of images
+ * - we show one can use multiple threads to execute a more complex work
+ * - we show how to use `execution::split` / `execution::when_all` and `execution::bulk`
+ * - error and cancellation handling is performed outside the handler
+ *
+ * Example goals:
+ * - show how one can create work to fill up multiple threads
+ * - exemplify the use of `then`, `split`, `when_all`, `bulk` and `let_value` algorithms
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sstream>
+
+// Pull in the reference implementation of P2300:
+#include <execution.hpp>
+// Keep track of spawned work in an async_scope:
+#include <async_scope.hpp>
+// Use a thread pool
+#include "../schedulers/static_thread_pool.hpp"
+
+namespace ex = std::execution;
+
+struct http_request {
+  std::string url_;
+  std::vector<std::pair<std::string, std::string>> headers_;
+  std::string body_;
+};
+
+struct http_response {
+  int status_code_;
+  std::string body_;
+};
+
+struct image {
+  std::string image_data_;
+};
+
+// Extract the image from the HTTP request
+image extract_image(http_request req) { return {req.body_}; }
+// Extract multiple images from the HTTP request
+std::vector<image> extract_images(http_request req) {
+  std::vector<image> res;
+  size_t last_idx = 0;
+  while (last_idx >= std::string::npos) {
+    size_t idx = req.body_.find("\n", last_idx);
+    if (idx == std::string::npos) {
+      break;
+    } else {
+      res.push_back(image{req.body_.substr(last_idx, idx - last_idx)});
+      last_idx = idx + 1;
+    }
+  }
+  if (last_idx != req.body_.size())
+    res.push_back(image{req.body_.substr(last_idx)});
+  return res;
+}
+
+// Convert the given set of images into the corresponding HTTP response
+http_response img3_to_response(const image& img1, const image& img2, const image& img3) {
+  std::ostringstream oss;
+  oss << img1.image_data_ << ", " << img2.image_data_ << ", " << img3.image_data_ << "\n";
+  return {200, oss.str()};
+}
+
+// Convert the given set of images into the corresponding HTTP response
+http_response imgvec_to_response(const std::vector<image>& imgs) {
+  std::ostringstream oss;
+  for (const auto& img : imgs)
+    oss << img.image_data_ << "\n";
+  return {200, oss.str()};
+}
+
+// Apply the Canny edge detector on the given image
+image apply_canny(const image& img) { return {"canny / " + img.image_data_}; }
+// Apply the Sobel edge detector on the given image
+image apply_sobel(const image& img) { return {"sobel / " + img.image_data_}; }
+// Apply the Prewitt edge detector on the given image
+image apply_prewitt(const image& img) { return {"prewitt / " + img.image_data_}; }
+// Apply blur filter on the given image
+image apply_blur(const image& img) { return {"blur / " + img.image_data_}; }
+
+ex::sender auto handle_edge_detection_request(const http_request& req) {
+  // extract the input image from the request
+  ex::sender auto in_img_sender = ex::just(req) | ex::then(extract_image);
+
+  // Prepare for using multiple parallel flows on the same input sender
+  // ex::sender auto multi_shot_img = ex::split(in_img_sender);
+  auto& multi_shot_img = in_img_sender;
+
+  // Apply the three methods of edge detection on the same input image, in parallel.
+  // Then, join the results and generate the HTTP response
+  return ex::when_all(                                //
+             multi_shot_img | ex::then(apply_canny),  //
+             multi_shot_img | ex::then(apply_sobel),  //
+             multi_shot_img | ex::then(apply_prewitt) //
+             ) |
+         // transform the resulting 3 images into an HTTP response
+         ex::then(img3_to_response);
+  // error and cancellation handling is performed outside
+}
+
+ex::sender auto handle_multi_blur_request(const http_request& req) {
+  return
+      // extract the input images from the request
+      ex::just(req) |
+      ex::then(extract_images)
+      // process images in parallel with bulk.
+      // use let_value to access the image count before calling bulk.
+      | ex::let_value([](std::vector<image> imgs) {
+          // get the image count
+          size_t img_count = imgs.size();
+          // return a sender that bulk-processes the image in parallel
+          return ex::just(std::move(imgs)) |
+                 ex::bulk(img_count,
+                     [](size_t i, std::vector<image>& imgs) { imgs[i] = apply_blur(imgs[i]); });
+        })
+      // transform the resulting 3 images into an HTTP response
+      | ex::then(imgvec_to_response)
+      // done; error and cancellation handling is performed outside
+      ;
+}
+
+int main() {
+  // Create a thread pool and get a scheduler from it
+  example::static_thread_pool pool{8};
+  _P2519::execution::async_scope scope;
+  ex::scheduler auto sched = pool.get_scheduler();
+
+  // Fake a couple of edge_detect requests
+  for (int i = 0; i < 3; i++) {
+    // Create a test request
+    http_request req{"/edge_detect", {}, "scene"};
+
+    // The handler for the /edge_detect requests
+    ex::sender auto snd = handle_edge_detection_request(req);
+
+    // Pack this into a simplified flow and execute it asynchronously
+    ex::sender auto action = std::move(snd) | ex::then([](http_response resp) {
+      std::ostringstream oss;
+      oss << "Sending response: " << resp.status_code_ << " / " << resp.body_ << "\n";
+      std::cout << oss.str();
+    });
+    scope.spawn(ex::on(sched, std::move(action)));
+  }
+
+  // Fake a couple of multi_blur requests
+  for (int i = 0; i < 3; i++) {
+    // Create a test request
+    http_request req{"/multi_blur", {}, "img1\nimg2\nimg3\nimg4\n"};
+
+    // The handler for the /edge_detect requests
+    ex::sender auto snd = handle_multi_blur_request(req);
+
+    // Pack this into a simplified flow and execute it asynchronously
+    ex::sender auto action = std::move(snd) | ex::then([](http_response resp) {
+      std::ostringstream oss;
+      oss << "Sending response: " << resp.status_code_ << " / " << resp.body_ << "\n";
+      std::cout << oss.str();
+    });
+    scope.spawn(ex::on(sched, std::move(action)));
+  }
+
+  std::this_thread::sync_wait(scope.empty());
+  pool.request_stop();
+}

--- a/examples/server_theme/then_upon.cpp
+++ b/examples/server_theme/then_upon.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * General context:
+ * - server application that processes images
+ * - execution contexts:
+ *    - 1 dedicated thread for network I/O
+ *    - N worker threads used for CPU-intensive work
+ *    - M threads for auxiliary I/O
+ *    - optional GPU context that may be used on some types of servers
+ *
+ * Specific problem description:
+ * - we are looking at the flow of handling a "classify" request type
+ * - show how a single-threaded process can be broken into multiple steps with `execution::then` and
+ * `execution::upon_*` functions
+ * - handle errors and cancellations that might occur during the processing
+ * - at the end of the flow, we always end up with an HTTP response
+ *
+ * Example goals:
+ * - show how one can compose single-threaded steps to form a more complex flow
+ * - exemplify the use of `then`, `upon_error` and `upon_done` algorithms
+ */
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include <sstream>
+
+// Pull in the reference implementation of P2300:
+#include <execution.hpp>
+// Keep track of spawned work in an async_scope:
+#include <async_scope.hpp>
+// Use a thread pool
+#include "../schedulers/static_thread_pool.hpp"
+
+namespace ex = std::execution;
+
+struct http_request {
+  std::string url_;
+  std::vector<std::pair<std::string, std::string>> headers_;
+  std::string body_;
+};
+
+struct http_response {
+  int status_code_;
+  std::string body_;
+};
+
+enum class obj_type {
+  human,
+  dog,
+  cat,
+  bird,
+  unknown,
+  general_error,
+  cancelled,
+};
+
+const char* as_string(obj_type t) {
+  switch (t) {
+  case obj_type::human:
+    return "human";
+  case obj_type::dog:
+    return "dog";
+  case obj_type::cat:
+    return "cat";
+  case obj_type::bird:
+    return "bird";
+  case obj_type::unknown:
+    return "unknown";
+  case obj_type::general_error:
+    return "general error";
+  case obj_type::cancelled:
+    return "cancelled";
+  }
+  return "general error";
+}
+
+struct classification_result {
+  obj_type type_;
+  int accuracy_;
+  std::string details_;
+};
+
+struct image {
+  std::string image_data_;
+};
+
+// Extract the image from the HTTP request
+image extract_image(http_request req) {
+  // TODO: make upon_error work before enabling this
+  // if (req.body_.empty())
+  //   throw std::invalid_argument("no image found");
+  return {req.body_};
+}
+
+// Classify the image received
+classification_result do_classify(image img) {
+  if (img.image_data_ == "human")
+    return {obj_type::human, 93};
+  else if (img.image_data_ == "cat")
+    return {obj_type::cat, 97};
+  if (img.image_data_ == "dog")
+    return {obj_type::dog, 92};
+  if (img.image_data_ == "bird")
+    return {obj_type::bird, 96};
+  return {obj_type::unknown, 0};
+}
+
+// Check for errors and transform them into classification result
+classification_result on_classification_error(std::exception_ptr ex) {
+  return {obj_type::general_error, 100, {}};
+}
+
+// Check for cancellation and transform it into classification result
+classification_result on_classification_cancelled() { return {obj_type::cancelled, 100}; }
+
+// Convert the classification result into an HTTP response
+http_response to_response(classification_result res) {
+  if (res.type_ == obj_type::general_error)
+    // Send a 500 response back if we have a general error
+    return {500, res.details_};
+  else if (res.type_ == obj_type::cancelled) {
+    // Send a 503 response back if the computation is cancelled
+    return {503, "cancelled"};
+  } else {
+    // Send a success response back, with the object type, accuracy and details
+    std::ostringstream oss;
+    oss << as_string(res.type_) << " (" << res.accuracy_ << ")\n" << res.details_;
+    return {200, oss.str()};
+  }
+}
+
+// Handler for the "classify" request type
+ex::sender auto handle_classify_request(const http_request& req) {
+  return
+      // start with the input buffer
+      ex::just(req)
+      // extract the image from the input request
+      | ex::then(extract_image)
+      // analyze the content of the image and classify it
+      // we are doing the processing on the same thread
+      | ex::then(do_classify)
+      // handle errors
+      | ex::upon_error(on_classification_error)
+      // handle cancellation
+      | ex::upon_stopped(on_classification_cancelled)
+      // transform this into a response
+      | ex::then(to_response)
+      // done
+      ;
+}
+
+int main() {
+  // Create a thread pool and get a scheduler from it
+  _P2519::execution::async_scope scope;
+  example::static_thread_pool pool{8};
+  ex::scheduler auto sched = pool.get_scheduler();
+
+  // Fake a couple of requests
+  for (int i = 0; i < 12; i++) {
+    // Create a test request
+    const char* body = "";
+    if (i % 2 == 0)
+      body = "human";
+    else if (i % 3 == 0)
+      body = "cat";
+    else if (i % 5 == 0)
+      body = "dog";
+    else if (i % 7 == 0)
+      body = "bird";
+    http_request req{"/classify", {}, body};
+
+    // The handler for the "classify" requests
+    ex::sender auto snd = handle_classify_request(req);
+
+    // Pack this into a simplified flow and execute it asynchronously
+    ex::sender auto action = std::move(snd) | ex::then([](http_response resp) {
+      std::ostringstream oss;
+      oss << "Sending response: " << resp.status_code_ << " / " << resp.body_ << "\n";
+      std::cout << oss.str();
+    });
+    scope.spawn(ex::on(sched, std::move(action)));
+  }
+
+  std::this_thread::sync_wait(scope.empty());
+  pool.request_stop();
+}

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -982,6 +982,101 @@ In this simplified case, one can simplify the signature of the functions to not 
 At the end of the flow we always transform a `classification_result` into an `http_response` object.
 With these constraints, errors and cancellations are handled as if the flow is linear.
 
+### Using multiple threads with `execution::split`, `execution::when_all` and `execution::bulk` ### {#example-server-split}
+
+Example context:
+- implement the handler for applying 3 edge detection algorithms on one image
+- implement the handler for applying a blur filter over the given set of images
+- we show one can use multiple threads to execute a more complex work
+- we show how to use `execution::split` / `execution::when_all` and `execution::bulk`
+- error and cancellation handling is performed outside the handler
+
+Goals:
+- show how one can create work to fill up multiple threads
+- exemplify the use of `then`, `split`, `when_all`, `bulk` and `let_value` algorithms
+
+```c++
+namespace ex = std::execution;
+
+// Extract the image from the HTTP request
+image extract_image(http_request req) {...}
+// Extract multiple images from the HTTP request
+std::vector<image> extract_images(http_request req) {...}
+// Convert the given set of images into the corresponding HTTP response
+http_response img3_to_response(const image& img1, const image& img2, const image& img3) {...}
+// Convert the given set of images into the corresponding HTTP response
+http_response imgvec_to_response(const std::vector<image>& imgs) {...}
+
+// Apply the Canny edge detector on the given image
+image apply_canny(const image& img) {...}
+// Apply the Sobel edge detector on the given image
+image apply_sobel(const image& img) {...}
+// Apply the Prewitt edge detector on the given image
+image apply_prewitt(const image& img) {...}
+// Apply blur filter on the given image
+image apply_blur(const image& img) {...}
+
+ex::sender auto handle_edge_detection_request(const http_request& req) {
+  // extract the input image from the request
+  ex::sender auto in_img_sender = ex::just(req) | ex::then(extract_image);
+
+  // Prepare for using multiple parallel flows on the same input sender
+  // ex::sender auto multi_shot_img = ex::split(in_img_sender);
+  auto& multi_shot_img = in_img_sender;
+
+  // Apply the three methods of edge detection on the same input image, in parallel.
+  // Then, join the results and generate the HTTP response
+  return ex::when_all(                                //
+             multi_shot_img | ex::then(apply_canny),  //
+             multi_shot_img | ex::then(apply_sobel),  //
+             multi_shot_img | ex::then(apply_prewitt) //
+             ) |
+         // transform the resulting 3 images into an HTTP response
+         ex::then(img3_to_response);
+  // error and cancellation handling is performed outside
+}
+
+ex::sender auto handle_multi_blur_request(const http_request& req) {
+  return
+      // extract the input images from the request
+      ex::just(req) |
+      ex::then(extract_images)
+      // process images in parallel with bulk.
+      // use let_value to access the image count before calling bulk.
+      | ex::let_value([](std::vector<image> imgs) {
+          // get the image count
+          size_t img_count = imgs.size();
+          // return a sender that bulk-processes the image in parallel
+          return ex::just(std::move(imgs)) |
+                 ex::bulk(img_count,
+                     [](size_t i, std::vector<image>& imgs) {
+                        imgs[i] = apply_blur(imgs[i]);
+                 });
+        })
+      // transform the resulting 3 images into an HTTP response
+      | ex::then(imgvec_to_response)
+      // done; error and cancellation handling is performed outside
+      ;
+}
+```
+
+The example shows how one can use multiple threads when handling a request.
+We show two handlers that processes multiple things in parallel: one that applies 3 edge detection filters, and one that applies a blur filter to multiple images.
+
+In the first example we know upfront the maximum level of parallelism for the request: as we are computing 3 filters, we have 3 top-level independent processing units that can happen in parallel.
+We use `execution::split` to ensure that the sender that gives the input image can be used multiple times.
+After applying the filter to a copy of the image, we join all 3 processing paths using `execution::when_all`; this will return a sender that completes whenever all given senders complete.
+
+For the second request type, we have a dynamic number of images, so we don't know upfront how to divide the independent top-level work.
+To process all images in parallel we use `execution::bulk`.
+We need to pass the number of work items that can be executed in parallel, and for that we need to query the value that is being issued through the sender.
+For this inspection we use the `execution::let_value` sender algorithm; this allows us to access the value being passed to the sender before retuning an appropriate sender.
+In our case, we get the size of the vector of images, and then we return a sender that, given the set of images will apply `execution::bulk` for that size and the set of images.
+
+
+In our example we assume that that error handling is done outside our handlers.
+See previous examples on how error handling can be implemented.
+
 ## What this proposal is **not** ## {#intro-is-not}
 
 This paper is not a patch on top of [[P0443R14]]; we are not asking to update the existing paper, we are asking to retire it in favor of this paper, which is already self-contained; any example code within this paper can be written in Standard C++, without the need

--- a/std_execution.bs
+++ b/std_execution.bs
@@ -926,6 +926,62 @@ The reader should notice the difference between `execution::on` and `execution::
 The `execution::on` algorithm will ensure that the given sender will start in the specified context, and doesn't care where the completion signal for that sender is sent.
 The `execution::transfer` algorithm will not care where the given sender is going to be started, but will ensure that the completion signal of will be transferred to the given context.
 
+### Single-threaded chaining with `execution::then` `execution::upon_*` ### {#example-server-then-upon}
+
+Example context:
+- we are looking at the flow of handling a "classify" request type
+- show how a single-threaded process can be broken into multiple steps with `execution::then` and `execution::upon_*` functions
+- handle errors and cancellations that might occur during the processing
+- at the end of the flow, we always end up with an HTTP response
+
+Goals:
+- show how one can compose single-threaded steps to form a more complex flow
+- exemplify the use of `then`, `upon_error` and `upon_stopped` algorithms
+
+```c++
+namespace ex = std::execution;
+
+// Extract the image from the HTTP request
+image extract_image(http_request req) {...}
+// Classify the image received
+classification_result do_classify(image img) {...}
+// Check for errors and transform them into classification result
+classification_result on_classification_error(std::exception_ptr ex) {...}
+// Check for cancellation and transform it into classification result
+classification_result on_classification_cancelled() {...}
+// Convert the classification result into an HTTP response
+http_response to_response(classification_result res) {
+
+// Handler for the "classify" request type
+ex::sender auto handle_classify_request(const http_request& req) {
+  return
+      // start with the input buffer
+      ex::just(req)
+      // extract the image from the input request
+      | ex::then(extract_image)
+      // analyze the content of the image and classify it
+      // we are doing the processing on the same thread
+      | ex::then(do_classify)
+      // handle errors
+      | ex::upon_error(on_classification_error)
+      // handle cancellation
+      | ex::upon_stopped(on_classification_cancelled)
+      // transform this into a response
+      | ex::then(to_response)
+      // done
+      ;
+}
+```
+
+The example shows how one (simple) request can be implemented, without using multiple execution contexts.
+One can structure the code such that it's functionally decoupled, and still use senders for properly handling success/error/cancellation flows.
+
+This is similar to the `execution::let_*` example, but all the execution flow is assumed to be on a single thread.
+In this simplified case, one can simplify the signature of the functions to not return senders, but the actual computed values.
+
+At the end of the flow we always transform a `classification_result` into an `http_response` object.
+With these constraints, errors and cancellations are handled as if the flow is linear.
+
 ## What this proposal is **not** ## {#intro-is-not}
 
 This paper is not a patch on top of [[P0443R14]]; we are not asking to update the existing paper, we are asking to retire it in favor of this paper, which is already self-contained; any example code within this paper can be written in Standard C++, without the need


### PR DESCRIPTION
Add "server theme" example that uses then and upon_* to show how single-
threaded actions can be chained together with senders.

This chaining will properly react to errors and cancellations.

Also remove TODO in "on_transfer.cpp" example, as now the code works
fine.