### PR TITLE
Add `ensure_started` implementation

### DIFF
--- a/include/__memory.hpp
+++ b/include/__memory.hpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) NVIDIA
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <__utility.hpp>
+
+#include <atomic>
+#include <memory>
+#include <new>
+
+namespace _P2300 {
+  namespace __ptr {
+    template <class _Ty>
+      struct __make_intrusive_ptr_t;
+
+    template <class _Ty>
+      struct __enable_intrusive_from_this;
+
+    template <class _Ty>
+      struct __control_block {
+        alignas(_Ty) unsigned char __value_[sizeof(_Ty)];
+        std::atomic<unsigned long> __refcount_;
+
+        template <class... _Us>
+          explicit __control_block(_Us&&... __us)
+            noexcept(noexcept(_Ty{__declval<_Us>()...}))
+            : __refcount_(1u) {
+            // Construct the value *after* the initialization of the
+            // atomic in case the constructor of _Ty calls
+            // __intrusive_from_this() (which increments the atomic):
+            ::new ((void*) __value_) _Ty{(_Us&&) __us...};
+          }
+        ~__control_block() {
+          __value().~_Ty();
+        }
+
+        _Ty& __value() const noexcept {
+          return *(_Ty*) __value_;
+        }
+      };
+
+    template <class _Ty>
+      class __intrusive_ptr {
+        using _UncvTy = std::remove_cv_t<_Ty>;
+        friend struct __make_intrusive_ptr_t<_Ty>;
+        friend struct __enable_intrusive_from_this<_UncvTy>;
+
+        __control_block<_UncvTy>* __data_{nullptr};
+
+        explicit __intrusive_ptr(__control_block<_UncvTy>* __data) noexcept
+          : __data_(__data) {}
+
+        void __addref_() noexcept {
+          if (__data_) {
+            __data_->__refcount_.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+
+        void __release_() noexcept {
+          if (__data_ && (1u == __data_->__refcount_.fetch_sub(1, std::memory_order_release))) {
+            std::atomic_thread_fence(std::memory_order_acquire);
+            delete __data_;
+          }
+        }
+
+       public:
+        __intrusive_ptr() = default;
+        bool operator==(const __intrusive_ptr&) const = default;
+
+        __intrusive_ptr(__intrusive_ptr&& __that) noexcept
+          : __data_(std::exchange(__that.__data_, nullptr)) {}
+
+        __intrusive_ptr(const __intrusive_ptr&& __that) noexcept
+          : __data_(__that.__data_) {
+          __addref_();
+        }
+
+        __intrusive_ptr& operator=(__intrusive_ptr&& __that) noexcept {
+          __release_();
+          __data_ = std::exchange(__that.__data_, nullptr);
+        }
+
+        __intrusive_ptr& operator=(const __intrusive_ptr&& __that) noexcept {
+          __release_();
+          __data_ = __that.__data_;
+          __addref_();
+        }
+
+        ~__intrusive_ptr() {
+          __release_();
+        }
+
+        void reset() noexcept {
+          __release_();
+          __data_ = nullptr;
+        }
+
+        _Ty* get() const noexcept {
+          return &__data_->__value();
+        }
+
+        _Ty* operator->() const noexcept {
+          return &__data_->__value();
+        }
+
+        _Ty& operator*() const noexcept {
+          return __data_->__value();
+        }
+      };
+
+    template <class _Ty>
+      struct __enable_intrusive_from_this {
+        __intrusive_ptr<_Ty> __intrusive_from_this() noexcept {
+          static_assert(0 == offsetof(__control_block<_Ty>, __value_));
+          _Ty* __this = static_cast<_Ty*>(this);
+          __intrusive_ptr<_Ty> __p{(__control_block<_Ty>*) __this};
+          __p.__addref_();
+          return __p;
+        }
+
+        __intrusive_ptr<const _Ty> __intrusive_from_this() const noexcept {
+          static_assert(0 == offsetof(__control_block<_Ty>, __value_));
+          const _Ty* __this = static_cast<const _Ty*>(this);
+          __intrusive_ptr<const _Ty> __p{(__control_block<_Ty>*) __this};
+          __p.__addref_();
+          return __p;
+        }
+      };
+
+    template <class _Ty>
+      struct __make_intrusive_ptr_t {
+        template <class... _Us>
+            requires std::constructible_from<_Ty, _Us...>
+          __intrusive_ptr<_Ty> operator()(_Us&&... __us) const {
+            using _UncvTy = std::remove_cv_t<_Ty>;
+            return __intrusive_ptr<_Ty>{::new __control_block<_UncvTy>{(_Us&&) __us...}};
+          }
+      };
+  } // namespace __ptr
+
+  using __ptr::__intrusive_ptr;
+  using __ptr::__enable_intrusive_from_this;
+  template <class _Ty>
+    inline constexpr __ptr::__make_intrusive_ptr_t<_Ty> __make_intrusive_ptr {};
+
+} // namespace _P2300

--- a/include/__memory.hpp
+++ b/include/__memory.hpp
@@ -83,7 +83,7 @@ namespace _P2300 {
         __intrusive_ptr(__intrusive_ptr&& __that) noexcept
           : __data_(std::exchange(__that.__data_, nullptr)) {}
 
-        __intrusive_ptr(const __intrusive_ptr&& __that) noexcept
+        __intrusive_ptr(const __intrusive_ptr& __that) noexcept
           : __data_(__that.__data_) {
           __addref_();
         }
@@ -93,7 +93,7 @@ namespace _P2300 {
           __data_ = std::exchange(__that.__data_, nullptr);
         }
 
-        __intrusive_ptr& operator=(const __intrusive_ptr&& __that) noexcept {
+        __intrusive_ptr& operator=(const __intrusive_ptr& __that) noexcept {
           __release_();
           __data_ = __that.__data_;
           __addref_();

--- a/include/__memory.hpp
+++ b/include/__memory.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <__utility.hpp>
+#include <concepts.hpp>
 
 #include <atomic>
 #include <memory>
@@ -143,7 +144,7 @@ namespace _P2300 {
     template <class _Ty>
       struct __make_intrusive_ptr_t {
         template <class... _Us>
-            requires std::constructible_from<_Ty, _Us...>
+            requires constructible_from<_Ty, _Us...>
           __intrusive_ptr<_Ty> operator()(_Us&&... __us) const {
             using _UncvTy = std::remove_cv_t<_Ty>;
             return __intrusive_ptr<_Ty>{::new __control_block<_UncvTy>{(_Us&&) __us...}};

--- a/include/__memory.hpp
+++ b/include/__memory.hpp
@@ -79,7 +79,6 @@ namespace _P2300 {
 
        public:
         __intrusive_ptr() = default;
-        bool operator==(const __intrusive_ptr&) const = default;
 
         __intrusive_ptr(__intrusive_ptr&& __that) noexcept
           : __data_(std::exchange(__that.__data_, nullptr)) {}
@@ -119,6 +118,19 @@ namespace _P2300 {
 
         _Ty& operator*() const noexcept {
           return __data_->__value();
+        }
+
+        explicit operator bool() const noexcept {
+          return __data_ != nullptr;
+        }
+
+        bool operator!() const noexcept {
+          return __data_ == nullptr;
+        }
+
+        bool operator==(const __intrusive_ptr&) const = default;
+        bool operator==(std::nullptr_t) const noexcept {
+          return __data_ == nullptr;
         }
       };
 

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -3001,6 +3001,13 @@ namespace _P2300::execution {
           , __rcvr_((_Receiver&&) __rcvr)
           , __shared_state_(std::move(__shared_state)) {
         }
+        ~__operation() {
+          // Check to see if this operation was ever started. If not,
+          // detach the (potentially still running) operation:
+          if (nullptr == __shared_state_->__op_state1_.load(std::memory_order_acquire)) {
+            __shared_state_->__detach();
+          }
+        }
         _P2300_IMMOVABLE(__operation);
 
         static void __notify(__operation_base* __self) noexcept {

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -3092,7 +3092,7 @@ namespace _P2300::execution {
               _Sender,
               __env,
               completion_signatures<set_error_t(std::exception_ptr&&),
-                                    set_stopped_t()>,
+                                    set_stopped_t()>, // BUGBUG NOT TO SPEC
               __set_value_t,
               __set_error_t>;
 
@@ -3104,7 +3104,7 @@ namespace _P2300::execution {
         ~__sender() {
           if (nullptr != __shared_state_) {
             // We're detaching a potentially running operation. Request cancellation.
-            __shared_state_->__detach();
+            __shared_state_->__detach(); // BUGBUG NOT TO SPEC
           }
         }
         // Move-only:

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -3135,6 +3135,12 @@ namespace _P2300::execution {
       __sender<_Sender> operator()(_Sender&& __sndr) const {
         return __sender<_Sender>{(_Sender&&) __sndr};
       }
+      template <sender _Sender>
+        requires (!__tag_invocable_with_completion_scheduler<ensure_started_t, set_value_t, __sender<_Sender>>) &&
+          (!tag_invocable<ensure_started_t, __sender<_Sender>>)
+      __sender<_Sender> operator()(__sender<_Sender> __sndr) const {
+        return __sndr;
+      }
       __binder_back<ensure_started_t> operator()() const {
         return {{}, {}, {}};
       }

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -3095,7 +3095,7 @@ namespace _P2300::execution {
             make_completion_signatures<
               _Sender,
               __env,
-              completion_signatures<set_error_t(std::exception_ptr&&)
+              completion_signatures<set_error_t(std::exception_ptr&&),
                                     set_stopped_t()>,
               __set_value_t,
               __set_error_t>;

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2958,13 +2958,10 @@ namespace _P2300::execution {
         }
 
         void __notify() noexcept {
-          void* __old{nullptr};
           void* const __completion_state = static_cast<void*>(this);
-          bool const changed = __op_state1_.compare_exchange_weak(
-            __old, __completion_state,
-            std::memory_order_release,
-            std::memory_order_acquire);
-          if (changed && __old != nullptr) {
+          void* const __old =
+            __op_state1_.exchange(__completion_state, std::memory_order_acq_rel);
+          if (__old != nullptr) {
             auto* __op = static_cast<__operation_base*>(__old);
             __op->__notify_(__op);
           }

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -3095,7 +3095,8 @@ namespace _P2300::execution {
             make_completion_signatures<
               _Sender,
               __env,
-              completion_signatures<set_error_t(std::exception_ptr&&)>,
+              completion_signatures<set_error_t(std::exception_ptr&&)
+                                    set_stopped_t()>,
               __set_value_t,
               __set_error_t>;
 

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -4134,8 +4134,7 @@ namespace _P2300::execution {
             , __sndr_((_Sender2&&) __sndr)
             , __rcvr_((_Receiver2&&) __rcvr)
             , __data_{std::in_place_index<0>, __conv{[&, this]{
-                return connect(schedule(__sched),
-                                __receiver_t{{}, this});
+                return connect(schedule(__sched), __receiver_t{{}, this});
               }}} {}
           _P2300_IMMOVABLE(__operation);
 

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -2476,7 +2476,7 @@ namespace _P2300::execution {
         [[no_unique_address]] _Fun __f_;
 
         template <class... _As>
-        void set_value(_As&&... __as) && noexcept 
+        void set_value(_As&&... __as) && noexcept
           requires __nothrow_callable<_Fun, _Shape, _As&...> {
           for (_Shape __i{}; __i != __shape_; ++__i) {
             __f_(__i, __as...);
@@ -2485,7 +2485,7 @@ namespace _P2300::execution {
         }
 
         template <class... _As>
-        void set_value(_As&&... __as) && noexcept 
+        void set_value(_As&&... __as) && noexcept
           requires __callable<_Fun, _Shape, _As&...> {
           try {
             for (_Shape __i{}; __i != __shape_; ++__i) {
@@ -2542,8 +2542,8 @@ namespace _P2300::execution {
           return execution::connect(
               ((_Self&&) __self).__sndr_,
               __receiver<_Receiver>{
-                (_Receiver&&) __rcvr, 
-                __self.__shape_, 
+                (_Receiver&&) __rcvr,
+                __self.__shape_,
                 ((_Self&&) __self).__fun_});
         }
 
@@ -2852,7 +2852,217 @@ namespace _P2300::execution {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.senders.adaptors.ensure_started]
   namespace __ensure_started {
+
+    template <class _SharedState>
+      class __receiver {
+        _SharedState& __shared_state_;
+
+      public:
+        explicit __receiver(_SharedState &__shared_state) noexcept
+          : __shared_state_(__shared_state) {
+        }
+
+        template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag, class... _As>
+        friend void tag_invoke(_Tag __tag, __receiver&& __self, _As&&... __as) noexcept {
+          _SharedState& __state = __self.__shared_state_;
+
+          try {
+            using __tuple_t = __decayed_tuple<_Tag, _As...>;
+            __state.__data_.template emplace<__tuple_t>(__tag, (_As &&) __as...);
+          } catch (...) {
+            using __tuple_t = __decayed_tuple<set_error_t, std::exception_ptr>;
+            __state.__data_.template emplace<__tuple_t>(set_error, std::current_exception());
+          }
+
+          __state.__notify();
+        }
+
+        friend auto tag_invoke(get_env_t, const __receiver& __self)
+          -> make_env_t<with_t<get_stop_token_t, in_place_stop_token>> {
+          return make_env(with(get_stop_token, __self.__shared_state_.__stop_source_.get_token()));
+        }
+      };
+
+    struct __operation_base {
+      using __notify_fn = void(__operation_base*) noexcept;
+      __notify_fn* __notify_{};
+    };
+
+    template <class _SenderId>
+      struct __sh_state {
+        using _Sender = __t<_SenderId>;
+
+        template <class... _Ts>
+          using __bind_tuples =
+            __mbind_front_q<
+              __variant,
+              std::tuple<set_stopped_t>, // Initial state of the variant is set_stopped
+              std::tuple<set_error_t, std::exception_ptr>,
+              _Ts...>;
+
+        using __bound_values_t =
+          __value_types_of_t<
+            _Sender,
+            make_env_t<with_t<get_stop_token_t, in_place_stop_token>>,
+            __mbind_front_q<__decayed_tuple, set_value_t>,
+            __q<__bind_tuples>>;
+
+        using __variant_t =
+          __error_types_of_t<
+            _Sender,
+            make_env_t<with_t<get_stop_token_t, in_place_stop_token>>,
+            __transform<
+              __mbind_front_q<__decayed_tuple, set_error_t>,
+              __bound_values_t>>;
+
+        using __receiver = __receiver<__sh_state>;
+
+        __variant_t __data_;
+        in_place_stop_source __stop_source_{};
+
+        std::atomic<void*> __op_state1_;
+        connect_result_t<_Sender, __receiver> __op_state2_;
+
+        explicit __sh_state(_Sender& __sndr)
+          : __op_state1_{nullptr}
+          , __op_state2_(connect((_Sender&&) __sndr, __receiver{*this}))
+        {
+          start(__op_state2_);
+        }
+
+        void __notify() noexcept {
+          void* __old{nullptr};
+          void* const __completion_state = static_cast<void*>(this);
+          bool const changed = __op_state1_.compare_exchange_weak(
+            __old, __completion_state,
+            std::memory_order_release,
+            std::memory_order_acquire
+          );
+          if(changed && __old != nullptr) {
+            static_cast<__operation_base*>(__old)->__notify_(static_cast<__operation_base*>(__old));
+          }
+        }
+      };
+
+    template <class _SenderId, class _ReceiverId>
+      class __operation : public __operation_base {
+        using _Sender = __t<_SenderId>;
+        using _Receiver = __t<_ReceiverId>;
+
+        struct __on_stop_requested {
+          in_place_stop_source& __stop_source_;
+          void operator()() noexcept {
+            __stop_source_.request_stop();
+          }
+        };
+        using __on_stop = std::optional<typename stop_token_of_t<
+            env_of_t<_Receiver> &>::template callback_type<__on_stop_requested>>;
+
+        _Receiver __recvr_;
+        __on_stop __on_stop_{};
+        std::shared_ptr<__sh_state<_SenderId>> __shared_state_;
+
+      public:
+        __operation(_Receiver&& __rcvr,
+                    std::shared_ptr<__sh_state<_SenderId>> __shared_state)
+            noexcept(std::is_nothrow_move_constructible_v<_Receiver>)
+          : __operation_base{__notify}
+          , __recvr_((_Receiver&&)__rcvr)
+          , __shared_state_(move(__shared_state)) {
+        }
+        _P2300_IMMOVABLE(__operation);
+
+        static void __notify(__operation_base* __self) noexcept {
+          __operation *__op = static_cast<__operation*>(__self);
+          __op->__on_stop_.reset();
+
+          std::visit([&](const auto& __tupl) noexcept -> void {
+            std::apply([&](auto __tag, const auto&... __args) noexcept -> void {
+              __tag((_Receiver&&) __op->__recvr_, __args...);
+            }, __tupl);
+          }, __op->__shared_state_->__data_);
+        }
+
+        friend void tag_invoke(start_t, __operation& __self) noexcept {
+          __sh_state<_SenderId>* __shared_state = __self.__shared_state_.get();
+          std::atomic<void*>& __op_state1 = __shared_state->__op_state1_;
+          void* const __completion_state = static_cast<void*>(__shared_state);
+          void* const __old = __op_state1.load(std::memory_order_acquire);
+          if (__old == __completion_state) {
+            __self.__notify(&__self);
+          } else {
+              // register stop callback:
+            __self.__on_stop_.emplace(
+                get_stop_token(get_env(__self.__recvr_)),
+                __on_stop_requested{__shared_state->__stop_source_});
+            // Check if the stop_source has requested cancellation
+            if (__shared_state->__stop_source_.stop_requested()) {
+              // Stop has already been requested. Don't bother starting
+              // the child operations.
+              execution::set_stopped((_Receiver&&) __self.__recvr_);
+            } else {
+              // Otherwise, the inner source hasn't notified completion.
+              // Set this operation as the __op_state1 so it's notified.
+              __op_state1.store(&__self, std::memory_order_release);
+            }
+          }
+        }
+      };
+
+    template <class _SenderId>
+      class __sender {
+        using _Sender = __t<_SenderId>;
+        using __sh_state_ = __sh_state<_SenderId>;
+        template <class _Receiver>
+          using __operation = __operation<_SenderId, __x<remove_cvref_t<_Receiver>>>;
+
+        _Sender __sndr_;
+        std::shared_ptr<__sh_state_> __shared_state_;
+
+      public:
+        template <__decays_to<__sender> _Self, receiver _Receiver>
+            requires receiver_of<_Receiver, completion_signatures_of_t<_Self, __empty_env>>
+          friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __recvr)
+            noexcept(std::is_nothrow_constructible_v<decay_t<_Receiver>, _Receiver>)
+            -> __operation<_Receiver> {
+            return __operation<_Receiver>{(_Receiver &&) __recvr,
+                                          __self.__shared_state_};
+          }
+
+        template <tag_category<forwarding_sender_query> _Tag, class... _As>
+            requires (!__is_instance_of<_Tag, get_completion_scheduler_t>) &&
+              __callable<_Tag, const _Sender&, _As...>
+          friend auto tag_invoke(_Tag __tag, const __sender& __self, _As&&... __as)
+            noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
+            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
+            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
+          }
+
+        template <class... _Tys>
+        using __set_value_t = completion_signatures<set_value_t(const decay_t<_Tys>&...)>;
+
+        template <class _Ty>
+        using __set_error_t = completion_signatures<set_error_t(const decay_t<_Ty>&)>;
+
+        template <__decays_to<__sender> _Self, class _Env>
+          friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env) ->
+            make_completion_signatures<
+              _Sender,
+              make_env_t<with_t<get_stop_token_t, in_place_stop_token>>,
+              completion_signatures<set_error_t(const std::exception_ptr&)>,
+              __set_value_t,
+              __set_error_t>;
+
+        explicit __sender(_Sender __sndr)
+            : __sndr_((_Sender&&) __sndr)
+            , __shared_state_{std::make_shared<__sh_state_>(__sndr_)}
+        {}
+      };
+
     struct ensure_started_t {
+      template <class _Sender>
+        using __sender = __sender<__x<remove_cvref_t<_Sender>>>;
+
       template <sender _Sender>
         requires __tag_invocable_with_completion_scheduler<ensure_started_t, set_value_t, _Sender>
       sender auto operator()(_Sender&& __sndr) const
@@ -2866,6 +3076,15 @@ namespace _P2300::execution {
       sender auto operator()(_Sender&& __sndr) const
         noexcept(nothrow_tag_invocable<ensure_started_t, _Sender>) {
         return tag_invoke(ensure_started_t{}, (_Sender&&) __sndr);
+      }
+      template <sender _Sender>
+        requires (!__tag_invocable_with_completion_scheduler<ensure_started_t, set_value_t, _Sender>) &&
+          (!tag_invocable<ensure_started_t, _Sender>)
+      __sender<_Sender> operator()(_Sender&& __sndr) const {
+        return __sender<_Sender>{(_Sender&&) __sndr};
+      }
+      __binder_back<ensure_started_t> operator()() const {
+        return {{}, {}, {}};
       }
     };
   }

--- a/test/algos/adaptors/test_bulk.cpp
+++ b/test/algos/adaptors/test_bulk.cpp
@@ -167,13 +167,13 @@ TEST_CASE("bulk can throw, and set_error will be called", "[adaptors][bulk]") {
   ex::start(op);
 }
 
-TEST_CASE("bulk function in not called on error", "[adaptors][bulk]") {
+TEST_CASE("bulk function is not called on error", "[adaptors][bulk]") {
   constexpr int n = 2;
   int called{};
 
   auto snd = ex::just_error(std::string{"err"}) 
            | ex::bulk(n, [&called](int) { called++; });
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"err"}});
   ex::start(op);
 }
 

--- a/test/algos/adaptors/test_ensure_started.cpp
+++ b/test/algos/adaptors/test_ensure_started.cpp
@@ -38,13 +38,159 @@ TEST_CASE("ensure_started with environment returns a sender", "[adaptors][ensure
   (void)snd;
 }
 
-TEST_CASE("ensure_started simple example", "[adaptors][ensure_started]") {
+TEST_CASE("ensure_started void value early", "[adaptors][ensure_started]") {
   bool called{false};
   auto snd1 = ex::just() | ex::then([&] { called = true; });
   CHECK_FALSE(called);
   auto snd = ex::ensure_started(std::move(snd1));
   CHECK(called);
   auto op = ex::connect(std::move(snd), expect_void_receiver{});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started void value late", "[adaptors][ensure_started]") {
+  impulse_scheduler sch;
+  bool called{false};
+  auto snd1 = ex::on(sch, ex::just()) | ex::then([&] { called = true; });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK_FALSE(called);
+  // execute the next scheduled item
+  sch.start_next();
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_void_receiver{});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started single value early", "[adaptors][ensure_started]") {
+  bool called{false};
+  auto snd1 = ex::just() | ex::then([&] { called = true; return 42; });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_value_receiver{42});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started single value late", "[adaptors][ensure_started]") {
+  impulse_scheduler sch;
+  bool called{false};
+  auto snd1 = ex::on(sch, ex::just()) | ex::then([&] { called = true; return 42; });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK_FALSE(called);
+  // execute the next scheduled item
+  sch.start_next();
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_value_receiver{42});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started multiple values early", "[adaptors][ensure_started]") {
+  bool called{false};
+  auto snd1 =
+    ex::let_value(
+      ex::just(),
+      [&] {
+        called = true;
+        return ex::just(42, movable{56});
+      });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_value_receiver{42, movable{56}});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started multiple values late", "[adaptors][ensure_started]") {
+  impulse_scheduler sch;
+  bool called{false};
+  auto snd1 =
+    ex::let_value(
+      ex::on(sch, ex::just()),
+      [&] {
+        called = true;
+        return ex::just(42, movable{56});
+      });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK_FALSE(called);
+  // execute the next scheduled item
+  sch.start_next();
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_value_receiver{42, movable{56}});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started error early", "[adaptors][ensure_started]") {
+  bool called{false};
+  auto snd1 =
+    ex::let_value(
+      ex::just(),
+      [&] {
+        called = true;
+        return ex::just_error(42);
+      });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_error_receiver{42});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started error late", "[adaptors][ensure_started]") {
+  impulse_scheduler sch;
+  bool called{false};
+  auto snd1 =
+    ex::let_value(
+      ex::on(sch, ex::just()),
+      [&] {
+        called = true;
+        return ex::just_error(42);
+      });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK_FALSE(called);
+  // execute the next scheduled item
+  sch.start_next();
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_error_receiver{42});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started stopped early", "[adaptors][ensure_started]") {
+  bool called{false};
+  auto snd1 =
+    ex::let_value(
+      ex::just(),
+      [&] {
+        called = true;
+        return ex::just_stopped();
+      });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_stopped_receiver{});
+  ex::start(op);
+}
+
+TEST_CASE("ensure_started stopped late", "[adaptors][ensure_started]") {
+  impulse_scheduler sch;
+  bool called{false};
+  auto snd1 =
+    ex::let_value(
+      ex::on(sch, ex::just()),
+      [&] {
+        called = true;
+        return ex::just_stopped();
+      });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK_FALSE(called);
+  // execute the next scheduled item
+  sch.start_next();
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_stopped_receiver{});
   ex::start(op);
 }
 
@@ -64,6 +210,40 @@ TEST_CASE("stopping ensure_started before the source completes calls set_stopped
   CHECK(called);
 }
 
+TEST_CASE("stopping ensure_started before the lazy opstate is started calls set_stopped", "[adaptors][ensure_started]") {
+  ex::in_place_stop_source stop_source;
+  impulse_scheduler sch;
+  int count = 0;
+  bool called{false};
+  auto snd = ex::let_value(
+                ex::just() | ex::then([&]{ ++count; }),
+                [=] { return ex::on(sch, ex::just(19)); })
+           | ex::write(ex::with(ex::get_stop_token, stop_source.get_token()))
+           | ex::ensure_started();
+  CHECK(count == 1);
+  auto op = ex::connect(std::move(snd), expect_stopped_receiver_ex{called});
+  // request stop before the source yields a value
+  stop_source.request_stop();
+  ex::start(op);
+  // make the source yield the value
+  sch.start_next();
+  CHECK(called);
+}
+
+TEST_CASE("stopping ensure_started after the task has already completed doesn't change the result", "[adaptors][ensure_started]") {
+  ex::in_place_stop_source stop_source;
+  int count = 0;
+  auto snd = ex::just()
+           | ex::then([&] { ++count; return 42; })
+           | ex::write(ex::with(ex::get_stop_token, stop_source.get_token()))
+           | ex::ensure_started();
+  CHECK(count == 1);
+  auto op = ex::connect(std::move(snd), expect_value_receiver{42});
+  // request stop before the source yields a value
+  stop_source.request_stop();
+  ex::start(op);
+}
+
 TEST_CASE("Dropping the sender without connecting it calls set_stopped", "[adaptors][ensure_started]") {
   impulse_scheduler sch;
   bool called = false;
@@ -80,14 +260,18 @@ TEST_CASE("Dropping the sender without connecting it calls set_stopped", "[adapt
 
 TEST_CASE("Dropping the opstate without starting it calls set_stopped", "[adaptors][ensure_started]") {
   impulse_scheduler sch;
+  int state = -1;
   bool called = false;
   {
     auto snd =
         ex::on(sch, ex::just())
       | ex::upon_stopped([&] { called = true; })
       | ex::ensure_started();
+    auto op = ex::connect(std::move(snd), logging_receiver{state});
   }
   // make the source yield the value
   sch.start_next();
   CHECK(called);
+  // make sure the logging_receiver was never called
+  CHECK(state == -1);
 }

--- a/test/algos/adaptors/test_ensure_started.cpp
+++ b/test/algos/adaptors/test_ensure_started.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Lucian Radu Teodorescu
+ * Copyright (c) NVIDIA
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with
@@ -15,30 +16,47 @@
  */
 
 #include <catch2/catch.hpp>
+
 #include <execution.hpp>
+#include <async_scope.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
 namespace ex = std::execution;
+using _P2519::execution::async_scope;
 
 // TODO: implement ensure_started
-// TEST_CASE("ensure_started returns a sender", "[adaptors][ensure_started]") {
-//   auto snd = ex::ensure_started(ex::just(19));
-//   static_assert(ex::sender<decltype(snd)>);
-//   (void)snd;
-// }
-// TEST_CASE("ensure_started with environment returns a sender", "[adaptors][ensure_started]") {
-//   auto snd = ex::ensure_started(ex::just(19), 8, [](int idx, int val) {});
-//   static_assert(ex::sender<decltype(snd), empty_env>);
-//   (void)snd;
-// }
-// TEST_CASE("ensure_started simple example", "[adaptors][ensure_started]") {
-//   bool called{false};
-//   auto snd1 = ex::just() | ex::then([&] { called = true; });
-//   CHECK_FALSE(called);
-//   auto snd = ex::ensure_started(std::move(snd1));
-//   CHECK(called);
-//   auto op = ex::connect(std::move(snd), expect_void_receiver{});
-//   ex::start(op);
-// }
+TEST_CASE("ensure_started returns a sender", "[adaptors][ensure_started]") {
+  auto snd = ex::ensure_started(ex::just(19));
+  static_assert(ex::sender<decltype(snd)>);
+  (void)snd;
+}
+
+TEST_CASE("ensure_started with environment returns a sender", "[adaptors][ensure_started]") {
+  auto snd = ex::ensure_started(ex::just(19));
+  static_assert(ex::sender<decltype(snd), empty_env>);
+  (void)snd;
+}
+
+TEST_CASE("ensure_started simple example", "[adaptors][ensure_started]") {
+  bool called{false};
+  auto snd1 = ex::just() | ex::then([&] { called = true; });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_void_receiver{});
+  ex::start(op);
+}
+
+TEST_CASE("stopping ensure_started before the source completes calls set_stopped", "[adaptors][ensure_started]") {
+  async_scope scope;
+  impulse_scheduler sch;
+  auto snd = ex::on(sch, ex::just(19)) | ex::ensure_started();
+  auto op = ex::connect(std::move(snd), expect_stopped_receiver_ex{});
+  ex::start(op);
+  // request stop before the source yields a value
+  scope.get_stop_source().request_stop();
+  // make the source yield the value
+  sch.start_next();
+}

--- a/test/algos/adaptors/test_ensure_started.cpp
+++ b/test/algos/adaptors/test_ensure_started.cpp
@@ -63,3 +63,31 @@ TEST_CASE("stopping ensure_started before the source completes calls set_stopped
   sch.start_next();
   CHECK(called);
 }
+
+TEST_CASE("Dropping the sender without connecting it calls set_stopped", "[adaptors][ensure_started]") {
+  impulse_scheduler sch;
+  bool called = false;
+  {
+    auto snd =
+        ex::on(sch, ex::just())
+      | ex::upon_stopped([&] { called = true; })
+      | ex::ensure_started();
+  }
+  // make the source yield the value
+  sch.start_next();
+  CHECK(called);
+}
+
+TEST_CASE("Dropping the opstate without starting it calls set_stopped", "[adaptors][ensure_started]") {
+  impulse_scheduler sch;
+  bool called = false;
+  {
+    auto snd =
+        ex::on(sch, ex::just())
+      | ex::upon_stopped([&] { called = true; })
+      | ex::ensure_started();
+  }
+  // make the source yield the value
+  sch.start_next();
+  CHECK(called);
+}

--- a/test/algos/adaptors/test_ensure_started.cpp
+++ b/test/algos/adaptors/test_ensure_started.cpp
@@ -26,7 +26,6 @@
 namespace ex = std::execution;
 using _P2519::execution::async_scope;
 
-// TODO: implement ensure_started
 TEST_CASE("ensure_started returns a sender", "[adaptors][ensure_started]") {
   auto snd = ex::ensure_started(ex::just(19));
   static_assert(ex::sender<decltype(snd)>);

--- a/test/algos/adaptors/test_into_variant.cpp
+++ b/test/algos/adaptors/test_into_variant.cpp
@@ -70,7 +70,7 @@ TEST_CASE("into_variant with senders that have multiple alternatives", "[adaptor
 TEST_CASE("into_variant can be used with just_error", "[adaptors][into_variant]") {
   ex::sender auto snd = ex::just_error(std::string{"err"}) //
                         | ex::into_variant();
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"err"}});
   ex::start(op);
 }
 TEST_CASE("into_variant can be used with just_stopped", "[adaptors][into_variant]") {

--- a/test/algos/adaptors/test_let_error.cpp
+++ b/test/algos/adaptors/test_let_error.cpp
@@ -114,7 +114,7 @@ TEST_CASE("let_error can throw, and yield a different error type", "[adaptors][l
                    throw std::logic_error{"err"};
                  return ex::just_error(x);
                });
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{13});
   ex::start(op);
 }
 

--- a/test/algos/adaptors/test_let_stopped.cpp
+++ b/test/algos/adaptors/test_let_stopped.cpp
@@ -80,7 +80,7 @@ TEST_CASE("let_stopped can throw, calling set_error", "[adaptors][let_stopped]")
 TEST_CASE("let_stopped can be used with just_error", "[adaptors][let_stopped]") {
   ex::sender auto snd = ex::just_error(1) //
                         | ex::let_stopped([] { return ex::just(17); });
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{1});
   ex::start(op);
 }
 
@@ -98,13 +98,13 @@ TEST_CASE("let_stopped function is not called on regular flow", "[adaptors][let_
 }
 TEST_CASE("let_stopped function is not called on error flow", "[adaptors][let_stopped]") {
   bool called{false};
-  error_scheduler<int> sched;
+  error_scheduler<int> sched{42};
   ex::sender auto snd = ex::transfer_just(sched, 13) //
                         | ex::let_stopped([&] {
                             called = true;
                             return ex::just(0);
                           });
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{42});
   ex::start(op);
   CHECK_FALSE(called);
 }

--- a/test/algos/adaptors/test_let_value.cpp
+++ b/test/algos/adaptors/test_let_value.cpp
@@ -77,7 +77,7 @@ TEST_CASE("let_value can be used with multiple parameters", "[adaptors][let_valu
 
 TEST_CASE("let_value can be used to change the sender", "[adaptors][let_value]") {
   ex::sender auto snd = ex::just(13) | ex::let_value([](int& x) { return ex::just_error(x + 4); });
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{13 + 4});
   ex::start(op);
 }
 
@@ -135,7 +135,7 @@ TEST_CASE("let_value can throw, and set_error will be called", "[adaptors][let_v
 TEST_CASE("let_value can be used with just_error", "[adaptors][let_value]") {
   ex::sender auto snd = ex::just_error(std::string{"err"}) //
                         | ex::let_value([]() { return ex::just(17); });
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"err"}});
   ex::start(op);
 }
 TEST_CASE("let_value can be used with just_stopped", "[adaptors][let_value]") {

--- a/test/algos/adaptors/test_on.cpp
+++ b/test/algos/adaptors/test_on.cpp
@@ -131,7 +131,7 @@ TEST_CASE("on forwards set_error calls", "[adaptors][on]") {
 TEST_CASE("on forwards set_error calls of other types", "[adaptors][on]") {
   error_scheduler<std::string> sched{std::string{"error"}};
   auto snd = ex::on(sched, ex::just(13));
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"error"}});
   ex::start(op);
   // The receiver checks if we receive an error
 }

--- a/test/algos/adaptors/test_schedule_from.cpp
+++ b/test/algos/adaptors/test_schedule_from.cpp
@@ -151,7 +151,7 @@ TEST_CASE("schedule_from forwards set_error calls", "[adaptors][schedule_from]")
 TEST_CASE("schedule_from forwards set_error calls of other types", "[adaptors][schedule_from]") {
   error_scheduler<std::string> sched{std::string{"error"}};
   auto snd = ex::schedule_from(sched, ex::just(13));
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"error"}});
   ex::start(op);
   // The receiver checks if we receive an error
 }

--- a/test/algos/adaptors/test_split.cpp
+++ b/test/algos/adaptors/test_split.cpp
@@ -104,7 +104,7 @@ TEST_CASE("split forwards errors", "[adaptors][split]") {
     using error_t = ex::error_types_of_t<split_t, ex::__empty_env, std::variant>;
     static_assert(std::is_same_v<error_t, std::variant<const std::exception_ptr&, const int&>>);
 
-    auto op = ex::connect(split, expect_error_receiver_t<int>{});
+    auto op = ex::connect(split, expect_error_receiver<int>{});
     ex::start(op);
   }
 }

--- a/test/algos/adaptors/test_stopped_as_error.cpp
+++ b/test/algos/adaptors/test_stopped_as_error.cpp
@@ -35,7 +35,7 @@ TEST_CASE("stopped_as_error with environment returns a sender", "[adaptors][stop
 TEST_CASE("stopped_as_error simple example", "[adaptors][stopped_as_error]") {
   stopped_scheduler sched;
   auto snd = ex::stopped_as_error(ex::transfer_just(sched, 11), -1);
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{-1});
   ex::start(op);
 }
 
@@ -48,7 +48,7 @@ TEST_CASE("stopped_as_error can we piped", "[adaptors][stopped_as_error]") {
 
 TEST_CASE("stopped_as_error can work with `just_stopped`", "[adaptors][stopped_as_error]") {
   ex::sender auto snd = ex::just_stopped() | ex::stopped_as_error(-1);
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{-1});
   ex::start(op);
 }
 
@@ -74,13 +74,14 @@ TEST_CASE("stopped_as_error using error_code error type", "[adaptors][stopped_as
 TEST_CASE("stopped_as_error using error_code error type, for stopped signal",
     "[adaptors][stopped_as_error]") {
   stopped_scheduler sched;
+  std::error_code errcode(1, std::generic_category());
   ex::sender auto snd = ex::transfer_just(sched, 11) |
-                        ex::stopped_as_error(std::error_code(1, std::generic_category()));
+                        ex::stopped_as_error(errcode);
   check_val_types<type_array<type_array<int>>>(snd);
   check_err_types<type_array<std::exception_ptr, std::error_code>>(snd);
   check_sends_stopped<false>(snd);
 
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{errcode});
   ex::start(op);
 }
 

--- a/test/algos/adaptors/test_stopped_as_optional.cpp
+++ b/test/algos/adaptors/test_stopped_as_optional.cpp
@@ -49,7 +49,7 @@ TEST_CASE("stopped_as_optional can we waited on", "[adaptors][stopped_as_optiona
 TEST_CASE("stopped_as_optional shall not work with multi-value senders",
     "[adaptors][stopped_as_optional]") {
   auto snd = ex::just(3, 0.1415) | ex::stopped_as_optional();
-  static_assert(!std::invocable<ex::connect_t, decltype(snd), expect_error_receiver>);
+  static_assert(!std::invocable<ex::connect_t, decltype(snd), expect_error_receiver<>>);
 }
 
 TEST_CASE("stopped_as_optional shall not work with senders that have multiple alternatives",
@@ -59,7 +59,7 @@ TEST_CASE("stopped_as_optional shall not work with senders that have multiple al
       | ex::let_error([](std::exception_ptr) { return ex::just(std::string{"err"}); });
   check_val_types<type_array<type_array<int>, type_array<std::string>>>(in_snd);
   auto snd = std::move(in_snd) | ex::stopped_as_optional();
-  static_assert(!std::invocable<ex::connect_t, decltype(snd), expect_error_receiver>);
+  static_assert(!std::invocable<ex::connect_t, decltype(snd), expect_error_receiver<>>);
 }
 
 TEST_CASE("stopped_as_optional forwards errors", "[adaptors][stopped_as_optional]") {

--- a/test/algos/adaptors/test_then.cpp
+++ b/test/algos/adaptors/test_then.cpp
@@ -80,7 +80,7 @@ TEST_CASE("then can throw, and set_error will be called", "[adaptors][then]") {
 TEST_CASE("then can be used with just_error", "[adaptors][then]") {
   ex::sender auto snd = ex::just_error(std::string{"err"}) //
                         | ex::then([]() -> int { return 17; });
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"err"}});
   ex::start(op);
 }
 TEST_CASE("then can be used with just_stopped", "[adaptors][then]") {

--- a/test/algos/adaptors/test_transfer.cpp
+++ b/test/algos/adaptors/test_transfer.cpp
@@ -147,7 +147,7 @@ TEST_CASE("transfer forwards set_error calls", "[adaptors][transfer]") {
 TEST_CASE("transfer forwards set_error calls of other types", "[adaptors][transfer]") {
   error_scheduler<std::string> sched{std::string{"error"}};
   auto snd = ex::transfer(ex::just(13), sched);
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"error"}});
   ex::start(op);
   // The receiver checks if we receive an error
 }

--- a/test/algos/factories/test_transfer_just.cpp
+++ b/test/algos/factories/test_transfer_just.cpp
@@ -91,7 +91,7 @@ TEST_CASE("transfer_just forwards set_error calls", "[factories][transfer_just]"
 TEST_CASE("transfer_just forwards set_error calls of other types", "[factories][transfer_just]") {
   error_scheduler<std::string> sched{std::string{"error"}};
   auto snd = ex::transfer_just(sched, 13);
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string{"error"}});
   ex::start(op);
   // The receiver checks if we receive an error
 }

--- a/test/async_scope/test_spawn_future.cpp
+++ b/test/async_scope/test_spawn_future.cpp
@@ -52,7 +52,7 @@ TEST_CASE("spawn_future sender will complete", "[async_scope][spawn_future]") {
   // Non-blocking call
   ex::sender auto snd =
       scope.spawn_future(ex::on(sch, ex::just() | ex::then([&] { executed1 = true; })));
-  auto op = ex::connect(std::move(snd), expect_void_receiver_ex{&executed2});
+  auto op = ex::connect(std::move(snd), expect_void_receiver_ex{executed2});
   ex::start(op);
   REQUIRE_FALSE(executed1);
   REQUIRE_FALSE(executed2);
@@ -119,7 +119,7 @@ TEST_CASE("spawn_future returned sender can be connected but not started",
   // Non-blocking call; simply ignore the returned sender
   ex::sender auto snd =
       scope.spawn_future(ex::on(sch, ex::just() | ex::then([&] { executed = true; })));
-  auto op = ex::connect(std::move(snd), expect_void_receiver_ex{&executed2});
+  auto op = ex::connect(std::move(snd), expect_void_receiver_ex{executed2});
   REQUIRE_FALSE(executed);
   REQUIRE_FALSE(executed2);
   // Execute the given work
@@ -153,7 +153,7 @@ TEST_CASE("spawn_future returned sender can be started after given sender comple
   sch.start_next();
   REQUIRE_FALSE(executed2);
   // Now connect the returned sender
-  auto op = ex::connect(std::move(snd), expect_void_receiver_ex{&executed2});
+  auto op = ex::connect(std::move(snd), expect_void_receiver_ex{executed2});
   ex::start(op);
   REQUIRE(executed2);
 }

--- a/test/cpos/test_cpo_receiver.cpp
+++ b/test/cpos/test_cpo_receiver.cpp
@@ -92,7 +92,7 @@ TEST_CASE("can call set_error on a receiver", "[cpo][cpo_receiver]") {
 
 TEST_CASE("can call set_error with an error code on a receiver", "[cpo][cpo_receiver]") {
   std::error_code errCode{100, std::generic_category()};
-  ex::set_error(expect_error_receiver{}, errCode);
+  ex::set_error(expect_error_receiver{errCode}, errCode);
 }
 
 TEST_CASE("set_value with a value passes the value to the receiver", "[cpo][cpo_receiver]") {

--- a/test/test_common/receivers.hpp
+++ b/test/test_common/receivers.hpp
@@ -213,8 +213,11 @@ class expect_stopped_receiver {
 };
 
 struct expect_stopped_receiver_ex {
-  bool* executed_;
+  explicit expect_stopped_receiver_ex(bool& executed)
+    : executed_(&executed)
+  {}
 
+private:
   template <typename... Ts>
   friend void tag_invoke(ex::set_value_t, expect_stopped_receiver_ex&&, Ts...) noexcept {
     FAIL_CHECK("set_value called on expect_stopped_receiver_ex");
@@ -229,6 +232,7 @@ struct expect_stopped_receiver_ex {
   friend empty_env tag_invoke(ex::get_env_t, const expect_stopped_receiver_ex&) noexcept {
     return {};
   }
+  bool* executed_;
 };
 
 template <class T>

--- a/test/test_common/type_helpers.hpp
+++ b/test/test_common/type_helpers.hpp
@@ -27,6 +27,17 @@ struct immovable {
   _P2300_IMMOVABLE(immovable);
 };
 
+//! A move-only type
+struct movable {
+  movable(int value)
+    : value_(value)
+  {}
+  movable(movable&&) = default;
+  bool operator==(const movable&) const noexcept = default;
+private:
+  int value_;
+};
+
 //! Used for debugging, to generate errors to the console
 template <typename T>
 struct type_printer;


### PR DESCRIPTION
This PR adds [`ensure_started`](https://brycelelbach.github.io/wg21_p2300_std_execution/std_execution.html#spec-execution.senders.adapt.ensure_started). Need to add more tests, but figured I'd get it up for review.