### PR TITLE
RFC Sequence prototype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,8 @@ set(test_sourceFiles
     test/exec/async_scope/test_spawn_future.cpp
     test/exec/async_scope/test_empty.cpp
     test/exec/async_scope/test_stop.cpp
+    test/exec/test_ignore_all.cpp
+    test/exec/test_iotas.cpp
     )
 
 add_executable(test.stdexec ${test_sourceFiles})
@@ -257,6 +259,7 @@ def_example(clangd.helper "examples/_clangd_helper_file.cpp")
 def_example(example.hello_world "examples/hello_world.cpp")
 def_example(example.hello_coro "examples/hello_coro.cpp")
 def_example(example.scope "examples/scope.cpp")
+def_example(example.sequence "examples/sequence.cpp")
 def_example(example.retry "examples/retry.cpp")
 def_example(example.then "examples/then.cpp")
 def_example(example.server_theme.let_value "examples/server_theme/let_value.cpp")

--- a/examples/sequence.cpp
+++ b/examples/sequence.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pull in the reference implementation of P2300:
+#include <exec/sequence.hpp>
+
+#include <exec/static_thread_pool.hpp>
+#include <test/test_common/type_helpers.hpp>
+
+#include <cstdio>
+
+///////////////////////////////////////////////////////////////////////////////
+// Example code:
+using namespace stdexec;
+using namespace _P0TBD::execution;
+using std::this_thread::sync_wait;
+
+int main() {
+  auto print_each = iotas(1, 10)
+  | then_each([](int v){ printf("%d, ", v); })
+  | ignore_all()
+  | ex::then([](){ printf("\n"); });
+
+  check_val_types<type_array<type_array<>>>(print_each);
+  check_err_types<type_array<std::exception_ptr>>(print_each);
+  check_sends_stopped<false>(print_each);
+
+  stdexec::sync_wait(std::move(print_each));
+}

