### PR TITLE
fix `when_all` and `async_scope::spawn_future` with correct initialization order

### DIFF
--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -458,13 +458,12 @@ namespace exec {
         }
 
         std::optional<in_place_stop_callback<__forward_stopped>> __forward_scope_;
-        connect_result_t<_Sender, __future_rcvr<__x<_Sender>>> __op_;
-
         std::mutex __mutex_;
         __future_step __step_ = __future_step::__created;
         std::unique_ptr<__future_state> __no_future_;
         std::variant<std::monostate, __future_result_t<_Sender>, std::tuple<set_stopped_t>> __data_;
         __intrusive_queue<&__subscription::__next_> __subscribers_;
+        connect_result_t<_Sender, __future_rcvr<__x<_Sender>>> __op_;
       };
 
     template <class _SenderId>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4736,14 +4736,14 @@ namespace stdexec {
 
               template <size_t... _Is>
                 __operation(_WhenAll&& __when_all, _Receiver __rcvr, std::index_sequence<_Is...>)
-                  : __child_states_{
+                  : __recvr_((_Receiver&&) __rcvr)
+                  , __child_states_{
                       __conv{[&__when_all, this]() {
                         return execution::connect(
                             std::get<_Is>(((_WhenAll&&) __when_all).__sndrs_),
                             __receiver<_CvrefReceiverId, _Is>{{}, this});
                       }}...
                     }
-                  , __recvr_((_Receiver&&) __rcvr)
                 {}
               __operation(_WhenAll&& __when_all, _Receiver __rcvr)
                 : __operation((_WhenAll&&) __when_all, (_Receiver&&) __rcvr, _Indices{})
@@ -4783,7 +4783,6 @@ namespace stdexec {
                   __>;
 
               in_place_stop_source __stop_source_{};
-              __child_op_states_tuple_t __child_states_;
               _Receiver __recvr_;
               std::atomic<std::size_t> __count_{sizeof...(_SenderIds)};
               // Could be non-atomic here and atomic_ref everywhere except __completion_fn
@@ -4792,6 +4791,7 @@ namespace stdexec {
               [[no_unique_address]] __child_values_tuple_t __values_{};
               std::optional<typename stop_token_of_t<env_of_t<_Receiver>&>::template
                   callback_type<__on_stop_requested>> __on_stop_{};
+              __child_op_states_tuple_t __child_states_;
             };
 
           template <__decays_to<__sender> _Self, receiver _Receiver>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4779,6 +4779,7 @@ namespace stdexec {
                       __single_or<void>>...>,
                   __>;
 
+              in_place_stop_source __stop_source_{};
               __child_op_states_tuple_t __child_states_;
               _Receiver __recvr_;
               std::atomic<std::size_t> __count_{sizeof...(_SenderIds)};
@@ -4786,7 +4787,6 @@ namespace stdexec {
               std::atomic<__state_t> __state_{__started};
               error_types_of_t<__sender, __env_t<_Env>, __variant> __errors_{};
               [[no_unique_address]] __child_values_tuple_t __values_{};
-              in_place_stop_source __stop_source_{};
               std::optional<typename stop_token_of_t<env_of_t<_Receiver>&>::template
                   callback_type<__on_stop_requested>> __on_stop_{};
             };


### PR DESCRIPTION
Yet it will forever wait on `sync_wait(std::move(allDone));`

I'm not sure these `on(sch, ...)` are needed, or it is a bug inside `when_all`. 
A more simple case, `sync_wait(when_all(scope.spawn_future(...)));` will never return.

