### PR TITLE
[awaitables] fix: get_completion_signatures to test for await-ability with a promise type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ set(test_sourceFiles
     test/concepts/test_concepts_receiver.cpp
     test/concepts/test_concept_operation_state.cpp
     test/concepts/test_concepts_sender.cpp
+    test/concepts/test_awaitables.cpp
     test/types/test_type_async_scope.cpp
     test/algos/factories/test_just.cpp
     test/algos/factories/test_transfer_just.cpp

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -470,8 +470,6 @@ namespace _P2300::execution {
   // sender's metadata. If sender<S> and sender<S, Ctx> are both true, then they
   // had better report the same metadata. This completion signatures wrapper
   // enforces that at compile time.
-  // However when env is a promise type, the evaluation will lead to different
-  // results and hence not required.
   template <class _Sender, class _Env>
     struct __checked_completion_signatures {
      private:

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -456,8 +456,7 @@ namespace _P2300::execution {
         __one_of<
           _WithoutEnv,
           _WithEnv,
-          dependent_completion_signatures<no_env>> ||
-          __awaitable<_Sender,__env_or_void<_Env>>);
+          dependent_completion_signatures<no_env>>);
      public:
       using __t = _WithEnv;
     };

--- a/include/execution.hpp
+++ b/include/execution.hpp
@@ -365,7 +365,7 @@ namespace _P2300::execution {
             __required_completions) } ->
           __receiver_concepts::__is_valid_completion<remove_cvref_t<_Receiver>>;
       };