--- a/include/exec/sequence.hpp
+++ b/include/exec/sequence.hpp
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdexec/execution.hpp>
+
+namespace _P0TBD::execution {
+
+  using namespace stdexec;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.set_next]
+  namespace __set_next {
+    struct set_next_t {
+      template <class _Receiver, class _Sender>
+      auto operator()(_Receiver& __rcvr, _Sender&& __sndr) const
+        noexcept(nothrow_tag_invocable<set_next_t, _Receiver&, _Sender>)
+        -> tag_invoke_result_t<set_next_t, _Receiver&, _Sender> {
+        static_assert(
+          sender<tag_invoke_result_t<set_next_t, _Receiver&, _Sender>>,
+          "execution::set_next(receiver, sender) must return a type that "
+          "satisfies the sender concept");
+        return tag_invoke(set_next_t{}, __rcvr, (_Sender&&) __sndr);
+      }
+    };
+  } // namespace __set_next
+
+  using __set_next::set_next_t;
+  inline constexpr __set_next::set_next_t set_next {};
+
+  template <class _Receiver, class _Sender>
+    using set_next_result_t = __call_result_t<set_next_t, _Receiver, _Sender>;
+
+  template <class _SequenceReceiver, class _ValueSender>
+    concept __sequence_receiver_of =
+      requires (_SequenceReceiver&& __seq_rcvr, _ValueSender&& __val_sndr) {
+        { set_next((_SequenceReceiver&&) __seq_rcvr, (_ValueSender&&) __val_sndr) } -> sender<>;
+      };
+
+  template <class _SequenceReceiver, class _ValueSender>
+    concept sequence_receiver_of =
+      receiver<_SequenceReceiver> &&
+      __sequence_receiver_of<_SequenceReceiver, _ValueSender>;
+
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.factories]
+  namespace __iotas {
+
+    template <class _CPO, class _V>
+    using __completion_signatures_ = completion_signatures<_CPO(_V)>;
+
+    template <class _CPO, class _V>
+    struct __value_sender {
+        template <__decays_to<__value_sender<_CPO, _V>> _Self, class _Env>
+        friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env) ->
+          __completion_signatures_<_CPO, _V>;
+
+        template <class _ReceiverId>
+          struct __operation : __immovable {
+            using _Receiver = __t<_ReceiverId>;
+            _Receiver __rcvr_;
+            _V __last_;
+
+            friend void tag_invoke(start_t, __operation& __op_state) noexcept {
+              static_assert(__nothrow_callable<_CPO, _Receiver, _V>);
+              _CPO{}(std::move(__op_state.__rcvr_), std::move(__op_state.__last_));
+            }
+          };
+
+        _V __last_;
+
+        template <class _Receiver>
+          requires copy_constructible<_V>
+        friend auto tag_invoke(connect_t, const __value_sender& __sndr, _Receiver&& __rcvr)
+          noexcept(std::is_nothrow_copy_constructible_v<_V>)
+          -> __operation<__x<remove_cvref_t<_Receiver>>> {
+          return {{}, (_Receiver&&) __rcvr, ((__value_sender&&) __sndr).__last_};
+        }
+
+        template <class _Receiver>
+        friend auto tag_invoke(connect_t, __value_sender&& __sndr, _Receiver&& __rcvr)
+          noexcept(std::is_nothrow_move_constructible_v<_V>)
+          -> __operation<__x<remove_cvref_t<_Receiver>>> {
+          return {{}, (_Receiver&&) __rcvr, ((__value_sender&&) __sndr).__last_};
+        }
+    };
+
+    template <class _CPO, class _V, class _B>
+      struct __sender {
+        template <__decays_to<__sender<_CPO, _V, _B>> _Self, class _Env>
+        friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env) ->
+          completion_signatures<set_value_t()>;
+
+        template <class _SequenceReceiverId>
+          struct __operation : __immovable {
+            using _SequenceReceiver = __t<_SequenceReceiverId>;
+
+            struct __value_receiver {
+                __operation* __op_state_;
+
+                template<class... _Args>
+                friend void tag_invoke(set_value_t, __value_receiver&& __value_rcvr, _Args&&...) noexcept try {
+                    auto __op_state = ((__value_receiver&&) __value_rcvr).__op_state_;
+                    auto& __value_op = __op_state->__value_op_;
+                    __value_op.reset();
+                    if (__op_state->__bound_ == __op_state->__next_) {
+                      execution::set_value(std::move(__op_state->__rcvr_));
+                      return;
+                    }
+                    auto __adapted_value{_P0TBD::execution::set_next(__op_state->__rcvr_, __value_sender<_CPO, _V>{__op_state->__next_++})};
+                    __value_op.emplace(
+                        __conv{
+                            [&](){
+                                return execution::connect(on(__op_state->__schd_, std::move(__adapted_value)), __value_receiver{__op_state});
+                            }
+                        });
+                    execution::start(*__value_op);
+                } catch(...) {
+                    execution::set_error(
+                        (_SequenceReceiver&&) ((__value_receiver&&) __value_rcvr).__op_state_->__rcvr_,
+                        std::current_exception());
+                }
+
+                template <__one_of<set_error_t, set_stopped_t> _Tag, class... _Args>
+                  requires __callable<_Tag, _SequenceReceiver, _Args...>
+                friend void tag_invoke(_Tag, __value_receiver&& __value_rcvr, _Args&&... __args) noexcept {
+                  auto __op_state = ((__value_receiver&&) __value_rcvr).__op_state_;
+                  __op_state->__value_op_.reset();
+                  _Tag{}((_SequenceReceiver&&) __op_state->__rcvr_, (_Args&&) __args...);
+                }
+
+                friend auto tag_invoke(get_env_t, const __value_receiver& __value_rcvr)
+                  -> env_of_t<_SequenceReceiver> {
+                  return get_env(__value_rcvr.__op_state_->__rcvr_);
+                }
+            };
+
+            using scheduler_t = std::invoke_result_t<get_scheduler_t, env_of_t<_SequenceReceiver>>;
+            using __adapted_sender_t=std::invoke_result_t<_P0TBD::execution::set_next_t, _SequenceReceiver&, __value_sender<_CPO, _V>>;
+            using __value_sender_t=std::invoke_result_t<execution::on_t, scheduler_t, __adapted_sender_t>;
+            using __value_op_t=connect_result_t<__value_sender_t, __value_receiver>;
+
+            scheduler_t __schd_;
+            _SequenceReceiver __rcvr_;
+            [[no_unique_address]] _V __next_;
+            [[no_unique_address]] _B __bound_;
+
+            std::optional<__value_op_t> __value_op_;
+
+            friend void tag_invoke(start_t, __operation& __op_state) noexcept {
+              static_assert(__nothrow_callable<set_value_t, _SequenceReceiver>);
+              if (__op_state.__bound_ == __op_state.__next_) {
+                execution::set_value(std::move(__op_state.__rcvr_));
+                return;
+              }
+              auto __adapted_value{_P0TBD::execution::set_next(__op_state.__rcvr_, __value_sender<_CPO, _V>{__op_state.__next_++})};
+              __op_state.__value_op_.emplace(
+                  __conv{
+                      [&](){
+                          return execution::connect(on(__op_state.__schd_, std::move(__adapted_value)), __value_receiver{&__op_state});
+                      }
+                  });
+              execution::start(*__op_state.__value_op_);
+            }
+          };
+
+        [[no_unique_address]] _V __value_;
+        [[no_unique_address]] _B __bound_;
+
+        template <class _SequenceReceiver>
+          requires copy_constructible<_V> && copy_constructible<_B> && __scheduler_provider<env_of_t<_SequenceReceiver>>
+        friend auto tag_invoke(connect_t, const __sender& __sndr, _SequenceReceiver&& __rcvr)
+          noexcept(std::is_nothrow_copy_constructible_v<_V> && std::is_nothrow_copy_constructible_v<_B>)
+          -> __operation<__x<remove_cvref_t<_SequenceReceiver>>> {
+          return {{}, get_scheduler(get_env(__rcvr)), (_SequenceReceiver&&) __rcvr, ((__sender&&) __sndr).__value_, ((__sender&&) __sndr).__bound_};
+        }
+
+        template <class _SequenceReceiver>
+          requires __scheduler_provider<env_of_t<_SequenceReceiver>>
+        friend auto tag_invoke(connect_t, __sender&& __sndr, _SequenceReceiver&& __rcvr)
+          noexcept(std::is_nothrow_move_constructible_v<_V> && std::is_nothrow_move_constructible_v<_B>)
+          -> __operation<__x<remove_cvref_t<_SequenceReceiver>>> {
+          return {{}, get_scheduler(get_env(__rcvr)), (_SequenceReceiver&&) __rcvr, ((__sender&&) __sndr).__value_, ((__sender&&) __sndr).__bound_};
+        }
+      };
+
+    inline constexpr struct __iotas_t {
+      template <copy_constructible _V, __equality_comparable_with<_V> _B>
+      __sender<set_value_t, decay_t<_V>, decay_t<_B>> operator()(_V&& __v, _B&& __b) const
+        noexcept(std::is_nothrow_constructible_v<decay_t<_V>, _V> && std::is_nothrow_constructible_v<decay_t<_B>, _B>) {
+        return {(_V&&) __v, (_B&&) __b};
+      }
+    } iotas {};
+  }
+  using __iotas::iotas;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.adaptors.ignore_all]
+  namespace __ignore_all {
+
+    template<class _ReceiverId>
+    struct __sequence_receiver {
+        using _Receiver = __t<_ReceiverId>;
+
+        [[no_unique_address]] _Receiver __rcvr_;
+
+        template<class _ValueSender>
+        friend auto tag_invoke(set_next_t, __sequence_receiver&, _ValueSender&& __vs) noexcept {
+          return (_ValueSender&&)__vs;
+        }
+
+        template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag, class... _Args>
+          requires __callable<_Tag, _Receiver, _Args...>
+        friend void tag_invoke(_Tag, __sequence_receiver&& __seq_rcvr, _Args&&... __args) noexcept {
+          _Tag{}((_Receiver&&) __seq_rcvr.__rcvr_, (_Args&&) __args...);
+        }
+
+        friend auto tag_invoke(get_env_t, const __sequence_receiver& __seq_rcvr)
+          -> env_of_t<_Receiver> {
+          return get_env(__seq_rcvr.__rcvr_);
+        }
+    };
+
+    template <class _SequenceSenderId>
+      struct __sequence_sender {
+        using _SequenceSender = __t<_SequenceSenderId>;
+
+        [[no_unique_address]] _SequenceSender __seq_sndr_;
+
+      template <class _Receiver>
+        using __sequence_receiver = __sequence_receiver<__x<remove_cvref_t<_Receiver>>>;
+
+        template <__decays_to<__sequence_sender> _Self, receiver _Receiver>
+          requires sender_to<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver<_Receiver>>
+        friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
+          noexcept(__nothrow_connectable<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver<_Receiver>>)
+          //recursive template instantiation
+          {//-> connect_result_t<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver<_Receiver>> {
+          return connect(((_Self&&) __self).__seq_sndr_, __sequence_receiver<_Receiver>{(_Receiver&&) __rcvr});
+        }
+
+        template <__decays_to<__sequence_sender> _Self, receiver _Receiver, class _ValueAdaptor>
+          requires sender_to<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver<_Receiver>>
+        friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr, _ValueAdaptor&&)
+          noexcept(__nothrow_connectable<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver<_Receiver>>)
+          //recursive template instantiation
+          {//-> connect_result_t<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver<_Receiver>> {
+          return connect(((_Self&&) __self).__seq_sndr_, __sequence_receiver<_Receiver>{(_Receiver&&) __rcvr});
+        }
+
+        template <__decays_to<__sequence_sender> _Self, class _Env>
+        friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env) ->
+          completion_signatures_of_t<_SequenceSender, _Env>;
+
+        // forward sender queries:
+        template <tag_category<forwarding_sender_query> _Tag, class... _As>
+            requires __callable<_Tag, const _SequenceSender&, _As...>
+          friend auto tag_invoke(_Tag __tag, const __sequence_sender& __self, _As&&... __as)
+            noexcept(__nothrow_callable<_Tag, const _SequenceSender&, _As...>)
+            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _SequenceSender&, _As...> {
+            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
+          }
+      };
+
+    struct ignore_all_t {
+      template <class _SequenceSender>
+        using __sequence_sender = __sequence_sender<__x<remove_cvref_t<_SequenceSender>>>;
+
+      template <sender _SequenceSender>
+        requires __tag_invocable_with_completion_scheduler<ignore_all_t, set_value_t, _SequenceSender>
+      sender auto operator()(_SequenceSender&& __seq_sndr) const
+        noexcept(nothrow_tag_invocable<ignore_all_t, __completion_scheduler_for<_SequenceSender, set_value_t>, _SequenceSender>) {
+        auto __sched = get_completion_scheduler<set_value_t>(__seq_sndr);
+        return tag_invoke(ignore_all_t{}, std::move(__sched), (_SequenceSender&&) __seq_sndr);
+      }
+      template <sender _SequenceSender>
+        requires (!__tag_invocable_with_completion_scheduler<ignore_all_t, set_value_t, _SequenceSender>) &&
+          tag_invocable<ignore_all_t, _SequenceSender>
+      sender auto operator()(_SequenceSender&& __seq_sndr) const
+        noexcept(nothrow_tag_invocable<ignore_all_t, _SequenceSender>) {
+        return tag_invoke(ignore_all_t{}, (_SequenceSender&&) __seq_sndr);
+      }
+      template <sender _SequenceSender>
+        requires
+          (!__tag_invocable_with_completion_scheduler<ignore_all_t, set_value_t, _SequenceSender>) &&
+          (!tag_invocable<ignore_all_t, _SequenceSender>) &&
+          sender<__sequence_sender<_SequenceSender>>
+      __sequence_sender<_SequenceSender> operator()(_SequenceSender&& __seq_sndr) const {
+        return __sequence_sender<_SequenceSender>{(_SequenceSender&&) __seq_sndr};
+      }
+      __binder_back<ignore_all_t> operator()() const {
+        return {{}, {}};
+      }
+    };
+  }
+  using __ignore_all::ignore_all_t;
+  inline constexpr ignore_all_t ignore_all{};
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [execution.senders.adaptors.then_each]
+  namespace __then_each {
+
+    template <class _SequenceSenderId, class _FunId>
+      struct __sequence_sender {
+        using _SequenceSender = __t<_SequenceSenderId>;
+        using _Fun = __t<_FunId>;
+
+        [[no_unique_address]] _SequenceSender __seq_sndr_;
+        [[no_unique_address]] _Fun __fun_;
+
+        template<class _SequenceReceiverId>
+        struct __sequence_receiver {
+            using _SequenceReceiver = __t<_SequenceReceiverId>;
+
+            [[no_unique_address]] _SequenceReceiver __rcvr_;
+            [[no_unique_address]] _Fun __fun_;
+
+            template<class _ValueSender>
+            friend auto tag_invoke(set_next_t, __sequence_receiver& __self, _ValueSender&& __vs) noexcept {
+              return set_next(__self.__rcvr_, execution::then((_ValueSender&&)__vs, __self.__fun_));
+            }
+
+            template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag, class... _Args>
+              requires __callable<_Tag, _SequenceReceiver, _Args...>
+            friend void tag_invoke(_Tag, __sequence_receiver&& __seq_rcvr, _Args&&... __args) noexcept {
+              _Tag{}((_SequenceReceiver&&) __seq_rcvr.__rcvr_, (_Args&&) __args...);
+            }
+
+            friend auto tag_invoke(get_env_t, const __sequence_receiver& __seq_rcvr)
+              -> env_of_t<_SequenceReceiver> {
+              return get_env(__seq_rcvr.__rcvr_);
+            }
+        };
+
+        template <class _SequenceReceiver>
+          using __sequence_receiver_t = __sequence_receiver<__x<remove_cvref_t<_SequenceReceiver>>>;
+
+        template <class...>
+          using __set_value =
+            completion_signatures<set_value_t()>;
+
+        template <class _Self, class _Env>
+          using __completion_signatures =
+            make_completion_signatures<
+              __copy_cvref_t<_Self, _SequenceSender>, _Env, __with_exception_ptr, __set_value>;
+
+        template <__decays_to<__sequence_sender> _Self, receiver _SequenceReceiver>
+          requires sender_to<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver_t<_SequenceReceiver>>
+        friend auto tag_invoke(connect_t, _Self&& __self, _SequenceReceiver&& __rcvr)
+          noexcept(__nothrow_connectable<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver_t<_SequenceReceiver>>)
+          // recursive template instantiation
+          {//-> connect_result_t<__copy_cvref_t<_Self, _SequenceSender>, __sequence_receiver_t<_SequenceReceiver>> {
+          return connect(
+              ((_Self&&) __self).__seq_sndr_,
+              __sequence_receiver_t<_SequenceReceiver>{(_SequenceReceiver&&) __rcvr, __self.__fun_});
+        }
+
+        template <__decays_to<__sequence_sender> _Self, class _Env>
+        friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env) ->
+          __completion_signatures<_Self, _Env>;
+
+        // forward sender queries:
+        template <tag_category<forwarding_sender_query> _Tag, class... _As>
+            requires __callable<_Tag, const _SequenceSender&, _As...>
+          friend auto tag_invoke(_Tag __tag, const __sequence_sender& __self, _As&&... __as)
+            noexcept(__nothrow_callable<_Tag, const _SequenceSender&, _As...>)
+            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _SequenceSender&, _As...> {
+            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
+          }
+      };
+
+    struct then_each_t {
+      template <class _SequenceSender, class _Fun>
+        using __sequence_sender = __sequence_sender<__x<remove_cvref_t<_SequenceSender>>, __x<remove_cvref_t<_Fun>>>;
+
+      template <sender _SequenceSender, __movable_value _Fun>
+        requires __tag_invocable_with_completion_scheduler<then_each_t, set_value_t, _SequenceSender, _Fun>
+      sender auto operator()(_SequenceSender&& __seq_sndr, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<then_each_t, __completion_scheduler_for<_SequenceSender, set_value_t>, _SequenceSender, _Fun>) {
+        auto __sched = get_completion_scheduler<set_value_t>(__seq_sndr);
+        return tag_invoke(then_each_t{}, std::move(__sched), (_SequenceSender&&) __seq_sndr, (_Fun&&) __fun);
+      }
+      template <sender _SequenceSender, __movable_value _Fun>
+        requires (!__tag_invocable_with_completion_scheduler<then_each_t, set_value_t, _SequenceSender, _Fun>) &&
+          tag_invocable<then_each_t, _SequenceSender, _Fun>
+      sender auto operator()(_SequenceSender&& __seq_sndr, _Fun __fun) const
+        noexcept(nothrow_tag_invocable<then_each_t, _SequenceSender, _Fun>) {
+        return tag_invoke(then_each_t{}, (_SequenceSender&&) __seq_sndr, (_Fun&&) __fun);
+      }
+      template <sender _SequenceSender, __movable_value _Fun>
+        requires
+          (!__tag_invocable_with_completion_scheduler<then_each_t, set_value_t, _SequenceSender, _Fun>) &&
+          (!tag_invocable<then_each_t, _SequenceSender, _Fun>) &&
+          sender<__sequence_sender<_SequenceSender, _Fun>>
+      __sequence_sender<_SequenceSender, _Fun> operator()(_SequenceSender&& __seq_sndr, _Fun __fun) const {
+        return __sequence_sender<_SequenceSender, _Fun>{(_SequenceSender&&) __seq_sndr, (_Fun&&) __fun};
+      }
+      template <class _Fun>
+      __binder_back<then_each_t, _Fun> operator()(_Fun __fun) const {
+        return {{}, {}, {(_Fun&&) __fun}};
+      }
+    };
+  }
+  using __then_each::then_each_t;
+  inline constexpr then_each_t then_each{};
+
+} // namespace _P0TBD::execution

