### PR TITLE
Update github pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `std::execution`, the proposed C++ framework for asynchronous and parallel programming.
 
-You can see a rendered copy of the current draft [here](https://brycelelbach.github.io/wg21_p2300_std_execution/std_execution.html).
+You can see a rendered copy of the current draft [here](https://nvidia.github.io/stdexe/std_execution.html).
 
 ## Reference implementation
 


### PR DESCRIPTION
github forwards some links after a repository moves locations, but doesn't forward the github pages link