### PR TITLE
Make `clangd` use NVHPC macros in nvexec files, temporaril…

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -30,6 +30,7 @@ CompileFlags:
   Add:
     - -x
     - cuda
+    - -D__NVCOMPILER
 
 ---
 
@@ -63,3 +64,6 @@ Diagnostics:
   Suppress:
     - "variadic_device_fn"
     - "attributes_not_allowed"
+    # The NVHPC version of _NVCXX_EXPAND_PACK macro triggers this clang error.
+    # Temporarily suppressing it, but should probably fix
+    - "template_param_shadow"

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4360,7 +4360,7 @@ namespace stdexec {
         friend auto tag_invoke(_Tag __tag, const __sender& __self, _As&&... __as)
           noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
           -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-          _NVCXX_EXPAND_PACK_RETURN(_As, _as,
+          _NVCXX_EXPAND_PACK_RETURN(_As, __as,
             return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
           )
         }


### PR DESCRIPTION
* Makes `clangd` use the `nvc++` variants of macros when viewing files under `nvexec` dirs
  * Fixes errors (like [this](https://gist.github.com/trxcllnt/2a8c669a9dcdfb7feb1f64e02aec60be)) I was seeing using `clang++` for intellisense on test files under  `test/nvexec`.
* Temporarily suppress shadow template parameter diagnostic
  * The `nvc++` version of [`_NVCXX_EXPAND_PACK`](https://github.com/NVIDIA/stdexec/blob/4c67901667e038749ffdf00a923499da402f52e2/include/stdexec/execution.hpp#L50-L55) causes a shadowed-template-parameter error. `nvc++` doesn't seem to mind, but probably worth fixing.