### PR TITLE
make the schedule_from implementation agree with its declared completion signatures

### DIFF
--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -101,16 +101,22 @@ namespace stdexec {
         using __f = _Fn<_Args...>;
     };
 
-  template <template <class> class _Fn>
+  template <template <class...> class _Fn>
     struct __q1 {
       template <class _Arg>
         using __f = _Fn<_Arg>;
     };
 
-  template <template <class, class> class _Fn>
+  template <template <class...> class _Fn>
     struct __q2 {
       template <class _First, class _Second>
         using __f = _Fn<_First, _Second>;
+    };
+
+  template <template <class...> class _Fn>
+    struct __q3 {
+      template <class _First, class _Second, class _Third>
+        using __f = _Fn<_First, _Second, _Third>;
     };
 
   template <template<class...> class _Fn, class... _Front>
@@ -184,12 +190,6 @@ namespace stdexec {
 
   template <class _Fn, class... _Back>
     using __mbind_back3 = __mbind_back_q3<_Fn::template __f, _Back...>;
-
-  template <template <class, class, class> class _Fn>
-    struct __q3 {
-      template <class _First, class _Second, class _Third>
-        using __f = _Fn<_First, _Second, _Third>;
-    };
 
   template <class _Fn, class... _Args>
     using __minvoke = typename _Fn::template __f<_Args...>;

--- a/include/stdexec/functional.hpp
+++ b/include/stdexec/functional.hpp
@@ -51,12 +51,13 @@ namespace stdexec {
 
   template <auto _Fun>
     struct __fun_c_t {
+      using _FunT = decltype(_Fun);
       template <class... _Args>
-          requires __callable<decltype(_Fun), _Args...>
+          requires __callable<_FunT, _Args...>
         auto operator()(_Args&&... __args) const
-          noexcept(noexcept(((decltype(_Fun)&&) _Fun)((_Args&&) __args...)))
-          -> __call_result_t<decltype(_Fun), _Args...> {
-          return ((decltype(_Fun)&&) _Fun)((_Args&&) __args...);
+          noexcept(noexcept(_Fun((_Args&&) __args...)))
+          -> __call_result_t<_FunT, _Args...> {
+          return _Fun((_Args&&) __args...);
         }
     };
   template <auto _Fun>


### PR DESCRIPTION
Also, remove egregious hack in the `let_*` implementation that was accommodating the incorrect `schedule_from` completion