### PR TITLE
when_all() should return just()

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4763,6 +4763,9 @@ namespace stdexec {
                   apply([](auto&&... __child_ops) noexcept -> void {
                     (execution::start(__child_ops), ...);
                   }, __self.__child_states_);
+                  if constexpr (sizeof...(_SenderIds) == 0) {
+                    __self.__complete();
+                  }
                 }
               }
 
@@ -4812,8 +4815,7 @@ namespace stdexec {
     struct when_all_t {
       template <sender... _Senders>
         requires tag_invocable<when_all_t, _Senders...> &&
-          sender<tag_invoke_result_t<when_all_t, _Senders...>> &&
-          (sizeof...(_Senders) > 0)
+          sender<tag_invoke_result_t<when_all_t, _Senders...>>
       auto operator()(_Senders&&... __sndrs) const
         noexcept(nothrow_tag_invocable<when_all_t, _Senders...>)
         -> tag_invoke_result_t<when_all_t, _Senders...> {
@@ -4821,8 +4823,7 @@ namespace stdexec {
       }
 
       template <sender... _Senders>
-          requires (!tag_invocable<when_all_t, _Senders...>) &&
-            (sizeof...(_Senders) > 0)
+          requires (!tag_invocable<when_all_t, _Senders...>)
       auto operator()(_Senders&&... __sndrs) const
         -> __impl::__sender<__x<decay_t<_Senders>>...> {
         return __impl::__sender<__x<decay_t<_Senders>>...>{

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -68,10 +68,9 @@ TEST_CASE("when_all with just one sender", "[adaptors][when_all]") {
   wait_for_value(std::move(snd), 2);
 }
 
-TEST_CASE("when_all with no senders sender -- should fail", "[adaptors][when_all]") {
-  // Should not compile:
-  // auto snd = ex::when_all();
-  static_assert(!std::invocable<ex::when_all_t>);
+TEST_CASE("when_all with no senders", "[adaptors][when_all]") {
+  ex::sender auto snd = ex::when_all();
+  wait_for_value(std::move(snd));
 }
 
 TEST_CASE("when_all when one sender sends void", "[adaptors][when_all]") {
@@ -98,6 +97,11 @@ TEST_CASE("when_all_with_variant with same type", "[adaptors][when_all]") {
   );
   wait_for_value(
       std::move(snd), std::variant<std::tuple<int>>{2}, std::variant<std::tuple<int>>{3});
+}
+
+TEST_CASE("when_all_with_variant with no senders", "[adaptors][when_all]") {
+  ex::sender auto snd = ex::when_all_with_variant();
+  wait_for_value(std::move(snd));
 }
 
 TEST_CASE("when_all completes when children complete", "[adaptors][when_all]") {


### PR DESCRIPTION
If I write a variadic function template that takes a pack of senders and passes them to `when_all`, I need to either (a) constrain it to take at least one sender, or (b) handle the case of zero senders specially.

It would be more convenient if `when_all()` returned the moral equivalent of `just(tuple{})`. [Correction: `just()`. A sender which, when connected to a receiver and started, calls `set_value(tuple{})` on the receiver.]

Patch supplied, but I don't seriously believe it can be as easy as this.
