### PR TITLE
Store 'split' sender in shared state

### DIFF
--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2260,13 +2260,15 @@ namespace std::execution {
 
         using __receiver_ = __receiver<__sh_state>;
 
+        _Sender __sndr_;
         in_place_stop_source __stop_source_{};
         connect_result_t<_Sender, __receiver_> __op_state2_;
         __variant_t __data_;
         atomic<void*> __head_;
 
-        explicit __sh_state(_Sender& __sndr)
-          : __op_state2_(connect((_Sender&&) __sndr, __receiver_{*this}))
+        explicit __sh_state(_Sender __sndr)
+          : __sndr_((_Sender&&)__sndr)
+          ,  __op_state2_(connect((_Sender&&) __sndr_, __receiver_{*this}))
           , __head_{nullptr}
         {}
 
@@ -2358,7 +2360,6 @@ namespace std::execution {
         template <class _Receiver>
           using __operation = __operation<_SenderId, __x<remove_cvref_t<_Receiver>>>;
 
-        _Sender __sndr_;
         shared_ptr<__sh_state_> __shared_state_;
 
       public:
@@ -2395,9 +2396,9 @@ namespace std::execution {
               __set_value_t,
               __set_error_t>;
 
-        explicit __sender(_Sender __sndr)
-            : __sndr_((_Sender&&) __sndr)
-            , __shared_state_{make_shared<__sh_state_>(__sndr_)}
+        template <class _Sender2>
+        explicit __sender(_Sender2&& __sndr)
+            : __shared_state_{make_shared<__sh_state_>((_Sender2&&)__sndr)}
         {}
       };
 

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2266,7 +2266,7 @@ namespace std::execution {
         __variant_t __data_;
         atomic<void*> __head_;
 
-        explicit __sh_state(_Sender __sndr)
+        explicit __sh_state(_Sender&& __sndr)
           : __sndr_((_Sender&&)__sndr)
           ,  __op_state2_(connect((_Sender&&) __sndr_, __receiver_{*this}))
           , __head_{nullptr}
@@ -2396,9 +2396,8 @@ namespace std::execution {
               __set_value_t,
               __set_error_t>;
 
-        template <class _Sender2>
-        explicit __sender(_Sender2&& __sndr)
-            : __shared_state_{make_shared<__sh_state_>((_Sender2&&)__sndr)}
+        explicit __sender(_Sender __sndr)
+            : __shared_state_{make_shared<__sh_state_>((_Sender&&)__sndr)}
         {}
       };
 

--- a/test/algos/adaptors/test_split.cpp
+++ b/test/algos/adaptors/test_split.cpp
@@ -210,6 +210,18 @@ TEMPLATE_TEST_CASE("split move only sender", "[adaptors][split]", move_only_type
   REQUIRE( v2 == 22 );
   REQUIRE( v3 == 33 );
 }
+TEST_CASE("split into when_all", "[adaptors][split]") {
+  int counter{};
+  auto snd = ex::split(ex::just() | ex::then([&]{ counter++; return counter; }));
+  auto wa = ex::when_all(
+    snd | ex::then([](auto) { return 10; }),
+    snd | ex::then([](auto) { return 20; }));
+  REQUIRE( counter == 0 );
+  auto [v1, v2] = std::this_thread::sync_wait(std::move(wa)).value();
+  REQUIRE( counter == 1 );
+  REQUIRE( v1 == 10 );
+  REQUIRE( v2 == 20 );
+}
 TEST_CASE("split can nest", "[adaptors][split]") {
   auto split_1 = ex::just(42) | ex::split();
   auto split_2 = split_1 | ex::split();

--- a/test/algos/adaptors/test_split.cpp
+++ b/test/algos/adaptors/test_split.cpp
@@ -194,13 +194,13 @@ TEMPLATE_TEST_CASE("split move only sender", "[adaptors][split]", move_only_type
   int called = 0;
   auto multishot = 
       ex::just(TestType(10)) |
-      ex::then([&](TestType mot) { ++called; return TestType(mot.val+1); }) |
+      ex::then([&](TestType obj) { ++called; return TestType(obj.val+1); }) |
       ex::split();
   auto wa =
     ex::when_all(
-        ex::then(multishot, [](const TestType& mot) { return mot.val; }),
-        ex::then(multishot, [](const TestType& mot) { return mot.val * 2; }),
-        ex::then(multishot, [](const TestType& mot) { return mot.val * 3; })
+        ex::then(multishot, [](const TestType& obj) { return obj.val; }),
+        ex::then(multishot, [](const TestType& obj) { return obj.val * 2; }),
+        ex::then(multishot, [](const TestType& obj) { return obj.val * 3; })
       );
 
   auto [v1, v2, v3] = std::this_thread::sync_wait(std::move(wa)).value();


### PR DESCRIPTION
I was looking to get a version of "split" working on top of libunifex, but found the reference implementation of `split` here did not allow me to fork a `unifex::task` (e.g., as with the example in https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2300r5.html#design-forkable).

I didn't quite follow https://github.com/brycelelbach/wg21_p2300_std_execution/issues/466 as I'm not sure I fully understand what environments are, but I can look into that approach as well.