### PR TITLE
Use GPU-enabled action runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,19 +5,24 @@ jobs:
   build-gcc-11:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: docker://lucteo/action-cxx-toolkit.gcc11:latest
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:gcc11
         with:
           cc: gcc-11
           checks: build test
           prebuild_command: |
             wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -;
             apt update && apt install -y --no-install-recommends git cmake;
+
   build-clang-12:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: docker://lucteo/action-cxx-toolkit.clang12:latest
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:clang12
         with:
           cc: clang-12
           checks: build test
@@ -25,11 +30,51 @@ jobs:
           prebuild_command: |
             wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -;
             apt update && apt install -y --no-install-recommends git cmake;
+
+  build-nvc++-22.7:
+    strategy:
+      matrix:
+        include:
+          - { GPU: "v100", DRIVER: "450", ARCH: "amd64" }
+          # - { GPU: "v100", DRIVER: "495", ARCH: "amd64" }
+          # Note: can't do ARM64 until we build multiarch action-cxx-toolkit images
+          # - { GPU: "v100", DRIVER: "450", ARCH: "arm64" }
+          # - { GPU: "v100", DRIVER: "495", ARCH: "arm64" }
+          # - { GPU: "a100", DRIVER: "495", ARCH: "arm64" }
+    runs-on:
+      - self-hosted
+      - linux
+      - gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1
+      - ${{ matrix.ARCH }}
+    container:
+      image: ghcr.io/trxcllnt/action-cxx-toolkit:gcc11-cuda11.7-nvhpc22.7
+      options: --entrypoint /bin/bash
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+        INPUT_CC: "nvc++"
+        INPUT_MAKEFLAGS: "-j"
+        INPUT_IGNORE_CONAN: true
+        INPUT_CHECKS: "build test"
+        NVLOCALRC: "/opt/nvidia/localrc"
+        INPUT_PREBUILD_COMMAND: |
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -;
+          apt update && apt install -y --no-install-recommends git cmake;
+          makelocalrc -d /opt/nvidia -x "$(dirname $(which nvc++))";
+    steps:
+      - name: Run nvidia-smi to make sure GPU is working
+        run: nvidia-smi
+      - name: Checkout stdexec
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Build and test with nvc++ (v22.7)
+        run: entrypoint.py
+
 #  build-clang-13:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@master
-#      - uses: docker://lucteo/action-cxx-toolkit.clang13:latest
+#      - uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:clang13
 #        with:
 #          cc: clang-13
 #          checks: build test
@@ -42,7 +87,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@master
-#      - uses: docker://lucteo/action-cxx-toolkit.main:latest
+#      - uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:main
 #        with:
 #          cc: clang-13
 #          checks: cppcheck clang-tidy
@@ -56,7 +101,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@master
-#      - uses: docker://lucteo/action-cxx-toolkit.main:latest
+#      - uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:main
 #        with:
 #          checks: clang-format
 #          clangformatdirs: src test
@@ -68,7 +113,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@master
-#      - uses: docker://lucteo/action-cxx-toolkit.main:latest
+#      - uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:main
 #        with:
 #          checks: sanitize=address sanitize=undefined
 #          prebuild_command: |

--- a/.github/workflows/test-clang-12.sh
+++ b/.github/workflows/test-clang-12.sh
@@ -22,6 +22,6 @@ docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_PREBUILD_COMMAND="\
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -; \
 apt update && apt install -y --no-install-recommends git cmake" \
-    lucteo/action-cxx-toolkit.clang12:latest
+    ghcr.io/trxcllnt/action-cxx-toolkit:clang12
 status=$?
 printStatus $status

--- a/.github/workflows/test-clang-13.sh
+++ b/.github/workflows/test-clang-13.sh
@@ -22,6 +22,6 @@ docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_PREBUILD_COMMAND="\
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -; \
 apt update && apt install -y --no-install-recommends git cmake" \
-    lucteo/action-cxx-toolkit.clang13:latest
+    ghcr.io/trxcllnt/action-cxx-toolkit:clang13
 status=$?
 printStatus $status

--- a/.github/workflows/test-clang-format.sh
+++ b/.github/workflows/test-clang-format.sh
@@ -11,6 +11,7 @@ startTest "clang-format test"
 # Run docker with action-cxx-toolkit to check our code
 docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_CHECKS='clang-format' \
-    -e INPUT_CLANGFORMATDIRS='include test examples' lucteo/action-cxx-toolkit.main:latest
+    -e INPUT_CLANGFORMATDIRS='include test examples' \
+    ghcr.io/trxcllnt/action-cxx-toolkit:main
 status=$?
 printStatus $status