--- a/include/stdexec/concepts.hpp
+++ b/include/stdexec/concepts.hpp
@@ -172,6 +172,15 @@ namespace stdexec {
       move_constructible<decay_t<_T>> &&
       constructible_from<decay_t<_T>, _T>;
 
+  template<class _T, class _U>
+    concept __equality_comparable_with =
+      requires(const typename std::remove_reference<_T>::type& __t, const typename std::remove_reference<_U>::type& __u) {
+        { __t == __u } -> convertible_to<bool>;
+        { __t != __u } -> convertible_to<bool>;
+        { __u == __t } -> convertible_to<bool>;
+        { __u != __t } -> convertible_to<bool>;
+      };
+
   template <class _Trait>
     concept __is_true = _Trait::value;
 

--- a/test/exec/test_ignore_all.cpp
+++ b/test/exec/test_ignore_all.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <exec/env.hpp>
+#include <exec/sequence.hpp>
+#include <test_common/receivers.hpp>
+#include <test_common/sequences.hpp>
+#include <exec/static_thread_pool.hpp>
+
+namespace ex = stdexec;
+namespace P0TBD = _P0TBD::execution;
+using expect_void = expect_void_receiver<exec::make_env_t<
+  exec::with_t<ex::get_scheduler_t, decltype(exec::static_thread_pool{}.get_scheduler())&>>>;
+
+TEST_CASE("Simple test for ignore_all", "[factories][sequence][ignore_all]") {
+  std::optional<exec::static_thread_pool> pool{2};
+  ex::scheduler auto schd = pool->get_scheduler();
+  auto r = expect_void{exec::make_env(exec::with(ex::get_scheduler, schd))};
+  auto s = P0TBD::ignore_all(P0TBD::iotas(1, 3));
+  auto o1 = ex::connect(std::move(s), std::move(r));
+  ex::start(o1);
+  pool.reset();
+}
+
+TEST_CASE("Stack overflow test for ignore_all", "[factories][sequence][ignore_all]") {
+  std::optional<exec::static_thread_pool> pool{2};
+  ex::scheduler auto schd = pool->get_scheduler();
+  auto o1 = ex::connect(
+    P0TBD::ignore_all(P0TBD::iotas(1, 3000000)),
+    expect_void{exec::make_env(exec::with(ex::get_scheduler, schd))});
+  ex::start(o1);
+  pool.reset();
+}
+
+TEST_CASE("ignore_all returns a sequence_sender", "[factories][sequence][ignore_all]") {
+  using r = expect_void;
+  using s = decltype(P0TBD::ignore_all(P0TBD::iotas(1, 3)));
+  static_assert(ex::sender_to<s, r>, "P0TBD::ignore_all must return a sender");
+  REQUIRE(ex::sender_to<s, r>);
+}

--- a/test/exec/test_iotas.cpp
+++ b/test/exec/test_iotas.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <exec/env.hpp>
+#include <exec/sequence.hpp>
+#include <test_common/receivers.hpp>
+#include <test_common/sequences.hpp>
+#include <exec/static_thread_pool.hpp>
+
+namespace ex = stdexec;
+namespace P0TBD = _P0TBD::execution;
+
+TEST_CASE("Simple test for iotas", "[factories][sequence][iotas]") {
+  std::optional<exec::static_thread_pool> pool{2};
+  ex::scheduler auto schd = pool->get_scheduler();
+  auto r = make_expect_sequence_receiver(
+    [](int v){return v > 0 && v <= 3;},
+    exec::make_env(exec::with(ex::get_scheduler, schd)));
+  auto s = P0TBD::iotas(1, 3);
+  auto o1 = ex::connect(std::move(s), std::move(r));
+  ex::start(o1);
+  pool.reset();
+}
+
+TEST_CASE("Stack overflow test for iotas", "[factories][sequence][iotas]") {
+  std::optional<exec::static_thread_pool> pool{2};
+  ex::scheduler auto schd = pool->get_scheduler();
+  auto o1 = ex::connect(
+    P0TBD::iotas(1, 3000000),
+    make_expect_sequence_receiver(
+      [](int v){return v > 0 && v <= 3000000;},
+      exec::make_env(exec::with(ex::get_scheduler, schd))));
+  ex::start(o1);
+  pool.reset();
+}
+
+TEST_CASE("iotas returns a sequence_sender", "[factories][sequence][iotas]") {
+  exec::static_thread_pool pool{2};
+  ex::scheduler auto schd = pool.get_scheduler();
+  auto p = [](int v){return v > 0 && v <= 3;};
+  using r = decltype(make_expect_sequence_receiver(
+    std::move(p),
+    exec::make_env(exec::with(ex::get_scheduler, schd))));
+  using s = decltype(P0TBD::iotas(1, 3));
+  static_assert(ex::sender_to<s, r>, "P0TBD::iotas must return a sender");
+  REQUIRE(ex::sender_to<s, r>);
+}

--- a/test/test_common/sequences.hpp
+++ b/test/test_common/sequences.hpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <catch2/catch.hpp>
+#include <test_common/type_helpers.hpp>
+#include <stdexec/execution.hpp>
+#include <exec/sequence.hpp>
+
+namespace ex = stdexec;
+
+template<class _Env = empty_env>
+class expect_empty_sequence_receiver {
+  _Env env_;
+  bool called_{false};
+
+  public:
+  expect_empty_sequence_receiver(_Env env = _Env{}) : env_(env), called_(false) {}
+  ~expect_empty_sequence_receiver() { CHECK(called_); }
+
+  expect_empty_sequence_receiver(expect_empty_sequence_receiver&& other)
+      : env_(other.env_)
+      , called_(std::exchange(other.called_, true)) {
+  }
+  expect_empty_sequence_receiver& operator=(expect_empty_sequence_receiver&& other) {
+    env_ = other.env_;
+    called_ = std::exchange(other.called_, true);
+    return *this;
+  }
+
+
+  template <typename ValueSender>
+  friend void tag_invoke(_P0TBD::execution::set_next_t, expect_empty_sequence_receiver&, ValueSender&&) noexcept {
+    FAIL_CHECK("set_next called on expect_empty_sequence_receiver");
+  }
+  friend void tag_invoke(ex::set_value_t, expect_empty_sequence_receiver&& self) noexcept {
+    self.called_ = true;
+  }
+  template <typename... Ts>
+  friend void tag_invoke(ex::set_value_t, expect_empty_sequence_receiver&&, Ts...) noexcept {
+    FAIL_CHECK("set_value called on expect_empty_sequence_receiver with some non-void value");
+  }
+  friend void tag_invoke(ex::set_stopped_t, expect_empty_sequence_receiver&&) noexcept {
+    FAIL_CHECK("set_stopped called on expect_empty_sequence_receiver");
+  }
+  friend void tag_invoke(ex::set_error_t, expect_empty_sequence_receiver&&, std::exception_ptr) noexcept {
+    FAIL_CHECK("set_error called on expect_empty_sequence_receiver");
+  }
+  friend _Env tag_invoke(ex::get_env_t, const expect_empty_sequence_receiver& self) noexcept {
+    return self.env_;
+  }
+};
+
+struct expect_empty_sequence_receiver_ex {
+  bool* executed_;
+
+  template <typename ValueSender>
+  friend void tag_invoke(_P0TBD::execution::set_next_t, expect_empty_sequence_receiver_ex& self, ValueSender&&) noexcept {
+    FAIL_CHECK("set_next called on expect_empty_sequence_receiver_ex");
+  }
+  friend void tag_invoke(ex::set_value_t, expect_empty_sequence_receiver_ex&& self, const auto&...) noexcept {
+    *self.executed_ = true;
+  }
+  friend void tag_invoke(ex::set_stopped_t, expect_empty_sequence_receiver_ex&&) noexcept {
+    FAIL_CHECK("set_stopped called on expect_empty_sequence_receiver_ex");
+  }
+  friend void tag_invoke(ex::set_error_t, expect_empty_sequence_receiver_ex&&, std::exception_ptr) noexcept {
+    FAIL_CHECK("set_error called on expect_empty_sequence_receiver_ex");
+  }
+  friend empty_env tag_invoke(ex::get_env_t, const expect_empty_sequence_receiver_ex&) noexcept {
+    return {};
+  }
+};
+
+template <typename ValidFn, class _Env = empty_env, bool RuntimeCheck = true>
+class expect_sequence_receiver {
+  std::int_least32_t called_{0};
+  std::atomic_bool ended_{false};
+  ValidFn valid_;
+  _Env env_;
+
+  public:
+  explicit expect_sequence_receiver(ValidFn valid, _Env env = {})
+      : valid_(std::move(valid))
+      , env_(std::move(env)) {}
+  ~expect_sequence_receiver() { CHECK(ended_.load() != false); }
+
+  expect_sequence_receiver(expect_sequence_receiver&& other)
+      : called_(std::exchange(other.called_, -1))
+      , ended_(other.ended_.load())
+      , valid_(std::move(other.valid_))
+      , env_(std::move(other.env_))
+  {other.ended_ = true;}
+  expect_sequence_receiver& operator=(expect_sequence_receiver&& other) {
+    called_ = std::exchange(other.called_, -1);
+    ended_ = other.ended_.load();
+    other.ended_ = true;
+    valid_ = std::move(other.valid_);
+    env_ = std::move(other.env_);
+    return *this;
+  }
+
+  template<class ValueSender>
+  friend auto tag_invoke(_P0TBD::execution::set_next_t, expect_sequence_receiver& self, ValueSender&& vs) noexcept {
+    return ex::then(std::forward<ValueSender>(vs),
+      [&self](auto&&... tn) noexcept requires std::is_invocable_v<ValidFn, decltype(tn)...> {
+        CHECK(self.valid_(std::forward<decltype(tn)>(tn)...));
+        ++self.called_;
+      });
+  }
+  friend void tag_invoke(ex::set_value_t, expect_sequence_receiver&& self) noexcept {
+    // end of sequence
+    self.ended_ = true;
+  }
+  friend void tag_invoke(ex::set_value_t, expect_sequence_receiver&&, const auto&...) noexcept
+      requires RuntimeCheck {
+    FAIL_CHECK("set_value called with wrong value types on expect_sequence_receiver");
+  }
+  friend void tag_invoke(ex::set_stopped_t, expect_sequence_receiver&& ) noexcept {
+    FAIL_CHECK("set_stopped called on expect_sequence_receiver");
+  }
+  template <typename E>
+  friend void tag_invoke(ex::set_error_t, expect_sequence_receiver&&, E) noexcept {
+    FAIL_CHECK("set_error called on expect_sequence_receiver");
+  }
+  friend _Env tag_invoke(ex::get_env_t, const expect_sequence_receiver& __self) noexcept {
+    return __self.env_;
+  }
+};
+
+template <typename ValidFn, class _Env = empty_env, bool RuntimeCheck = true>
+expect_sequence_receiver<ValidFn, _Env, RuntimeCheck> make_expect_sequence_receiver(ValidFn&& valid, _Env&& env = {}) {
+  return expect_sequence_receiver<ValidFn, _Env, RuntimeCheck>{std::forward<ValidFn>(valid), std::forward<_Env>(env)};
+}


### PR DESCRIPTION
This branch contains the prototype that I have been working on to represent sequences of async values.

there is one new cpo:
  `_ValueSenderOut set_next(_SequenceReceiver, _ValueSenderIn)`
  
The `set_next` function is called for each value, and passes a `_ValueSenderIn` for that value. The `set_next` function can compose that `_ValueSenderIn` and return a `_ValueSenderOut`. `_ValueSenderOut` in a SequenceAdaptor is often 

  `return set_next(_SequenceReceiver, compose(_ValueSenderIn));`

This onions the `set_next`s in a SequenceSender expression. 

`_ValueSenderOut` is given to the producer, which then connects and starts `_ValueSenderOut`. When `_ValueSenderOut` completes the producer knows that the value has been processed. This can be used for back-pressure and lock-step.

SequenceSender's do not have to be serial. `set_next` can be called simultaneously with different `_ValueSenderIn` to allow bulk/batch/parallel processing of values.

A `fork()` algo would have a fixed number of `_ValueOp` stored in its operation state and would make sure that each was replaced with a new op when the previous op completed. By applying `on(scheduler, _ValueSenderOut)` to each value, or by having a single `on(scheduler, repeat(next_value()))` that uses one schedule to loop through all the values, the scheduler will have control (up to the fixed number of `_ValueOp`) of the concurrency applied to the work.

There are design decisions that need review. 

The sender-per-value design, might be a perf trap. if construct/connect/start is expensive for a composed `_ValueSenderIn`, that cost will be per value. construction overhead could be removed if we allow an l-value connect `_ValueSenderOut` to be connected for each value with the `_ValueSenderIn` cooperating by sending a different value each time it is connected/started.