-  
+
   /////////////////////////////////////////////////////////////////////////////
   // [execution.sndtraits]
   namespace __get_completion_signatures {
@@ -427,9 +427,8 @@ namespace _P2300::execution {
 
   template <class _Sender, class _Env = no_env>
     concept sender =
-      ((__sender<_Sender, _Env> &&
-      __sender<_Sender, no_env> ) ||
-      __awaitable<_Sender, _Env>) &&
+      __sender<_Sender, _Env> &&
+      __sender<_Sender, no_env> &&
       move_constructible<remove_cvref_t<_Sender>> &&
       constructible_from<remove_cvref_t<_Sender>, _Sender>;
 

--- a/test/concepts/test_awaitables.cpp
+++ b/test/concepts/test_awaitables.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Shreyas Atre
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <execution.hpp>
+
+#include <coroutine.hpp>
+#include <tuple>
+#include <variant>
+
+namespace ex = std::execution;
+
+template <typename Awaiter>
+struct promise {
+  __coro::coroutine_handle<promise> get_return_object() {
+    return {__coro::coroutine_handle<promise>::from_promise(*this)};
+  }
+  __coro::suspend_always initial_suspend() noexcept { return {}; }
+  __coro::suspend_always final_suspend() noexcept { return {}; }
+  void return_void() {}
+  void unhandled_exception() {}
+
+  template <typename... T>
+  auto await_transform(T&&...) noexcept {
+    return Awaiter{};
+  }
+};
+
+struct awaiter {
+  bool await_ready() { return true; }
+  bool await_suspend(__coro::coroutine_handle<>) { return false; }
+  bool await_resume() { return false; }
+};
+
+template <typename Awaiter>
+struct awaitable_sender_1 {
+  Awaiter operator co_await();
+};
+
+struct awaitable_sender_2 {
+  using promise_type = promise<__coro::suspend_always>;
+};
+
+struct awaitable_sender_3 {
+  using promise_type = promise<awaiter>;
+};
+
+template <typename Signatures, typename Awaiter>
+void test_awaitable_sender1(Signatures&&, Awaiter&&) {
+  static_assert(ex::sender<awaitable_sender_1<Awaiter>>);
+  static_assert(ex::__awaitable<awaitable_sender_1<Awaiter>>);
+
+  awaitable_sender_1<Awaiter> s;
+  static_assert(!ex::__get_completion_signatures::__with_member_alias<awaitable_sender_1<Awaiter>>);
+  static_assert(std::is_same_v<decltype(ex::get_completion_signatures(s)), Signatures>);
+  static_assert(
+      std::is_same_v<ex::completion_signatures_of_t<awaitable_sender_1<Awaiter>>, Signatures>);
+
+  using value_types_of = ex::value_types_of_t<awaitable_sender_1<Awaiter>>;
+  using value_types = typename Signatures::template __gather_sigs<ex::set_value_t,
+      ex::__q<ex::__decayed_tuple>, ex::__q<ex::__variant>>;
+
+  static_assert(std::is_same_v<value_types_of, value_types>);
+
+  using error_types_of = ex::error_types_of_t<awaitable_sender_1<Awaiter>>;
+  using error_types = typename Signatures::template __gather_sigs<ex::set_error_t,
+      ex::__q1<ex::__id>, ex::__q<ex::__variant>>;
+
+  static_assert(std::is_same_v<error_types_of, error_types>);
+}
+
+template <typename Signatures>
+void test_awaitable_sender2(Signatures) {
+  // is_sender_v relies on get_completion_signatures and is not true
+  // even if a sender is an awaitable if it's promise type is not
+  // used to evaluate the concept awaitable
+  static_assert(ex::sender<awaitable_sender_2, promise<__coro::suspend_always>>);
+
+  static_assert(ex::__awaitable<awaitable_sender_2, promise<__coro::suspend_always>>);
+
+  awaitable_sender_2 s;
+  promise<__coro::suspend_always> p;
+  static_assert(!ex::__get_completion_signatures::__with_member_alias<awaitable_sender_2>);
+
+  static_assert(std::is_same_v<decltype(ex::get_completion_signatures(s, p)), Signatures>);
+  static_assert(
+      ex::__awaitable<awaitable_sender_2, ex::__env_or_void<promise<__coro::suspend_always>>>);
+  static_assert(std::is_same_v<
+      ex::completion_signatures_of_t<awaitable_sender_2, promise<__coro::suspend_always>>,
+      Signatures>);
+
+  using value_types_of = ex::value_types_of_t<awaitable_sender_2, promise<__coro::suspend_always>>;
+  using value_types = typename Signatures::template __gather_sigs<ex::set_value_t,
+      ex::__q<ex::__decayed_tuple>, ex::__q<ex::__variant>>;
+
+  static_assert(std::is_same_v<value_types_of, value_types>);
+
+  using error_types_of = ex::error_types_of_t<awaitable_sender_2, promise<__coro::suspend_always>>;
+  using error_types = typename Signatures::template __gather_sigs<ex::set_error_t,
+      ex::__q1<ex::__id>, ex::__q<ex::__variant>>;
+
+  static_assert(std::is_same_v<error_types_of, error_types>);
+}
+
+template <typename Signatures>
+void test_awaitable_sender3(Signatures) {
+  // is_sender_v relies on get_completion_signatures and is not true
+  // even if a sender is an awaitable if it's promise type is not
+  // used to evaluate the concept awaitable
+  static_assert(ex::sender<awaitable_sender_3, promise<awaiter>>);
+
+  static_assert(ex::__awaiter<awaiter>);
+  static_assert(ex::__awaitable<awaitable_sender_3, promise<awaiter>>);
+
+  awaitable_sender_3 s;
+  promise<awaiter> p;
+  static_assert(!ex::__get_completion_signatures::__with_member_alias<awaitable_sender_3>);
+  static_assert(std::is_same_v<decltype(ex::get_completion_signatures(s, p)), Signatures>);
+  static_assert(std::is_same_v<ex::completion_signatures_of_t<awaitable_sender_3, promise<awaiter>>,
+      Signatures>);
+
+  using value_types_of = ex::value_types_of_t<awaitable_sender_3, promise<awaiter>>;
+  using value_types = typename Signatures::template __gather_sigs<ex::set_value_t,
+      ex::__q<ex::__decayed_tuple>, ex::__q<ex::__variant>>;
+
+  static_assert(std::is_same_v<value_types_of, value_types>);
+
+  using error_types_of = ex::error_types_of_t<awaitable_sender_3, promise<awaiter>>;
+  using error_types = typename Signatures::template __gather_sigs<ex::set_error_t,
+      ex::__q1<ex::__id>, ex::__q<ex::__variant>>;
+
+  static_assert(std::is_same_v<error_types_of, error_types>);
+}
+
+template <typename Error, typename... Values>
+auto signature_error_values(Error, Values...)
+    -> ex::completion_signatures<ex::set_value_t(Values...), ex::set_error_t(Error)> {
+  return {};
+}
+
+TEST_CASE("get completion_signatures for awaitables", "[sndtraits][awaitables]") {
+  test_awaitable_sender1(signature_error_values(std::exception_ptr()), __coro::suspend_always{});
+  test_awaitable_sender1(signature_error_values(std::exception_ptr(),
+                             ex::__await_result_t<awaitable_sender_1<awaiter>>()),
+      awaiter{});
+  test_awaitable_sender2(signature_error_values(std::exception_ptr()));
+  test_awaitable_sender3(signature_error_values(
+      std::exception_ptr(), ex::__await_result_t<awaitable_sender_3, promise<awaiter>>()));
+}

--- a/test/concepts/test_awaitables.cpp
+++ b/test/concepts/test_awaitables.cpp
@@ -45,6 +45,8 @@ struct awaiter {
   bool await_resume() { return false; }
 };
 
+using dependent = ex::dependent_completion_signatures<ex::no_env>;
+
 template <typename Awaiter>
 struct awaitable_sender_1 {
   Awaiter operator co_await();
@@ -52,10 +54,14 @@ struct awaitable_sender_1 {
 
 struct awaitable_sender_2 {
   using promise_type = promise<__coro::suspend_always>;
+private:
+  friend dependent operator co_await(awaitable_sender_2);
 };
 
 struct awaitable_sender_3 {
   using promise_type = promise<awaiter>;
+private:
+  friend dependent operator co_await(awaitable_sender_3);
 };
 
 template <typename Signatures, typename Awaiter>
@@ -63,86 +69,49 @@ void test_awaitable_sender1(Signatures&&, Awaiter&&) {
   static_assert(ex::sender<awaitable_sender_1<Awaiter>>);
   static_assert(ex::__awaitable<awaitable_sender_1<Awaiter>>);
 
-  awaitable_sender_1<Awaiter> s;
-  static_assert(!ex::__get_completion_signatures::__with_member_alias<awaitable_sender_1<Awaiter>>);
-  static_assert(std::is_same_v<decltype(ex::get_completion_signatures(s)), Signatures>);
+  static_assert(
+    !ex::__get_completion_signatures::__with_member_alias<awaitable_sender_1<Awaiter>>);
   static_assert(
       std::is_same_v<ex::completion_signatures_of_t<awaitable_sender_1<Awaiter>>, Signatures>);
-
-  using value_types_of = ex::value_types_of_t<awaitable_sender_1<Awaiter>>;
-  using value_types = typename Signatures::template __gather_sigs<ex::set_value_t,
-      ex::__q<ex::__decayed_tuple>, ex::__q<ex::__variant>>;
-
-  static_assert(std::is_same_v<value_types_of, value_types>);
-
-  using error_types_of = ex::error_types_of_t<awaitable_sender_1<Awaiter>>;
-  using error_types = typename Signatures::template __gather_sigs<ex::set_error_t,
-      ex::__q1<ex::__id>, ex::__q<ex::__variant>>;
-
-  static_assert(std::is_same_v<error_types_of, error_types>);
 }
 
 template <typename Signatures>
 void test_awaitable_sender2(Signatures) {
-  // is_sender_v relies on get_completion_signatures and is not true
-  // even if a sender is an awaitable if it's promise type is not
-  // used to evaluate the concept awaitable
+  static_assert(ex::sender<awaitable_sender_2>);
   static_assert(ex::sender<awaitable_sender_2, promise<__coro::suspend_always>>);
 
+  static_assert(ex::__awaitable<awaitable_sender_2>);
   static_assert(ex::__awaitable<awaitable_sender_2, promise<__coro::suspend_always>>);
 
-  awaitable_sender_2 s;
-  promise<__coro::suspend_always> p;
-  static_assert(!ex::__get_completion_signatures::__with_member_alias<awaitable_sender_2>);
-
-  static_assert(std::is_same_v<decltype(ex::get_completion_signatures(s, p)), Signatures>);
   static_assert(
-      ex::__awaitable<awaitable_sender_2, ex::__env_or_void<promise<__coro::suspend_always>>>);
+    !ex::__get_completion_signatures::__with_member_alias<awaitable_sender_2>);
+
+  static_assert(std::is_same_v<
+      ex::completion_signatures_of_t<awaitable_sender_2>,
+      dependent>);
   static_assert(std::is_same_v<
       ex::completion_signatures_of_t<awaitable_sender_2, promise<__coro::suspend_always>>,
       Signatures>);
-
-  using value_types_of = ex::value_types_of_t<awaitable_sender_2, promise<__coro::suspend_always>>;
-  using value_types = typename Signatures::template __gather_sigs<ex::set_value_t,
-      ex::__q<ex::__decayed_tuple>, ex::__q<ex::__variant>>;
-
-  static_assert(std::is_same_v<value_types_of, value_types>);
-
-  using error_types_of = ex::error_types_of_t<awaitable_sender_2, promise<__coro::suspend_always>>;
-  using error_types = typename Signatures::template __gather_sigs<ex::set_error_t,
-      ex::__q1<ex::__id>, ex::__q<ex::__variant>>;
-
-  static_assert(std::is_same_v<error_types_of, error_types>);
 }
 
 template <typename Signatures>
 void test_awaitable_sender3(Signatures) {
-  // is_sender_v relies on get_completion_signatures and is not true
-  // even if a sender is an awaitable if it's promise type is not
-  // used to evaluate the concept awaitable
+  static_assert(ex::sender<awaitable_sender_3>);
   static_assert(ex::sender<awaitable_sender_3, promise<awaiter>>);
 
   static_assert(ex::__awaiter<awaiter>);
+  static_assert(ex::__awaitable<awaitable_sender_3>);
   static_assert(ex::__awaitable<awaitable_sender_3, promise<awaiter>>);
 
-  awaitable_sender_3 s;
-  promise<awaiter> p;
-  static_assert(!ex::__get_completion_signatures::__with_member_alias<awaitable_sender_3>);
-  static_assert(std::is_same_v<decltype(ex::get_completion_signatures(s, p)), Signatures>);
-  static_assert(std::is_same_v<ex::completion_signatures_of_t<awaitable_sender_3, promise<awaiter>>,
+  static_assert(
+    !ex::__get_completion_signatures::__with_member_alias<awaitable_sender_3>);
+
+  static_assert(std::is_same_v<
+      ex::completion_signatures_of_t<awaitable_sender_3>,
+      dependent>);
+  static_assert(std::is_same_v<
+      ex::completion_signatures_of_t<awaitable_sender_3, promise<awaiter>>,
       Signatures>);
-
-  using value_types_of = ex::value_types_of_t<awaitable_sender_3, promise<awaiter>>;
-  using value_types = typename Signatures::template __gather_sigs<ex::set_value_t,
-      ex::__q<ex::__decayed_tuple>, ex::__q<ex::__variant>>;
-
-  static_assert(std::is_same_v<value_types_of, value_types>);
-
-  using error_types_of = ex::error_types_of_t<awaitable_sender_3, promise<awaiter>>;
-  using error_types = typename Signatures::template __gather_sigs<ex::set_error_t,
-      ex::__q1<ex::__id>, ex::__q<ex::__variant>>;
-
-  static_assert(std::is_same_v<error_types_of, error_types>);
 }
 
 template <typename Error, typename... Values>
@@ -152,11 +121,20 @@ auto signature_error_values(Error, Values...)
 }
 
 TEST_CASE("get completion_signatures for awaitables", "[sndtraits][awaitables]") {
-  test_awaitable_sender1(signature_error_values(std::exception_ptr()), __coro::suspend_always{});
-  test_awaitable_sender1(signature_error_values(std::exception_ptr(),
-                             ex::__await_result_t<awaitable_sender_1<awaiter>>()),
-      awaiter{});
-  test_awaitable_sender2(signature_error_values(std::exception_ptr()));
-  test_awaitable_sender3(signature_error_values(
-      std::exception_ptr(), ex::__await_result_t<awaitable_sender_3, promise<awaiter>>()));
+  test_awaitable_sender1(
+    signature_error_values(std::exception_ptr()), __coro::suspend_always{});
+  test_awaitable_sender1(
+    signature_error_values(
+      std::exception_ptr(),
+      ex::__await_result_t<awaitable_sender_1<awaiter>>()),
+    awaiter{});
+
+  test_awaitable_sender2(
+    signature_error_values(
+      std::exception_ptr()));
+
+  test_awaitable_sender3(
+    signature_error_values(
+      std::exception_ptr(),
+      ex::__await_result_t<awaitable_sender_3, promise<awaiter>>()));
 }


### PR DESCRIPTION
fixes: https://github.com/brycelelbach/wg21_p2300_std_execution/issues/598

Assumptions: 
1. Used Promise type and Environment analogously  

Questions:
1. If the above assumptions are false as there may or may not be a state associated with the promise type, what should be a better approach?

TODO:
1. Change std_execution.bs

Signed-off-by: Shreyas Atre <shreyasatre16@gmail.com>