--- a/.github/workflows/test-gcc-11.sh
+++ b/.github/workflows/test-gcc-11.sh
@@ -21,6 +21,6 @@ docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_PREBUILD_COMMAND="\
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -; \
 apt update && apt install -y --no-install-recommends git cmake" \
-    lucteo/action-cxx-toolkit.gcc11:latest
+    ghcr.io/trxcllnt/action-cxx-toolkit:gcc11
 status=$?
 printStatus $status

--- a/.github/workflows/test-nvc++-22.7.sh
+++ b/.github/workflows/test-nvc++-22.7.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+CURDIR=$(realpath $(dirname "$0"))
+source ${CURDIR}/_test_common.sh
+
+startTest "nvc++ compilation"
+
+# Create a temporary directory to store results between runs
+BUILDDIR="build/gh-checks/nvc++-22.7/"
+mkdir -p "${CURDIR}/../../${BUILDDIR}"
+
+# Run docker with action-cxx-toolkit to check our code
+docker run ${DOCKER_RUN_PARAMS} \
+    --runtime=nvidia \
+    -e NVLOCALRC="/opt/nvidia/localrc" \
+    -e INPUT_BUILDDIR="/github/workspace/${BUILDDIR}" \
+    -e INPUT_MAKEFLAGS='-j 4' \
+    -e INPUT_IGNORE_CONAN='true' \
+    -e INPUT_CC='nvc++' \
+    -e INPUT_CHECKS='build test install' \
+    -e INPUT_PREBUILD_COMMAND='
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -;
+apt update && apt install -y --no-install-recommends git cmake;
+makelocalrc -d /opt/nvidia -x "$(dirname $(which nvc++))";' \
+    ghcr.io/trxcllnt/action-cxx-toolkit:gcc11-cuda11.7-nvhpc22.7
+status=$?
+printStatus $status

--- a/.github/workflows/test-nvc++-22.9.sh
+++ b/.github/workflows/test-nvc++-22.9.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+CURDIR=$(realpath $(dirname "$0"))
+source ${CURDIR}/_test_common.sh
+
+startTest "nvc++ compilation"
+
+# Create a temporary directory to store results between runs
+BUILDDIR="build/gh-checks/nvc++-22.9/"
+mkdir -p "${CURDIR}/../../${BUILDDIR}"
+
+# Run docker with action-cxx-toolkit to check our code
+docker run ${DOCKER_RUN_PARAMS} \
+    --runtime=nvidia \
+    -e NVLOCALRC="/opt/nvidia/localrc" \
+    -e INPUT_BUILDDIR="/github/workspace/${BUILDDIR}" \
+    -e INPUT_MAKEFLAGS='-j 4' \
+    -e INPUT_IGNORE_CONAN='true' \
+    -e INPUT_CC='nvc++' \
+    -e INPUT_CHECKS='build test install' \
+    -e INPUT_PREBUILD_COMMAND='
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -;
+apt update && apt install -y --no-install-recommends git cmake;
+makelocalrc -d /opt/nvidia -x "$(dirname $(which nvc++))";' \
+    ghcr.io/trxcllnt/action-cxx-toolkit:gcc11-cuda11.7-nvhpc22.9
+status=$?
+printStatus $status

--- a/.github/workflows/test-sanitizer.sh
+++ b/.github/workflows/test-sanitizer.sh
@@ -18,6 +18,6 @@ docker run ${DOCKER_RUN_PARAMS} \
     -e INPUT_CC='clang-13' \
     -e INPUT_MAKEFLAGS='-j 4' \
     -e INPUT_CHECKS='sanitize=address sanitize=undefined' \
-    lucteo/action-cxx-toolkit.main:latest
+    ghcr.io/trxcllnt/action-cxx-toolkit:main
 status=$?
 printStatus $status

--- a/.github/workflows/test-static-checks.sh
+++ b/.github/workflows/test-static-checks.sh
@@ -20,6 +20,6 @@ docker run ${DOCKER_RUN_PARAMS} -e INPUT_CC='gcc-9' -e INPUT_CHECKS='cppcheck cl
     -e INPUT_CPPCHECKFLAGS='--enable=warning,style,performance,portability --inline-suppr' \
     -e INPUT_CLANGTIDYFLAGS="-quiet ${SRCFILES} -j 4" \
     -e INPUT_CC='clang-13' \
-    lucteo/action-cxx-toolkit.main:latest
+    ghcr.io/trxcllnt/action-cxx-toolkit:main
 status=$?
 printStatus $status


### PR DESCRIPTION
This PR adds a CI job that uses the new GPU-accelerated action runners to build with `nvc++` and run the `nvexec` CUDA tests.