### PR TITLE
Deprecate all P2300 entities found under namespace `std::`

### DIFF
--- a/examples/algorithms/then.hpp
+++ b/examples/algorithms/then.hpp
@@ -19,38 +19,36 @@
 // Pull in the reference implementation of P2300:
 #include <stdexec/execution.hpp>
 
-namespace stdex = std::execution;
-
 ///////////////////////////////////////////////////////////////////////////////
 // then algorithm:
 template<class R, class F>
 class _then_receiver
-    : stdex::receiver_adaptor<_then_receiver<R, F>, R> {
-  friend stdex::receiver_adaptor<_then_receiver, R>;
+    : stdexec::receiver_adaptor<_then_receiver<R, F>, R> {
+  friend stdexec::receiver_adaptor<_then_receiver, R>;
   F f_;
 
   template <class... As>
   using _completions =
-    stdex::completion_signatures<
-      stdex::set_value_t(std::invoke_result_t<F, As...>),
-      stdex::set_error_t(std::exception_ptr)>;
+    stdexec::completion_signatures<
+      stdexec::set_value_t(std::invoke_result_t<F, As...>),
+      stdexec::set_error_t(std::exception_ptr)>;
 
   // Customize set_value by invoking the callable and passing the result to the inner receiver
   template<class... As>
-    requires stdex::receiver_of<R, _completions<As...>>
+    requires stdexec::receiver_of<R, _completions<As...>>
   void set_value(As&&... as) && noexcept try {
-    stdex::set_value(std::move(*this).base(), std::invoke((F&&) f_, (As&&) as...));
+    stdexec::set_value(std::move(*this).base(), std::invoke((F&&) f_, (As&&) as...));
   } catch(...) {
-    stdex::set_error(std::move(*this).base(), std::current_exception());
+    stdexec::set_error(std::move(*this).base(), std::current_exception());
   }
 
  public:
   _then_receiver(R r, F f)
-   : stdex::receiver_adaptor<_then_receiver, R>{std::move(r)}
+   : stdexec::receiver_adaptor<_then_receiver, R>{std::move(r)}
    , f_(std::move(f)) {}
 };
 
-template<stdex::sender S, class F>
+template<stdexec::sender S, class F>
 struct _then_sender {
   S s_;
   F f_;
@@ -58,31 +56,31 @@ struct _then_sender {
   // Compute the completion signatures
   template <class... Args>
     using _set_value_t =
-      stdex::completion_signatures<
-        stdex::set_value_t(std::invoke_result_t<F, Args...>)>;
+      stdexec::completion_signatures<
+        stdexec::set_value_t(std::invoke_result_t<F, Args...>)>;
 
   template <class Env>
     using _completions_t =
-      stdex::make_completion_signatures<S, Env,
-        stdex::completion_signatures<stdex::set_error_t(std::exception_ptr)>,
+      stdexec::make_completion_signatures<S, Env,
+        stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>,
         _set_value_t>;
 
   template<class Env>
-  friend auto tag_invoke(stdex::get_completion_signatures_t, _then_sender&&, Env)
+  friend auto tag_invoke(stdexec::get_completion_signatures_t, _then_sender&&, Env)
     -> _completions_t<Env>;
 
   // Connect:
   template<class R>
-    //requires stdex::receiver_of<R, _completions_t<stdex::env_of_t<R>>>
-    //requires stdex::receiver_of<R, stdex::completion_signatures_of_t<S, stdex::env_of_t<R>>>
-  friend auto tag_invoke(stdex::connect_t, _then_sender&& self, R r)
-    -> stdex::connect_result_t<S, _then_receiver<R, F>> {
-      return stdex::connect(
+    //requires stdexec::receiver_of<R, _completions_t<stdexec::env_of_t<R>>>
+    //requires stdexec::receiver_of<R, stdexec::completion_signatures_of_t<S, stdexec::env_of_t<R>>>
+  friend auto tag_invoke(stdexec::connect_t, _then_sender&& self, R r)
+    -> stdexec::connect_result_t<S, _then_receiver<R, F>> {
+      return stdexec::connect(
         (S&&) self.s_, _then_receiver<R, F>{(R&&) r, (F&&) self.f_});
   }
 };
 
-template<stdex::sender S, class F>
-stdex::sender auto then(S s, F f) {
+template<stdexec::sender S, class F>
+stdexec::sender auto then(S s, F f) {
   return _then_sender<S, F>{(S&&) s, (F&&) f};
 }

--- a/examples/hello_coro.cpp
+++ b/examples/hello_coro.cpp
@@ -21,7 +21,7 @@
 #if !_STD_NO_COROUTINES_
 #include <exec/task.hpp>
 
-using namespace std::execution;
+using namespace stdexec;
 
 template <sender S1, sender S2>
 exec::task<int> async_answer(S1 s1, S2 s2) {
@@ -36,13 +36,13 @@ exec::task<std::optional<int>> async_answer2(S1 s1, S2 s2) {
 }
 
 // tasks have an associated stop token
-exec::task<std::optional<std::in_place_stop_token>> async_stop_token() {
+exec::task<std::optional<stdexec::in_place_stop_token>> async_stop_token() {
   co_return co_await stopped_as_optional(get_stop_token());
 }
 
 int main() try {
   // Awaitables are implicitly senders:
-  auto [i] = std::this_thread::sync_wait(async_answer2(just(42), just())).value();
+  auto [i] = stdexec::sync_wait(async_answer2(just(42), just())).value();
   std::cout << "The answer is " << i.value() << '\n';
 } catch(std::exception & e) {
   std::cout << e.what() << '\n';

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -20,8 +20,8 @@
 
 #include "exec/static_thread_pool.hpp"
 
-using namespace std::execution;
-using std::this_thread::sync_wait;
+using namespace stdexec;
+using stdexec::sync_wait;
 
 int main() {
   exec::static_thread_pool ctx{8};

--- a/examples/nvexec/bulk.cpp
+++ b/examples/nvexec/bulk.cpp
@@ -3,7 +3,7 @@
 
 #include <cstdio>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 int main() {
   using nvexec::is_on_gpu;
@@ -30,6 +30,6 @@ int main() {
                ex::schedule(sch) | ex::bulk(4, bulk_fn(2)))
            | ex::then(then_fn(2));
 
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 }
 

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -43,7 +43,7 @@ namespace nvexec {
 #include <exec/inline_scheduler.hpp>
 #include <exec/static_thread_pool.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 #ifdef _NVHPC_CUDA
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
@@ -71,11 +71,11 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           op_state.i_++;
 
           if (op_state.i_ == op_state.n_) {
-            op_state.propagate_completion_signal(std::execution::set_value);
+            op_state.propagate_completion_signal(stdexec::set_value);
             return;
           }
 
-          auto sch = std::execution::get_scheduler(std::execution::get_env(op_state.receiver_));
+          auto sch = stdexec::get_scheduler(stdexec::get_env(op_state.receiver_));
           inner_op_state_t& inner_op_state = op_state.inner_op_state_.emplace(
               stdexec::__conv{[&]() noexcept {
                 return ex::connect(ex::schedule(sch) | op_state.closure_, receiver_2_t<OpT>{op_state});
@@ -117,7 +117,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           OpT &op_state = __self.op_state_;
 
           if (op_state.n_) {
-            auto sch = std::execution::get_scheduler(std::execution::get_env(op_state.receiver_));
+            auto sch = stdexec::get_scheduler(stdexec::get_env(op_state.receiver_));
             inner_op_state_t& inner_op_state = op_state.inner_op_state_.emplace(
                 stdexec::__conv{[&]() noexcept {
                   return ex::connect(ex::schedule(sch) | op_state.closure_, receiver_2_t<OpT>{op_state});
@@ -125,7 +125,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
             ex::start(inner_op_state);
           } else {
-            op_state.propagate_completion_signal(std::execution::set_value);
+            op_state.propagate_completion_signal(stdexec::set_value);
           }
         }
 
@@ -146,8 +146,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         using PredSender = stdexec::__t<PredecessorSenderId>;
         using Closure = stdexec::__t<ClosureId>;
         using Receiver = stdexec::__t<ReceiverId>;
-        using Scheduler = std::tag_invoke_result_t<std::execution::get_scheduler_t, std::execution::env_of_t<Receiver>>;
-        using InnerSender = std::invoke_result_t<Closure, std::tag_invoke_result_t<std::execution::schedule_t, Scheduler>>;
+        using Scheduler = stdexec::tag_invoke_result_t<stdexec::get_scheduler_t, stdexec::env_of_t<Receiver>>;
+        using InnerSender = std::invoke_result_t<Closure, stdexec::tag_invoke_result_t<stdexec::schedule_t, Scheduler>>;
 
         using predecessor_op_state_t = ex::connect_result_t<PredSender, receiver_1_t<operation_state_t>>;
         using inner_op_state_t = ex::connect_result_t<InnerSender, receiver_2_t<operation_state_t>>;
@@ -163,17 +163,17 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           return this->stream_;
         }
 
-        friend void tag_invoke(std::execution::start_t, operation_state_t& op) noexcept {
+        friend void tag_invoke(stdexec::start_t, operation_state_t& op) noexcept {
           op.stream_ = op.allocate();
 
           if (op.status_ != cudaSuccess) {
             // Couldn't allocate memory for operation state, complete with error
-            op.propagate_completion_signal(std::execution::set_error, std::move(op.status_));
+            op.propagate_completion_signal(stdexec::set_error, std::move(op.status_));
           } else {
             if (op.n_) {
-              std::execution::start(*op.pred_op_state_);
+              stdexec::start(*op.pred_op_state_);
             } else {
-              op.propagate_completion_signal(std::execution::set_value);
+              op.propagate_completion_signal(stdexec::set_value);
             }
           }
         }
@@ -210,13 +210,13 @@ namespace repeat_n_detail {
         using inner_op_state_t = typename OpT::inner_op_state_t;
 
         OpT &op_state = __self.op_state_;
-        auto sch = std::execution::get_scheduler(std::execution::get_env(op_state.receiver_));
+        auto sch = stdexec::get_scheduler(stdexec::get_env(op_state.receiver_));
 
         for (std::size_t i = 0; i < op_state.n_; i++) {
-          std::this_thread::sync_wait(ex::schedule(exec::inline_scheduler{}) | op_state.closure_);
+          stdexec::sync_wait(ex::schedule(exec::inline_scheduler{}) | op_state.closure_);
         }
 
-        std::execution::set_value(std::move(op_state.receiver_));
+        stdexec::set_value(std::move(op_state.receiver_));
       }
 
       friend auto tag_invoke(ex::get_env_t, const receiver_t& self) noexcept
@@ -236,7 +236,7 @@ namespace repeat_n_detail {
       using Receiver = stdexec::__t<ReceiverId>;
 
       using inner_op_state_t = 
-        std::execution::connect_result_t<Sender, receiver_t<operation_state_t>>;
+        stdexec::connect_result_t<Sender, receiver_t<operation_state_t>>;
 
       inner_op_state_t op_state_;
       Closure closure_;
@@ -244,12 +244,12 @@ namespace repeat_n_detail {
       std::size_t n_{};
 
       friend void
-      tag_invoke(std::execution::start_t, operation_state_t &self) noexcept {
-        std::execution::start(self.op_state_);
+      tag_invoke(stdexec::start_t, operation_state_t &self) noexcept {
+        stdexec::start(self.op_state_);
       }
 
       operation_state_t(Sender&& sender, Closure closure, Receiver&& receiver, std::size_t n)
-        : op_state_{std::execution::connect((Sender&&) sender, receiver_t<operation_state_t>{*this})}
+        : op_state_{stdexec::connect((Sender&&) sender, receiver_t<operation_state_t>{*this})}
         , closure_{closure}
         , receiver_{(Receiver&&)receiver}
         , n_(n) {
@@ -263,21 +263,21 @@ struct repeat_n_t {
       using Sender = stdexec::__t<SenderId>;
       using Closure = stdexec::__t<ClosureId>;
 
-      using completion_signatures = std::execution::completion_signatures<
-        std::execution::set_value_t(),
-        std::execution::set_stopped_t(),
-        std::execution::set_error_t(std::exception_ptr)>;
+      using completion_signatures = stdexec::completion_signatures<
+        stdexec::set_value_t(),
+        stdexec::set_stopped_t(),
+        stdexec::set_error_t(std::exception_ptr)>;
 
       Sender sender_;
       Closure closure_;
       std::size_t n_{};
 
 #ifdef _NVHPC_CUDA
-      template <stdexec::__decays_to<repeat_n_sender_t> Self, std::execution::receiver Receiver>
-        requires (std::tag_invocable<std::execution::connect_t, Sender, Receiver>) &&
+      template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
+        requires (std::tag_invocable<stdexec::connect_t, Sender, Receiver>) &&
                  (!nvexec::STDEXEC_STREAM_DETAIL_NS::receiver_with_stream_env<Receiver>)
       friend auto
-      tag_invoke(std::execution::connect_t, Self &&self, Receiver &&r)
+      tag_invoke(stdexec::connect_t, Self &&self, Receiver &&r)
         -> repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__x<Receiver>> {
         return repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__x<Receiver>>(
           (Sender&&)self.sender_,
@@ -286,11 +286,11 @@ struct repeat_n_t {
           self.n_);
       }
 
-      template <stdexec::__decays_to<repeat_n_sender_t> Self, std::execution::receiver Receiver>
-        requires (std::tag_invocable<std::execution::connect_t, Sender, Receiver>) &&
+      template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
+        requires (std::tag_invocable<stdexec::connect_t, Sender, Receiver>) &&
                  (nvexec::STDEXEC_STREAM_DETAIL_NS::receiver_with_stream_env<Receiver>)
       friend auto
-      tag_invoke(std::execution::connect_t, Self &&self, Receiver &&r) 
+      tag_invoke(stdexec::connect_t, Self &&self, Receiver &&r) 
         -> nvexec::STDEXEC_STREAM_DETAIL_NS::repeat_n::operation_state_t<SenderId, ClosureId, stdexec::__x<Receiver>> {
         return nvexec::STDEXEC_STREAM_DETAIL_NS::repeat_n::operation_state_t<SenderId, ClosureId, stdexec::__x<Receiver>>(
           (Sender&&)self.sender_,
@@ -299,9 +299,9 @@ struct repeat_n_t {
           self.n_);
       }
 #else
-      template <stdexec::__decays_to<repeat_n_sender_t> Self, std::execution::receiver Receiver>
-        requires std::tag_invocable<std::execution::connect_t, Sender, Receiver> friend auto
-      tag_invoke(std::execution::connect_t, Self &&self, Receiver &&r)
+      template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
+        requires std::tag_invocable<stdexec::connect_t, Sender, Receiver> friend auto
+      tag_invoke(stdexec::connect_t, Self &&self, Receiver &&r)
         -> repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__x<Receiver>> {
         return repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__x<Receiver>>(
           (Sender&&)self.sender_,
@@ -311,14 +311,14 @@ struct repeat_n_t {
       }
 #endif
 
-      template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... Ts>
+      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... Ts>
         requires std::tag_invocable<Tag, Sender, Ts...> friend decltype(auto)
       tag_invoke(Tag tag, const repeat_n_sender_t &s, Ts &&...ts) noexcept {
         return tag(s.sender_, std::forward<Ts>(ts)...);
       }
     };
 
-  template <std::execution::sender Sender,
+  template <stdexec::sender Sender,
             stdexec::__sender_adaptor_closure Closure>
     auto operator()(Sender &&__sndr, std::size_t n, Closure closure) const noexcept
       -> repeat_n_sender_t<stdexec::__x<Sender>, stdexec::__x<Closure>> {
@@ -338,7 +338,7 @@ inline constexpr repeat_n_t repeat_n{};
 template <class SchedulerT>
 [[nodiscard]] bool is_gpu_scheduler(SchedulerT &&scheduler) {
   auto snd = ex::just() | exec::on(scheduler, ex::then([] { return nvexec::is_on_gpu(); }));
-  auto [on_gpu] = std::this_thread::sync_wait(std::move(snd)).value();
+  auto [on_gpu] = stdexec::sync_wait(std::move(snd)).value();
   return on_gpu;
 }
 
@@ -347,7 +347,7 @@ auto maxwell_eqs_snr(float dt,
                      bool write_results,
                      std::size_t n_iterations,
                      fields_accessor accessor,
-                     std::execution::scheduler auto &&computer) {
+                     stdexec::scheduler auto &&computer) {
   return ex::just()
        | exec::on(computer,
                   repeat_n(n_iterations,
@@ -361,13 +361,13 @@ void run_snr(float dt,
              std::size_t n_iterations,
              grid_t &grid,
              std::string_view scheduler_name,
-             std::execution::scheduler auto &&computer) {
+             stdexec::scheduler auto &&computer) {
   time_storage_t time{is_gpu_scheduler(computer)};
   fields_accessor accessor = grid.accessor();
 
   auto init = ex::just() 
             | exec::on(computer, ex::bulk(grid.cells, grid_initializer(dt, accessor)));
-  std::this_thread::sync_wait(init);
+  stdexec::sync_wait(init);
 
   auto snd = maxwell_eqs_snr(dt,
                              time.get(),
@@ -379,6 +379,6 @@ void run_snr(float dt,
   report_performance(grid.cells,
                      n_iterations,
                      scheduler_name,
-                     [&snd] { std::this_thread::sync_wait(std::move(snd)); });
+                     [&snd] { stdexec::sync_wait(std::move(snd)); });
 }
 

--- a/examples/nvexec/maxwell_cpu_mt.cpp
+++ b/examples/nvexec/maxwell_cpu_mt.cpp
@@ -43,7 +43,7 @@ int main(int argc, char *argv[]) {
   const std::size_t N = value(params, "N", 512);
 
   auto run_snr_on = [&](std::string_view scheduler_name,
-                        std::execution::scheduler auto &&scheduler) {
+                        stdexec::scheduler auto &&scheduler) {
     grid_t grid{N, is_gpu_scheduler(scheduler)};
 
     auto accessor = grid.accessor();

--- a/examples/nvexec/maxwell_cpu_st.cpp
+++ b/examples/nvexec/maxwell_cpu_st.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
   const std::size_t N = value(params, "N", 512);
 
   auto run_snr_on = [&](std::string_view scheduler_name,
-                        std::execution::scheduler auto &&scheduler) {
+                        stdexec::scheduler auto &&scheduler) {
     grid_t grid{N, is_gpu_scheduler(scheduler)};
 
     auto accessor = grid.accessor();

--- a/examples/nvexec/maxwell_gpu_m.cpp
+++ b/examples/nvexec/maxwell_gpu_m.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
   const std::size_t N = value(params, "N", 512);
 
   auto run_snr_on = [&](std::string_view scheduler_name,
-                        std::execution::scheduler auto &&scheduler) {
+                        stdexec::scheduler auto &&scheduler) {
     grid_t grid{N, is_gpu_scheduler(scheduler)};
 
     auto accessor = grid.accessor();

--- a/examples/nvexec/maxwell_gpu_s.cpp
+++ b/examples/nvexec/maxwell_gpu_s.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
   const std::size_t N = value(params, "N", 512);
 
   auto run_snr_on = [&](std::string_view scheduler_name,
-                        std::execution::scheduler auto &&scheduler) {
+                        stdexec::scheduler auto &&scheduler) {
     grid_t grid{N, is_gpu_scheduler(scheduler)};
 
     auto accessor = grid.accessor();

--- a/examples/nvexec/reduce.cpp
+++ b/examples/nvexec/reduce.cpp
@@ -21,7 +21,7 @@ auto end(simple_range<Iterator>& rng) {
   return rng.last;
 }
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 int main() {
   const int n = 2 * 1024;
@@ -34,7 +34,7 @@ int main() {
   auto snd = ex::transfer_just(stream_ctx.get_scheduler(), simple_range{first, last})
            | nvexec::reduce();
 
-  auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   std::cout << "result: " << result << std::endl;
 }

--- a/examples/nvexec/split.cpp
+++ b/examples/nvexec/split.cpp
@@ -3,7 +3,7 @@
 
 #include <cstdio>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 int main() {
   using nvexec::is_on_gpu;
@@ -34,6 +34,6 @@ int main() {
                fork | ex::bulk(4, bulk_fn(2)))
            | ex::then(then_fn(2));
 
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 }
 

--- a/examples/retry.cpp
+++ b/examples/retry.cpp
@@ -24,26 +24,26 @@
 // Example code:
 struct fail_some {
   using completion_signatures =
-    std::execution::completion_signatures<
-      std::execution::set_value_t(int),
-      std::execution::set_error_t(std::exception_ptr)>;
+    stdexec::completion_signatures<
+      stdexec::set_value_t(int),
+      stdexec::set_error_t(std::exception_ptr)>;
   template <class R>
   struct op {
     R r_;
-    friend void tag_invoke(std::execution::start_t, op& self) noexcept {
+    friend void tag_invoke(stdexec::start_t, op& self) noexcept {
       static int i = 0;
       if (++i < 3) {
         std::printf("fail!\n");
-        std::execution::set_error(std::move(self.r_), std::exception_ptr{});
+        stdexec::set_error(std::move(self.r_), std::exception_ptr{});
       } else {
         std::printf("success!\n");
-        std::execution::set_value(std::move(self.r_), 42);
+        stdexec::set_value(std::move(self.r_), 42);
       }
     }
   };
 
   template <class R>
-  friend op<R> tag_invoke(std::execution::connect_t, fail_some, R r) {
+  friend op<R> tag_invoke(stdexec::connect_t, fail_some, R r) {
     return {std::move(r)};
   }
 };
@@ -54,6 +54,6 @@ int main() {
   //   fail!
   //   fail!
   //   success!
-  auto [a] = std::this_thread::sync_wait(std::move(x)).value();
+  auto [a] = stdexec::sync_wait(std::move(x)).value();
   (void) a;
 }

--- a/examples/scope.cpp
+++ b/examples/scope.cpp
@@ -25,8 +25,8 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 // Example code:
-using namespace std::execution;
-using std::this_thread::sync_wait;
+using namespace stdexec;
+using stdexec::sync_wait;
 
 class noop_receiver : receiver_adaptor<noop_receiver> {
   friend receiver_adaptor<noop_receiver>;

--- a/examples/server_theme/let_value.cpp
+++ b/examples/server_theme/let_value.cpp
@@ -52,7 +52,7 @@
 // Use a thread pool
 #include "exec/static_thread_pool.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct http_request {
   std::string url_;

--- a/examples/server_theme/on_transfer.cpp
+++ b/examples/server_theme/on_transfer.cpp
@@ -45,7 +45,7 @@
 // Use a thread pool
 #include "exec/static_thread_pool.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct sync_stream {
 private:
@@ -113,7 +113,7 @@ int main() {
     scope.spawn(std::move(snd));
   }
 
-  (void) std::this_thread::sync_wait(scope.on_empty());
+  (void) stdexec::sync_wait(scope.on_empty());
 
   return 0;
 }

--- a/examples/server_theme/split_bulk.cpp
+++ b/examples/server_theme/split_bulk.cpp
@@ -27,7 +27,7 @@
  * - implement the handler for applying 3 edge detection algorithms on one image
  * - implement the handler for applying a blur filter over the given set of images
  * - we show one can use multiple threads to execute a more complex work
- * - we show how to use `execution::split` / `execution::when_all` and `execution::bulk`
+ * - we show how to use `stdexec::split` / `stdexec::when_all` and `stdexec::bulk`
  * - error and cancellation handling is performed outside the handler
  *
  * Example goals:
@@ -47,7 +47,7 @@
 // Use a thread pool
 #include "exec/static_thread_pool.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct http_request {
   std::string url_;
@@ -189,6 +189,6 @@ int main() {
     scope.spawn(ex::on(sched, std::move(action)));
   }
 
-  std::this_thread::sync_wait(scope.on_empty());
+  stdexec::sync_wait(scope.on_empty());
   pool.request_stop();
 }

--- a/examples/server_theme/then_upon.cpp
+++ b/examples/server_theme/then_upon.cpp
@@ -25,8 +25,8 @@
  *
  * Specific problem description:
  * - we are looking at the flow of handling a "classify" request type
- * - show how a single-threaded process can be broken into multiple steps with `execution::then` and
- * `execution::upon_*` functions
+ * - show how a single-threaded process can be broken into multiple steps with `stdexec::then` and
+ * `stdexec::upon_*` functions
  * - handle errors and cancellations that might occur during the processing
  * - at the end of the flow, we always end up with an HTTP response
  *
@@ -49,7 +49,7 @@
 // Use a thread pool
 #include "exec/static_thread_pool.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct http_request {
   std::string url_;
@@ -199,6 +199,6 @@ int main() {
     scope.spawn(ex::on(sched, std::move(action)));
   }
 
-  std::this_thread::sync_wait(scope.on_empty());
+  stdexec::sync_wait(scope.on_empty());
   pool.request_stop();
 }

--- a/examples/then.cpp
+++ b/examples/then.cpp
@@ -25,7 +25,7 @@
 int main() {
   auto x =
     then(
-      std::execution::just(42),
+      stdexec::just(42),
       [](int i) {
         std::printf("Got: %d\n", i);
         return i;
@@ -34,6 +34,6 @@ int main() {
 
   // prints:
   //   Got: 42
-  auto [a] = std::this_thread::sync_wait(std::move(x)).value();
+  auto [a] = stdexec::sync_wait(std::move(x)).value();
   (void) a;
 }

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -144,7 +144,7 @@ namespace exec {
           -> make_env_t<env_of_t<_Receiver>, _Withs...> {
           return std::apply(
             [this](auto&... __withs) {
-              return make_env(execution::get_env(base()), __withs...);
+              return make_env(stdexec::get_env(base()), __withs...);
             },
             __op_->__withs_);
         }

--- a/include/exec/inline_scheduler.hpp
+++ b/include/exec/inline_scheduler.hpp
@@ -27,40 +27,40 @@ namespace exec {
       struct __op {
         using R = stdexec::__t<R_>;
         [[no_unique_address]] R rec_;
-        friend void tag_invoke(std::execution::start_t, __op& op) noexcept try {
-          std::execution::set_value((R&&) op.rec_);
+        friend void tag_invoke(stdexec::start_t, __op& op) noexcept try {
+          stdexec::set_value((R&&) op.rec_);
         } catch(...) {
-          std::execution::set_error((R&&) op.rec_, std::current_exception());
+          stdexec::set_error((R&&) op.rec_, std::current_exception());
         }
       };
 
     struct __sender {
       using completion_signatures =
-        std::execution::completion_signatures<
-          std::execution::set_value_t(),
-          std::execution::set_error_t(std::exception_ptr)>;
+        stdexec::completion_signatures<
+          stdexec::set_value_t(),
+          stdexec::set_error_t(std::exception_ptr)>;
 
       template <class R>
-        friend auto tag_invoke(std::execution::connect_t, __sender, R&& rec)
+        friend auto tag_invoke(stdexec::connect_t, __sender, R&& rec)
           noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<R>, R>)
           -> __op<stdexec::__x<std::remove_cvref_t<R>>> {
           return {(R&&) rec};
         }
 
       friend inline_scheduler
-      tag_invoke(std::execution::get_completion_scheduler_t<std::execution::set_value_t>, __sender) noexcept {
+      tag_invoke(stdexec::get_completion_scheduler_t<stdexec::set_value_t>, __sender) noexcept {
         return {};
       }
     };
 
-    friend __sender tag_invoke(std::execution::schedule_t, const inline_scheduler&) noexcept {
+    friend __sender tag_invoke(stdexec::schedule_t, const inline_scheduler&) noexcept {
       return {};
     }
 
-    friend std::execution::forward_progress_guarantee tag_invoke(
-        std::execution::get_forward_progress_guarantee_t,
+    friend stdexec::forward_progress_guarantee tag_invoke(
+        stdexec::get_forward_progress_guarantee_t,
         const inline_scheduler&) noexcept {
-      return std::execution::forward_progress_guarantee::weakly_parallel;
+      return stdexec::forward_progress_guarantee::weakly_parallel;
     }
 
     bool operator==(const inline_scheduler&) const noexcept = default;

--- a/include/exec/single_thread_context.hpp
+++ b/include/exec/single_thread_context.hpp
@@ -22,7 +22,7 @@
 
 namespace exec {
   class single_thread_context {
-    std::execution::run_loop loop_;
+    stdexec::run_loop loop_;
     std::thread thread_;
 
   public:

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -195,7 +195,7 @@ namespace nvexec {
       if (holds_alternative()) {
         visit([](auto& val) noexcept {
           using val_t = std::decay_t<decltype(val)>;
-          if constexpr(std::is_same_v<val_t, ::cuda::std::tuple<std::execution::set_error_t, std::exception_ptr>>) {
+          if constexpr(std::is_same_v<val_t, ::cuda::std::tuple<stdexec::set_error_t, std::exception_ptr>>) {
             // TODO Not quite possible at the moment
           } else {
             val.~val_t();

--- a/include/nvexec/multi_gpu_context.cuh
+++ b/include/nvexec/multi_gpu_context.cuh
@@ -22,13 +22,13 @@
 
 namespace nvexec {
   namespace STDEXEC_STREAM_DETAIL_NS {
-    template <std::execution::sender Sender, std::integral Shape, class Fun>
+    template <stdexec::sender Sender, std::integral Shape, class Fun>
       using multi_gpu_bulk_sender_th = multi_gpu_bulk_sender_t<stdexec::__x<std::remove_cvref_t<Sender>>, Shape, stdexec::__x<std::remove_cvref_t<Fun>>>;
 
     struct multi_gpu_stream_scheduler {
       friend stream_context;
 
-      template <std::execution::sender Sender>
+      template <stdexec::sender Sender>
         using schedule_from_sender_th = schedule_from_sender_t<stream_scheduler, stdexec::__x<std::remove_cvref_t<Sender>>>;
 
       template <class RId>
@@ -52,22 +52,22 @@ namespace nvexec {
             return stream_;
           }
 
-          friend void tag_invoke(std::execution::start_t, operation_state_t& op) noexcept {
+          friend void tag_invoke(stdexec::start_t, operation_state_t& op) noexcept {
             if constexpr (stream_receiver<R>) {
               if (op.status_ == cudaSuccess) {
-                std::execution::set_value((R&&)op.rec_);
+                stdexec::set_value((R&&)op.rec_);
               } else {
-                std::execution::set_error((R&&)op.rec_, std::move(op.status_));
+                stdexec::set_error((R&&)op.rec_, std::move(op.status_));
               }
             } else {
               if (op.status_ == cudaSuccess) {
                 continuation_kernel
-                  <std::decay_t<R>, std::execution::set_value_t>
-                    <<<1, 1, 0, op.stream_>>>(op.rec_, std::execution::set_value);
+                  <std::decay_t<R>, stdexec::set_value_t>
+                    <<<1, 1, 0, op.stream_>>>(op.rec_, stdexec::set_value);
               } else {
                 continuation_kernel
-                  <std::decay_t<R>, std::execution::set_error_t, cudaError_t>
-                    <<<1, 1, 0, op.stream_>>>(op.rec_, std::execution::set_error, op.status_);
+                  <std::decay_t<R>, stdexec::set_error_t, cudaError_t>
+                    <<<1, 1, 0, op.stream_>>>(op.rec_, stdexec::set_error, op.status_);
               }
             }
           }
@@ -75,12 +75,12 @@ namespace nvexec {
 
       struct sender_t : stream_sender_base {
         using completion_signatures =
-          std::execution::completion_signatures<
-            std::execution::set_value_t(),
-            std::execution::set_error_t(cudaError_t)>;
+          stdexec::completion_signatures<
+            stdexec::set_value_t(),
+            stdexec::set_error_t(cudaError_t)>;
 
         template <class R>
-          friend auto tag_invoke(std::execution::connect_t, sender_t, R&& rec)
+          friend auto tag_invoke(stdexec::connect_t, sender_t, R&& rec)
             noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<R>, R>)
             -> operation_state_t<stdexec::__x<std::remove_cvref_t<R>>> {
             return operation_state_t<stdexec::__x<std::remove_cvref_t<R>>>((R&&) rec);
@@ -92,7 +92,7 @@ namespace nvexec {
 
         template <class CPO>
         friend multi_gpu_stream_scheduler
-        tag_invoke(std::execution::get_completion_scheduler_t<CPO>, sender_t self) noexcept {
+        tag_invoke(stdexec::get_completion_scheduler_t<CPO>, sender_t self) noexcept {
           return self.make_scheduler();
         }
 
@@ -105,93 +105,93 @@ namespace nvexec {
         queue::task_hub_t * hub_;
       };
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend schedule_from_sender_th<S>
-        tag_invoke(std::execution::schedule_from_t, const multi_gpu_stream_scheduler& sch, S&& sndr) noexcept {
+        tag_invoke(stdexec::schedule_from_t, const multi_gpu_stream_scheduler& sch, S&& sndr) noexcept {
           return schedule_from_sender_th<S>(sch.hub_, (S&&) sndr);
         }
 
-      template <std::execution::sender S, std::integral Shape, class Fn>
+      template <stdexec::sender S, std::integral Shape, class Fn>
         friend multi_gpu_bulk_sender_th<S, Shape, Fn>
-        tag_invoke(std::execution::bulk_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Shape shape, Fn fun) noexcept {
+        tag_invoke(stdexec::bulk_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Shape shape, Fn fun) noexcept {
           return multi_gpu_bulk_sender_th<S, Shape, Fn>{{}, sch.num_devices_, (S&&) sndr, shape, (Fn&&)fun};
         }
 
-      template <std::execution::sender S, class Fn>
+      template <stdexec::sender S, class Fn>
         friend then_sender_th<S, Fn>
-        tag_invoke(std::execution::then_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
+        tag_invoke(stdexec::then_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return then_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
         }
 
-      template <stdexec::__one_of<std::execution::let_value_t, 
-                                  std::execution::let_stopped_t, 
-                                  std::execution::let_error_t> Let, 
-                std::execution::sender S, 
+      template <stdexec::__one_of<stdexec::let_value_t, 
+                                  stdexec::let_stopped_t, 
+                                  stdexec::let_error_t> Let, 
+                stdexec::sender S, 
                 class Fn>
         friend let_xxx_th<Let, S, Fn>
         tag_invoke(Let, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return let_xxx_th<Let, S, Fn>{{}, (S &&) sndr, (Fn &&) fun};
         }
 
-      template <std::execution::sender S, class Fn>
+      template <stdexec::sender S, class Fn>
         friend upon_error_sender_th<S, Fn>
-        tag_invoke(std::execution::upon_error_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
+        tag_invoke(stdexec::upon_error_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return upon_error_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
         }
 
-      template <std::execution::sender S, class Fn>
+      template <stdexec::sender S, class Fn>
         friend upon_stopped_sender_th<S, Fn>
-        tag_invoke(std::execution::upon_stopped_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
+        tag_invoke(stdexec::upon_stopped_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return upon_stopped_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
         }
 
-      template <std::execution::sender... Senders>
+      template <stdexec::sender... Senders>
         friend auto
-        tag_invoke(std::execution::transfer_when_all_t, const multi_gpu_stream_scheduler& sch, Senders&&... sndrs) noexcept {
+        tag_invoke(stdexec::transfer_when_all_t, const multi_gpu_stream_scheduler& sch, Senders&&... sndrs) noexcept {
           return transfer_when_all_sender_th<multi_gpu_stream_scheduler, Senders...>(sch.hub_, (Senders&&)sndrs...);
         }
 
-      template <std::execution::sender... Senders>
+      template <stdexec::sender... Senders>
         friend auto
-        tag_invoke(std::execution::transfer_when_all_with_variant_t, const multi_gpu_stream_scheduler& sch, Senders&&... sndrs) noexcept {
+        tag_invoke(stdexec::transfer_when_all_with_variant_t, const multi_gpu_stream_scheduler& sch, Senders&&... sndrs) noexcept {
           return 
-            transfer_when_all_sender_th<multi_gpu_stream_scheduler, std::tag_invoke_result_t<std::execution::into_variant_t, Senders>...>(
+            transfer_when_all_sender_th<multi_gpu_stream_scheduler, stdexec::tag_invoke_result_t<stdexec::into_variant_t, Senders>...>(
                 sch.hub_, 
-                std::execution::into_variant((Senders&&)sndrs)...);
+                stdexec::into_variant((Senders&&)sndrs)...);
         }
 
-      template <std::execution::sender S, std::execution::scheduler Sch>
+      template <stdexec::sender S, stdexec::scheduler Sch>
         friend auto
-        tag_invoke(std::execution::transfer_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Sch&& scheduler) noexcept {
-          return std::execution::schedule_from((Sch&&)scheduler, transfer_sender_th<S>(sch.hub_, (S&&)sndr));
+        tag_invoke(stdexec::transfer_t, const multi_gpu_stream_scheduler& sch, S&& sndr, Sch&& scheduler) noexcept {
+          return stdexec::schedule_from((Sch&&)scheduler, transfer_sender_th<S>(sch.hub_, (S&&)sndr));
         }
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend split_sender_th<S>
-        tag_invoke(std::execution::split_t, const multi_gpu_stream_scheduler& sch, S&& sndr) noexcept {
+        tag_invoke(stdexec::split_t, const multi_gpu_stream_scheduler& sch, S&& sndr) noexcept {
           return split_sender_th<S>((S&&)sndr, sch.hub_);
         }
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend ensure_started_th<S>
-        tag_invoke(std::execution::ensure_started_t, const multi_gpu_stream_scheduler& sch, S&& sndr) noexcept {
+        tag_invoke(stdexec::ensure_started_t, const multi_gpu_stream_scheduler& sch, S&& sndr) noexcept {
           return ensure_started_th<S>((S&&) sndr, sch.hub_);
         }
 
-      friend sender_t tag_invoke(std::execution::schedule_t, const multi_gpu_stream_scheduler& self) noexcept {
+      friend sender_t tag_invoke(stdexec::schedule_t, const multi_gpu_stream_scheduler& self) noexcept {
         return {self.num_devices_, self.hub_};
       }
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend auto
-        tag_invoke(std::this_thread::sync_wait_t, const multi_gpu_stream_scheduler& self, S&& sndr) {
+        tag_invoke(stdexec::sync_wait_t, const multi_gpu_stream_scheduler& self, S&& sndr) {
           return sync_wait::sync_wait_t{}(self.hub_, (S&&)sndr);
         }
 
-      friend std::execution::forward_progress_guarantee tag_invoke(
-          std::execution::get_forward_progress_guarantee_t,
+      friend stdexec::forward_progress_guarantee tag_invoke(
+          stdexec::get_forward_progress_guarantee_t,
           const multi_gpu_stream_scheduler&) noexcept {
-        return std::execution::forward_progress_guarantee::weakly_parallel;
+        return stdexec::forward_progress_guarantee::weakly_parallel;
       }
 
       bool operator==(const multi_gpu_stream_scheduler&) const noexcept = default;

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -44,7 +44,7 @@ namespace bulk {
 
     public:
       template <class... As _NVCXX_CAPTURE_PACK(As)>
-        friend void tag_invoke(std::execution::set_value_t, receiver_t&& self, As&&... as)
+        friend void tag_invoke(stdexec::set_value_t, receiver_t&& self, As&&... as)
           noexcept requires stdexec::__callable<Fun, Shape, As...> {
           operation_state_base_t<ReceiverId> &op_state = self.op_state_;
 
@@ -60,15 +60,15 @@ namespace bulk {
             }
 
             if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError()); status == cudaSuccess) {
-              op_state.propagate_completion_signal(std::execution::set_value, (As&&)as...);
+              op_state.propagate_completion_signal(stdexec::set_value, (As&&)as...);
             } else {
-              op_state.propagate_completion_signal(std::execution::set_error, std::move(status));
+              op_state.propagate_completion_signal(stdexec::set_error, std::move(status));
             }
           );
         }
 
-      template <stdexec::__one_of<std::execution::set_error_t,
-                                  std::execution::set_stopped_t> Tag, 
+      template <stdexec::__one_of<stdexec::set_error_t,
+                                  stdexec::set_stopped_t> Tag, 
                 class... As _NVCXX_CAPTURE_PACK(As)>
         friend void tag_invoke(Tag tag, receiver_t&& self, As&&... as) noexcept {
           _NVCXX_EXPAND_PACK(As, as,
@@ -76,8 +76,8 @@ namespace bulk {
           );
         }
 
-      friend std::execution::env_of_t<Receiver> tag_invoke(std::execution::get_env_t, const receiver_t& self) {
-        return std::execution::get_env(self.op_state_.receiver_);
+      friend stdexec::env_of_t<Receiver> tag_invoke(stdexec::get_env_t, const receiver_t& self) {
+        return stdexec::get_env(self.op_state_.receiver_);
       }
 
       explicit receiver_t(Shape shape, Fun fun, operation_state_base_t<ReceiverId>& op_state)
@@ -98,16 +98,16 @@ template <class SenderId, std::integral Shape, class FunId>
     Fun fun_;
 
     using set_error_t =
-      std::execution::completion_signatures<
-        std::execution::set_error_t(cudaError_t)>;
+      stdexec::completion_signatures<
+        stdexec::set_error_t(cudaError_t)>;
 
     template <class Receiver>
       using receiver_t = bulk::receiver_t<stdexec::__x<Receiver>, Shape, Fun>;
 
     template <class... Tys>
     using set_value_t =
-      std::execution::completion_signatures<
-        std::execution::set_value_t(Tys...)>;
+      stdexec::completion_signatures<
+        stdexec::set_value_t(Tys...)>;
 
     template <class Self, class Env>
       using completion_signatures =
@@ -117,9 +117,9 @@ template <class SenderId, std::integral Shape, class FunId>
           set_error_t,
           stdexec::__q<set_value_t>>;
 
-    template <stdexec::__decays_to<bulk_sender_t> Self, std::execution::receiver Receiver>
-      requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
-    friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+    template <stdexec::__decays_to<bulk_sender_t> Self, stdexec::receiver Receiver>
+      requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
+    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
       -> stream_op_state_t<stdexec::__member_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<stdexec::__member_t<Self, Sender>>(
             ((Self&&)self).sndr_,
@@ -130,18 +130,18 @@ template <class SenderId, std::integral Shape, class FunId>
       }
 
     template <stdexec::__decays_to<bulk_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
-      -> std::execution::dependent_completion_signatures<Env>;
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
+      -> stdexec::dependent_completion_signatures<Env>;
 
     template <stdexec::__decays_to<bulk_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
       -> completion_signatures<Self, Env> requires true;
 
-    template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+    template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
       requires stdexec::__callable<Tag, const Sender&, As...>
     friend auto tag_invoke(Tag tag, const bulk_sender_t& self, As&&... as)
       noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, std::execution::forwarding_sender_query>, Tag, const Sender&, As...> {
+      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
       return ((Tag&&) tag)(self.sndr_, (As&&) as...);
     }
   };
@@ -186,7 +186,7 @@ namespace multi_gpu_bulk {
 
     public:
       template <class... As _NVCXX_CAPTURE_PACK(As)>
-        friend void tag_invoke(std::execution::set_value_t, receiver_t&& self, As&&... as)
+        friend void tag_invoke(stdexec::set_value_t, receiver_t&& self, As&&... as)
           noexcept requires stdexec::__callable<Fun, Shape, As...> {
           operation_t<SenderId, ReceiverId, Shape, Fun> &op_state = self.op_state_;
 
@@ -240,15 +240,15 @@ namespace multi_gpu_bulk {
             }
 
             if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError()); status == cudaSuccess) {
-              op_state.propagate_completion_signal(std::execution::set_value, (As&&)as...);
+              op_state.propagate_completion_signal(stdexec::set_value, (As&&)as...);
             } else {
-              op_state.propagate_completion_signal(std::execution::set_error, std::move(status));
+              op_state.propagate_completion_signal(stdexec::set_error, std::move(status));
             }
           );
         }
 
-      template <stdexec::__one_of<std::execution::set_error_t,
-                                  std::execution::set_stopped_t> Tag, 
+      template <stdexec::__one_of<stdexec::set_error_t,
+                                  stdexec::set_stopped_t> Tag, 
                 class... As _NVCXX_CAPTURE_PACK(As)>
         friend void tag_invoke(Tag tag, receiver_t&& self, As&&... as) noexcept {
           _NVCXX_EXPAND_PACK(As, as,
@@ -256,8 +256,8 @@ namespace multi_gpu_bulk {
           );
         }
 
-      friend std::execution::env_of_t<Receiver> tag_invoke(std::execution::get_env_t, const receiver_t& self) {
-        return std::execution::get_env(self.op_state_.receiver_);
+      friend stdexec::env_of_t<Receiver> tag_invoke(stdexec::get_env_t, const receiver_t& self) {
+        return stdexec::get_env(self.op_state_.receiver_);
       }
 
       explicit receiver_t(Shape shape, Fun fun, operation_t<SenderId, ReceiverId, Shape, Fun>& op_state)
@@ -288,7 +288,7 @@ namespace multi_gpu_bulk {
             Fun fun)
           : operation_base_t<SenderId, ReceiverId, Shape, Fun>(
               (Sender&&) __sndr,
-              std::execution::get_completion_scheduler<std::execution::set_value_t>(__sndr).hub_,
+              stdexec::get_completion_scheduler<stdexec::set_value_t>(__sndr).hub_,
               (_Receiver2&&)__rcvr,
               [&] (operation_state_base_t<stdexec::__x<_Receiver2>> &) -> receiver_t<SenderId, ReceiverId, Shape, Fun> {
                 return receiver_t<SenderId, ReceiverId, Shape, Fun>(shape, fun, *this);
@@ -339,16 +339,16 @@ template <class SenderId, std::integral Shape, class FunId>
     Fun fun_;
 
     using set_error_t =
-      std::execution::completion_signatures<
-        std::execution::set_error_t(cudaError_t)>;
+      stdexec::completion_signatures<
+        stdexec::set_error_t(cudaError_t)>;
 
     template <class Receiver>
       using receiver_t = multi_gpu_bulk::receiver_t<SenderId, stdexec::__x<Receiver>, Shape, Fun>;
 
     template <class... Tys>
       using set_value_t =
-        std::execution::completion_signatures<
-          std::execution::set_value_t(Tys...)>;
+        stdexec::completion_signatures<
+          stdexec::set_value_t(Tys...)>;
 
     template <class Self, class Env>
       using completion_signatures =
@@ -358,9 +358,9 @@ template <class SenderId, std::integral Shape, class FunId>
           set_error_t,
           stdexec::__q<set_value_t>>;
 
-    template <stdexec::__decays_to<multi_gpu_bulk_sender_t> Self, std::execution::receiver Receiver>
-        requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
-      friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+    template <stdexec::__decays_to<multi_gpu_bulk_sender_t> Self, stdexec::receiver Receiver>
+        requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
+      friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
         -> multi_gpu_bulk::operation_t<stdexec::__x<stdexec::__member_t<Self, Sender>>, stdexec::__x<Receiver>, Shape, Fun> {
         return multi_gpu_bulk::operation_t<stdexec::__x<stdexec::__member_t<Self, Sender>>, stdexec::__x<Receiver>, Shape, Fun>(
             self.num_devices_,
@@ -371,18 +371,18 @@ template <class SenderId, std::integral Shape, class FunId>
         }
 
     template <stdexec::__decays_to<multi_gpu_bulk_sender_t> Self, class Env>
-      friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
-        -> std::execution::dependent_completion_signatures<Env>;
+      friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
+        -> stdexec::dependent_completion_signatures<Env>;
 
     template <stdexec::__decays_to<multi_gpu_bulk_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
       -> completion_signatures<Self, Env> requires true;
 
-    template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+    template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
         requires stdexec::__callable<Tag, const Sender&, As...>
       friend auto tag_invoke(Tag tag, const multi_gpu_bulk_sender_t& self, As&&... as)
         noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, std::execution::forwarding_sender_query>, 
+        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, 
                                       Tag, const Sender&, As...> {
         return ((Tag&&) tag)(self.sndr_, (As&&) as...);
       }

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -89,8 +89,8 @@ namespace nvexec {
         using bind_tuples =
           stdexec::__mbind_front_q<
             variant,
-            ::cuda::std::tuple<std::execution::set_stopped_t>,
-            ::cuda::std::tuple<std::execution::set_error_t, cudaError_t>,
+            ::cuda::std::tuple<stdexec::set_stopped_t>,
+            ::cuda::std::tuple<stdexec::set_error_t, cudaError_t>,
             _Ts...>;
 
       template <class Sender, class Env>
@@ -98,7 +98,7 @@ namespace nvexec {
           stdexec::__value_types_of_t<
             Sender,
             Env,
-            stdexec::__mbind_front_q<decayed_tuple, std::execution::set_value_t>,
+            stdexec::__mbind_front_q<decayed_tuple, stdexec::set_value_t>,
             stdexec::__q<bind_tuples>>;
     }
 
@@ -108,7 +108,7 @@ namespace nvexec {
           Sender,
           Env,
           stdexec::__transform<
-            stdexec::__mbind_front_q<decayed_tuple, std::execution::set_error_t>,
+            stdexec::__mbind_front_q<decayed_tuple, stdexec::set_error_t>,
             stream_storage_impl::bound_values_t<Sender, Env>>>;
 
     inline constexpr get_stream_t get_stream{};
@@ -144,12 +144,12 @@ namespace nvexec {
 
     template <class S>
       concept stream_sender =
-        std::execution::sender<S> &&
+        stdexec::sender<S> &&
         std::is_base_of_v<stream_sender_base, std::decay_t<S>>;
 
     template <class R>
       concept stream_receiver =
-        std::execution::receiver<R> &&
+        stdexec::receiver<R> &&
         std::is_base_of_v<stream_receiver_base, std::decay_t<R>>;
 
     struct stream_op_state_base{};
@@ -165,9 +165,9 @@ namespace nvexec {
         queue::producer_t producer_;
 
       public:
-        template <stdexec::__one_of<std::execution::set_value_t,
-                                    std::execution::set_error_t,
-                                    std::execution::set_stopped_t> Tag,
+        template <stdexec::__one_of<stdexec::set_value_t,
+                                    stdexec::set_error_t,
+                                    stdexec::set_stopped_t> Tag,
                   class... As _NVCXX_CAPTURE_PACK(As)>
           friend void tag_invoke(Tag tag, stream_enqueue_receiver&& self, As&&... as) noexcept {
             _NVCXX_EXPAND_PACK(As, as,
@@ -177,13 +177,13 @@ namespace nvexec {
           }
 
         template <stdexec::__decays_to<std::exception_ptr> E>
-          friend void tag_invoke(std::execution::set_error_t, stream_enqueue_receiver&& self, E&& e) noexcept {
+          friend void tag_invoke(stdexec::set_error_t, stream_enqueue_receiver&& self, E&& e) noexcept {
             // What is `exception_ptr` but death pending
-            self.variant_->template emplace<decayed_tuple<std::execution::set_error_t, cudaError_t>>(std::execution::set_error, cudaErrorUnknown);
+            self.variant_->template emplace<decayed_tuple<stdexec::set_error_t, cudaError_t>>(stdexec::set_error, cudaErrorUnknown);
             self.producer_(self.task_);
           }
 
-        friend Env tag_invoke(std::execution::get_env_t, const stream_enqueue_receiver& self) {
+        friend Env tag_invoke(stdexec::get_env_t, const stream_enqueue_receiver& self) {
           return self.env_;
         }
 
@@ -291,9 +291,9 @@ namespace nvexec {
       struct propagate_receiver_t : stream_receiver_base {
         operation_state_base_t<ReceiverId>& operation_state_;
 
-        template <stdexec::__one_of<std::execution::set_value_t,
-                                    std::execution::set_error_t,
-                                    std::execution::set_stopped_t> Tag,
+        template <stdexec::__one_of<stdexec::set_value_t,
+                                    stdexec::set_error_t,
+                                    stdexec::set_stopped_t> Tag,
                   class... As  _NVCXX_CAPTURE_PACK(As)>
         friend void tag_invoke(Tag tag, propagate_receiver_t&& self, As&&... as) noexcept {
           _NVCXX_EXPAND_PACK(As, as,
@@ -301,9 +301,9 @@ namespace nvexec {
           );
         }
 
-        friend std::execution::env_of_t<stdexec::__t<ReceiverId>>
-        tag_invoke(std::execution::get_env_t, const propagate_receiver_t& self) {
-          return std::execution::get_env(self.operation_state_.receiver_);
+        friend stdexec::env_of_t<stdexec::__t<ReceiverId>>
+        tag_invoke(stdexec::get_env_t, const propagate_receiver_t& self) {
+          return stdexec::get_env(self.operation_state_.receiver_);
         }
       };
 
@@ -312,7 +312,7 @@ namespace nvexec {
         using sender_t = stdexec::__t<SenderId>;
         using inner_receiver_t = stdexec::__t<InnerReceiverId>;
         using outer_receiver_t = stdexec::__t<OuterReceiverId>;
-        using env_t = std::execution::env_of_t<outer_receiver_t>;
+        using env_t = stdexec::env_of_t<outer_receiver_t>;
         using variant_t = variant_storage_t<sender_t, env_t>;
 
         using task_t = continuation_task_t<inner_receiver_t, variant_t>;
@@ -320,15 +320,15 @@ namespace nvexec {
           stream_sender<sender_t>,
           stdexec::__x<inner_receiver_t>,
           stdexec::__x<stream_enqueue_receiver<stdexec::__x<env_t>, stdexec::__x<variant_t>>>>>;
-        using inner_op_state_t = std::execution::connect_result_t<sender_t, intermediate_receiver>;
+        using inner_op_state_t = stdexec::connect_result_t<sender_t, intermediate_receiver>;
 
-        friend void tag_invoke(std::execution::start_t, operation_state_t& op) noexcept {
+        friend void tag_invoke(stdexec::start_t, operation_state_t& op) noexcept {
           op.started_.test_and_set(::cuda::std::memory_order::relaxed);
           op.stream_ = op.get_stream();
 
           if (op.status_ != cudaSuccess) {
             // Couldn't allocate memory for operation state, complete with error
-            op.propagate_completion_signal(std::execution::set_error, std::move(op.status_));
+            op.propagate_completion_signal(stdexec::set_error, std::move(op.status_));
             return;
           }
 
@@ -338,13 +338,13 @@ namespace nvexec {
                     STDEXEC_DBG_ERR(cudaMallocManaged(&op.temp_storage_, inner_receiver_t::memory_allocation_size)); 
                     status != cudaSuccess) {
                 // Couldn't allocate memory for intermediate receiver, complete with error
-                op.propagate_completion_signal(std::execution::set_error, std::move(status));
+                op.propagate_completion_signal(stdexec::set_error, std::move(status));
                 return;
               }
             }
           }
 
-          std::execution::start(op.inner_op_);
+          stdexec::start(op.inner_op_);
         }
 
         cudaStream_t get_stream() {
@@ -369,7 +369,7 @@ namespace nvexec {
           requires stream_sender<sender_t>
         operation_state_t(sender_t&& sender, queue::task_hub_t*, OutR&& out_receiver, ReceiverProvider receiver_provider)
           : operation_state_base_t<OuterReceiverId>((outer_receiver_t&&)out_receiver)
-          , inner_op_{std::execution::connect((sender_t&&)sender, receiver_provider(*this))}
+          , inner_op_{stdexec::connect((sender_t&&)sender, receiver_provider(*this))}
         {}
 
         template <stdexec::__decays_to<outer_receiver_t> OutR, class ReceiverProvider>
@@ -381,9 +381,9 @@ namespace nvexec {
           , task_(queue::make_host<task_t>(this->status_, receiver_provider(*this), storage_.get()).release())
           , started_(ATOMIC_FLAG_INIT)
           , inner_op_{
-              std::execution::connect((sender_t&&)sender,
+              stdexec::connect((sender_t&&)sender,
               stream_enqueue_receiver<stdexec::__x<env_t>, stdexec::__x<variant_t>>{
-                std::execution::get_env(out_receiver), storage_.get(), task_, hub_->producer()})} {
+                stdexec::get_env(out_receiver), storage_.get(), task_, hub_->producer()})} {
           if (this->status_ == cudaSuccess) {
             this->status_ = task_->status_;
           }
@@ -431,17 +431,17 @@ namespace nvexec {
 
     template <class S>
       concept stream_completing_sender =
-        std::execution::sender<S> &&
+        stdexec::sender<S> &&
         requires (const S& sndr) {
-          { std::execution::get_completion_scheduler<std::execution::set_value_t>(sndr).hub_ } -> 
+          { stdexec::get_completion_scheduler<stdexec::set_value_t>(sndr).hub_ } -> 
               std::same_as<queue::task_hub_t*>;
         };
 
     template <class R>
       concept receiver_with_stream_env =
-        std::execution::receiver<R> &&
+        stdexec::receiver<R> &&
         requires (const R& rcvr) {
-          { std::execution::get_scheduler(std::execution::get_env(rcvr)).hub_ } -> 
+          { stdexec::get_scheduler(stdexec::get_env(rcvr)).hub_ } -> 
               std::same_as<queue::task_hub_t*>;
         };
 
@@ -453,7 +453,7 @@ namespace nvexec {
     template <stream_completing_sender Sender, class OuterReceiver, class ReceiverProvider>
       stream_op_state_t<Sender, std::invoke_result_t<ReceiverProvider, operation_state_base_t<stdexec::__x<OuterReceiver>>&>, OuterReceiver>
       stream_op_state(Sender&& sndr, OuterReceiver&& out_receiver, ReceiverProvider receiver_provider) {
-        queue::task_hub_t* hub = std::execution::get_completion_scheduler<std::execution::set_value_t>(sndr).hub_;
+        queue::task_hub_t* hub = stdexec::get_completion_scheduler<stdexec::set_value_t>(sndr).hub_;
 
         return stream_op_state_t<
           Sender,

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -51,17 +51,17 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         stdexec::__decayed_tuple<_Ts...> operator()(_Ts&&...) const;
     };
 
-    template <std::execution::sender, class, class>
+    template <stdexec::sender, class, class>
       struct __which_tuple : __which_tuple_base {};
 
     template <class _Sender, class _Env>
-        requires std::execution::sender<_Sender, _Env>
-      struct __which_tuple<_Sender, _Env, std::execution::set_value_t>
-        : std::execution::value_types_of_t<_Sender, _Env, __as_tuple, __which_tuple_> {};
+        requires stdexec::sender<_Sender, _Env>
+      struct __which_tuple<_Sender, _Env, stdexec::set_value_t>
+        : stdexec::value_types_of_t<_Sender, _Env, __as_tuple, __which_tuple_> {};
 
     template <class _Sender, class _Env>
-        requires std::execution::sender<_Sender, _Env>
-      struct __which_tuple<_Sender, _Env, std::execution::set_error_t>
+        requires stdexec::sender<_Sender, _Env>
+      struct __which_tuple<_Sender, _Env, stdexec::set_error_t>
         : stdexec::__error_types_of_t<
             _Sender,
             _Env,
@@ -96,12 +96,12 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       using __result_sender_t = std::decay_t<stdexec::__call_result_t<_Fun, __decay_ref<_As>...>>;
 
     template <class _Sender, class _Receiver, class _Fun, class _SetTag>
-        requires std::execution::sender<_Sender, std::execution::env_of_t<_Receiver>>
+        requires stdexec::sender<_Sender, stdexec::env_of_t<_Receiver>>
       struct __storage {
         template <class... _As>
           struct __op_state_for_ {
             using __t =
-              std::execution::connect_result_t<
+              stdexec::connect_result_t<
                 __result_sender_t<_Fun, _As...>,
                 propagate_receiver_t<stdexec::__x<_Receiver>>>;
           };
@@ -111,16 +111,16 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         // Compute a variant of tuples to hold all the values of the input
         // sender:
         using __args_t =
-          stdexec::__gather_sigs_t<_SetTag, _Sender, std::execution::env_of_t<_Receiver>, stdexec::__q<stdexec::__decayed_tuple>, stdexec::__nullable_variant_t>;
+          stdexec::__gather_sigs_t<_SetTag, _Sender, stdexec::env_of_t<_Receiver>, stdexec::__q<stdexec::__decayed_tuple>, stdexec::__nullable_variant_t>;
 
         // Compute a variant of operation states:
         using __op_state3_t =
-          stdexec::__gather_sigs_t<_SetTag, _Sender, std::execution::env_of_t<_Receiver>, stdexec::__q<__op_state_for_t>, stdexec::__nullable_variant_t>;
+          stdexec::__gather_sigs_t<_SetTag, _Sender, stdexec::env_of_t<_Receiver>, stdexec::__q<__op_state_for_t>, stdexec::__nullable_variant_t>;
         __op_state3_t __op_state3_;
       };
 
     template <class _Sender, class _Receiver, class _Fun, class _SetTag>
-        requires std::execution::sender<_Sender, std::execution::env_of_t<_Receiver>>
+        requires stdexec::sender<_Sender, stdexec::env_of_t<_Receiver>>
       struct __max_sender_size {
         template <class... _As>
           struct __sender_size_for_ {
@@ -130,7 +130,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           using __sender_size_for_t = stdexec::__t<__sender_size_for_<_As...>>;
 
         static constexpr std::size_t value =
-          stdexec::__v<stdexec::__gather_sigs_t<_SetTag, _Sender, std::execution::env_of_t<_Receiver>, stdexec::__q<__sender_size_for_t>, stdexec::__q<max_in_pack>>>;
+          stdexec::__v<stdexec::__gather_sigs_t<_SetTag, _Sender, stdexec::env_of_t<_Receiver>, stdexec::__q<__sender_size_for_t>, stdexec::__q<max_in_pack>>>;
       };
 
     template <class _Env, class _Fun, class _Set, class _Sig>
@@ -139,19 +139,19 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     template <class _Env, class _Fun, class _Set, class _Ret, class... _Args>
         requires (!std::same_as<_Set, _Ret>)
       struct __tfx_signal_impl<_Env, _Fun, _Set, _Ret(_Args...)> {
-        using __t = std::execution::completion_signatures<_Ret(_Args...)>;
+        using __t = stdexec::completion_signatures<_Ret(_Args...)>;
       };
 
     template <class _Env, class _Fun, class _Set, class... _Args>
         requires std::invocable<_Fun, __decay_ref<_Args>...> &&
-          std::execution::sender<std::invoke_result_t<_Fun, __decay_ref<_Args>...>, _Env>
+          stdexec::sender<std::invoke_result_t<_Fun, __decay_ref<_Args>...>, _Env>
       struct __tfx_signal_impl<_Env, _Fun, _Set, _Set(_Args...)> {
         using __t =
-          std::execution::make_completion_signatures<
+          stdexec::make_completion_signatures<
             __result_sender_t<_Fun, _Args...>,
             _Env,
             // because we don't know if connect-ing the result sender will throw:
-            std::execution::completion_signatures<std::execution::set_error_t(std::exception_ptr)>>;
+            stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>>;
       };
 
     template <class _SenderId, class _ReceiverId, class _FunId, class _Let>
@@ -162,7 +162,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         using _Sender = stdexec::__t<_SenderId>;
         using _Receiver = stdexec::__t<_ReceiverId>;
         using _Fun = stdexec::__t<_FunId>;
-        using _Env = std::execution::env_of_t<_Receiver>;
+        using _Env = stdexec::env_of_t<_Receiver>;
 
         constexpr static std::size_t memory_allocation_size = 
           stdexec::__v<__max_sender_size<_Sender, _Receiver, _Fun, _Let>>;
@@ -173,20 +173,20 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
         template <class... _As>
           using __op_state_for_t =
-            stdexec::__minvoke2<stdexec::__q2<std::execution::connect_result_t>, __result_sender_t<_Fun, _As...>, propagate_receiver_t<_ReceiverId>>;
+            stdexec::__minvoke2<stdexec::__q2<stdexec::connect_result_t>, __result_sender_t<_Fun, _As...>, propagate_receiver_t<_ReceiverId>>;
 
         // handle the case when let_error is used with an input sender that
         // never completes with set_error(exception_ptr)
         template <stdexec::__decays_to<std::exception_ptr> _Error>
-            requires std::same_as<_Let, std::execution::set_error_t> &&
+            requires std::same_as<_Let, stdexec::set_error_t> &&
               (!stdexec::__v<stdexec::__error_types_of_t<_Sender, _Env, stdexec::__transform<stdexec::__q1<std::decay_t>, stdexec::__contains<std::exception_ptr>>>>)
-          friend void tag_invoke(std::execution::set_error_t, __receiver&& __self, _Error&& __err) noexcept {
-            __self.__op_state_->propagate_completion_signal(std::execution::set_error, (_Error&&) __err);
+          friend void tag_invoke(stdexec::set_error_t, __receiver&& __self, _Error&& __err) noexcept {
+            __self.__op_state_->propagate_completion_signal(stdexec::set_error, (_Error&&) __err);
           }
 
         template <stdexec::__one_of<_Let> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
             requires __applyable<_Fun, __which_tuple_t<_As...>&> &&
-              std::execution::sender_to<__apply_result_t<_Fun, __which_tuple_t<_As...>&>, _Receiver>
+              stdexec::sender_to<__apply_result_t<_Fun, __which_tuple_t<_As...>&>, _Receiver>
           friend void tag_invoke(_Tag, __receiver&& __self, _As&&... __as) noexcept {
             _NVCXX_EXPAND_PACK(_As, __as,
               using __tuple_t = __which_tuple_t<_As...>;
@@ -204,7 +204,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
               if (cudaError_t status = STDEXEC_DBG_ERR(cudaStreamSynchronize(stream)); status == cudaSuccess) {
                 auto& __op = __self.__op_state_->__storage_.__op_state3_.template emplace<__op_state_t>(
                   stdexec::__conv{[&] {
-                    return std::execution::connect(
+                    return stdexec::connect(
                         *result_sender,
                         propagate_receiver_t<_ReceiverId>{
                           {},
@@ -212,15 +212,15 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                               *__self.__op_state_)});
                   }}
                 );
-                std::execution::start(__op);
+                stdexec::start(__op);
               } else {
                 __self.__op_state_->propagate_completion_signal(
-                    std::execution::set_error, std::move(status));
+                    stdexec::set_error, std::move(status));
               }
             )
           }
 
-        template <stdexec::__one_of<std::execution::set_value_t, std::execution::set_error_t, std::execution::set_stopped_t> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
+        template <stdexec::__one_of<stdexec::set_value_t, stdexec::set_error_t, stdexec::set_stopped_t> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
             requires stdexec::__none_of<_Tag, _Let> && stdexec::__callable<_Tag, _Receiver, _As...>
           friend void tag_invoke(_Tag __tag, __receiver&& __self, _As&&... __as) noexcept {
             _NVCXX_EXPAND_PACK(_As, __as,
@@ -229,9 +229,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             )
           }
 
-        friend auto tag_invoke(std::execution::get_env_t, const __receiver& __self)
-          -> std::execution::env_of_t<_Receiver> {
-          return std::execution::get_env(__self.__op_state_->receiver_);
+        friend auto tag_invoke(stdexec::get_env_t, const __receiver& __self)
+          -> stdexec::env_of_t<_Receiver> {
+          return stdexec::get_env(__self.__op_state_->receiver_);
         }
 
         __operation<_SenderId, _ReceiverId, _FunId, _Let>* __op_state_;
@@ -255,7 +255,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           __operation(_Sender&& __sndr, _Receiver2&& __rcvr, _Fun __fun)
             : __operation_base<_SenderId, _ReceiverId, _FunId, _Let>(
                 (_Sender&&) __sndr,
-                std::execution::get_completion_scheduler<std::execution::set_value_t>(__sndr).hub_,
+                stdexec::get_completion_scheduler<stdexec::set_value_t>(__sndr).hub_,
                 (_Receiver2&&)__rcvr,
                 [this] (operation_state_base_t<stdexec::__x<_Receiver2>> &) -> __receiver_t {
                   return __receiver_t{{}, this};
@@ -299,8 +299,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         using __with_error =
           stdexec::__if_c<
             stdexec::__sends<_Set, _Sender, _Env>,
-            stdexec::completion_signatures<std::execution::set_error_t(cudaError_t)>,
-            std::execution::completion_signatures<>>;
+            stdexec::completion_signatures<stdexec::set_error_t(cudaError_t)>,
+            stdexec::completion_signatures<>>;
 
       template <class _Sender, class _Env>
         using __completions =
@@ -308,12 +308,12 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             stdexec::__transform<
               __tfx_signal<_Env>,
               stdexec::__mbind_front_q<stdexec::__concat_completion_signatures_t, __with_error<_Sender, _Env>>>,
-            std::execution::completion_signatures_of_t<_Sender, _Env>>;
+            stdexec::completion_signatures_of_t<_Sender, _Env>>;
 
-      template <stdexec::__decays_to<let_sender_t> _Self, std::execution::receiver _Receiver>
+      template <stdexec::__decays_to<let_sender_t> _Self, stdexec::receiver _Receiver>
           requires
-            std::execution::sender_to<stdexec::__member_t<_Self, _Sender>, __receiver_t<_Self, _Receiver>>
-        friend auto tag_invoke(std::execution::connect_t, _Self&& __self, _Receiver&& __rcvr)
+            stdexec::sender_to<stdexec::__member_t<_Self, _Sender>, __receiver_t<_Self, _Receiver>>
+        friend auto tag_invoke(stdexec::connect_t, _Self&& __self, _Receiver&& __rcvr)
           -> __operation_t<_Self, _Receiver> {
           return __operation_t<_Self, _Receiver>{
               ((_Self&&) __self).__sndr_,
@@ -322,21 +322,21 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           };
         }
 
-      template <stdexec::tag_category<std::execution::forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
+      template <stdexec::tag_category<stdexec::forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
           requires stdexec::__callable<_Tag, const _Sender&, _As...>
         friend auto tag_invoke(_Tag __tag, const let_sender_t& __self, _As&&... __as)
           noexcept(stdexec::__nothrow_callable<_Tag, const _Sender&, _As...>)
-          -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, std::execution::forwarding_sender_query>, _Tag, const _Sender&, _As...> {
+          -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, stdexec::forwarding_sender_query>, _Tag, const _Sender&, _As...> {
           _NVCXX_EXPAND_PACK_RETURN(_As, __as,
             return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
           )
         }
 
       template <stdexec::__decays_to<let_sender_t> _Self, class _Env>
-        friend auto tag_invoke(std::execution::get_completion_signatures_t, _Self&&, _Env)
-          -> std::execution::dependent_completion_signatures<_Env>;
+        friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env)
+          -> stdexec::dependent_completion_signatures<_Env>;
       template <stdexec::__decays_to<let_sender_t> _Self, class _Env>
-        friend auto tag_invoke(std::execution::get_completion_signatures_t, _Self&&, _Env)
+        friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env)
           -> __completions<stdexec::__member_t<_Self, _Sender>, _Env> requires true;
 
       _Sender __sndr_;

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -75,9 +75,9 @@ namespace reduce_ {
         static constexpr std::size_t value =
           stdexec::__v<
             stdexec::__gather_sigs_t<
-              std::execution::set_value_t, 
+              stdexec::set_value_t, 
               Sender,  
-              std::execution::env_of_t<Receiver>, 
+              stdexec::env_of_t<Receiver>, 
               stdexec::__q<result_size_for_t>, 
               stdexec::__q<max_in_pack>>>;
       };
@@ -90,7 +90,7 @@ namespace reduce_ {
       constexpr static std::size_t memory_allocation_size = max_result_size::value;
 
       template <class Range>
-      friend void tag_invoke(std::execution::set_value_t, receiver_t&& self, Range&& range) noexcept {
+      friend void tag_invoke(stdexec::set_value_t, receiver_t&& self, Range&& range) noexcept {
         cudaStream_t stream = self.op_state_.stream_;
 
         using Result = ::cuda::std::decay_t<
@@ -135,14 +135,14 @@ namespace reduce_ {
         } while(false);
 
         if (status == cudaSuccess) {
-          self.op_state_.propagate_completion_signal(std::execution::set_value, *d_out);
+          self.op_state_.propagate_completion_signal(stdexec::set_value, *d_out);
         } else {
-          self.op_state_.propagate_completion_signal(std::execution::set_error, std::move(status));
+          self.op_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
         }
       }
 
-      template <stdexec::__one_of<std::execution::set_error_t,
-                              std::execution::set_stopped_t> Tag,
+      template <stdexec::__one_of<stdexec::set_error_t,
+                              stdexec::set_stopped_t> Tag,
                 class... As _NVCXX_CAPTURE_PACK(As)>
         friend void tag_invoke(Tag tag, receiver_t&& self, As&&... as) noexcept {
           _NVCXX_EXPAND_PACK(As, as,
@@ -150,8 +150,8 @@ namespace reduce_ {
           );
         }
 
-      friend std::execution::env_of_t<Receiver> tag_invoke(std::execution::get_env_t, const receiver_t& self) {
-        return std::execution::get_env(self.op_state_.receiver_);
+      friend stdexec::env_of_t<Receiver> tag_invoke(stdexec::get_env_t, const receiver_t& self) {
+        return stdexec::get_env(self.op_state_.receiver_);
       }
 
       receiver_t(Fun fun, operation_state_base_t<ReceiverId> &op_state)
@@ -178,7 +178,7 @@ template <class SenderId, class FunId>
     template <class... Range>
         requires (sizeof...(Range) == 1)
       using set_value_t =
-        std::execution::completion_signatures<std::execution::set_value_t(
+        stdexec::completion_signatures<stdexec::set_value_t(
           std::add_lvalue_reference_t<
             ::cuda::std::decay_t<
               ::cuda::std::invoke_result_t<Fun, decltype(*__begin(std::declval<Range>())), decltype(*__begin(std::declval<Range>()))>
@@ -188,16 +188,16 @@ template <class SenderId, class FunId>
 
     template <class Self, class Env>
       using completion_signatures =
-        std::execution::make_completion_signatures<
+        stdexec::make_completion_signatures<
           stdexec::__member_t<Self, Sender>,
           Env,
-          std::execution::completion_signatures<std::execution::set_error_t(cudaError_t)>,
+          stdexec::completion_signatures<stdexec::set_error_t(cudaError_t)>,
           set_value_t
           >;
 
-    template <stdexec::__decays_to<reduce_sender_t> Self, std::execution::receiver Receiver>
-      requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
-    friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+    template <stdexec::__decays_to<reduce_sender_t> Self, stdexec::receiver Receiver>
+      requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
+    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
       -> stream_op_state_t<stdexec::__member_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<stdexec::__member_t<Self, Sender>>(
           ((Self&&)self).sndr_,
@@ -208,18 +208,18 @@ template <class SenderId, class FunId>
     }
 
     template <stdexec::__decays_to<reduce_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
-      -> std::execution::dependent_completion_signatures<Env>;
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
+      -> stdexec::dependent_completion_signatures<Env>;
 
     template <stdexec::__decays_to<reduce_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
       -> completion_signatures<Self, Env> requires true;
 
-    template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+    template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
       requires stdexec::__callable<Tag, const Sender&, As...>
     friend auto tag_invoke(Tag tag, const reduce_sender_t& self, As&&... as)
       noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, std::execution::forwarding_sender_query>, Tag, const Sender&, As...> {
+      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
       return ((Tag&&) tag)(self.sndr_, (As&&) as...);
     }
   };
@@ -231,7 +231,7 @@ struct reduce_t {
         stdexec::__x<std::remove_cvref_t<Sender>>,
         stdexec::__x<std::remove_cvref_t<Fun>>>;
 
-  template <std::execution::sender Sender, stdexec::__movable_value Fun>
+  template <stdexec::sender Sender, stdexec::__movable_value Fun>
     __sender<Sender, Fun> operator()(Sender&& __sndr, Fun __fun) const {
       return __sender<Sender, Fun>{{}, (Sender&&) __sndr, (Fun&&) __fun};
     }

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -29,16 +29,16 @@ namespace schedule_from {
     struct receiver_t : stream_receiver_base {
       using Sender = stdexec::__t<SenderId>;
       using Receiver = stdexec::__t<ReceiverId>;
-      using Env = std::execution::env_of_t<Receiver>;
+      using Env = stdexec::env_of_t<Receiver>;
       using storage_t = variant_storage_t<Sender, Env>;
 
       constexpr static std::size_t memory_allocation_size = sizeof(storage_t);
 
       operation_state_base_t<ReceiverId>& operation_state_;
 
-      template <stdexec::__one_of<std::execution::set_value_t,
-                                  std::execution::set_error_t,
-                                  std::execution::set_stopped_t> Tag,
+      template <stdexec::__one_of<stdexec::set_value_t,
+                                  stdexec::set_error_t,
+                                  stdexec::set_stopped_t> Tag,
                 class... As  _NVCXX_CAPTURE_PACK(As)>
       friend void tag_invoke(Tag tag, receiver_t&& self, As&&... as) noexcept {
         auto stream = self.operation_state_.stream_;
@@ -54,33 +54,33 @@ namespace schedule_from {
         );
       }
 
-      friend std::execution::env_of_t<stdexec::__t<ReceiverId>>
-      tag_invoke(std::execution::get_env_t, const receiver_t& self) {
-        return std::execution::get_env(self.operation_state_.receiver_);
+      friend stdexec::env_of_t<stdexec::__t<ReceiverId>>
+      tag_invoke(stdexec::get_env_t, const receiver_t& self) {
+        return stdexec::get_env(self.operation_state_.receiver_);
       }
     };
 
   template <class Sender>
     struct source_sender_t : stream_sender_base {
-      template <stdexec::__decays_to<source_sender_t> Self, std::execution::receiver Receiver>
-      friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
-        -> std::execution::connect_result_t<stdexec::__member_t<Self, Sender>, Receiver> {
-          return std::execution::connect(((Self&&)self).sender_, (Receiver&&)rcvr);
+      template <stdexec::__decays_to<source_sender_t> Self, stdexec::receiver Receiver>
+      friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
+        -> stdexec::connect_result_t<stdexec::__member_t<Self, Sender>, Receiver> {
+          return stdexec::connect(((Self&&)self).sender_, (Receiver&&)rcvr);
         }
 
-      template <stdexec::tag_category<std::execution::forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
+      template <stdexec::tag_category<stdexec::forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
         requires stdexec::__callable<_Tag, const Sender&, _As...>
       friend auto tag_invoke(_Tag __tag, const source_sender_t& __self, _As&&... __as)
         noexcept(stdexec::__nothrow_callable<_Tag, const Sender&, _As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, std::execution::forwarding_sender_query>, _Tag, const Sender&, _As...> {
+        -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, stdexec::forwarding_sender_query>, _Tag, const Sender&, _As...> {
         _NVCXX_EXPAND_PACK_RETURN(_As, _as,
           return ((_Tag&&) __tag)(__self.sender_, (_As&&) __as...);
         )
       }
 
       template <stdexec::__decays_to<source_sender_t> _Self, class _Env>
-        friend auto tag_invoke(std::execution::get_completion_signatures_t, _Self&&, _Env) ->
-          std::execution::make_completion_signatures<
+        friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env) ->
+          stdexec::make_completion_signatures<
             stdexec::__member_t<_Self, Sender>,
             _Env>;
 
@@ -101,9 +101,9 @@ template <class Scheduler, class SenderId>
         stdexec::__x<stdexec::__member_t<Self, Sender>>, 
         stdexec::__x<Receiver>>;
 
-    template <stdexec::__decays_to<schedule_from_sender_t> Self, std::execution::receiver Receiver>
-      requires std::execution::sender_to<stdexec::__member_t<Self, source_sender_th>, Receiver>
-    friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+    template <stdexec::__decays_to<schedule_from_sender_t> Self, stdexec::receiver Receiver>
+      requires stdexec::sender_to<stdexec::__member_t<Self, source_sender_th>, Receiver>
+    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
       -> stream_op_state_t<stdexec::__member_t<Self, source_sender_th>, receiver_t<Self, Receiver>, Receiver> {
         return stream_op_state<stdexec::__member_t<Self, source_sender_th>>(
             self.hub_,
@@ -114,27 +114,27 @@ template <class Scheduler, class SenderId>
             });
     }
 
-    template <stdexec::__one_of<std::execution::set_value_t, std::execution::set_stopped_t, std::execution::set_error_t> _Tag>
-    friend Scheduler tag_invoke(std::execution::get_completion_scheduler_t<_Tag>, const schedule_from_sender_t& __self) noexcept {
+    template <stdexec::__one_of<stdexec::set_value_t, stdexec::set_stopped_t, stdexec::set_error_t> _Tag>
+    friend Scheduler tag_invoke(stdexec::get_completion_scheduler_t<_Tag>, const schedule_from_sender_t& __self) noexcept {
       return {__self.hub_};
     }
 
-    template <stdexec::tag_category<std::execution::forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
+    template <stdexec::tag_category<stdexec::forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
       requires stdexec::__callable<_Tag, const Sender&, _As...>
     friend auto tag_invoke(_Tag __tag, const schedule_from_sender_t& __self, _As&&... __as)
       noexcept(stdexec::__nothrow_callable<_Tag, const Sender&, _As...>)
-      -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, std::execution::forwarding_sender_query>, _Tag, const Sender&, _As...> {
+      -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, stdexec::forwarding_sender_query>, _Tag, const Sender&, _As...> {
       _NVCXX_EXPAND_PACK_RETURN(_As, _as,
         return ((_Tag&&) __tag)(__self.sndr_, (_As&&) __as...);
       )
     }
 
     template <stdexec::__decays_to<schedule_from_sender_t> _Self, class _Env>
-      friend auto tag_invoke(std::execution::get_completion_signatures_t, _Self&&, _Env) ->
-        std::execution::make_completion_signatures<
+      friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env) ->
+        stdexec::make_completion_signatures<
           stdexec::__member_t<_Self, Sender>,
           _Env,
-          std::execution::completion_signatures<std::execution::set_error_t(cudaError_t)>>;
+          stdexec::completion_signatures<stdexec::set_error_t(cudaError_t)>>;
 
     schedule_from_sender_t(queue::task_hub_t* hub, Sender sndr)
       : hub_(hub)

--- a/include/nvexec/stream/start_detached.cuh
+++ b/include/nvexec/stream/start_detached.cuh
@@ -23,14 +23,14 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS::start_detached {
 
 struct detached_receiver_t : stream_receiver_base {
-  friend void tag_invoke(std::execution::set_value_t, detached_receiver_t&&, auto&&...) noexcept {}
+  friend void tag_invoke(stdexec::set_value_t, detached_receiver_t&&, auto&&...) noexcept {}
 
   [[noreturn]]
-  friend void tag_invoke(std::execution::set_error_t, detached_receiver_t&&, auto&&) noexcept {
+  friend void tag_invoke(stdexec::set_error_t, detached_receiver_t&&, auto&&) noexcept {
     std::terminate();
   }
-  friend void tag_invoke(std::execution::set_stopped_t, detached_receiver_t&&) noexcept {}
-  friend stdexec::__empty_env tag_invoke(std::execution::get_env_t, const detached_receiver_t&) noexcept {
+  friend void tag_invoke(stdexec::set_stopped_t, detached_receiver_t&&) noexcept {}
+  friend stdexec::__empty_env tag_invoke(stdexec::get_env_t, const detached_receiver_t&) noexcept {
     return {};
   }
 };

--- a/include/nvexec/stream/submit.cuh
+++ b/include/nvexec/stream/submit.cuh
@@ -29,7 +29,7 @@ struct op_state_t {
   struct receiver_t : stream_receiver_base {
     op_state_t* op_state_;
 
-    template <stdexec::__one_of<std::execution::set_value_t, std::execution::set_error_t, std::execution::set_stopped_t> Tag, class... As>
+    template <stdexec::__one_of<stdexec::set_value_t, stdexec::set_error_t, stdexec::set_stopped_t> Tag, class... As>
       requires stdexec::__callable<Tag, Receiver, As...>
     friend void tag_invoke(Tag tag, receiver_t&& self, As&&... as)
         noexcept(stdexec::__nothrow_callable<Tag, Receiver, As...>) {
@@ -38,25 +38,25 @@ struct op_state_t {
       return tag((Receiver&&) self.op_state_->rcvr_, (As&&) as...);
     }
     // Forward all receiever queries.
-    friend auto tag_invoke(std::execution::get_env_t, const receiver_t& self)
-      -> std::execution::env_of_t<Receiver> {
-      return std::execution::get_env((const Receiver&) self.op_state_->rcvr_);
+    friend auto tag_invoke(stdexec::get_env_t, const receiver_t& self)
+      -> stdexec::env_of_t<Receiver> {
+      return stdexec::get_env((const Receiver&) self.op_state_->rcvr_);
     }
   };
   Receiver rcvr_;
-  std::execution::connect_result_t<Sender, receiver_t> op_state_;
+  stdexec::connect_result_t<Sender, receiver_t> op_state_;
 
   template <stdexec::__decays_to<Receiver> CvrefReceiver>
   op_state_t(Sender&& sndr, CvrefReceiver&& rcvr)
     : rcvr_((CvrefReceiver&&) rcvr)
-    , op_state_(std::execution::connect((Sender&&) sndr, receiver_t{{}, this}))
+    , op_state_(stdexec::connect((Sender&&) sndr, receiver_t{{}, this}))
   {}
 };
 
 struct submit_t {
-  template <std::execution::receiver Receiver, std::execution::sender_to<Receiver> Sender>
+  template <stdexec::receiver Receiver, stdexec::sender_to<Receiver> Sender>
   void operator()(Sender&& sndr, Receiver&& rcvr) const noexcept(false) {
-    std::execution::start((new op_state_t<stdexec::__x<Sender>, stdexec::__x<std::decay_t<Receiver>>>{
+    stdexec::start((new op_state_t<stdexec::__x<Sender>, stdexec::__x<std::decay_t<Receiver>>>{
         (Sender&&) sndr, (Receiver&&) rcvr})->op_state_);
   }
 };

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -24,24 +24,24 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace sync_wait {
     namespace __impl {
       struct __env {
-        std::execution::run_loop::__scheduler __sched_;
+        stdexec::run_loop::__scheduler __sched_;
 
-        friend auto tag_invoke(std::execution::get_scheduler_t, const __env& __self) noexcept
-          -> std::execution::run_loop::__scheduler {
+        friend auto tag_invoke(stdexec::get_scheduler_t, const __env& __self) noexcept
+          -> stdexec::run_loop::__scheduler {
           return __self.__sched_;
         }
 
-        friend auto tag_invoke(std::execution::get_delegatee_scheduler_t, const __env& __self) noexcept
-          -> std::execution::run_loop::__scheduler {
+        friend auto tag_invoke(stdexec::get_delegatee_scheduler_t, const __env& __self) noexcept
+          -> stdexec::run_loop::__scheduler {
           return __self.__sched_;
         }
       };
 
       // What should sync_wait(just_stopped()) return?
       template <class Sender>
-          requires std::execution::sender<Sender, __env>
+          requires stdexec::sender<Sender, __env>
         using sync_wait_result_t =
-          std::execution::value_types_of_t<
+          stdexec::value_types_of_t<
             Sender,
             __env,
             stdexec::__decayed_tuple,
@@ -55,7 +55,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           using Sender = stdexec::__t<SenderId>;
 
           state_t<SenderId>* state_;
-          std::execution::run_loop* loop_;
+          stdexec::run_loop* loop_;
 
           template <class Error>
             void set_error(Error err) noexcept {
@@ -70,7 +70,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
           template <class Sender2 = Sender, class... As _NVCXX_CAPTURE_PACK(As)>
               requires std::constructible_from<sync_wait_result_t<Sender2>, As...>
-            friend void tag_invoke(std::execution::set_value_t, receiver_t&& rcvr, As&&... as) noexcept try {
+            friend void tag_invoke(stdexec::set_value_t, receiver_t&& rcvr, As&&... as) noexcept try {
               if (cudaError_t status = STDEXEC_DBG_ERR(cudaStreamSynchronize(rcvr.state_->stream_));
                   status == cudaSuccess) {
                 _NVCXX_EXPAND_PACK(As, as,
@@ -85,7 +85,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             }
 
           template <class Error>
-            friend void tag_invoke(std::execution::set_error_t, receiver_t&& rcvr, Error err) noexcept {
+            friend void tag_invoke(stdexec::set_error_t, receiver_t&& rcvr, Error err) noexcept {
               if (cudaError_t status = STDEXEC_DBG_ERR(cudaStreamSynchronize(rcvr.state_->stream_));
                   status == cudaSuccess) {
                 rcvr.set_error((Error &&) err);
@@ -94,7 +94,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
               }
             }
 
-          friend void tag_invoke(std::execution::set_stopped_t __d, receiver_t&& rcvr) noexcept {
+          friend void tag_invoke(stdexec::set_stopped_t __d, receiver_t&& rcvr) noexcept {
             if (cudaError_t status = STDEXEC_DBG_ERR(cudaStreamSynchronize(rcvr.state_->stream_));
                 status == cudaSuccess) {
               rcvr.state_->data_.template emplace<3>(__d);
@@ -105,7 +105,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           }
 
           friend stdexec::__empty_env
-          tag_invoke(std::execution::get_env_t, const receiver_t& rcvr) noexcept {
+          tag_invoke(stdexec::get_env_t, const receiver_t& rcvr) noexcept {
             return {};
           }
         };
@@ -115,7 +115,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           using _Tuple = sync_wait_result_t<stdexec::__t<SenderId>>;
 
           cudaStream_t stream_{};
-          std::variant<std::monostate, _Tuple, cudaError_t, std::execution::set_stopped_t> data_{};
+          std::variant<std::monostate, _Tuple, cudaError_t, stdexec::set_stopped_t> data_{};
         };
     } // namespace __impl
 
@@ -123,21 +123,21 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <stdexec::__single_value_variant_sender<__impl::__env> Sender>
         requires
           (!stdexec::__tag_invocable_with_completion_scheduler<
-            sync_wait_t, std::execution::set_value_t, Sender>) &&
+            sync_wait_t, stdexec::set_value_t, Sender>) &&
           (!std::tag_invocable<sync_wait_t, Sender>) &&
-          std::execution::sender<Sender, __impl::__env> &&
-          std::execution::sender_to<Sender, __impl::receiver_t<stdexec::__x<Sender>>>
+          stdexec::sender<Sender, __impl::__env> &&
+          stdexec::sender_to<Sender, __impl::receiver_t<stdexec::__x<Sender>>>
       auto operator()(queue::task_hub_t* hub, Sender&& __sndr) const
         -> std::optional<__impl::sync_wait_result_t<Sender>> {
         using state_t = __impl::state_t<stdexec::__x<Sender>>;
         state_t state {};
-        std::execution::run_loop loop;
+        stdexec::run_loop loop;
 
         exit_operation_state_t<Sender, __impl::receiver_t<stdexec::__x<Sender>>> __op_state =
           exit_op_state(hub, (Sender&&)__sndr, __impl::receiver_t<stdexec::__x<Sender>>{{}, &state, &loop});
         state.stream_ = __op_state.get_stream();
 
-        std::execution::start(__op_state);
+        stdexec::start(__op_state);
 
         // Wait for the variant to be filled in.
         loop.run();

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -47,7 +47,7 @@ template <std::size_t MemoryAllocationSize, class ReceiverId, class Fun>
     constexpr static std::size_t memory_allocation_size = MemoryAllocationSize;
 
     template <class... As _NVCXX_CAPTURE_PACK(As)>
-      friend void tag_invoke(std::execution::set_value_t, receiver_t&& self, As&&... as)
+      friend void tag_invoke(stdexec::set_value_t, receiver_t&& self, As&&... as)
         noexcept requires std::invocable<Fun, std::add_rvalue_reference_t<std::decay_t<As>>...> {
 
         _NVCXX_EXPAND_PACK(As, as,
@@ -60,25 +60,25 @@ template <std::size_t MemoryAllocationSize, class ReceiverId, class Fun>
             kernel<std::decay_t<Fun>, As...><<<1, 1, 0, stream>>>(self.f_, (As&&)as...);
 
             if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError()); status == cudaSuccess) {
-              op_state.propagate_completion_signal(std::execution::set_value);
+              op_state.propagate_completion_signal(stdexec::set_value);
             } else {
-              op_state.propagate_completion_signal(std::execution::set_error, std::move(status));
+              op_state.propagate_completion_signal(stdexec::set_error, std::move(status));
             }
           } else {
             result_t *d_result = reinterpret_cast<result_t*>(op_state.temp_storage_);
             kernel_with_result<std::decay_t<Fun>, result_t, As...><<<1, 1, 0, stream>>>(self.f_, d_result, (As&&)as...);
 
             if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError()); status == cudaSuccess) {
-              op_state.propagate_completion_signal(std::execution::set_value, *d_result);
+              op_state.propagate_completion_signal(stdexec::set_value, *d_result);
             } else {
-              op_state.propagate_completion_signal(std::execution::set_error, std::move(status));
+              op_state.propagate_completion_signal(stdexec::set_error, std::move(status));
             }
           }
         );
       }
 
-    template <stdexec::__one_of<std::execution::set_error_t,
-                                std::execution::set_stopped_t> Tag,
+    template <stdexec::__one_of<stdexec::set_error_t,
+                                stdexec::set_stopped_t> Tag,
               class... As _NVCXX_CAPTURE_PACK(As)>
       friend void tag_invoke(Tag tag, receiver_t&& self, As&&... as) noexcept {
         _NVCXX_EXPAND_PACK(As, as,
@@ -86,8 +86,8 @@ template <std::size_t MemoryAllocationSize, class ReceiverId, class Fun>
         );
       }
 
-    friend std::execution::env_of_t<Receiver> tag_invoke(std::execution::get_env_t, const receiver_t& self) {
-      return std::execution::get_env(self.op_state_.receiver_);
+    friend stdexec::env_of_t<Receiver> tag_invoke(stdexec::get_env_t, const receiver_t& self) {
+      return stdexec::get_env(self.op_state_.receiver_);
     }
 
     explicit receiver_t(Fun fun, operation_state_base_t<ReceiverId> &op_state)
@@ -127,7 +127,7 @@ template <class SenderId, class FunId>
       };
 
     template <class Receiver>
-        requires std::execution::sender<Sender, std::execution::env_of_t<Receiver>>
+        requires stdexec::sender<Sender, stdexec::env_of_t<Receiver>>
       struct max_result_size {
         template <class... _As>
           using result_size_for_t = stdexec::__t<result_size_for<_As...>>;
@@ -135,9 +135,9 @@ template <class SenderId, class FunId>
         static constexpr std::size_t value =
           stdexec::__v<
             stdexec::__gather_sigs_t<
-              std::execution::set_value_t, 
+              stdexec::set_value_t, 
               Sender,  
-              std::execution::env_of_t<Receiver>, 
+              stdexec::env_of_t<Receiver>, 
               stdexec::__q<result_size_for_t>, 
               stdexec::__q<max_in_pack>>>;
       };
@@ -150,7 +150,7 @@ template <class SenderId, class FunId>
 
     template <class _Error>
       using set_error = 
-        std::execution::completion_signatures<std::execution::set_error_t(cudaError_t)>;
+        stdexec::completion_signatures<stdexec::set_error_t(cudaError_t)>;
 
     template <class Self, class Env>
       using completion_signatures =
@@ -158,16 +158,16 @@ template <class SenderId, class FunId>
           stdexec::__member_t<Self, Sender>,
           Env,
           stdexec::__with_error_invoke_t<
-            std::execution::set_value_t,
+            stdexec::set_value_t,
             Fun,
             stdexec::__member_t<Self, Sender>,
             Env>,
           stdexec::__mbind_front_q<stdexec::__set_value_invoke_t, Fun>,
           stdexec::__q1<set_error>>;
 
-    template <stdexec::__decays_to<then_sender_t> Self, std::execution::receiver Receiver>
-      requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
-    friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+    template <stdexec::__decays_to<then_sender_t> Self, stdexec::receiver Receiver>
+      requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
+    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
       -> stream_op_state_t<stdexec::__member_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<stdexec::__member_t<Self, Sender>>(
           ((Self&&)self).sndr_,
@@ -178,18 +178,18 @@ template <class SenderId, class FunId>
     }
 
     template <stdexec::__decays_to<then_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
-      -> std::execution::dependent_completion_signatures<Env>;
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
+      -> stdexec::dependent_completion_signatures<Env>;
 
     template <stdexec::__decays_to<then_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
       -> completion_signatures<Self, Env> requires true;
 
-    template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+    template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
       requires stdexec::__callable<Tag, const Sender&, As...>
     friend auto tag_invoke(Tag tag, const then_sender_t& self, As&&... as)
       noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, std::execution::forwarding_sender_query>, Tag, const Sender&, As...> {
+      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
       return ((Tag&&) tag)(self.sndr_, (As&&) as...);
     }
   };

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -52,30 +52,30 @@ template <class ReceiverId, class Fun>
   public:
     constexpr static std::size_t memory_allocation_size = size_of_<result_t>;
 
-    friend void tag_invoke(std::execution::set_stopped_t, receiver_t&& self) noexcept {
+    friend void tag_invoke(stdexec::set_stopped_t, receiver_t&& self) noexcept {
       constexpr bool does_not_return_a_value = std::is_same_v<void, result_t>;
       cudaStream_t stream = self.op_state_.stream_;
 
       if constexpr (does_not_return_a_value) {
         kernel<Fun><<<1, 1, 0, stream>>>(self.f_);
         if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError()); status == cudaSuccess) {
-          self.op_state_.propagate_completion_signal(std::execution::set_value);
+          self.op_state_.propagate_completion_signal(stdexec::set_value);
         } else {
-          self.op_state_.propagate_completion_signal(std::execution::set_error, std::move(status));
+          self.op_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
         }
       } else {
         result_t *d_result = reinterpret_cast<result_t*>(self.op_state_.temp_storage_);
         kernel_with_result<Fun><<<1, 1, 0, stream>>>(self.f_, d_result);
         if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError()); status == cudaSuccess) {
-          self.op_state_.propagate_completion_signal(std::execution::set_value, *d_result);
+          self.op_state_.propagate_completion_signal(stdexec::set_value, *d_result);
         } else {
-          self.op_state_.propagate_completion_signal(std::execution::set_error, std::move(status));
+          self.op_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
         }
       }
     }
 
-    template <stdexec::__one_of<std::execution::set_value_t,
-                               std::execution::set_error_t> Tag, 
+    template <stdexec::__one_of<stdexec::set_value_t,
+                               stdexec::set_error_t> Tag, 
               class... As _NVCXX_CAPTURE_PACK(As)>
       friend void tag_invoke(Tag tag, receiver_t&& self, As&&... as) noexcept {
         _NVCXX_EXPAND_PACK(As, as,
@@ -83,9 +83,9 @@ template <class ReceiverId, class Fun>
         );
       }
 
-    friend std::execution::env_of_t<stdexec::__t<ReceiverId>>
-    tag_invoke(std::execution::get_env_t, const receiver_t& self) {
-      return std::execution::get_env(self.op_state_.receiver_);
+    friend stdexec::env_of_t<stdexec::__t<ReceiverId>>
+    tag_invoke(stdexec::get_env_t, const receiver_t& self) {
+      return stdexec::get_env(self.op_state_.receiver_);
     }
 
     explicit receiver_t(Fun fun, operation_state_base_t<ReceiverId> &op_state)
@@ -105,8 +105,8 @@ template <class SenderId, class FunId>
     Fun fun_;
 
     using set_error_t =
-      std::execution::completion_signatures<
-        std::execution::set_error_t(std::exception_ptr)>;
+      stdexec::completion_signatures<
+        stdexec::set_error_t(std::exception_ptr)>;
 
     template <class Receiver>
       using receiver_t = upon_stopped::receiver_t<stdexec::__x<Receiver>, Fun>;
@@ -117,7 +117,7 @@ template <class SenderId, class FunId>
           stdexec::__member_t<Self, Sender>,
           Env,
           stdexec::__with_error_invoke_t<
-            std::execution::set_stopped_t,
+            stdexec::set_stopped_t,
             Fun,
             stdexec::__member_t<Self, Sender>,
             Env>,
@@ -125,9 +125,9 @@ template <class SenderId, class FunId>
           stdexec::__q1<stdexec::__compl_sigs::__default_set_error>,
           stdexec::__set_value_invoke_t<Fun>>;
 
-    template <stdexec::__decays_to<upon_stopped_sender_t> Self, std::execution::receiver Receiver>
-      requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
-    friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+    template <stdexec::__decays_to<upon_stopped_sender_t> Self, stdexec::receiver Receiver>
+      requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
+    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
       -> stream_op_state_t<stdexec::__member_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<stdexec::__member_t<Self, Sender>>(
             ((Self&&)self).sndr_,
@@ -138,18 +138,18 @@ template <class SenderId, class FunId>
     }
 
     template <stdexec::__decays_to<upon_stopped_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
-      -> std::execution::dependent_completion_signatures<Env>;
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
+      -> stdexec::dependent_completion_signatures<Env>;
 
     template <stdexec::__decays_to<upon_stopped_sender_t> Self, class Env>
-    friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
       -> completion_signatures<Self, Env> requires true;
 
-    template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+    template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
       requires stdexec::__callable<Tag, const Sender&, As...>
     friend auto tag_invoke(Tag tag, const upon_stopped_sender_t& self, As&&... as)
       noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, std::execution::forwarding_sender_query>, Tag, const Sender&, As...> {
+      -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
       return ((Tag&&) tag)(self.sndr_, (As&&) as...);
     }
   };

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -40,40 +40,40 @@
 
 namespace nvexec {
   namespace STDEXEC_STREAM_DETAIL_NS {
-    template <std::execution::sender Sender, std::integral Shape, class Fun>
+    template <stdexec::sender Sender, std::integral Shape, class Fun>
       using bulk_sender_th = bulk_sender_t<stdexec::__x<std::remove_cvref_t<Sender>>, Shape, stdexec::__x<std::remove_cvref_t<Fun>>>;
 
-    template <std::execution::sender Sender>
+    template <stdexec::sender Sender>
       using split_sender_th = split_sender_t<stdexec::__x<std::remove_cvref_t<Sender>>>;
 
-    template <std::execution::sender Sender, class Fun>
+    template <stdexec::sender Sender, class Fun>
       using then_sender_th = then_sender_t<stdexec::__x<std::remove_cvref_t<Sender>>, stdexec::__x<std::remove_cvref_t<Fun>>>;
 
-    template <class Scheduler, std::execution::sender... Senders>
+    template <class Scheduler, stdexec::sender... Senders>
       using when_all_sender_th = when_all_sender_t<false, Scheduler, stdexec::__x<std::decay_t<Senders>>...>;
 
-    template <class Scheduler, std::execution::sender... Senders>
+    template <class Scheduler, stdexec::sender... Senders>
       using transfer_when_all_sender_th = when_all_sender_t<true, Scheduler, stdexec::__x<std::decay_t<Senders>>...>;
 
-    template <std::execution::sender Sender, class Fun>
+    template <stdexec::sender Sender, class Fun>
       using upon_error_sender_th = upon_error_sender_t<stdexec::__x<std::remove_cvref_t<Sender>>, stdexec::__x<std::remove_cvref_t<Fun>>>;
 
-    template <std::execution::sender Sender, class Fun>
+    template <stdexec::sender Sender, class Fun>
       using upon_stopped_sender_th = upon_stopped_sender_t<stdexec::__x<std::remove_cvref_t<Sender>>, stdexec::__x<std::remove_cvref_t<Fun>>>;
 
-    template <class Let, std::execution::sender Sender, class Fun>
+    template <class Let, stdexec::sender Sender, class Fun>
       using let_xxx_th = let_sender_t<stdexec::__x<std::remove_cvref_t<Sender>>, stdexec::__x<std::remove_cvref_t<Fun>>, Let>;
 
-    template <std::execution::sender Sender>
+    template <stdexec::sender Sender>
       using transfer_sender_th = transfer_sender_t<stdexec::__x<Sender>>;
 
-    template <std::execution::sender Sender>
+    template <stdexec::sender Sender>
       using ensure_started_th = ensure_started_sender_t<stdexec::__x<Sender>>;
 
     struct stream_scheduler {
       friend stream_context;
 
-      template <std::execution::sender Sender>
+      template <stdexec::sender Sender>
         using schedule_from_sender_th = schedule_from_sender_t<stream_scheduler, stdexec::__x<std::remove_cvref_t<Sender>>>;
 
       template <class RId>
@@ -96,22 +96,22 @@ namespace nvexec {
             return stream_;
           }
 
-          friend void tag_invoke(std::execution::start_t, operation_state_t& op) noexcept {
+          friend void tag_invoke(stdexec::start_t, operation_state_t& op) noexcept {
             if constexpr (stream_receiver<R>) {
               if (op.status_ == cudaSuccess) {
-                std::execution::set_value((R&&)op.rec_);
+                stdexec::set_value((R&&)op.rec_);
               } else {
-                std::execution::set_error((R&&)op.rec_, std::move(op.status_));
+                stdexec::set_error((R&&)op.rec_, std::move(op.status_));
               }
             } else {
               if (op.status_ == cudaSuccess) {
                 continuation_kernel
-                  <std::decay_t<R>, std::execution::set_value_t>
-                    <<<1, 1, 0, op.stream_>>>(op.rec_, std::execution::set_value);
+                  <std::decay_t<R>, stdexec::set_value_t>
+                    <<<1, 1, 0, op.stream_>>>(op.rec_, stdexec::set_value);
               } else {
                 continuation_kernel
-                  <std::decay_t<R>, std::execution::set_error_t, cudaError_t>
-                    <<<1, 1, 0, op.stream_>>>(op.rec_, std::execution::set_error, op.status_);
+                  <std::decay_t<R>, stdexec::set_error_t, cudaError_t>
+                    <<<1, 1, 0, op.stream_>>>(op.rec_, stdexec::set_error, op.status_);
               }
             }
           }
@@ -119,12 +119,12 @@ namespace nvexec {
 
       struct sender_t : stream_sender_base {
         using completion_signatures =
-          std::execution::completion_signatures<
-            std::execution::set_value_t(),
-            std::execution::set_error_t(cudaError_t)>;
+          stdexec::completion_signatures<
+            stdexec::set_value_t(),
+            stdexec::set_error_t(cudaError_t)>;
 
         template <class R>
-          friend auto tag_invoke(std::execution::connect_t, sender_t, R&& rec)
+          friend auto tag_invoke(stdexec::connect_t, sender_t, R&& rec)
             noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<R>, R>)
             -> operation_state_t<stdexec::__x<std::remove_cvref_t<R>>> {
             return operation_state_t<stdexec::__x<std::remove_cvref_t<R>>>((R&&) rec);
@@ -136,7 +136,7 @@ namespace nvexec {
 
         template <class CPO>
         friend stream_scheduler
-        tag_invoke(std::execution::get_completion_scheduler_t<CPO>, sender_t self) noexcept {
+        tag_invoke(stdexec::get_completion_scheduler_t<CPO>, sender_t self) noexcept {
           return self.make_scheduler();
         }
 
@@ -146,81 +146,81 @@ namespace nvexec {
         queue::task_hub_t * hub_;
       };
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend schedule_from_sender_th<S>
-        tag_invoke(std::execution::schedule_from_t, const stream_scheduler& sch, S&& sndr) noexcept {
+        tag_invoke(stdexec::schedule_from_t, const stream_scheduler& sch, S&& sndr) noexcept {
           return schedule_from_sender_th<S>(sch.hub_, (S&&) sndr);
         }
 
-      template <std::execution::sender S, std::integral Shape, class Fn>
+      template <stdexec::sender S, std::integral Shape, class Fn>
         friend bulk_sender_th<S, Shape, Fn>
-        tag_invoke(std::execution::bulk_t, const stream_scheduler& sch, S&& sndr, Shape shape, Fn fun) noexcept {
+        tag_invoke(stdexec::bulk_t, const stream_scheduler& sch, S&& sndr, Shape shape, Fn fun) noexcept {
           return bulk_sender_th<S, Shape, Fn>{{}, (S&&) sndr, shape, (Fn&&)fun};
         }
 
-      template <std::execution::sender S, class Fn>
+      template <stdexec::sender S, class Fn>
         friend then_sender_th<S, Fn>
-        tag_invoke(std::execution::then_t, const stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
+        tag_invoke(stdexec::then_t, const stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return then_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
         }
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend ensure_started_th<S>
-        tag_invoke(std::execution::ensure_started_t, const stream_scheduler& sch, S&& sndr) noexcept {
+        tag_invoke(stdexec::ensure_started_t, const stream_scheduler& sch, S&& sndr) noexcept {
           return ensure_started_th<S>((S&&) sndr, sch.hub_);
         }
 
       template <stdexec::__one_of<
-                  std::execution::let_value_t, 
-                  std::execution::let_stopped_t, 
-                  std::execution::let_error_t> Let, 
-                std::execution::sender S, 
+                  stdexec::let_value_t, 
+                  stdexec::let_stopped_t, 
+                  stdexec::let_error_t> Let, 
+                stdexec::sender S, 
                 class Fn>
         friend let_xxx_th<Let, S, Fn>
         tag_invoke(Let, const stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return let_xxx_th<Let, S, Fn>{{}, (S &&) sndr, (Fn &&) fun};
         }
 
-      template <std::execution::sender S, class Fn>
+      template <stdexec::sender S, class Fn>
         friend upon_error_sender_th<S, Fn>
-        tag_invoke(std::execution::upon_error_t, const stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
+        tag_invoke(stdexec::upon_error_t, const stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return upon_error_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
         }
 
-      template <std::execution::sender S, class Fn>
+      template <stdexec::sender S, class Fn>
         friend upon_stopped_sender_th<S, Fn>
-        tag_invoke(std::execution::upon_stopped_t, const stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
+        tag_invoke(stdexec::upon_stopped_t, const stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
           return upon_stopped_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
         }
 
-      template <std::execution::sender... Senders>
+      template <stdexec::sender... Senders>
         friend auto
-        tag_invoke(std::execution::transfer_when_all_t, const stream_scheduler& sch, Senders&&... sndrs) noexcept {
+        tag_invoke(stdexec::transfer_when_all_t, const stream_scheduler& sch, Senders&&... sndrs) noexcept {
           return transfer_when_all_sender_th<stream_scheduler, Senders...>(sch.hub_, (Senders&&)sndrs...);
         }
 
-      template <std::execution::sender... Senders>
+      template <stdexec::sender... Senders>
         friend auto
-        tag_invoke(std::execution::transfer_when_all_with_variant_t, const stream_scheduler& sch, Senders&&... sndrs) noexcept {
+        tag_invoke(stdexec::transfer_when_all_with_variant_t, const stream_scheduler& sch, Senders&&... sndrs) noexcept {
           return 
-            transfer_when_all_sender_th<stream_scheduler, std::tag_invoke_result_t<std::execution::into_variant_t, Senders>...>(
+            transfer_when_all_sender_th<stream_scheduler, stdexec::tag_invoke_result_t<stdexec::into_variant_t, Senders>...>(
                 sch.hub_, 
-                std::execution::into_variant((Senders&&)sndrs)...);
+                stdexec::into_variant((Senders&&)sndrs)...);
         }
 
-      template <std::execution::sender S, std::execution::scheduler Sch>
+      template <stdexec::sender S, stdexec::scheduler Sch>
         friend auto
-        tag_invoke(std::execution::transfer_t, const stream_scheduler& sch, S&& sndr, Sch&& scheduler) noexcept {
-          return std::execution::schedule_from((Sch&&)scheduler, transfer_sender_th<S>(sch.hub_, (S&&)sndr));
+        tag_invoke(stdexec::transfer_t, const stream_scheduler& sch, S&& sndr, Sch&& scheduler) noexcept {
+          return stdexec::schedule_from((Sch&&)scheduler, transfer_sender_th<S>(sch.hub_, (S&&)sndr));
         }
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend split_sender_th<S>
-        tag_invoke(std::execution::split_t, const stream_scheduler& sch, S&& sndr) noexcept {
+        tag_invoke(stdexec::split_t, const stream_scheduler& sch, S&& sndr) noexcept {
           return split_sender_th<S>((S&&)sndr, sch.hub_);
         }
 
-      friend sender_t tag_invoke(std::execution::schedule_t, const stream_scheduler& self) noexcept {
+      friend sender_t tag_invoke(stdexec::schedule_t, const stream_scheduler& self) noexcept {
         return {self.hub_};
       }
 
@@ -228,16 +228,16 @@ namespace nvexec {
         return {};
       }
 
-      template <std::execution::sender S>
+      template <stdexec::sender S>
         friend auto
-        tag_invoke(std::this_thread::sync_wait_t, const stream_scheduler& self, S&& sndr) {
+        tag_invoke(stdexec::sync_wait_t, const stream_scheduler& self, S&& sndr) {
           return sync_wait::sync_wait_t{}(self.hub_, (S&&)sndr);
         }
 
-      friend std::execution::forward_progress_guarantee tag_invoke(
-          std::execution::get_forward_progress_guarantee_t,
+      friend stdexec::forward_progress_guarantee tag_invoke(
+          stdexec::get_forward_progress_guarantee_t,
           const stream_scheduler&) noexcept {
-        return std::execution::forward_progress_guarantee::weakly_parallel;
+        return stdexec::forward_progress_guarantee::weakly_parallel;
       }
 
       bool operator==(const stream_scheduler&) const noexcept = default;
@@ -251,34 +251,34 @@ namespace nvexec {
     };
 
     template <stream_completing_sender Sender>
-      void tag_invoke(std::execution::start_detached_t, Sender&& sndr) noexcept(false) {
+      void tag_invoke(stdexec::start_detached_t, Sender&& sndr) noexcept(false) {
         submit::submit_t{}((Sender&&)sndr, start_detached::detached_receiver_t{});
       }
 
     template <stream_completing_sender... Senders>
       when_all_sender_th<stream_scheduler, Senders...>
-      tag_invoke(std::execution::when_all_t, Senders&&... sndrs) noexcept {
+      tag_invoke(stdexec::when_all_t, Senders&&... sndrs) noexcept {
         return when_all_sender_th<stream_scheduler, Senders...>{nullptr, (Senders&&)sndrs...};
       }
 
     template <stream_completing_sender... Senders>
-      when_all_sender_th<stream_scheduler, std::tag_invoke_result_t<std::execution::into_variant_t, Senders>...>
-      tag_invoke(std::execution::when_all_with_variant_t, Senders&&... sndrs) noexcept {
-        return when_all_sender_th<stream_scheduler, std::tag_invoke_result_t<std::execution::into_variant_t, Senders>...>{
+      when_all_sender_th<stream_scheduler, stdexec::tag_invoke_result_t<stdexec::into_variant_t, Senders>...>
+      tag_invoke(stdexec::when_all_with_variant_t, Senders&&... sndrs) noexcept {
+        return when_all_sender_th<stream_scheduler, stdexec::tag_invoke_result_t<stdexec::into_variant_t, Senders>...>{
           nullptr, 
-          std::execution::into_variant((Senders&&)sndrs)...
+          stdexec::into_variant((Senders&&)sndrs)...
         };
       }
 
-    template <std::execution::sender S, class Fn>
+    template <stdexec::sender S, class Fn>
       upon_error_sender_th<S, Fn>
-      tag_invoke(std::execution::upon_error_t, S&& sndr, Fn fun) noexcept {
+      tag_invoke(stdexec::upon_error_t, S&& sndr, Fn fun) noexcept {
         return upon_error_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
       }
 
-    template <std::execution::sender S, class Fn>
+    template <stdexec::sender S, class Fn>
       upon_stopped_sender_th<S, Fn>
-      tag_invoke(std::execution::upon_stopped_t, S&& sndr, Fn fun) noexcept {
+      tag_invoke(stdexec::upon_stopped_t, S&& sndr, Fn fun) noexcept {
         return upon_stopped_sender_th<S, Fn>{{}, (S&&) sndr, (Fn&&)fun};
       }
   }

--- a/include/stdexec/__detail/__p2300.hpp
+++ b/include/stdexec/__detail/__p2300.hpp
@@ -17,93 +17,110 @@
 
 // Internal header, do not include directly
 
+#ifdef STDEXEC_DISABLE_STD_DEPRECATIONS
+#define STDEXEC_STD_DEPRECATED
+#else
+#define STDEXEC_STD_DEPRECATED [[deprecated("Please access this entity in the ::stdexec:: namespace. Define STDEXEC_DISABLE_STD_DEPRECATIONS to silence this warning.")]]
+#endif
+
 namespace std {
   //////////////////////////////////////////////////////////////////////////////
   // <functional>
+  STDEXEC_STD_DEPRECATED
   inline constexpr stdexec::tag_invoke_t tag_invoke{};
 
   template <class _Tag, class... _Ts>
-    using tag_invoke_result = stdexec::tag_invoke_result<_Tag, _Ts...>;
+    using tag_invoke_result STDEXEC_STD_DEPRECATED = stdexec::tag_invoke_result<_Tag, _Ts...>;
 
   template <class _Tag, class... _Ts>
-    using tag_invoke_result_t = stdexec::tag_invoke_result_t<_Tag, _Ts...>;
+    using tag_invoke_result_t STDEXEC_STD_DEPRECATED = stdexec::tag_invoke_result_t<_Tag, _Ts...>;
 
   template <class _Tag, class... _Ts>
-    concept tag_invocable = stdexec::tag_invocable<_Tag, _Ts...>;
+    concept tag_invocable /*STDEXEC_STD_DEPRECATED*/ = stdexec::tag_invocable<_Tag, _Ts...>;
 
   template <class _Tag, class... _Ts>
-    concept nothrow_tag_invocable = stdexec::nothrow_tag_invocable<_Tag, _Ts...>;
+    concept nothrow_tag_invocable /*STDEXEC_STD_DEPRECATED*/ = stdexec::nothrow_tag_invocable<_Tag, _Ts...>;
 
   template <auto& _Tag>
-    using tag_t = stdexec::tag_t<_Tag>;
+    using tag_t STDEXEC_STD_DEPRECATED = stdexec::tag_t<_Tag>;
 
   //////////////////////////////////////////////////////////////////////////////
   // <stop_token>
   template <class _Token>
-    concept stoppable_token = stdexec::stoppable_token<_Token>;
+    concept stoppable_token /*STDEXEC_STD_DEPRECATED*/ = stdexec::stoppable_token<_Token>;
 
   template <class _Token, typename _Callback, typename _Initializer = _Callback>
-    concept stoppable_token_for = stdexec::stoppable_token_for<_Token, _Callback, _Initializer>;
+    concept stoppable_token_for /*STDEXEC_STD_DEPRECATED*/ = stdexec::stoppable_token_for<_Token, _Callback, _Initializer>;
 
   template <class _Token>
-    concept unstoppable_token = stdexec::unstoppable_token<_Token>;
+    concept unstoppable_token /*STDEXEC_STD_DEPRECATED*/ = stdexec::unstoppable_token<_Token>;
  
-  using never_stop_token = stdexec::never_stop_token;
-  using in_place_stop_token = stdexec::in_place_stop_token;
-  using in_place_stop_source = stdexec::in_place_stop_source;
+  using never_stop_token STDEXEC_STD_DEPRECATED = stdexec::never_stop_token;
+  using in_place_stop_token STDEXEC_STD_DEPRECATED = stdexec::in_place_stop_token;
+  using in_place_stop_source STDEXEC_STD_DEPRECATED = stdexec::in_place_stop_source;
 
   template <class _Callback>
-    using in_place_stop_callback = stdexec::in_place_stop_callback<_Callback>;
+    using in_place_stop_callback STDEXEC_STD_DEPRECATED = stdexec::in_place_stop_callback<_Callback>;
 
   //////////////////////////////////////////////////////////////////////////////
   // <execution>
   namespace execution {
     // [exec.queries], general queries
-    using get_scheduler_t = stdexec::get_scheduler_t;
-    using get_delegatee_scheduler_t = stdexec::get_delegatee_scheduler_t;
-    using get_allocator_t = stdexec::get_allocator_t;
-    using get_stop_token_t = stdexec::get_stop_token_t;
+    using get_scheduler_t STDEXEC_STD_DEPRECATED = stdexec::get_scheduler_t;
+    using get_delegatee_scheduler_t STDEXEC_STD_DEPRECATED = stdexec::get_delegatee_scheduler_t;
+    using get_allocator_t STDEXEC_STD_DEPRECATED = stdexec::get_allocator_t;
+    using get_stop_token_t STDEXEC_STD_DEPRECATED = stdexec::get_stop_token_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_scheduler_t get_scheduler{};
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_delegatee_scheduler_t get_delegatee_scheduler{};
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_allocator_t get_allocator{};
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_stop_token_t get_stop_token{};
 
     template <class _StopTokenProvider>
-      using stop_token_of_t = stdexec::stop_token_of_t<_StopTokenProvider>;
+      using stop_token_of_t STDEXEC_STD_DEPRECATED = stdexec::stop_token_of_t<_StopTokenProvider>;
 
     // [exec.env], execution environments
-    using no_env = stdexec::no_env;
-    using get_env_t = stdexec::get_env_t;
-    //using forwarding_env_query_t = stdexec::forwarding_env_query_t; // BUGBUG
+    using no_env STDEXEC_STD_DEPRECATED = stdexec::no_env;
+    using get_env_t STDEXEC_STD_DEPRECATED = stdexec::get_env_t;
+    //using forwarding_env_query_t STDEXEC_STD_DEPRECATED = stdexec::forwarding_env_query_t; // BUGBUG
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_env_t get_env{};
     //inline constexpr stdexec::forwarding_env_query_t forwarding_env_query{}; // BUGBUG
 
     template <class _EnvProvider>
-      using env_of_t = stdexec::env_of_t<_EnvProvider>;
+      using env_of_t STDEXEC_STD_DEPRECATED = stdexec::env_of_t<_EnvProvider>;
 
     // [exec.sched], schedulers
     template <class _Scheduler>
-      concept scheduler = stdexec::scheduler<_Scheduler>;
+      concept scheduler /*STDEXEC_STD_DEPRECATED*/ = stdexec::scheduler<_Scheduler>;
 
     // [exec.sched_queries], scheduler queries
-    using forward_progress_guarantee = stdexec::forward_progress_guarantee;
-    using forwarding_scheduler_query_t = stdexec::forwarding_scheduler_query_t;
-    using get_forward_progress_guarantee_t = stdexec::get_forward_progress_guarantee_t;
+    using forward_progress_guarantee STDEXEC_STD_DEPRECATED = stdexec::forward_progress_guarantee;
+    using forwarding_scheduler_query_t STDEXEC_STD_DEPRECATED = stdexec::forwarding_scheduler_query_t;
+    using get_forward_progress_guarantee_t STDEXEC_STD_DEPRECATED = stdexec::get_forward_progress_guarantee_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::forwarding_scheduler_query_t forwarding_scheduler_query{};
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_forward_progress_guarantee_t get_forward_progress_guarantee{};
 
     // [exec.recv], receivers
     template <class _Receiver>
-      concept receiver = stdexec::receiver<_Receiver>;
+      concept receiver /*STDEXEC_STD_DEPRECATED*/ = stdexec::receiver<_Receiver>;
 
     template <class _Receiver, class _Completions>
-      concept receiver_of = stdexec::receiver_of<_Receiver, _Completions>;
+      concept receiver_of /*STDEXEC_STD_DEPRECATED*/ = stdexec::receiver_of<_Receiver, _Completions>;
 
-    using set_value_t = stdexec::set_value_t;
-    using set_error_t = stdexec::set_error_t;
-    using set_stopped_t = stdexec::set_stopped_t;
+    using set_value_t STDEXEC_STD_DEPRECATED = stdexec::set_value_t;
+    using set_error_t STDEXEC_STD_DEPRECATED = stdexec::set_error_t;
+    using set_stopped_t STDEXEC_STD_DEPRECATED = stdexec::set_stopped_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::set_value_t set_value{};
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::set_error_t set_error{};
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::set_stopped_t set_stopped{};
 
     // [exec.recv_queries], receiver queries
@@ -112,130 +129,162 @@ namespace std {
 
     // [exec.op_state], operation states
     template <class _OpState>
-      concept operation_state = stdexec::operation_state<_OpState>;
+      concept operation_state /*STDEXEC_STD_DEPRECATED*/ = stdexec::operation_state<_OpState>;
 
-    using start_t = stdexec::start_t;
+    using start_t STDEXEC_STD_DEPRECATED = stdexec::start_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::start_t start{};
 
     // [exec.snd], senders
     template <class _Sender, class _Env = no_env>
-      concept sender = stdexec::sender<_Sender, _Env>;
+      concept sender /*STDEXEC_STD_DEPRECATED*/ = stdexec::sender<_Sender, _Env>;
 
     template <class _Sender, class _Receiver>
-      concept sender_to = stdexec::sender_to<_Sender, _Receiver>;
+      concept sender_to /*STDEXEC_STD_DEPRECATED*/ = stdexec::sender_to<_Sender, _Receiver>;
 
     template<class _Sender, class _SetSig, class _Env = no_env>
-      concept sender_of = stdexec::sender_of<_Sender, _SetSig, _Env>;
+      concept sender_of /*STDEXEC_STD_DEPRECATED*/ = stdexec::sender_of<_Sender, _SetSig, _Env>;
 
     // [exec.sndtraits], completion signatures
-    using get_completion_signatures_t = stdexec::get_completion_signatures_t;
+    using get_completion_signatures_t STDEXEC_STD_DEPRECATED = stdexec::get_completion_signatures_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_completion_signatures_t get_completion_signatures{};
 
     template<class _Sender, class _Env = no_env>
-      using completion_signatures_of_t = stdexec::completion_signatures_of_t<_Sender, _Env>;
+      using completion_signatures_of_t STDEXEC_STD_DEPRECATED = stdexec::completion_signatures_of_t<_Sender, _Env>;
 
     template <class _Env>
-      using dependent_completion_signatures = stdexec::dependent_completion_signatures<_Env>;
+      using dependent_completion_signatures STDEXEC_STD_DEPRECATED = stdexec::dependent_completion_signatures<_Env>;
 
     template <class _Sender,
               class _Env = no_env,
               template <class...> class _Tuple = stdexec::__decayed_tuple,
               template <class...> class _Variant = stdexec::__variant>
-      using value_types_of_t = stdexec::value_types_of_t<_Sender, _Env, _Tuple, _Variant>;
+      using value_types_of_t STDEXEC_STD_DEPRECATED = stdexec::value_types_of_t<_Sender, _Env, _Tuple, _Variant>;
 
     template <class _Sender,
               class _Env = no_env,
               template <class...> class _Variant = stdexec::__variant>
-      using error_types_of_t = stdexec::error_types_of_t<_Sender, _Env, _Variant>;
+      using error_types_of_t STDEXEC_STD_DEPRECATED = stdexec::error_types_of_t<_Sender, _Env, _Variant>;
 
     template <class _Sender, class _Env = no_env>
+      STDEXEC_STD_DEPRECATED
       inline constexpr bool sends_stopped = stdexec::sends_stopped<_Sender, _Env>;
 
     // [exec.connect], the connect sender algorithm
-    using connect_t = stdexec::connect_t;
+    using connect_t STDEXEC_STD_DEPRECATED = stdexec::connect_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::connect_t connect{};
 
     template <class _Sender, class _Receiver>
-      using connect_result_t = stdexec::connect_result_t<_Sender, _Receiver>;
+      using connect_result_t STDEXEC_STD_DEPRECATED = stdexec::connect_result_t<_Sender, _Receiver>;
 
     // [exec.snd_queries], sender queries
-    using forwarding_sender_query_t = stdexec::forwarding_sender_query_t;
+    using forwarding_sender_query_t STDEXEC_STD_DEPRECATED = stdexec::forwarding_sender_query_t;
     template <class _Tag>
-      using get_completion_scheduler_t = stdexec::get_completion_scheduler_t<_Tag>;
+      using get_completion_scheduler_t STDEXEC_STD_DEPRECATED = stdexec::get_completion_scheduler_t<_Tag>;
+    STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::forwarding_sender_query_t forwarding_sender_query{};
 
     template <class _Tag>
+      STDEXEC_STD_DEPRECATED
       inline constexpr stdexec::get_completion_scheduler_t<_Tag> get_completion_scheduler{};
 
     // [exec.factories], sender factories
-    using schedule_t = stdexec::schedule_t;
-    using transfer_just_t = stdexec::transfer_just_t;
+    using schedule_t STDEXEC_STD_DEPRECATED = stdexec::schedule_t;
+    using transfer_just_t STDEXEC_STD_DEPRECATED = stdexec::transfer_just_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto just = stdexec::just;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto just_error = stdexec::just_error;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto just_stopped = stdexec::just_stopped;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto schedule = stdexec::schedule;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto transfer_just = stdexec::transfer_just;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto read = stdexec::read;
 
     template <class _Scheduler>
-      using schedule_result_t = stdexec::schedule_result_t<_Scheduler>;
+      using schedule_result_t STDEXEC_STD_DEPRECATED = stdexec::schedule_result_t<_Scheduler>;
 
     // [exec.adapt], sender adaptors
     template <class _Closure>
-      using sender_adaptor_closure = stdexec::sender_adaptor_closure<_Closure>;
+      using sender_adaptor_closure STDEXEC_STD_DEPRECATED = stdexec::sender_adaptor_closure<_Closure>;
 
-    using on_t = stdexec::on_t;
-    using transfer_t = stdexec::transfer_t;
-    using schedule_from_t = stdexec::schedule_from_t;
-    using then_t = stdexec::then_t;
-    using upon_error_t = stdexec::upon_error_t;
-    using upon_stopped_t = stdexec::upon_stopped_t;
-    using let_value_t = stdexec::let_value_t;
-    using let_error_t = stdexec::let_error_t;
-    using let_stopped_t = stdexec::let_stopped_t;
-    using bulk_t = stdexec::bulk_t;
-    using split_t = stdexec::split_t;
-    using when_all_t = stdexec::when_all_t;
-    using when_all_with_variant_t = stdexec::when_all_with_variant_t;
-    using transfer_when_all_t = stdexec::transfer_when_all_t;
-    using transfer_when_all_with_variant_t = stdexec::transfer_when_all_with_variant_t;
-    using into_variant_t = stdexec::into_variant_t;
-    using stopped_as_optional_t = stdexec::stopped_as_optional_t;
-    using stopped_as_error_t = stdexec::stopped_as_error_t;
-    using ensure_started_t = stdexec::ensure_started_t;
+    using on_t STDEXEC_STD_DEPRECATED = stdexec::on_t;
+    using transfer_t STDEXEC_STD_DEPRECATED = stdexec::transfer_t;
+    using schedule_from_t STDEXEC_STD_DEPRECATED = stdexec::schedule_from_t;
+    using then_t STDEXEC_STD_DEPRECATED = stdexec::then_t;
+    using upon_error_t STDEXEC_STD_DEPRECATED = stdexec::upon_error_t;
+    using upon_stopped_t STDEXEC_STD_DEPRECATED = stdexec::upon_stopped_t;
+    using let_value_t STDEXEC_STD_DEPRECATED = stdexec::let_value_t;
+    using let_error_t STDEXEC_STD_DEPRECATED = stdexec::let_error_t;
+    using let_stopped_t STDEXEC_STD_DEPRECATED = stdexec::let_stopped_t;
+    using bulk_t STDEXEC_STD_DEPRECATED = stdexec::bulk_t;
+    using split_t STDEXEC_STD_DEPRECATED = stdexec::split_t;
+    using when_all_t STDEXEC_STD_DEPRECATED = stdexec::when_all_t;
+    using when_all_with_variant_t STDEXEC_STD_DEPRECATED = stdexec::when_all_with_variant_t;
+    using transfer_when_all_t STDEXEC_STD_DEPRECATED = stdexec::transfer_when_all_t;
+    using transfer_when_all_with_variant_t STDEXEC_STD_DEPRECATED = stdexec::transfer_when_all_with_variant_t;
+    using into_variant_t STDEXEC_STD_DEPRECATED = stdexec::into_variant_t;
+    using stopped_as_optional_t STDEXEC_STD_DEPRECATED = stdexec::stopped_as_optional_t;
+    using stopped_as_error_t STDEXEC_STD_DEPRECATED = stdexec::stopped_as_error_t;
+    using ensure_started_t STDEXEC_STD_DEPRECATED = stdexec::ensure_started_t;
 
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto on = stdexec::on;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto transfer = stdexec::transfer;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto schedule_from = stdexec::schedule_from;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto then = stdexec::then;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto upon_error = stdexec::upon_error;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto upon_stopped = stdexec::upon_stopped;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto let_value = stdexec::let_value;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto let_error = stdexec::let_error;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto let_stopped = stdexec::let_stopped;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto bulk = stdexec::bulk;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto split = stdexec::split;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto when_all = stdexec::when_all;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto when_all_with_variant = stdexec::when_all_with_variant;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto transfer_when_all = stdexec::transfer_when_all;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto transfer_when_all_with_variant = stdexec::transfer_when_all_with_variant;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto into_variant = stdexec::into_variant;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto stopped_as_optional = stdexec::stopped_as_optional;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto stopped_as_error = stdexec::stopped_as_error;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto ensure_started = stdexec::ensure_started;
 
     // [exec.consumers], sender consumers
-    using start_detached_t = stdexec::start_detached_t;
+    using start_detached_t STDEXEC_STD_DEPRECATED = stdexec::start_detached_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto start_detached = stdexec::start_detached;
 
     // [exec.utils], sender and receiver utilities
     // [exec.utils.rcvr_adptr]
     template <class _Derived, class _Base = stdexec::__adaptors::__not_a_receiver>
-      using receiver_adaptor = stdexec::receiver_adaptor<_Derived, _Base>;
+      using receiver_adaptor STDEXEC_STD_DEPRECATED = stdexec::receiver_adaptor<_Derived, _Base>;
 
     // [exec.utils.cmplsigs]
     template <class... _Sigs>
-      using completion_signatures = stdexec::completion_signatures<_Sigs...>;
+      using completion_signatures STDEXEC_STD_DEPRECATED = stdexec::completion_signatures<_Sigs...>;
 
     // [exec.utils.mkcmplsigs]
     template<
@@ -245,34 +294,39 @@ namespace std {
       template <class...> class _SetValue = stdexec::__compl_sigs::__default_set_value,
       template <class> class _SetError = stdexec::__compl_sigs::__default_set_error,
       class _SetStopped = completion_signatures<set_stopped_t()>>
-    using make_completion_signatures =
+    using make_completion_signatures STDEXEC_STD_DEPRECATED =
       stdexec::make_completion_signatures<_Sender, _Env, _Sigs, _SetValue, _SetError, _SetStopped>;
 
     // [exec.ctx], execution contexts
-    using run_loop = stdexec::run_loop;
+    using run_loop STDEXEC_STD_DEPRECATED = stdexec::run_loop;
 
     // [exec.execute], execute
-    using execute_t = stdexec::execute_t;
+    using execute_t STDEXEC_STD_DEPRECATED = stdexec::execute_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto execute = stdexec::execute;
 
     #if !_STD_NO_COROUTINES_
     // [exec.as_awaitable]
-    using as_awaitable_t = stdexec::as_awaitable_t;
+    using as_awaitable_t STDEXEC_STD_DEPRECATED = stdexec::as_awaitable_t;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto as_awaitable = stdexec::as_awaitable;
 
     // [exec.with_awaitable_senders]
     template <class _Promise>
-      using with_awaitable_senders = stdexec::with_awaitable_senders<_Promise>;
+      using with_awaitable_senders STDEXEC_STD_DEPRECATED = stdexec::with_awaitable_senders<_Promise>;
     #endif // !_STD_NO_COROUTINES_
   } // namespace execution
 
   namespace this_thread {
-    using execute_may_block_caller_t = stdexec::execute_may_block_caller_t;
-    using sync_wait_t = stdexec::sync_wait_t;
-    using sync_wait_with_variant_t = stdexec::sync_wait_with_variant_t;
+    using execute_may_block_caller_t STDEXEC_STD_DEPRECATED = stdexec::execute_may_block_caller_t;
+    using sync_wait_t STDEXEC_STD_DEPRECATED = stdexec::sync_wait_t;
+    using sync_wait_with_variant_t STDEXEC_STD_DEPRECATED = stdexec::sync_wait_with_variant_t;
 
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto execute_may_block_caller = stdexec::execute_may_block_caller;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto sync_wait = stdexec::sync_wait;
+    STDEXEC_STD_DEPRECATED
     inline constexpr auto sync_wait_with_variant = stdexec::sync_wait_with_variant;
   } // namespace this_thread
 } // namespace std

--- a/include/stdexec/__detail/__p2300.hpp
+++ b/include/stdexec/__detail/__p2300.hpp
@@ -18,206 +18,261 @@
 // Internal header, do not include directly
 
 namespace std {
+  //////////////////////////////////////////////////////////////////////////////
   // <functional>
-  using stdexec::tag_invoke;
-  using stdexec::tag_invoke_t;
-  using stdexec::tag_invoke_result;
-  using stdexec::tag_invoke_result_t;
-  using stdexec::tag_invocable;
-  using stdexec::nothrow_tag_invocable;
-  using stdexec::tag_t;
+  inline constexpr stdexec::tag_invoke_t tag_invoke{};
 
+  template <class _Tag, class... _Ts>
+    using tag_invoke_result = stdexec::tag_invoke_result<_Tag, _Ts...>;
+
+  template <class _Tag, class... _Ts>
+    using tag_invoke_result_t = stdexec::tag_invoke_result_t<_Tag, _Ts...>;
+
+  template <class _Tag, class... _Ts>
+    concept tag_invocable = stdexec::tag_invocable<_Tag, _Ts...>;
+
+  template <class _Tag, class... _Ts>
+    concept nothrow_tag_invocable = stdexec::nothrow_tag_invocable<_Tag, _Ts...>;
+
+  template <auto& _Tag>
+    using tag_t = stdexec::tag_t<_Tag>;
+
+  //////////////////////////////////////////////////////////////////////////////
   // <stop_token>
-  using stdexec::stoppable_token;
-  using stdexec::stoppable_token_for;
-  using stdexec::unstoppable_token;
-  using stdexec::never_stop_token;
-  using stdexec::in_place_stop_token;
-  using stdexec::in_place_stop_source;
-  using stdexec::in_place_stop_callback;
+  template <class _Token>
+    concept stoppable_token = stdexec::stoppable_token<_Token>;
 
+  template <class _Token, typename _Callback, typename _Initializer = _Callback>
+    concept stoppable_token_for = stdexec::stoppable_token_for<_Token, _Callback, _Initializer>;
+
+  template <class _Token>
+    concept unstoppable_token = stdexec::unstoppable_token<_Token>;
+ 
+  using never_stop_token = stdexec::never_stop_token;
+  using in_place_stop_token = stdexec::in_place_stop_token;
+  using in_place_stop_source = stdexec::in_place_stop_source;
+
+  template <class _Callback>
+    using in_place_stop_callback = stdexec::in_place_stop_callback<_Callback>;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // <execution>
   namespace execution {
     // [exec.queries], general queries
-    using stdexec::get_scheduler_t;
-    using stdexec::get_delegatee_scheduler_t;
-    using stdexec::get_allocator_t;
-    using stdexec::get_stop_token_t;
-    using stdexec::get_scheduler;
-    using stdexec::get_delegatee_scheduler;
-    using stdexec::get_allocator;
-    using stdexec::get_stop_token;
+    using get_scheduler_t = stdexec::get_scheduler_t;
+    using get_delegatee_scheduler_t = stdexec::get_delegatee_scheduler_t;
+    using get_allocator_t = stdexec::get_allocator_t;
+    using get_stop_token_t = stdexec::get_stop_token_t;
+    inline constexpr stdexec::get_scheduler_t get_scheduler{};
+    inline constexpr stdexec::get_delegatee_scheduler_t get_delegatee_scheduler{};
+    inline constexpr stdexec::get_allocator_t get_allocator{};
+    inline constexpr stdexec::get_stop_token_t get_stop_token{};
 
-    using stdexec::stop_token_of_t;
+    template <class _StopTokenProvider>
+      using stop_token_of_t = stdexec::stop_token_of_t<_StopTokenProvider>;
 
     // [exec.env], execution environments
-    using stdexec::no_env;
-    using stdexec::get_env_t;
-    //using stdexec::forwarding_env_query_t; // BUGBUG
-    using stdexec::get_env;
-    //using stdexec::forwarding_env_query; // BUGBUG
+    using no_env = stdexec::no_env;
+    using get_env_t = stdexec::get_env_t;
+    //using forwarding_env_query_t = stdexec::forwarding_env_query_t; // BUGBUG
+    inline constexpr stdexec::get_env_t get_env{};
+    //inline constexpr stdexec::forwarding_env_query_t forwarding_env_query{}; // BUGBUG
 
-    using stdexec::env_of_t;
+    template <class _EnvProvider>
+      using env_of_t = stdexec::env_of_t<_EnvProvider>;
 
     // [exec.sched], schedulers
-    using stdexec::scheduler;
+    template <class _Scheduler>
+      concept scheduler = stdexec::scheduler<_Scheduler>;
 
     // [exec.sched_queries], scheduler queries
-    using stdexec::forward_progress_guarantee;
-    using stdexec::forwarding_scheduler_query_t;
-    using stdexec::get_forward_progress_guarantee_t;
-    using stdexec::forwarding_scheduler_query;
-    using stdexec::get_forward_progress_guarantee;
+    using forward_progress_guarantee = stdexec::forward_progress_guarantee;
+    using forwarding_scheduler_query_t = stdexec::forwarding_scheduler_query_t;
+    using get_forward_progress_guarantee_t = stdexec::get_forward_progress_guarantee_t;
+    inline constexpr stdexec::forwarding_scheduler_query_t forwarding_scheduler_query{};
+    inline constexpr stdexec::get_forward_progress_guarantee_t get_forward_progress_guarantee{};
 
     // [exec.recv], receivers
-    using stdexec::receiver;
+    template <class _Receiver>
+      concept receiver = stdexec::receiver<_Receiver>;
 
-    using stdexec::receiver_of;
+    template <class _Receiver, class _Completions>
+      concept receiver_of = stdexec::receiver_of<_Receiver, _Completions>;
 
-    using stdexec::set_value_t;
-    using stdexec::set_error_t;
-    using stdexec::set_stopped_t;
-    using stdexec::set_value;
-    using stdexec::set_error;
-    using stdexec::set_stopped;
+    using set_value_t = stdexec::set_value_t;
+    using set_error_t = stdexec::set_error_t;
+    using set_stopped_t = stdexec::set_stopped_t;
+    inline constexpr stdexec::set_value_t set_value{};
+    inline constexpr stdexec::set_error_t set_error{};
+    inline constexpr stdexec::set_stopped_t set_stopped{};
 
     // [exec.recv_queries], receiver queries
     // using stdexec::forwarding_receiver_query_t; // BUGBUG
     // using stdexec::forwarding_receiver_query; // BUGBUG
 
     // [exec.op_state], operation states
-    using stdexec::operation_state;
+    template <class _OpState>
+      concept operation_state = stdexec::operation_state<_OpState>;
 
-    using stdexec::start_t;
-    using stdexec::start;
+    using start_t = stdexec::start_t;
+    inline constexpr stdexec::start_t start{};
 
     // [exec.snd], senders
-    using stdexec::sender;
-    using stdexec::sender_to;
-    using stdexec::sender_of;
+    template <class _Sender, class _Env = no_env>
+      concept sender = stdexec::sender<_Sender, _Env>;
+
+    template <class _Sender, class _Receiver>
+      concept sender_to = stdexec::sender_to<_Sender, _Receiver>;
+
+    template<class _Sender, class _SetSig, class _Env = no_env>
+      concept sender_of = stdexec::sender_of<_Sender, _SetSig, _Env>;
 
     // [exec.sndtraits], completion signatures
-    using stdexec::get_completion_signatures_t;
-    using stdexec::get_completion_signatures;
-    using stdexec::completion_signatures_of_t;
+    using get_completion_signatures_t = stdexec::get_completion_signatures_t;
+    inline constexpr stdexec::get_completion_signatures_t get_completion_signatures{};
 
-    using stdexec::dependent_completion_signatures;
+    template<class _Sender, class _Env = no_env>
+      using completion_signatures_of_t = stdexec::completion_signatures_of_t<_Sender, _Env>;
 
-    using stdexec::value_types_of_t;
-    using stdexec::error_types_of_t;
-    using stdexec::sends_stopped;
+    template <class _Env>
+      using dependent_completion_signatures = stdexec::dependent_completion_signatures<_Env>;
+
+    template <class _Sender,
+              class _Env = no_env,
+              template <class...> class _Tuple = stdexec::__decayed_tuple,
+              template <class...> class _Variant = stdexec::__variant>
+      using value_types_of_t = stdexec::value_types_of_t<_Sender, _Env, _Tuple, _Variant>;
+
+    template <class _Sender,
+              class _Env = no_env,
+              template <class...> class _Variant = stdexec::__variant>
+      using error_types_of_t = stdexec::error_types_of_t<_Sender, _Env, _Variant>;
+
+    template <class _Sender, class _Env = no_env>
+      inline constexpr bool sends_stopped = stdexec::sends_stopped<_Sender, _Env>;
 
     // [exec.connect], the connect sender algorithm
-    using stdexec::connect_t;
-    using stdexec::connect;
+    using connect_t = stdexec::connect_t;
+    inline constexpr stdexec::connect_t connect{};
 
-    using stdexec::connect_result_t;
+    template <class _Sender, class _Receiver>
+      using connect_result_t = stdexec::connect_result_t<_Sender, _Receiver>;
 
     // [exec.snd_queries], sender queries
-    using stdexec::forwarding_sender_query_t;
-    using stdexec::get_completion_scheduler_t;
-    using stdexec::forwarding_sender_query;
+    using forwarding_sender_query_t = stdexec::forwarding_sender_query_t;
+    template <class _Tag>
+      using get_completion_scheduler_t = stdexec::get_completion_scheduler_t<_Tag>;
+    inline constexpr stdexec::forwarding_sender_query_t forwarding_sender_query{};
 
-    using stdexec::get_completion_scheduler;
+    template <class _Tag>
+      inline constexpr stdexec::get_completion_scheduler_t<_Tag> get_completion_scheduler{};
 
     // [exec.factories], sender factories
-    using stdexec::just;
-    using stdexec::just_error;
-    using stdexec::just_stopped;
-    using stdexec::schedule_t;
-    using stdexec::transfer_just_t;
-    using stdexec::schedule;
-    using stdexec::transfer_just;
-    using stdexec::read;
+    using schedule_t = stdexec::schedule_t;
+    using transfer_just_t = stdexec::transfer_just_t;
+    inline constexpr auto just = stdexec::just;
+    inline constexpr auto just_error = stdexec::just_error;
+    inline constexpr auto just_stopped = stdexec::just_stopped;
+    inline constexpr auto schedule = stdexec::schedule;
+    inline constexpr auto transfer_just = stdexec::transfer_just;
+    inline constexpr auto read = stdexec::read;
 
-    using stdexec::schedule_result_t;
+    template <class _Scheduler>
+      using schedule_result_t = stdexec::schedule_result_t<_Scheduler>;
 
     // [exec.adapt], sender adaptors
-    using stdexec::sender_adaptor_closure;
+    template <class _Closure>
+      using sender_adaptor_closure = stdexec::sender_adaptor_closure<_Closure>;
 
-    using stdexec::on_t;
-    using stdexec::transfer_t;
-    using stdexec::schedule_from_t;
-    using stdexec::then_t;
-    using stdexec::upon_error_t;
-    using stdexec::upon_stopped_t;
-    using stdexec::let_value_t;
-    using stdexec::let_error_t;
-    using stdexec::let_stopped_t;
-    using stdexec::bulk_t;
-    using stdexec::split_t;
-    using stdexec::when_all_t;
-    using stdexec::when_all_with_variant_t;
-    using stdexec::transfer_when_all_t;
-    using stdexec::transfer_when_all_with_variant_t;
-    using stdexec::into_variant_t;
-    using stdexec::stopped_as_optional_t;
-    using stdexec::stopped_as_error_t;
-    using stdexec::ensure_started_t;
+    using on_t = stdexec::on_t;
+    using transfer_t = stdexec::transfer_t;
+    using schedule_from_t = stdexec::schedule_from_t;
+    using then_t = stdexec::then_t;
+    using upon_error_t = stdexec::upon_error_t;
+    using upon_stopped_t = stdexec::upon_stopped_t;
+    using let_value_t = stdexec::let_value_t;
+    using let_error_t = stdexec::let_error_t;
+    using let_stopped_t = stdexec::let_stopped_t;
+    using bulk_t = stdexec::bulk_t;
+    using split_t = stdexec::split_t;
+    using when_all_t = stdexec::when_all_t;
+    using when_all_with_variant_t = stdexec::when_all_with_variant_t;
+    using transfer_when_all_t = stdexec::transfer_when_all_t;
+    using transfer_when_all_with_variant_t = stdexec::transfer_when_all_with_variant_t;
+    using into_variant_t = stdexec::into_variant_t;
+    using stopped_as_optional_t = stdexec::stopped_as_optional_t;
+    using stopped_as_error_t = stdexec::stopped_as_error_t;
+    using ensure_started_t = stdexec::ensure_started_t;
 
-    using stdexec::on;
-    using stdexec::transfer;
-    using stdexec::schedule_from;
-
-    using stdexec::then;
-    using stdexec::upon_error;
-    using stdexec::upon_stopped;
-
-    using stdexec::let_value;
-    using stdexec::let_error;
-    using stdexec::let_stopped;
-
-    using stdexec::bulk;
-
-    using stdexec::split;
-    using stdexec::when_all;
-    using stdexec::when_all_with_variant;
-    using stdexec::transfer_when_all;
-    using stdexec::transfer_when_all_with_variant;
-
-    using stdexec::into_variant;
-
-    using stdexec::stopped_as_optional;
-    using stdexec::stopped_as_error;
-
-    using stdexec::ensure_started;
+    inline constexpr auto on = stdexec::on;
+    inline constexpr auto transfer = stdexec::transfer;
+    inline constexpr auto schedule_from = stdexec::schedule_from;
+    inline constexpr auto then = stdexec::then;
+    inline constexpr auto upon_error = stdexec::upon_error;
+    inline constexpr auto upon_stopped = stdexec::upon_stopped;
+    inline constexpr auto let_value = stdexec::let_value;
+    inline constexpr auto let_error = stdexec::let_error;
+    inline constexpr auto let_stopped = stdexec::let_stopped;
+    inline constexpr auto bulk = stdexec::bulk;
+    inline constexpr auto split = stdexec::split;
+    inline constexpr auto when_all = stdexec::when_all;
+    inline constexpr auto when_all_with_variant = stdexec::when_all_with_variant;
+    inline constexpr auto transfer_when_all = stdexec::transfer_when_all;
+    inline constexpr auto transfer_when_all_with_variant = stdexec::transfer_when_all_with_variant;
+    inline constexpr auto into_variant = stdexec::into_variant;
+    inline constexpr auto stopped_as_optional = stdexec::stopped_as_optional;
+    inline constexpr auto stopped_as_error = stdexec::stopped_as_error;
+    inline constexpr auto ensure_started = stdexec::ensure_started;
 
     // [exec.consumers], sender consumers
-    using stdexec::start_detached_t;
-    using stdexec::start_detached;
+    using start_detached_t = stdexec::start_detached_t;
+    inline constexpr auto start_detached = stdexec::start_detached;
 
     // [exec.utils], sender and receiver utilities
     // [exec.utils.rcvr_adptr]
-    using stdexec::receiver_adaptor;
+    template <class _Derived, class _Base = stdexec::__adaptors::__not_a_receiver>
+      using receiver_adaptor = stdexec::receiver_adaptor<_Derived, _Base>;
 
     // [exec.utils.cmplsigs]
-    using stdexec::completion_signatures;
+    template <class... _Sigs>
+      using completion_signatures = stdexec::completion_signatures<_Sigs...>;
 
     // [exec.utils.mkcmplsigs]
-    using stdexec::make_completion_signatures;
+    template<
+      class _Sender,
+      class _Env = no_env,
+      class _Sigs = completion_signatures<>,
+      template <class...> class _SetValue = stdexec::__compl_sigs::__default_set_value,
+      template <class> class _SetError = stdexec::__compl_sigs::__default_set_error,
+      class _SetStopped = completion_signatures<set_stopped_t()>>
+    using make_completion_signatures =
+      stdexec::make_completion_signatures<_Sender, _Env, _Sigs, _SetValue, _SetError, _SetStopped>;
 
     // [exec.ctx], execution contexts
-    using stdexec::run_loop;
+    using run_loop = stdexec::run_loop;
 
     // [exec.execute], execute
-    using stdexec::execute_t;
-    using stdexec::execute;
+    using execute_t = stdexec::execute_t;
+    inline constexpr auto execute = stdexec::execute;
 
     #if !_STD_NO_COROUTINES_
     // [exec.as_awaitable]
-    using stdexec::as_awaitable_t;
-    using stdexec::as_awaitable;
+    using as_awaitable_t = stdexec::as_awaitable_t;
+    inline constexpr auto as_awaitable = stdexec::as_awaitable;
 
     // [exec.with_awaitable_senders]
-    using stdexec::with_awaitable_senders;
+    template <class _Promise>
+      using with_awaitable_senders = stdexec::with_awaitable_senders<_Promise>;
     #endif // !_STD_NO_COROUTINES_
   } // namespace execution
 
   namespace this_thread {
-    using stdexec::execute_may_block_caller_t;
-    using stdexec::execute_may_block_caller;
-    using stdexec::sync_wait_t;
-    using stdexec::sync_wait_with_variant_t;
-    using stdexec::sync_wait;
-    using stdexec::sync_wait_with_variant;
+    using execute_may_block_caller_t = stdexec::execute_may_block_caller_t;
+    using sync_wait_t = stdexec::sync_wait_t;
+    using sync_wait_with_variant_t = stdexec::sync_wait_with_variant_t;
+
+    inline constexpr auto execute_may_block_caller = stdexec::execute_may_block_caller;
+    inline constexpr auto sync_wait = stdexec::sync_wait;
+    inline constexpr auto sync_wait_with_variant = stdexec::sync_wait_with_variant;
   } // namespace this_thread
 } // namespace std

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -839,8 +839,8 @@ namespace stdexec {
         -> tag_invoke_result_t<get_forward_progress_guarantee_t, __cref_t<_T>> {
         return tag_invoke(get_forward_progress_guarantee_t{}, std::as_const(__t));
       }
-      constexpr execution::forward_progress_guarantee operator()(auto&&) const noexcept {
-        return execution::forward_progress_guarantee::weakly_parallel;
+      constexpr stdexec::forward_progress_guarantee operator()(auto&&) const noexcept {
+        return stdexec::forward_progress_guarantee::weakly_parallel;
       }
     };
 
@@ -1284,7 +1284,7 @@ namespace stdexec {
         if constexpr (__connectable_with_tag_invoke<_Sender, _Receiver>) {
           static_assert(
             operation_state<tag_invoke_result_t<connect_t, _Sender, _Receiver>>,
-            "execution::connect(sender, receiver) must return a type that "
+            "stdexec::connect(sender, receiver) must return a type that "
             "satisfies the operation_state concept");
           return tag_invoke(connect_t{}, (_Sender&&) __sndr, (_Receiver&&) __rcvr);
         } else if constexpr (__callable<__connect_awaitable_t, _Sender, _Receiver>) {
@@ -1452,7 +1452,7 @@ namespace stdexec {
 
 #if !_STD_NO_COROUTINES_
   /////////////////////////////////////////////////////////////////////////////
-  // execution::as_awaitable [execution.coro_utils.as_awaitable]
+  // stdexec::as_awaitable [execution.coro_utils.as_awaitable]
   namespace __as_awaitable {
     namespace __impl {
       struct __void {};
@@ -2105,7 +2105,7 @@ namespace stdexec {
           friend auto tag_invoke(_Connect, _Self&& __self, _Receiver&& __rcvr)
             noexcept(__nothrow_connectable<__member_t<_Self, _Base>, _Receiver>)
             -> connect_result_t<__member_t<_Self, _Base>, _Receiver> {
-            return execution::connect(((__t&&) __self).base(), (_Receiver&&) __rcvr);
+            return stdexec::connect(((__t&&) __self).base(), (_Receiver&&) __rcvr);
           }
 
           template <tag_category<forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
@@ -2173,7 +2173,7 @@ namespace stdexec {
               tag_invocable<set_value_t, __base_t<_D>, _As...>
           friend void tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept {
             _NVCXX_EXPAND_PACK(_As, __as,
-              execution::set_value(__get_base((_D&&) __self), (_As&&) __as...);
+              stdexec::set_value(__get_base((_D&&) __self), (_As&&) __as...);
             )
           }
 
@@ -2188,7 +2188,7 @@ namespace stdexec {
             requires _MISSING_MEMBER(_D, set_error) &&
               tag_invocable<set_error_t, __base_t<_D>, _Error>
           friend void tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept {
-            execution::set_error(__get_base((_Derived&&) __self), (_Error&&) __err);
+            stdexec::set_error(__get_base((_Derived&&) __self), (_Error&&) __err);
           }
 
           template <same_as<set_stopped_t> _SetStopped, class _D = _Derived>
@@ -2202,7 +2202,7 @@ namespace stdexec {
             requires _MISSING_MEMBER(_D, set_stopped) &&
               tag_invocable<set_stopped_t, __base_t<_D>>
           friend void tag_invoke(_SetStopped, _Derived&& __self) noexcept {
-            execution::set_stopped(__get_base((_Derived&&) __self));
+            stdexec::set_stopped(__get_base((_Derived&&) __self));
           }
 
           // Pass through the get_env receiver query
@@ -2216,7 +2216,7 @@ namespace stdexec {
             requires _MISSING_MEMBER(_D, get_env)
           friend auto tag_invoke(_GetEnv, const _Derived& __self)
             -> __call_result_t<get_env_t, __base_t<const _D&>> {
-            return execution::get_env(__get_base(__self));
+            return stdexec::get_env(__get_base(__self));
           }
 
          public:
@@ -2240,7 +2240,7 @@ namespace stdexec {
           template <same_as<start_t> _Start, class _D = _Derived>
             requires _MISSING_MEMBER(_D, start)
           friend void tag_invoke(_Start, _Derived& __self) noexcept {
-            execution::start(__c_cast<__t>(__self).base());
+            stdexec::start(__c_cast<__t>(__self).base());
           }
 
           template <__none_of<start_t> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
@@ -2278,9 +2278,9 @@ namespace stdexec {
             requires _MISSING_MEMBER(decay_t<_Self>, schedule) &&
               scheduler<__member_t<_Self, _Base>>
           friend auto tag_invoke(_Schedule, _Self&& __self)
-            noexcept(noexcept(execution::schedule(__declval<__member_t<_Self, _Base>>())))
+            noexcept(noexcept(stdexec::schedule(__declval<__member_t<_Self, _Base>>())))
             -> schedule_result_t<_Self> {
-            return execution::schedule(__c_cast<__t>((_Self&&) __self).base());
+            return stdexec::schedule(__c_cast<__t>((_Self&&) __self).base());
           }
 
           template <tag_category<forwarding_scheduler_query> _Tag, same_as<_Derived> _Self, class... _As _NVCXX_CAPTURE_PACK(_As)>
@@ -2440,7 +2440,7 @@ namespace stdexec {
           noexcept(__nothrow_connectable<__member_t<_Self, _Sender>, __receiver<_Receiver>>)
           // BUGBUG
           -> connect_result_t<__member_t<_Self, _Sender>, __receiver<_Receiver>> {
-          return execution::connect(
+          return stdexec::connect(
               ((_Self&&) __self).__sndr_,
               __receiver<_Receiver>{(_Receiver&&) __rcvr, ((_Self&&) __self).__fun_});
         }
@@ -2552,7 +2552,7 @@ namespace stdexec {
         friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
           noexcept(__nothrow_connectable<__member_t<_Self, _Sender>, __receiver<_Receiver>>)
           -> connect_result_t<__member_t<_Self, _Sender>, __receiver<_Receiver>> {
-          return execution::connect(
+          return stdexec::connect(
               ((_Self&&) __self).__sndr_,
               __receiver<_Receiver>{(_Receiver&&) __rcvr, ((_Self&&) __self).__fun_});
         }
@@ -2660,7 +2660,7 @@ namespace stdexec {
         friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
           noexcept(__nothrow_connectable<_Sender, __receiver<_Receiver>>)
           -> connect_result_t<__member_t<_Self, _Sender>, __receiver<_Receiver>> {
-          return execution::connect(
+          return stdexec::connect(
               ((_Self&&) __self).__sndr_,
               __receiver<_Receiver>{(_Receiver&&) __rcvr, ((_Self&&) __self).__fun_});
         }
@@ -2736,7 +2736,7 @@ namespace stdexec {
           for (_Shape __i{}; __i != __shape_; ++__i) {
             __f_(__i, __as...);
           }
-          execution::set_value(std::move(this->base()), (_As&&)__as...);
+          stdexec::set_value(std::move(this->base()), (_As&&)__as...);
         }
 
         template <class... _As>
@@ -2746,9 +2746,9 @@ namespace stdexec {
             for (_Shape __i{}; __i != __shape_; ++__i) {
               __f_(__i, __as...);
             }
-            execution::set_value(std::move(this->base()), (_As&&)__as...);
+            stdexec::set_value(std::move(this->base()), (_As&&)__as...);
           } catch(...) {
-            execution::set_error(std::move(this->base()), std::current_exception());
+            stdexec::set_error(std::move(this->base()), std::current_exception());
           }
         }
 
@@ -2794,7 +2794,7 @@ namespace stdexec {
         friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
           noexcept(__nothrow_connectable<__member_t<_Self, _Sender>, __receiver<_Receiver>>)
           -> connect_result_t<__member_t<_Self, _Sender>, __receiver<_Receiver>> {
-          return execution::connect(
+          return stdexec::connect(
               ((_Self&&) __self).__sndr_,
               __receiver<_Receiver>{
                 (_Receiver&&) __rcvr,
@@ -3342,7 +3342,7 @@ namespace stdexec {
             if (__shared_state->__stop_source_.stop_requested()) {
               // Stop has already been requested. Don't bother starting
               // the child operations.
-              execution::set_stopped((_Receiver&&) __self.__rcvr_);
+              stdexec::set_stopped((_Receiver&&) __self.__rcvr_);
             } else {
               // Otherwise, the inner source hasn't notified completion.
               // Set this operation as the __op_state1 so it's notified.
@@ -3849,17 +3849,17 @@ namespace stdexec {
           void set_value(_Ty&& __a) && noexcept try {
             using _Value = __single_sender_value_t<_Sender, env_of_t<_Receiver>>;
             static_assert(constructible_from<_Value, _Ty>);
-            execution::set_value(
+            stdexec::set_value(
                 ((__receiver&&) *this).base(),
                 std::optional<_Value>{(_Ty&&) __a});
           } catch(...) {
-            execution::set_error(
+            stdexec::set_error(
                 ((__receiver&&) *this).base(),
                 std::current_exception());
           }
         void set_stopped() && noexcept {
           using _Value = __single_sender_value_t<_Sender, env_of_t<_Receiver>>;
-          execution::set_value(((__receiver&&) *this).base(), std::optional<_Value>{std::nullopt});
+          stdexec::set_value(((__receiver&&) *this).base(), std::optional<_Value>{std::nullopt});
         }
 
         __operation<_SenderId, _ReceiverId>* __op_;
@@ -4070,9 +4070,9 @@ namespace stdexec {
           return __self.__schedule();
         }
 
-        friend execution::forward_progress_guarantee tag_invoke(
+        friend stdexec::forward_progress_guarantee tag_invoke(
             get_forward_progress_guarantee_t, const __scheduler&) noexcept {
-          return execution::forward_progress_guarantee::parallel;
+          return stdexec::forward_progress_guarantee::parallel;
         }
 
         // BUGBUG NOT TO SPEC
@@ -4463,7 +4463,7 @@ namespace stdexec {
           auto get_env() const
             -> __make_env_t<env_of_t<_Receiver>, __with_t<get_scheduler_t, _Scheduler>> {
             return __make_env(
-              execution::get_env(this->base()),
+              stdexec::get_env(this->base()),
               __with(get_scheduler, __op_state_->__scheduler_));
           }
         };
@@ -4663,11 +4663,11 @@ namespace stdexec {
             using __variant_t =
               __into_variant_result_t<_Sender, env_of_t<_Receiver>>;
             static_assert(constructible_from<__variant_t, std::tuple<_As&&...>>);
-            execution::set_value(
+            stdexec::set_value(
                 ((__receiver&&) *this).base(),
                 __variant_t{std::tuple<_As&&...>{(_As&&) __as...}});
           } catch(...) {
-            execution::set_error(
+            stdexec::set_error(
                 ((__receiver&&) *this).base(),
                 std::current_exception());
           }
@@ -4703,7 +4703,7 @@ namespace stdexec {
         friend auto tag_invoke(connect_t, __sender&& __self, _Receiver&& __rcvr)
           noexcept(__nothrow_connectable<_Sender, __receiver_t<_Receiver>>)
           -> connect_result_t<_Sender, __receiver_t<_Receiver>> {
-          return execution::connect(
+          return stdexec::connect(
               (_Sender&&) __self.__sndr_,
               __receiver_t<_Receiver>{(_Receiver&&) __rcvr});
         }
@@ -4882,7 +4882,7 @@ namespace stdexec {
               auto get_env() const
                 -> __make_env_t<env_of_t<_Receiver>, __with_t<get_stop_token_t, in_place_stop_token>> {
                 return __make_env(
-                  execution::get_env(base()),
+                  stdexec::get_env(base()),
                   __with(get_stop_token, __op_state_->__stop_source_.get_token()));
               }
               __operation<_CvrefReceiverId>* __op_state_;
@@ -4930,10 +4930,10 @@ namespace stdexec {
                         std::apply(
                           [this](auto&... __all_vals) -> void {
                             try {
-                              execution::set_value(
+                              stdexec::set_value(
                                   (_Receiver&&) __recvr_, std::move(__all_vals)...);
                             } catch(...) {
-                              execution::set_error(
+                              stdexec::set_error(
                                   (_Receiver&&) __recvr_, std::current_exception());
                             }
                           },
@@ -4951,11 +4951,11 @@ namespace stdexec {
                   break;
                 case __error:
                   std::visit([this](auto& __err) noexcept {
-                    execution::set_error((_Receiver&&) __recvr_, std::move(__err));
+                    stdexec::set_error((_Receiver&&) __recvr_, std::move(__err));
                   }, __errors_);
                   break;
                 case __stopped:
-                  execution::set_stopped((_Receiver&&) __recvr_);
+                  stdexec::set_stopped((_Receiver&&) __recvr_);
                   break;
                 default:
                   ;
@@ -4967,7 +4967,7 @@ namespace stdexec {
                   : __recvr_((_Receiver&&) __rcvr)
                   , __child_states_{
                       __conv{[&__when_all, this]() {
-                        return execution::connect(
+                        return stdexec::connect(
                             std::get<_Is>(((_WhenAll&&) __when_all).__sndrs_),
                             __receiver<_CvrefReceiverId, _Is>{{}, this});
                       }}...
@@ -4986,10 +4986,10 @@ namespace stdexec {
                 if (__self.__stop_source_.stop_requested()) {
                   // Stop has already been requested. Don't bother starting
                   // the child operations.
-                  execution::set_stopped((_Receiver&&) __self.__recvr_);
+                  stdexec::set_stopped((_Receiver&&) __self.__recvr_);
                 } else {
                   apply([](auto&&... __child_ops) noexcept -> void {
-                    (execution::start(__child_ops), ...);
+                    (stdexec::start(__child_ops), ...);
                   }, __self.__child_states_);
                   if constexpr (sizeof...(_SenderIds) == 0) {
                     __self.__complete();
@@ -5191,30 +5191,30 @@ namespace stdexec {
     namespace __impl {
       template <class _Sender>
         using __into_variant_result_t =
-          decltype(execution::into_variant(__declval<_Sender>()));
+          decltype(stdexec::into_variant(__declval<_Sender>()));
 
       struct __env {
-        execution::run_loop::__scheduler __sched_;
+        stdexec::run_loop::__scheduler __sched_;
 
-        friend auto tag_invoke(execution::get_scheduler_t, const __env& __self) noexcept
-          -> execution::run_loop::__scheduler {
+        friend auto tag_invoke(stdexec::get_scheduler_t, const __env& __self) noexcept
+          -> stdexec::run_loop::__scheduler {
           return __self.__sched_;
         }
 
-        friend auto tag_invoke(execution::get_delegatee_scheduler_t, const __env& __self) noexcept
-          -> execution::run_loop::__scheduler {
+        friend auto tag_invoke(stdexec::get_delegatee_scheduler_t, const __env& __self) noexcept
+          -> stdexec::run_loop::__scheduler {
           return __self.__sched_;
         }
       };
 
       // What should sync_wait(just_stopped()) return?
       template <class _Sender>
-          requires execution::sender<_Sender, __env>
+          requires stdexec::sender<_Sender, __env>
         using __sync_wait_result_t =
-          execution::value_types_of_t<
+          stdexec::value_types_of_t<
             _Sender,
             __env,
-            execution::__decayed_tuple,
+            stdexec::__decayed_tuple,
             __single>;
 
       template <class _Sender>
@@ -5228,7 +5228,7 @@ namespace stdexec {
         struct __receiver {
           using _Sender = __t<_SenderId>;
           __state<_SenderId>* __state_;
-          execution::run_loop* __loop_;
+          stdexec::run_loop* __loop_;
           template <class _Error>
           void __set_error(_Error __err) noexcept {
             if constexpr (__decays_to<_Error, std::exception_ptr>)
@@ -5241,7 +5241,7 @@ namespace stdexec {
           }
           template <class _Sender2 = _Sender, class... _As _NVCXX_CAPTURE_PACK(_As)>
             requires constructible_from<__sync_wait_result_t<_Sender2>, _As...>
-          friend void tag_invoke(execution::set_value_t, __receiver&& __rcvr, _As&&... __as) noexcept try {
+          friend void tag_invoke(stdexec::set_value_t, __receiver&& __rcvr, _As&&... __as) noexcept try {
             _NVCXX_EXPAND_PACK(_As, __as,
               __rcvr.__state_->__data_.template emplace<1>((_As&&) __as...);
             )
@@ -5250,15 +5250,15 @@ namespace stdexec {
             __rcvr.__set_error(std::current_exception());
           }
           template <class _Error>
-          friend void tag_invoke(execution::set_error_t, __receiver&& __rcvr, _Error __err) noexcept {
+          friend void tag_invoke(stdexec::set_error_t, __receiver&& __rcvr, _Error __err) noexcept {
             __rcvr.__set_error((_Error &&) __err);
           }
-          friend void tag_invoke(execution::set_stopped_t __d, __receiver&& __rcvr) noexcept {
+          friend void tag_invoke(stdexec::set_stopped_t __d, __receiver&& __rcvr) noexcept {
             __rcvr.__state_->__data_.template emplace<3>(__d);
             __rcvr.__loop_->finish();
           }
           friend __env
-          tag_invoke(execution::get_env_t, const __receiver& __rcvr) noexcept {
+          tag_invoke(stdexec::get_env_t, const __receiver& __rcvr) noexcept {
             return {__rcvr.__loop_->get_scheduler()};
           }
         };
@@ -5266,41 +5266,41 @@ namespace stdexec {
       template <class _SenderId>
         struct __state {
           using _Tuple = __sync_wait_result_t<__t<_SenderId>>;
-          std::variant<std::monostate, _Tuple, std::exception_ptr, execution::set_stopped_t> __data_{};
+          std::variant<std::monostate, _Tuple, std::exception_ptr, stdexec::set_stopped_t> __data_{};
         };
 
       template <class _Sender>
         using __into_variant_result_t =
-          decltype(execution::into_variant(__declval<_Sender>()));
+          decltype(stdexec::into_variant(__declval<_Sender>()));
     } // namespace __impl
 
     ////////////////////////////////////////////////////////////////////////////
     // [execution.senders.consumers.sync_wait]
     struct sync_wait_t {
       // TODO: constrain on return type
-      template <execution::__single_value_variant_sender<__impl::__env> _Sender> // NOT TO SPEC
+      template <stdexec::__single_value_variant_sender<__impl::__env> _Sender> // NOT TO SPEC
         requires
-          execution::__tag_invocable_with_completion_scheduler<
-            sync_wait_t, execution::set_value_t, _Sender>
+          stdexec::__tag_invocable_with_completion_scheduler<
+            sync_wait_t, stdexec::set_value_t, _Sender>
       tag_invoke_result_t<
         sync_wait_t,
-        execution::__completion_scheduler_for<_Sender, execution::set_value_t>,
+        stdexec::__completion_scheduler_for<_Sender, stdexec::set_value_t>,
         _Sender>
       operator()(_Sender&& __sndr) const noexcept(
         nothrow_tag_invocable<
           sync_wait_t,
-          execution::__completion_scheduler_for<_Sender, execution::set_value_t>,
+          stdexec::__completion_scheduler_for<_Sender, stdexec::set_value_t>,
           _Sender>) {
         auto __sched =
-          execution::get_completion_scheduler<execution::set_value_t>(__sndr);
+          stdexec::get_completion_scheduler<stdexec::set_value_t>(__sndr);
         return tag_invoke(sync_wait_t{}, std::move(__sched), (_Sender&&) __sndr);
       }
 
       // TODO: constrain on return type
-      template <execution::__single_value_variant_sender<__impl::__env> _Sender> // NOT TO SPEC
+      template <stdexec::__single_value_variant_sender<__impl::__env> _Sender> // NOT TO SPEC
         requires
-          (!execution::__tag_invocable_with_completion_scheduler<
-            sync_wait_t, execution::set_value_t, _Sender>) &&
+          (!stdexec::__tag_invocable_with_completion_scheduler<
+            sync_wait_t, stdexec::set_value_t, _Sender>) &&
           tag_invocable<sync_wait_t, _Sender>
       tag_invoke_result_t<sync_wait_t, _Sender>
       operator()(_Sender&& __sndr) const noexcept(
@@ -5308,26 +5308,26 @@ namespace stdexec {
         return tag_invoke(sync_wait_t{}, (_Sender&&) __sndr);
       }
 
-      template <execution::__single_value_variant_sender<__impl::__env> _Sender>
+      template <stdexec::__single_value_variant_sender<__impl::__env> _Sender>
         requires
-          (!execution::__tag_invocable_with_completion_scheduler<
-            sync_wait_t, execution::set_value_t, _Sender>) &&
+          (!stdexec::__tag_invocable_with_completion_scheduler<
+            sync_wait_t, stdexec::set_value_t, _Sender>) &&
           (!tag_invocable<sync_wait_t, _Sender>) &&
-          execution::sender<_Sender, __impl::__env> &&
-          execution::sender_to<_Sender, __impl::__receiver<__x<_Sender>>>
+          stdexec::sender<_Sender, __impl::__env> &&
+          stdexec::sender_to<_Sender, __impl::__receiver<__x<_Sender>>>
       auto operator()(_Sender&& __sndr) const
         -> std::optional<__impl::__sync_wait_result_t<_Sender>> {
         using state_t = __impl::__state<__x<_Sender>>;
         state_t __state {};
-        execution::run_loop __loop;
+        stdexec::run_loop __loop;
 
         // Launch the sender with a continuation that will fill in a variant
         // and notify a condition variable.
         auto __op_state =
-          execution::connect(
+          stdexec::connect(
             (_Sender&&) __sndr,
             __impl::__receiver<__x<_Sender>>{&__state, &__loop});
-        execution::start(__op_state);
+        stdexec::start(__op_state);
 
         // Wait for the variant to be filled in.
         __loop.run();
@@ -5345,38 +5345,38 @@ namespace stdexec {
     ////////////////////////////////////////////////////////////////////////////
     // [execution.senders.consumers.sync_wait_with_variant]
     struct sync_wait_with_variant_t {
-      template <execution::sender<__impl::__env> _Sender>
+      template <stdexec::sender<__impl::__env> _Sender>
         requires
-          execution::__tag_invocable_with_completion_scheduler<
-            sync_wait_with_variant_t, execution::set_value_t, _Sender>
+          stdexec::__tag_invocable_with_completion_scheduler<
+            sync_wait_with_variant_t, stdexec::set_value_t, _Sender>
       tag_invoke_result_t<
         sync_wait_with_variant_t,
-        execution::__completion_scheduler_for<_Sender, execution::set_value_t>,
+        stdexec::__completion_scheduler_for<_Sender, stdexec::set_value_t>,
         _Sender>
       operator()(_Sender&& __sndr) const noexcept(
         nothrow_tag_invocable<
           sync_wait_with_variant_t,
-          execution::__completion_scheduler_for<_Sender, execution::set_value_t>,
+          stdexec::__completion_scheduler_for<_Sender, stdexec::set_value_t>,
           _Sender>) {
 
         static_assert(std::is_same_v<
           tag_invoke_result_t<
             sync_wait_with_variant_t,
-            execution::__completion_scheduler_for<_Sender, execution::set_value_t>,
+            stdexec::__completion_scheduler_for<_Sender, stdexec::set_value_t>,
             _Sender>,
           std::optional<__impl::__sync_wait_with_variant_result_t<_Sender>>>,
-          "The type of tag_invoke(execution::sync_wait_with_variant, execution::get_completion_scheduler, S) "
+          "The type of tag_invoke(stdexec::sync_wait_with_variant, stdexec::get_completion_scheduler, S) "
           "must be sync-wait-with-variant-type<S, sync-wait-env>");
 
         auto __sched =
-          execution::get_completion_scheduler<execution::set_value_t>(__sndr);
+          stdexec::get_completion_scheduler<stdexec::set_value_t>(__sndr);
         return tag_invoke(
           sync_wait_with_variant_t{}, std::move(__sched), (_Sender&&) __sndr);
       }
-      template <execution::sender<__impl::__env> _Sender>
+      template <stdexec::sender<__impl::__env> _Sender>
         requires
-          (!execution::__tag_invocable_with_completion_scheduler<
-            sync_wait_with_variant_t, execution::set_value_t, _Sender>) &&
+          (!stdexec::__tag_invocable_with_completion_scheduler<
+            sync_wait_with_variant_t, stdexec::set_value_t, _Sender>) &&
           tag_invocable<sync_wait_with_variant_t, _Sender>
       tag_invoke_result_t<sync_wait_with_variant_t, _Sender>
       operator()(_Sender&& __sndr) const noexcept(
@@ -5385,20 +5385,20 @@ namespace stdexec {
         static_assert(std::is_same_v<
           tag_invoke_result_t<sync_wait_with_variant_t, _Sender>,
           std::optional<__impl::__sync_wait_with_variant_result_t<_Sender>>>,
-          "The type of tag_invoke(execution::sync_wait_with_variant, S) "
+          "The type of tag_invoke(stdexec::sync_wait_with_variant, S) "
           "must be sync-wait-with-variant-type<S, sync-wait-env>");
 
         return tag_invoke(sync_wait_with_variant_t{}, (_Sender&&) __sndr);
       }
-      template <execution::sender<__impl::__env> _Sender>
+      template <stdexec::sender<__impl::__env> _Sender>
         requires
-          (!execution::__tag_invocable_with_completion_scheduler<
-            sync_wait_with_variant_t, execution::set_value_t, _Sender>) &&
+          (!stdexec::__tag_invocable_with_completion_scheduler<
+            sync_wait_with_variant_t, stdexec::set_value_t, _Sender>) &&
           (!tag_invocable<sync_wait_with_variant_t, _Sender>) &&
           invocable<sync_wait_t, __impl::__into_variant_result_t<_Sender>>
       std::optional<__impl::__sync_wait_with_variant_result_t<_Sender>>
       operator()(_Sender&& __sndr) const {
-        return sync_wait_t{}(execution::into_variant((_Sender&&) __sndr));
+        return sync_wait_t{}(stdexec::into_variant((_Sender&&) __sndr));
       }
     };
   } // namespace __sync_wait

--- a/test/exec/async_scope/test_dtor.cpp
+++ b/test/exec/async_scope/test_dtor.cpp
@@ -2,9 +2,9 @@
 #include <exec/async_scope.hpp>
 #include "exec/static_thread_pool.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 using exec::async_scope;
-using std::this_thread::sync_wait;
+using stdexec::sync_wait;
 
 TEST_CASE("async_scope can be created and them immediately destructed", "[async_scope][dtor]") {
   async_scope scope;

--- a/test/exec/async_scope/test_empty.cpp
+++ b/test/exec/async_scope/test_empty.cpp
@@ -3,9 +3,9 @@
 #include "test_common/schedulers.hpp"
 #include "test_common/receivers.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 using exec::async_scope;
-using std::this_thread::sync_wait;
+using stdexec::sync_wait;
 
 TEST_CASE("empty will complete immediately on an empty async_scope", "[async_scope][empty]") {
   async_scope scope;

--- a/test/exec/async_scope/test_spawn.cpp
+++ b/test/exec/async_scope/test_spawn.cpp
@@ -3,9 +3,9 @@
 #include "test_common/schedulers.hpp"
 #include "test_common/receivers.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 using exec::async_scope;
-using std::this_thread::sync_wait;
+using stdexec::sync_wait;
 
 //! Sender that throws exception when connected
 struct throwing_sender {

--- a/test/exec/async_scope/test_spawn_future.cpp
+++ b/test/exec/async_scope/test_spawn_future.cpp
@@ -4,15 +4,15 @@
 #include "test_common/schedulers.hpp"
 #include "test_common/receivers.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 using exec::async_scope;
-using std::this_thread::sync_wait;
+using stdexec::sync_wait;
 
 namespace {
 void expect_empty(exec::async_scope& scope) {
   ex::run_loop loop;
   ex::scheduler auto sch = loop.get_scheduler();
-  CHECK_FALSE(std::this_thread::execute_may_block_caller(sch));
+  CHECK_FALSE(stdexec::execute_may_block_caller(sch));
   auto op = ex::connect(
     ex::then(scope.on_empty(), [&](){  loop.finish(); }),
     expect_void_receiver{exec::make_env(exec::with(ex::get_scheduler, sch))});

--- a/test/exec/async_scope/test_stop.cpp
+++ b/test/exec/async_scope/test_stop.cpp
@@ -4,9 +4,9 @@
 #include "test_common/receivers.hpp"
 #include "exec/single_thread_context.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 using exec::async_scope;
-using std::this_thread::sync_wait;
+using stdexec::sync_wait;
 
 TEST_CASE("calling request_stop will be visible in stop_source", "[async_scope][stop]") {
   async_scope scope;

--- a/test/exec/test_create.cpp
+++ b/test/exec/test_create.cpp
@@ -36,7 +36,7 @@ namespace {
     exec::async_scope scope_;
 
     ~create_test_fixture() {
-      std::this_thread::sync_wait(scope_.on_empty());
+      stdexec::sync_wait(scope_.on_empty());
     }
 
     void anIntAPI(int a, int b, void* context, void (*completed)(void* context, int result)) {
@@ -80,7 +80,7 @@ TEST_CASE_METHOD(create_test_fixture, "wrap an async API that computes a result"
   }(1, 2);
 
   REQUIRE_NOTHROW([&] {
-    auto [res] = std::this_thread::sync_wait(std::move(snd)).value();
+    auto [res] = stdexec::sync_wait(std::move(snd)).value();
     CHECK(res == 3);
   }());
 }
@@ -100,7 +100,7 @@ TEST_CASE_METHOD(create_test_fixture, "wrap an async API that doesn't compute a 
     );
   }();
 
-  std::optional<std::tuple<>> res = std::this_thread::sync_wait(std::move(snd));
+  std::optional<std::tuple<>> res = stdexec::sync_wait(std::move(snd));
   CHECK(res.has_value());
   CHECK(called);
 }

--- a/test/exec/test_env.cpp
+++ b/test/exec/test_env.cpp
@@ -18,7 +18,7 @@
 #include <stdexec/execution.hpp>
 #include <exec/env.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 namespace {
 // Two dummy properties:
@@ -26,7 +26,7 @@ constexpr struct Foo {
   template <class Env>
     requires std::tag_invocable<Foo, Env>
   auto operator()(const Env& e) const {
-    return std::tag_invoke(*this, e);
+    return stdexec::tag_invoke(*this, e);
   }
 } foo {};
 
@@ -34,7 +34,7 @@ constexpr struct Bar {
   template <class Env>
     requires std::tag_invocable<Bar, Env>
   auto operator()(const Env& e) const {
-    return std::tag_invoke(*this, e);
+    return stdexec::tag_invoke(*this, e);
   }
 } bar {};
 }

--- a/test/exec/test_on.cpp
+++ b/test/exec/test_on.cpp
@@ -23,7 +23,7 @@
 #include <exec/env.hpp>
 #include <exec/static_thread_pool.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 template <ex::scheduler Sched = inline_scheduler>
 inline auto _with_scheduler(Sched sched = {}) {
@@ -103,7 +103,7 @@ TEST_CASE("exec::on works when changing threads", "[adaptors][exec::on]") {
   ex::sender auto snd = exec::on(pool.get_scheduler(), ex::just()) //
                         | ex::then([&] { called = true; })
                         | _with_scheduler();
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
   // the work should be executed
   REQUIRE(called);
 }

--- a/test/exec/test_on2.cpp
+++ b/test/exec/test_on2.cpp
@@ -22,7 +22,7 @@
 #include <exec/on.hpp>
 #include <exec/env.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 template <ex::scheduler Sched = inline_scheduler>
 inline auto _with_scheduler(Sched sched = {}) {

--- a/test/exec/test_on3.cpp
+++ b/test/exec/test_on3.cpp
@@ -21,7 +21,7 @@
 #include <exec/on.hpp>
 #include <exec/async_scope.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 static const auto env = exec::make_env(exec::with(ex::get_scheduler, inline_scheduler{}));
 
@@ -44,7 +44,7 @@ TEST_CASE("Can pass exec::on sender to async_scope::spawn", "[adaptors][exec::on
   impulse_scheduler sched;
   scope.spawn(exec::on(sched, ex::just()), env);
   sched.start_next();
-  std::this_thread::sync_wait(scope.on_empty());
+  stdexec::sync_wait(scope.on_empty());
 }
 
 TEST_CASE("Can pass exec::on sender to async_scope::spawn_future", "[adaptors][exec::on]") {
@@ -52,7 +52,7 @@ TEST_CASE("Can pass exec::on sender to async_scope::spawn_future", "[adaptors][e
   impulse_scheduler sched;
   auto fut = scope.spawn_future(exec::on(sched, ex::just(42)), env);
   sched.start_next();
-  auto [i] = std::this_thread::sync_wait(std::move(fut)).value();
+  auto [i] = stdexec::sync_wait(std::move(fut)).value();
   CHECK(i == 42);
-  std::this_thread::sync_wait(scope.on_empty());
+  stdexec::sync_wait(scope.on_empty());
 }

--- a/test/exec/test_type_async_scope.cpp
+++ b/test/exec/test_type_async_scope.cpp
@@ -26,13 +26,13 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 namespace {
 void expect_empty(exec::async_scope& scope) {
   ex::run_loop loop;
   ex::scheduler auto sch = loop.get_scheduler();
-  CHECK_FALSE(std::this_thread::execute_may_block_caller(sch));
+  CHECK_FALSE(stdexec::execute_may_block_caller(sch));
   auto op = ex::connect(
     ex::then(scope.on_empty(), [&](){  loop.finish(); }),
     expect_void_receiver{exec::make_env(exec::with(ex::get_scheduler, sch))});
@@ -56,7 +56,7 @@ TEST_CASE("async_scope will complete", "[types][type_async_scope]") {
     exec::async_scope scope;
     ex::sender auto begin = ex::schedule(sch);
     scope.spawn(begin);
-    std::this_thread::sync_wait(scope.on_empty());
+    stdexec::sync_wait(scope.on_empty());
     expect_empty(scope);
   }
 
@@ -64,7 +64,7 @@ TEST_CASE("async_scope will complete", "[types][type_async_scope]") {
     exec::async_scope scope;
     ex::sender auto begin = ex::schedule(sch);
     {ex::sender auto nst = scope.nest(begin); (void)nst;}
-    std::this_thread::sync_wait(scope.on_empty());
+    stdexec::sync_wait(scope.on_empty());
     expect_empty(scope);
   }
 
@@ -74,7 +74,7 @@ TEST_CASE("async_scope will complete", "[types][type_async_scope]") {
     ex::sender auto nst = scope.nest(begin);
     auto op = ex::connect(std::move(nst), expect_void_receiver{});
     ex::start(op);
-    std::this_thread::sync_wait(scope.on_empty());
+    stdexec::sync_wait(scope.on_empty());
     expect_empty(scope);
   }
 
@@ -83,8 +83,8 @@ TEST_CASE("async_scope will complete", "[types][type_async_scope]") {
     exec::async_scope scope;
     std::atomic_bool produced{false};
     ex::sender auto begin = ex::schedule(sch);
-    {ex::sender auto ftr = scope.spawn_future(begin | std::execution::then([&](){produced = true;})); (void)ftr;}
-    std::this_thread::sync_wait(scope.on_empty() | std::execution::then([&](){STDEXEC_ASSERT(produced.load());}));
+    {ex::sender auto ftr = scope.spawn_future(begin | stdexec::then([&](){produced = true;})); (void)ftr;}
+    stdexec::sync_wait(scope.on_empty() | stdexec::then([&](){STDEXEC_ASSERT(produced.load());}));
     expect_empty(scope);
   }
   
@@ -93,11 +93,11 @@ TEST_CASE("async_scope will complete", "[types][type_async_scope]") {
     exec::async_scope scope;
     std::atomic_bool produced{false};
     ex::sender auto begin = ex::schedule(sch);
-    ex::sender auto ftr = scope.spawn_future(begin | std::execution::then([&](){produced = true;}));
-    std::this_thread::sync_wait(scope.on_empty() | std::execution::then([&](){STDEXEC_ASSERT(produced.load());}));
+    ex::sender auto ftr = scope.spawn_future(begin | stdexec::then([&](){produced = true;}));
+    stdexec::sync_wait(scope.on_empty() | stdexec::then([&](){STDEXEC_ASSERT(produced.load());}));
     auto op = ex::connect(std::move(ftr), expect_void_receiver{});
     ex::start(op);
-    std::this_thread::sync_wait(scope.on_empty());
+    stdexec::sync_wait(scope.on_empty());
     expect_empty(scope);
   }
 }

--- a/test/nvexec/bulk.cpp
+++ b/test/nvexec/bulk.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -27,7 +27,7 @@ TEST_CASE("bulk executes on GPU", "[cuda][stream][adaptors][bulk]") {
                  flags.set(idx);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -46,7 +46,7 @@ TEST_CASE("bulk forwards values on GPU", "[cuda][stream][adaptors][bulk]") {
                  }
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -65,7 +65,7 @@ TEST_CASE("bulk forwards multiple values on GPU", "[cuda][stream][adaptors][bulk
                  }
                }
              });
-  const auto [i, d] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [i, d] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(flags_storage.all_set_once());
   REQUIRE(i == 42);
@@ -89,7 +89,7 @@ TEST_CASE("bulk can preceed a sender without values", "[cuda][stream][adaptors][
                  flags.set(2);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -111,7 +111,7 @@ TEST_CASE("bulk can succeed a sender", "[cuda][stream][adaptors][bulk]") {
                    flags.set(idx);
                  }
                });
-    std::this_thread::sync_wait(std::move(snd));
+    stdexec::sync_wait(std::move(snd));
 
     REQUIRE(flags_storage.all_set_once());
   }
@@ -130,7 +130,7 @@ TEST_CASE("bulk can succeed a sender", "[cuda][stream][adaptors][bulk]") {
                    flags.set(idx);
                  }
                });
-    std::this_thread::sync_wait(std::move(snd)).value();
+    stdexec::sync_wait(std::move(snd)).value();
 
     REQUIRE(flags_storage.all_set_once());
   }

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -106,23 +106,23 @@ namespace detail::a_sender {
     struct operation_state_t {
       using Sender = stdexec::__t<SenderId>;
       using Receiver = stdexec::__t<ReceiverId>;
-      using inner_op_state_t = std::execution::connect_result_t<Sender, Receiver>;
+      using inner_op_state_t = stdexec::connect_result_t<Sender, Receiver>;
 
       inner_op_state_t inner_op_;
 
-      friend void tag_invoke(std::execution::start_t, operation_state_t& op) noexcept {
-        std::execution::start(op.inner_op_);
+      friend void tag_invoke(stdexec::start_t, operation_state_t& op) noexcept {
+        stdexec::start(op.inner_op_);
       }
 
       operation_state_t(Sender&& sender, Receiver&& receiver)
-        : inner_op_{std::execution::connect((Sender&&)sender, (Receiver&&)receiver)}
+        : inner_op_{stdexec::connect((Sender&&)sender, (Receiver&&)receiver)}
       {}
     };
 
   template <class ReceiverId, class Fun>
-    class receiver_t : std::execution::receiver_adaptor<receiver_t<ReceiverId, Fun>, stdexec::__t<ReceiverId>> {
+    class receiver_t : stdexec::receiver_adaptor<receiver_t<ReceiverId, Fun>, stdexec::__t<ReceiverId>> {
       using Receiver = stdexec::__t<ReceiverId>;
-      friend std::execution::receiver_adaptor<receiver_t, Receiver>;
+      friend stdexec::receiver_adaptor<receiver_t, Receiver>;
 
       Fun f_;
 
@@ -133,15 +133,15 @@ namespace detail::a_sender {
 
         if constexpr (std::is_same_v<void, result_t>) {
           f_((As&&)as...);
-          std::execution::set_value(std::move(this->base()));
+          stdexec::set_value(std::move(this->base()));
         } else {
-          std::execution::set_value(std::move(this->base()), f_((As&&)as...));
+          stdexec::set_value(std::move(this->base()), f_((As&&)as...));
         }
       }
 
      public:
       explicit receiver_t(Receiver rcvr, Fun fun)
-        : std::execution::receiver_adaptor<receiver_t, Receiver>((Receiver&&) rcvr)
+        : stdexec::receiver_adaptor<receiver_t, Receiver>((Receiver&&) rcvr)
         , f_((Fun&&) fun)
       {}
     };
@@ -167,29 +167,29 @@ namespace detail::a_sender {
           stdexec::__make_completion_signatures<
             stdexec::__member_t<Self, Sender>,
             Env,
-            std::execution::completion_signatures<>,
+            stdexec::completion_signatures<>,
             stdexec::__mbind_front_q<stdexec::__set_value_invoke_t, Fun>>;
 
-      template <stdexec::__decays_to<sender_t> Self, std::execution::receiver Receiver>
-        requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
-      friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+      template <stdexec::__decays_to<sender_t> Self, stdexec::receiver Receiver>
+        requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
+      friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
         -> op_t<Self, Receiver> {
         return op_t<Self, Receiver>(((Self&&)self).sndr_, receiver_th<Receiver>((Receiver&&)rcvr, self.fun_));
       }
 
       template <stdexec::__decays_to<sender_t> Self, class Env>
-      friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
-        -> std::execution::dependent_completion_signatures<Env>;
+      friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
+        -> stdexec::dependent_completion_signatures<Env>;
 
       template <stdexec::__decays_to<sender_t> Self, class Env>
-      friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+      friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
         requires stdexec::__callable<Tag, const Sender&, As...>
       friend auto tag_invoke(Tag tag, const sender_t& self, As&&... as)
         noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, std::execution::forwarding_sender_query>, Tag, const Sender&, As...> {
+        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
         return ((Tag&&) tag)(self.sndr_, (As&&) as...);
       }
     };
@@ -200,16 +200,16 @@ namespace detail::a_receiverless_sender {
     struct operation_state_t {
       using Sender = stdexec::__t<SenderId>;
       using Receiver = stdexec::__t<ReceiverId>;
-      using inner_op_state_t = std::execution::connect_result_t<Sender, Receiver>;
+      using inner_op_state_t = stdexec::connect_result_t<Sender, Receiver>;
 
       inner_op_state_t inner_op_;
 
-      friend void tag_invoke(std::execution::start_t, operation_state_t& op) noexcept {
-        std::execution::start(op.inner_op_);
+      friend void tag_invoke(stdexec::start_t, operation_state_t& op) noexcept {
+        stdexec::start(op.inner_op_);
       }
 
       operation_state_t(Sender&& sender, Receiver&& receiver)
-        : inner_op_{std::execution::connect((Sender&&)sender, (Receiver&&)receiver)}
+        : inner_op_{stdexec::connect((Sender&&)sender, (Receiver&&)receiver)}
       {}
     };
 
@@ -229,28 +229,28 @@ namespace detail::a_receiverless_sender {
           stdexec::__make_completion_signatures<
             stdexec::__member_t<Self, Sender>,
             Env,
-            std::execution::completion_signatures<>>;
+            stdexec::completion_signatures<>>;
 
-      template <stdexec::__decays_to<sender_t> Self, std::execution::receiver Receiver>
-        requires std::execution::receiver_of<Receiver, completion_signatures<Self, std::execution::env_of_t<Receiver>>>
-      friend auto tag_invoke(std::execution::connect_t, Self&& self, Receiver&& rcvr)
+      template <stdexec::__decays_to<sender_t> Self, stdexec::receiver Receiver>
+        requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
+      friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
         -> op_t<Self, Receiver> {
         return op_t<Self, Receiver>(((Self&&)self).sndr_, (Receiver&&)rcvr);
       }
 
       template <stdexec::__decays_to<sender_t> Self, class Env>
-      friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
-        -> std::execution::dependent_completion_signatures<Env>;
+      friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
+        -> stdexec::dependent_completion_signatures<Env>;
 
       template <stdexec::__decays_to<sender_t> Self, class Env>
-      friend auto tag_invoke(std::execution::get_completion_signatures_t, Self&&, Env)
+      friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<std::execution::forwarding_sender_query> Tag, class... As>
+      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
         requires stdexec::__callable<Tag, const Sender&, As...>
       friend auto tag_invoke(Tag tag, const sender_t& self, As&&... as)
         noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, std::execution::forwarding_sender_query>, Tag, const Sender&, As...> {
+        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
         return ((Tag&&) tag)(self.sndr_, (As&&) as...);
       }
     };
@@ -266,8 +266,8 @@ struct a_sender_t {
     using receiverless_sender_th = detail::a_receiverless_sender::sender_t<
       stdexec::__x<std::remove_cvref_t<_Sender>>>;
 
-  template <std::execution::sender _Sender, class _Fun>
-      requires std::execution::sender<sender_th<_Sender, _Fun>>
+  template <stdexec::sender _Sender, class _Fun>
+      requires stdexec::sender<sender_th<_Sender, _Fun>>
     sender_th<_Sender, _Fun> operator()(_Sender&& __sndr, _Fun __fun) const {
       return sender_th<_Sender, _Fun>{(_Sender&&) __sndr, (_Fun&&) __fun};
     }
@@ -277,8 +277,8 @@ struct a_sender_t {
       return {{}, {}, {(_Fun&&) __fun}};
     }
 
-  template <std::execution::sender _Sender>
-      requires std::execution::sender<receiverless_sender_th<_Sender>>
+  template <stdexec::sender _Sender>
+      requires stdexec::sender<receiverless_sender_th<_Sender>>
     receiverless_sender_th<_Sender> operator()(_Sender&& __sndr) const {
       return receiverless_sender_th<_Sender>{(_Sender&&) __sndr};
     }

--- a/test/nvexec/ensure_started.cpp
+++ b/test/nvexec/ensure_started.cpp
@@ -8,7 +8,7 @@
 #include "common.cuh"
 #include "stdexec/__detail/__p2300.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -30,7 +30,7 @@ TEST_CASE("ensure_started is eager", "[cuda][stream][adaptors][ensure_started]")
 
   REQUIRE(flags_storage.all_set_once());
 
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 }
 
 TEST_CASE("ensure_started propagates values", "[cuda][stream][adaptors][ensure_started]") {
@@ -48,7 +48,7 @@ TEST_CASE("ensure_started propagates values", "[cuda][stream][adaptors][ensure_s
                 return val * is_on_gpu();
               });
 
-  auto [v] = std::this_thread::sync_wait(std::move(snd2)).value();
+  auto [v] = stdexec::sync_wait(std::move(snd2)).value();
 
   REQUIRE(v == 1);
 }
@@ -71,7 +71,7 @@ TEST_CASE("ensure_started can preceed a sender without values", "[cuda][stream][
                  flags.set(1);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -94,7 +94,7 @@ TEST_CASE("ensure_started can succeed a sender", "[cuda][stream][adaptors][ensur
                    flags.set(0);
                  }
                });
-    std::this_thread::sync_wait(std::move(snd));
+    stdexec::sync_wait(std::move(snd));
 
     REQUIRE(flags_storage.all_set_once());
   }
@@ -114,7 +114,7 @@ TEST_CASE("ensure_started can succeed a sender", "[cuda][stream][adaptors][ensur
                    flags.set();
                  }
                });
-    std::this_thread::sync_wait(std::move(snd)).value();
+    stdexec::sync_wait(std::move(snd)).value();
 
     REQUIRE(flags_storage.all_set_once());
   }

--- a/test/nvexec/let_error.cpp
+++ b/test/nvexec/let_error.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -33,7 +33,7 @@ TEST_CASE("let_error executes on GPU", "[cuda][stream][adaptors][let_error]") {
 
                return ex::just();
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -58,7 +58,7 @@ TEST_CASE("let_error can preceed a sender without values", "[cuda][stream][adapt
                  flags.set(1);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -79,7 +79,7 @@ TEST_CASE("let_error can succeed a sender", "[cuda][stream][adaptors][let_error]
 
                return ex::schedule(sch);
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }

--- a/test/nvexec/let_stopped.cpp
+++ b/test/nvexec/let_stopped.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -33,7 +33,7 @@ TEST_CASE("let_stopped executes on GPU", "[cuda][stream][adaptors][let_stopped]"
 
                return ex::just();
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -58,7 +58,7 @@ TEST_CASE("let_stopped can preceed a sender without values", "[cuda][stream][ada
                  flags.set(1);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -79,7 +79,7 @@ TEST_CASE("let_stopped can succeed a sender", "[cuda][stream][adaptors][let_stop
 
                return ex::schedule(sch);
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }

--- a/test/nvexec/let_value.cpp
+++ b/test/nvexec/let_value.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -28,7 +28,7 @@ TEST_CASE("let_value executes on GPU", "[cuda][stream][adaptors][let_value]") {
                }
                return ex::just();
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -49,7 +49,7 @@ TEST_CASE("let_value accepts values on GPU", "[cuda][stream][adaptors][let_value
                }
                return ex::just();
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -69,7 +69,7 @@ TEST_CASE("let_value accepts multiple values on GPU", "[cuda][stream][adaptors][
                }
                return ex::just();
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -81,7 +81,7 @@ TEST_CASE("let_value returns values on GPU", "[cuda][stream][adaptors][let_value
            | ex::let_value([=]() {
                return ex::just(is_on_gpu());
              });
-  const auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(result == 1);
 }
@@ -105,7 +105,7 @@ TEST_CASE("let_value can preceed a sender without values", "[cuda][stream][adapt
                  flags.set(1);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -125,7 +125,7 @@ TEST_CASE("let_value can succeed a sender", "[cuda][stream][adaptors][let_value]
 
                return ex::schedule(sch);
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }

--- a/test/nvexec/split.cpp
+++ b/test/nvexec/split.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -27,8 +27,8 @@ TEST_CASE("split works", "[cuda][stream][adaptors][split]") {
   auto b1 = fork | ex::then([](bool on_gpu) { return on_gpu * 24; });
   auto b2 = fork | ex::then([](bool on_gpu) { return on_gpu * 42; });
 
-  auto [v1] = std::this_thread::sync_wait(std::move(b1)).value();
-  auto [v2] = std::this_thread::sync_wait(std::move(b2)).value();
+  auto [v1] = stdexec::sync_wait(std::move(b1)).value();
+  auto [v2] = stdexec::sync_wait(std::move(b2)).value();
 
   REQUIRE(v1 == 24);
   REQUIRE(v2 == 42);
@@ -48,7 +48,7 @@ TEST_CASE("split can preceed a sender without values", "[cuda][stream][adaptors]
                }
              });
 
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -71,7 +71,7 @@ TEST_CASE("split can succeed a sender", "[cuda][stream][adaptors][split]") {
                    flags.set(0);
                  }
                });
-    std::this_thread::sync_wait(std::move(snd));
+    stdexec::sync_wait(std::move(snd));
 
     REQUIRE(flags_storage.all_set_once());
   }
@@ -91,7 +91,7 @@ TEST_CASE("split can succeed a sender", "[cuda][stream][adaptors][split]") {
                    flags.set();
                  }
                });
-    std::this_thread::sync_wait(std::move(snd)).value();
+    stdexec::sync_wait(std::move(snd)).value();
 
     REQUIRE(flags_storage.all_set_once());
   }

--- a/test/nvexec/start_detached.cpp
+++ b/test/nvexec/start_detached.cpp
@@ -7,7 +7,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 

--- a/test/nvexec/then.cpp
+++ b/test/nvexec/then.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -27,7 +27,7 @@ TEST_CASE("then executes on GPU", "[cuda][stream][adaptors][then]") {
                  flags.set();
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -46,7 +46,7 @@ TEST_CASE("then accepts values on GPU", "[cuda][stream][adaptors][then]") {
                  }
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -65,7 +65,7 @@ TEST_CASE("then accepts multiple values on GPU", "[cuda][stream][adaptors][then]
                  }
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -81,7 +81,7 @@ TEST_CASE("then returns values on GPU", "[cuda][stream][adaptors][then]") {
 
                return 0;
              });
-  const auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(result == 42);
 }
@@ -103,7 +103,7 @@ TEST_CASE("then can preceed a sender without values", "[cuda][stream][adaptors][
                  flags.set(1);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -125,7 +125,7 @@ TEST_CASE("then can succeed a sender", "[cuda][stream][adaptors][then]") {
                    flags.set(0);
                  }
                });
-    std::this_thread::sync_wait(std::move(snd));
+    stdexec::sync_wait(std::move(snd));
 
     REQUIRE(flags_storage.all_set_once());
   }
@@ -144,7 +144,7 @@ TEST_CASE("then can succeed a sender", "[cuda][stream][adaptors][then]") {
                    flags.set();
                  }
                });
-    std::this_thread::sync_wait(std::move(snd)).value();
+    stdexec::sync_wait(std::move(snd)).value();
 
     REQUIRE(flags_storage.all_set_once());
   }
@@ -163,7 +163,7 @@ TEST_CASE("then can succeed a receiverless sender", "[cuda][stream][adaptors][th
                    flags.set();
                  }
                });
-    std::this_thread::sync_wait(std::move(snd));
+    stdexec::sync_wait(std::move(snd));
 
     REQUIRE(flags_storage.all_set_once());
   }
@@ -183,7 +183,7 @@ TEST_CASE("then can succeed a receiverless sender", "[cuda][stream][adaptors][th
                    flags.set();
                  }
                });
-    std::this_thread::sync_wait(std::move(snd)).value();
+    stdexec::sync_wait(std::move(snd)).value();
 
     REQUIRE(flags_storage.all_set_once());
   }
@@ -203,7 +203,7 @@ TEST_CASE("then can return values of non-trivial types", "[cuda][stream][adaptor
                  flags.set();
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }

--- a/test/nvexec/then_war.cpp
+++ b/test/nvexec/then_war.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -17,7 +17,7 @@ TEST_CASE("then can preceed a sender with values", "[cuda][stream][adaptors][the
            | a_sender([](bool then_was_on_gpu) -> bool {
                return then_was_on_gpu * is_on_gpu(); // nvbug/3810019
              });
-  auto [ok] = std::this_thread::sync_wait(std::move(snd)).value();
+  auto [ok] = stdexec::sync_wait(std::move(snd)).value();
   REQUIRE(ok);
 }
 

--- a/test/nvexec/transfer.cpp
+++ b/test/nvexec/transfer.cpp
@@ -5,7 +5,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -50,7 +50,7 @@ TEST_CASE("transfer changes context to GPU", "[cuda][stream][adaptors][transfer]
                }
                return 0;
              });
-  const auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(result == 2);
 }
@@ -75,7 +75,7 @@ TEST_CASE("transfer changes context from GPU", "[cuda][stream][adaptors][transfe
                }
                return 0;
              });
-  const auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(result == 2);
 }
@@ -93,7 +93,7 @@ TEST_CASE("transfer_just changes context to GPU", "[cuda][stream][adaptors][tran
                }
                return false;
              });
-  const auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(result == true);
 }
@@ -109,7 +109,7 @@ TEST_CASE("transfer_just supports move-only types", "[cuda][stream][adaptors][tr
                }
                return false;
              });
-  const auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(result == true);
 }
@@ -131,7 +131,7 @@ TEST_CASE("transfer supports move-only types", "[cuda][stream][adaptors][transfe
                }
                return false;
              });
-  const auto [result] = std::this_thread::sync_wait(std::move(snd)).value();
+  const auto [result] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(result == true);
 }

--- a/test/nvexec/upon_error.cpp
+++ b/test/nvexec/upon_error.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -53,7 +53,7 @@ TEST_CASE("upon_error executes on GPU", "[cuda][stream][adaptors][upon_error]") 
                  flags.set();
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -76,7 +76,7 @@ TEST_CASE("upon_error can preceed a sender without values", "[cuda][stream][adap
                 flags.set(1);
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -95,7 +95,7 @@ TEST_CASE("upon_error can succeed a sender without values", "[cuda][stream][adap
                  flags.set();
                }
              }); 
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }

--- a/test/nvexec/upon_stopped.cpp
+++ b/test/nvexec/upon_stopped.cpp
@@ -4,7 +4,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -31,7 +31,7 @@ TEST_CASE("upon_stopped executes on GPU", "[cuda][stream][adaptors][upon_stopped
                  flags.set();
                }
              });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }

--- a/test/nvexec/when_all.cpp
+++ b/test/nvexec/when_all.cpp
@@ -5,7 +5,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -27,7 +27,7 @@ TEST_CASE("when_all works", "[cuda][stream][adaptors][when_all]") {
   auto snd = ex::when_all(
       ex::schedule(stream_ctx.get_scheduler()) | ex::then([=]{ if (is_on_gpu()) { flags.set(0); }}),
       ex::schedule(stream_ctx.get_scheduler()) | ex::then([=]{ if (is_on_gpu()) { flags.set(1); }}));
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 
   REQUIRE(flags_storage.all_set_once());
 }
@@ -38,7 +38,7 @@ TEST_CASE("when_all returns values", "[cuda][stream][adaptors][when_all]") {
   auto snd = ex::when_all(
       ex::schedule(stream_ctx.get_scheduler()) | ex::then([]{ return is_on_gpu() * 24; }),
       ex::schedule(stream_ctx.get_scheduler()) | ex::then([]{ return is_on_gpu() * 42; }));
-  auto [v1, v2] = std::this_thread::sync_wait(std::move(snd)).value();
+  auto [v1, v2] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(v1 == 24);
   REQUIRE(v2 == 42);
@@ -53,7 +53,7 @@ TEST_CASE("when_all with many senders", "[cuda][stream][adaptors][when_all]") {
       ex::schedule(stream_ctx.get_scheduler()) | ex::then([]{ return is_on_gpu() * 3; }),
       ex::schedule(stream_ctx.get_scheduler()) | ex::then([]{ return is_on_gpu() * 4; }),
       ex::schedule(stream_ctx.get_scheduler()) | ex::then([]{ return is_on_gpu() * 5; }));
-  auto [v1, v2, v3, v4, v5] = std::this_thread::sync_wait(std::move(snd)).value();
+  auto [v1, v2, v3, v4, v5] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(v1 == 1);
   REQUIRE(v2 == 2);

--- a/test/nvexec/when_all_war.cpp
+++ b/test/nvexec/when_all_war.cpp
@@ -5,7 +5,7 @@
 #include "nvexec/stream_context.cuh"
 #include "common.cuh"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
@@ -16,7 +16,7 @@ TEST_CASE("when_all works with unknown senders", "[cuda][stream][adaptors][when_
   auto snd = ex::when_all(
       ex::schedule(sch) | ex::then([]() -> int { return is_on_gpu() * 24; }),
       ex::schedule(sch) | a_sender([]() -> int { return is_on_gpu() * 42; }));
-  auto [v1, v2] = std::this_thread::sync_wait(std::move(snd)).value();
+  auto [v1, v2] = stdexec::sync_wait(std::move(snd)).value();
 
   REQUIRE(v1 == 24);
   REQUIRE(v2 == 42);

--- a/test/stdexec/algos/adaptors/test_bulk.cpp
+++ b/test/stdexec/algos/adaptors/test_bulk.cpp
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 template <class Shape, int N, int (&Counter)[N]>
 void function(Shape i) {
@@ -198,7 +198,7 @@ TEST_CASE("bulk works with static thread pool", "[adaptors][bulk]") {
       auto snd = ex::transfer_just(sch)
                | ex::bulk(n, [&counter](int idx) { counter[idx] = 0; })
                | ex::bulk(n, [&counter](int idx) { counter[idx]++; });
-      std::this_thread::sync_wait(std::move(snd));
+      stdexec::sync_wait(std::move(snd));
 
       const std::size_t actual = std::count(counter.begin(), counter.end(), 1);
       const std::size_t expected = n;
@@ -214,7 +214,7 @@ TEST_CASE("bulk works with static thread pool", "[adaptors][bulk]") {
       auto snd = ex::transfer_just(sch, 42)
                | ex::bulk(n, [&counter](int idx, int val) { if (val == 42) { counter[idx] = 0; } })
                | ex::bulk(n, [&counter](int idx, int val) { if (val == 42) { counter[idx]++; } });
-      auto [val] = std::this_thread::sync_wait(std::move(snd)).value();
+      auto [val] = stdexec::sync_wait(std::move(snd)).value();
 
       CHECK(val == 42);
 
@@ -232,7 +232,7 @@ TEST_CASE("bulk works with static thread pool", "[adaptors][bulk]") {
                  throw std::runtime_error("bulk");
                });
 
-    CHECK_THROWS_AS(std::this_thread::sync_wait(std::move(snd)), std::runtime_error);
+    CHECK_THROWS_AS(stdexec::sync_wait(std::move(snd)), std::runtime_error);
   }
 }
 

--- a/test/stdexec/algos/adaptors/test_ensure_started.cpp
+++ b/test/stdexec/algos/adaptors/test_ensure_started.cpp
@@ -24,7 +24,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 using exec::async_scope;
 
 TEST_CASE("ensure_started returns a sender", "[adaptors][ensure_started]") {
@@ -196,7 +196,7 @@ TEST_CASE("ensure_started stopped late", "[adaptors][ensure_started]") {
 }
 
 TEST_CASE("stopping ensure_started before the source completes calls set_stopped", "[adaptors][ensure_started]") {
-  std::in_place_stop_source stop_source;
+  stdexec::in_place_stop_source stop_source;
   impulse_scheduler sch;
   bool called{false};
   auto snd = ex::on(sch, ex::just(19))
@@ -212,7 +212,7 @@ TEST_CASE("stopping ensure_started before the source completes calls set_stopped
 }
 
 TEST_CASE("stopping ensure_started before the lazy opstate is started calls set_stopped", "[adaptors][ensure_started]") {
-  std::in_place_stop_source stop_source;
+  stdexec::in_place_stop_source stop_source;
   impulse_scheduler sch;
   int count = 0;
   bool called{false};
@@ -232,7 +232,7 @@ TEST_CASE("stopping ensure_started before the lazy opstate is started calls set_
 }
 
 TEST_CASE("stopping ensure_started after the task has already completed doesn't change the result", "[adaptors][ensure_started]") {
-  std::in_place_stop_source stop_source;
+  stdexec::in_place_stop_source stop_source;
   int count = 0;
   auto snd = ex::just()
            | ex::then([&] { ++count; return 42; })

--- a/test/stdexec/algos/adaptors/test_into_variant.cpp
+++ b/test/stdexec/algos/adaptors/test_into_variant.cpp
@@ -21,7 +21,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("into_variant returns a sender", "[adaptors][into_variant]") {
   auto snd = ex::into_variant(ex::just(11));

--- a/test/stdexec/algos/adaptors/test_let_error.cpp
+++ b/test/stdexec/algos/adaptors/test_let_error.cpp
@@ -24,7 +24,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 
@@ -74,7 +74,7 @@ TEST_CASE(
     "let_error returning void can be waited on (error annihilation)", "[adaptors][let_error]") {
   ex::sender auto snd = ex::just_error(std::exception_ptr{}) |
                         ex::let_error([](std::exception_ptr) { return ex::just(); });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 }
 
 TEST_CASE("let_error can be used to produce values (error to value)", "[adaptors][let_error]") {

--- a/test/stdexec/algos/adaptors/test_let_stopped.cpp
+++ b/test/stdexec/algos/adaptors/test_let_stopped.cpp
@@ -22,7 +22,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 
@@ -57,7 +57,7 @@ TEST_CASE("let_stopped can be piped", "[adaptors][let_stopped]") {
 TEST_CASE("let_stopped returning void can we waited on (cancel annihilation)",
     "[adaptors][let_stopped]") {
   ex::sender auto snd = ex::just_stopped() | ex::let_stopped([] { return ex::just(); });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 }
 
 TEST_CASE(

--- a/test/stdexec/algos/adaptors/test_let_value.cpp
+++ b/test/stdexec/algos/adaptors/test_let_value.cpp
@@ -23,7 +23,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 
@@ -57,7 +57,7 @@ TEST_CASE("let_value can be piped", "[adaptors][let_value]") {
 
 TEST_CASE("let_value returning void can we waited on", "[adaptors][let_value]") {
   ex::sender auto snd = ex::just() | ex::let_value([] { return ex::just(); });
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 }
 
 TEST_CASE("let_value can be used to produce values", "[adaptors][let_value]") {

--- a/test/stdexec/algos/adaptors/test_on.cpp
+++ b/test/stdexec/algos/adaptors/test_on.cpp
@@ -23,7 +23,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 

--- a/test/stdexec/algos/adaptors/test_schedule_from.cpp
+++ b/test/stdexec/algos/adaptors/test_schedule_from.cpp
@@ -23,7 +23,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 

--- a/test/stdexec/algos/adaptors/test_stopped_as_error.cpp
+++ b/test/stdexec/algos/adaptors/test_stopped_as_error.cpp
@@ -20,7 +20,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("stopped_as_error returns a sender", "[adaptors][stopped_as_error]") {
   auto snd = ex::stopped_as_error(ex::just(11), -1);

--- a/test/stdexec/algos/adaptors/test_stopped_as_optional.cpp
+++ b/test/stdexec/algos/adaptors/test_stopped_as_optional.cpp
@@ -21,7 +21,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("stopped_as_optional returns a sender", "[adaptors][stopped_as_optional]") {
   auto snd = ex::stopped_as_optional(ex::just(11));

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -20,7 +20,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("then returns a sender", "[adaptors][then]") {
   auto snd = ex::then(ex::just(), [] {});
@@ -49,7 +49,7 @@ TEST_CASE("then can be piped", "[adaptors][then]") {
 
 TEST_CASE("then returning void can we waited on", "[adaptors][then]") {
   ex::sender auto snd = ex::just() | ex::then([] {});
-  std::this_thread::sync_wait(std::move(snd));
+  stdexec::sync_wait(std::move(snd));
 }
 
 TEST_CASE("then can be used to transform the value", "[adaptors][then]") {

--- a/test/stdexec/algos/adaptors/test_transfer.cpp
+++ b/test/stdexec/algos/adaptors/test_transfer.cpp
@@ -23,7 +23,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 

--- a/test/stdexec/algos/adaptors/test_transfer_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_transfer_when_all.cpp
@@ -20,7 +20,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 // For testing `transfer_when_all` we assume that, the main implementation is based on `transfer`
 // and `when_all`. As both of these are tested independently, we provide fewer tests here.

--- a/test/stdexec/algos/adaptors/test_upon_error.cpp
+++ b/test/stdexec/algos/adaptors/test_upon_error.cpp
@@ -20,7 +20,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("upon_error returns a sender", "[adaptors][upon_error]") {
   auto snd = ex::upon_error(ex::just_error(std::exception_ptr{}), [](std::exception_ptr) {});

--- a/test/stdexec/algos/adaptors/test_upon_stopped.cpp
+++ b/test/stdexec/algos/adaptors/test_upon_stopped.cpp
@@ -20,7 +20,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 // TODO: implement upon_stopped
 TEST_CASE("upon_stopped returns a sender", "[adaptors][upon_stopped]") {

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -20,7 +20,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 // For testing `when_all_with_variant`, we just check a couple of examples, check customization, and
 // we assume it's implemented in terms of `when_all`.

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -22,7 +22,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 

--- a/test/stdexec/algos/consumers/test_sync_wait.cpp
+++ b/test/stdexec/algos/consumers/test_sync_wait.cpp
@@ -25,11 +25,11 @@
 #include <thread>
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 using std::optional;
 using std::tuple;
-using std::this_thread::sync_wait;
-using std::this_thread::sync_wait_with_variant;
+using stdexec::sync_wait;
+using stdexec::sync_wait_with_variant;
 
 using namespace std::chrono_literals;
 

--- a/test/stdexec/algos/factories/test_just.cpp
+++ b/test/stdexec/algos/factories/test_just.cpp
@@ -19,7 +19,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("Simple test for just", "[factories][just]") {
   auto o1 = ex::connect(ex::just(1), expect_value_receiver(1));

--- a/test/stdexec/algos/factories/test_just_error.cpp
+++ b/test/stdexec/algos/factories/test_just_error.cpp
@@ -19,7 +19,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("Simple test for just_error", "[factories][just_error]") {
   auto op = ex::connect(ex::just_error(std::exception_ptr{}), expect_error_receiver{});

--- a/test/stdexec/algos/factories/test_transfer_just.cpp
+++ b/test/stdexec/algos/factories/test_transfer_just.cpp
@@ -20,7 +20,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 TEST_CASE("transfer_just returns a sender", "[factories][transfer_just]") {
   auto snd = ex::transfer_just(inline_scheduler{}, 13);

--- a/test/stdexec/algos/other/test_execute.cpp
+++ b/test/stdexec/algos/other/test_execute.cpp
@@ -21,7 +21,7 @@
 
 #include <chrono>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std::chrono_literals;
 

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -23,7 +23,7 @@
 
 #if !_STD_NO_COROUTINES_
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 template <typename Awaiter>
 struct promise {

--- a/test/stdexec/concepts/test_concept_operation_state.cpp
+++ b/test/stdexec/concepts/test_concept_operation_state.cpp
@@ -17,7 +17,7 @@
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct op_except {
   op_except() = default;

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -17,7 +17,7 @@
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct my_scheduler {
   struct my_sender  {

--- a/test/stdexec/concepts/test_concepts_receiver.cpp
+++ b/test/stdexec/concepts/test_concepts_receiver.cpp
@@ -18,7 +18,7 @@
 // #include <stdexec/execution.hpp>
 // #include <test_common/receivers.hpp>
 
-// namespace ex = std::execution;
+// namespace ex = stdexec;
 
 // struct recv_no_set_value {
 //   friend void tag_invoke(ex::set_stopped_t, recv_no_set_value) noexcept {}

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -19,7 +19,7 @@
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct oper {
   oper() = default;

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -16,7 +16,7 @@
 
 #include <stdexec/execution.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 enum class scope_t { free_standing, scheduler };
 

--- a/test/stdexec/cpos/test_cpo_connect.cpp
+++ b/test/stdexec/cpos/test_cpo_connect.cpp
@@ -19,7 +19,7 @@
 #include "test_common/receivers.hpp"
 #include "test_common/type_helpers.hpp"
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 template <typename R>
 struct op_state : immovable {

--- a/test/stdexec/cpos/test_cpo_receiver.cpp
+++ b/test/stdexec/cpos/test_cpo_receiver.cpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <climits>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct recv_value {
   int* target_;

--- a/test/stdexec/cpos/test_cpo_schedule.cpp
+++ b/test/stdexec/cpos/test_cpo_schedule.cpp
@@ -17,7 +17,7 @@
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct my_sender {
   using completion_signatures =

--- a/test/stdexec/cpos/test_cpo_start.cpp
+++ b/test/stdexec/cpos/test_cpo_start.cpp
@@ -18,7 +18,7 @@
 #include <stdexec/execution.hpp>
 #include <test_common/type_helpers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 struct my_oper : immovable {
   bool started_{false};

--- a/test/stdexec/detail/test_completion_signatures.cpp
+++ b/test/stdexec/detail/test_completion_signatures.cpp
@@ -17,7 +17,7 @@
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>
 #include <test_common/schedulers.hpp>
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 using namespace std;
 

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -18,7 +18,7 @@
 #include <stdexec/execution.hpp>
 #include <test_common/schedulers.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 namespace {
 struct uncustomized_scheduler {

--- a/test/test_common/receivers.hpp
+++ b/test/test_common/receivers.hpp
@@ -21,7 +21,7 @@
 #include <stdexec/execution.hpp>
 #include <tuple>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 namespace empty_recv {
 
@@ -437,7 +437,7 @@ inline void wait_for_value(S&& snd, Ts&&... val) {
   static_assert(stdexec::__single_value_variant_sender<S>,
       "Sender passed to sync_wait needs to have one variant for sending set_value");
 
-  std::optional<std::tuple<Ts...>> res = std::this_thread::sync_wait((S &&) snd);
+  std::optional<std::tuple<Ts...>> res = stdexec::sync_wait((S &&) snd);
   CHECK(res.has_value());
   std::tuple<Ts...> expected((Ts &&) val...);
   if constexpr (std::tuple_size_v<std::tuple<Ts...>> == 1)

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -22,7 +22,7 @@
 #include <functional>
 #include <vector>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 //! Scheduler that will send impulses on user's request.
 //! One can obtain senders from this, connect them to receivers and start the operation states.

--- a/test/test_common/senders.hpp
+++ b/test/test_common/senders.hpp
@@ -20,7 +20,7 @@
 #include <test_common/type_helpers.hpp>
 #include <stdexec/execution.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 template <class... Values>
 struct fallible_just {

--- a/test/test_common/type_helpers.hpp
+++ b/test/test_common/type_helpers.hpp
@@ -18,7 +18,7 @@
 
 #include <stdexec/execution.hpp>
 
-namespace ex = std::execution;
+namespace ex = stdexec;
 
 //! Used for to make a class non-movable without giving up aggregate initialization
 struct immovable {

--- a/test_package/test.cpp
+++ b/test_package/test.cpp
@@ -2,8 +2,8 @@
 
 int main()
 {
-	auto x = std::execution::just(42);
+	auto x = stdexec::just(42);
 
-	auto [a] = std::this_thread::sync_wait(std::move(x)).value();
+	auto [a] = stdexec::sync_wait(std::move(x)).value();
 	return (a==42)?0:-1;
 }


### PR DESCRIPTION
Find them in the `stdexec::` namespace instead.