### PR TITLE
`on`-with-continuation as custom sender

### DIFF
--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../../stdexec/execution.hpp"
+
+#ifdef __EDG__
+#pragma diagnostic push
+#pragma diag_suppress 1302
+#pragma diag_suppress 497
+#endif
+
+namespace exec {
+  namespace __stl {
+    using namespace stdexec;
+
+    struct __data_placeholder;
+
+    template <class...>
+      inline constexpr bool __never_true = false;
+
+    template <class _Env>
+      struct __receiver_placeholder {
+        template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag,
+                  class... _As>
+          friend void tag_invoke(_Tag, __receiver_placeholder, _As&&...) noexcept {
+            static_assert(
+              __never_true<_Tag, _As...>,
+              "we should never be instantiating the body of this function");
+          }
+
+        template <same_as<__receiver_placeholder> _Self>
+          [[noreturn]] friend _Env tag_invoke(get_env_t, _Self) {
+            static_assert(
+              __never_true<_Self>,
+              "we should never be instantiating the body of this function");
+            std::terminate();
+          }
+      };
+
+    template <class _Kernel, class _Receiver, class _Completions>
+      using __data_t =
+        decltype(
+          __declval<_Kernel&>().get_data(
+            __declval<_Receiver&>(),
+            (_Completions*) nullptr));
+
+    template <class _Kernel, class _Sender, class _Env>
+      using __tfx_sender_ =
+        decltype(
+          __declval<_Kernel&>().transform_sender(
+            __declval<_Sender>(),
+            __declval<__data_placeholder&>(),
+            __declval<__receiver_placeholder<_Env>&>()));
+
+    struct __dependent_sender {
+      friend auto tag_invoke(get_completion_signatures_t, __dependent_sender, no_env)
+        -> dependent_completion_signatures<no_env>;
+    };
+
+    template <class, class, class _Env>
+        requires same_as<_Env, no_env>
+      using __or_dependent_ = __dependent_sender;
+
+    template <class _Kernel, class _Sender, class _Env>
+      using __sender_t =
+        __minvoke<
+          __if_c<
+            __minvocable<__q<__tfx_sender_>, _Kernel, _Sender, _Env>,
+            __q<__tfx_sender_>,
+            __q<__or_dependent_>>,
+          _Kernel,
+          _Sender,
+          _Env>;
+
+    template <class _Kernel, class _Receiver, class _Tag, class... _As>
+      using __set_result_t =
+        decltype(
+          __declval<_Kernel&>().set_result(
+            _Tag{},
+            __declval<__data_placeholder&>(),
+            __declval<_Receiver&>(),
+            __declval<_As>()...));
+
+    template <class _Kernel, class _Env>
+      using __get_env_ =
+        decltype(__declval<_Kernel&>().get_env(__declval<_Env>()));
+
+    template <class _Kernel, class _Env>
+      using __env_t =
+        __minvoke<
+          __if_c<same_as<_Env, no_env>, __mconst<no_env>, __q<__get_env_>>,
+          _Kernel,
+          _Env>;
+
+    template <class _Kernel, class _Env, class _Tag, class... _As>
+      auto __completions_from_sig(_Tag(*)(_As...))
+        -> __set_result_t<_Kernel, __receiver_placeholder<_Env>, _Tag, _As...>;
+
+    template <class... _Completions>
+      auto __all_completions(_Completions*...)
+        -> __minvoke<
+            __concat<__munique<__q<completion_signatures>>>,
+            _Completions...>;
+
+    template <class _Kernel, class _Env, class... _Sigs>
+      auto __compute_completions_(completion_signatures<_Sigs...>*)
+        -> decltype(
+          __all_completions(
+            __completions_from_sig<_Kernel, _Env>((_Sigs*) nullptr)...));
+
+    template <class _Kernel, same_as<no_env>>
+      auto __compute_completions_(dependent_completion_signatures<no_env>*)
+        -> dependent_completion_signatures<no_env>;
+
+    template <class _Kernel, class _Env, class _Completions>
+      using __compute_completions_t =
+        decltype(__compute_completions_<_Kernel, _Env>((_Completions*) nullptr));
+
+    template <class _Kernel, class _Data, class _ReceiverId>
+      struct __receiver {
+        using _Receiver = stdexec::__t<_ReceiverId>;
+
+        struct __state {
+          template <class... _Sigs>
+            __state(_Kernel __kernel, _Receiver __rcvr, completion_signatures<_Sigs...>* __cmpl)
+              : __rcvr_((_Receiver&&) __rcvr)
+              , __kernel_{(_Kernel&&) __kernel}
+              , __data_(__kernel_.get_data(__rcvr_, __cmpl))
+            {}
+          _Receiver __rcvr_;
+          [[no_unique_address]] _Kernel __kernel_;
+          [[no_unique_address]] _Data __data_;
+        };
+
+        struct __t {
+          using __id = __receiver;
+          __state* __state_;
+
+          template <__one_of<set_value_t, set_error_t, set_stopped_t> _Tag,
+                    same_as<__t> _Self,
+                    class... _As _NVCXX_CAPTURE_PACK(_As)>
+              requires __valid<__set_result_t, _Kernel, _Receiver, _Tag, _As...>
+            friend void tag_invoke(_Tag __tag, _Self __self, _As&&... __as) noexcept {
+              _NVCXX_EXPAND_PACK(_As, __as,
+                __state& __st = *__self.__state_;
+                (void) __st.__kernel_.set_result(__tag, __st.__data_, __st.__rcvr_, (_As&&) __as...);
+              )
+            }
+
+          template <same_as<get_env_t> _Tag, same_as<__t> _Self>
+            friend auto tag_invoke(_Tag, _Self __self) -> __env_t<_Kernel, env_of_t<_Receiver>> {
+              __state& __st = *__self.__state_;
+              return __st.__kernel_.get_env(stdexec::get_env(__st.__rcvr_));
+            }
+        };
+      };
+
+    template <class _Sender, class _Kernel, class _ReceiverId>
+      struct __operation {
+        using _Receiver = stdexec::__t<_ReceiverId>;
+
+        using __env_t = __stl::__env_t<_Kernel, env_of_t<_Receiver>>;
+        using __sender_t = __stl::__sender_t<_Kernel, _Sender, env_of_t<_Receiver>>;
+        using __base_completions_t = completion_signatures_of_t<__sender_t, __env_t>;
+        using __completions_t = __compute_completions_t<_Kernel, __env_t, __base_completions_t>;
+        using __data_t = __stl::__data_t<_Kernel, _Receiver, __completions_t>;
+        using __receiver_id = __receiver<_Kernel, __data_t, _ReceiverId>;
+        using __receiver_t = stdexec::__t<__receiver_id>;
+        using __state_t = typename __receiver_id::__state;
+
+        struct __t : __immovable {
+          using __id = __operation;
+          __state_t __state_;
+          connect_result_t<__sender_t, __receiver_t> __op_;
+
+          __t(_Sender&& __sndr, _Kernel __kernel, _Receiver __rcvr)
+            : __state_{(_Kernel&&) __kernel, (_Receiver&&) __rcvr, (__completions_t*) nullptr}
+            , __op_(
+                connect(
+                  __state_.__kernel_.transform_sender(
+                    (_Sender&&) __sndr,
+                    __state_.__data_,
+                    __state_.__rcvr_),
+                  __receiver_t{&__state_}))
+          {}
+
+          friend void tag_invoke(start_t, __t& __self) noexcept {
+            __self.__state_.__kernel_.start(
+              __self.__op_,
+              __self.__state_.__data_,
+              __self.__state_.__rcvr_);
+          }
+        };
+      };
+
+    template <class _Derived, class _Sender, class _Kernel>
+      struct __sender {
+        template <class _Self, class _Env>
+          using __completions_t =
+            __compute_completions_t<
+              _Kernel,
+              __env_t<_Kernel, _Env>,
+              completion_signatures_of_t<
+                __sender_t<_Kernel, __member_t<_Self, _Sender>, _Env>,
+                __env_t<_Kernel, _Env>>>;
+
+        template <class _Self, class _Receiver>
+          using __operation_t =
+            stdexec::__t<
+              __operation<
+                __member_t<_Self, _Sender>,
+                _Kernel,
+                stdexec::__id<_Receiver>>>;
+
+        struct __t {
+          using __id = _Derived;
+          _Sender __sndr_;
+          _Kernel __kernel_;
+
+          template <class... _As>
+              requires constructible_from<_Kernel, _As...>
+            __t(_Sender __sndr, _As&&... __as)
+              : __sndr_((_Sender&&) __sndr)
+              , __kernel_{(_As&&) __as...}
+            {}
+
+          template <__decays_to<__t> _Self, receiver _Receiver>
+            friend auto tag_invoke(connect_t, _Self&& __self, _Receiver __rcvr)
+              -> __operation_t<_Self, _Receiver> {
+              return {((_Self&&) __self).__sndr_,
+                      ((_Self&&) __self).__kernel_,
+                      (_Receiver&&) __rcvr};
+            }
+
+          template <__decays_to<__t> _Self, class _Env>
+            friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
+              -> __completions_t<_Self, _Env>;
+
+          // forward sender queries:
+          template <tag_category<forwarding_sender_query> _Tag,
+                    class... _As _NVCXX_CAPTURE_PACK(_As)>
+              requires __callable<_Tag, const _Sender&, _As...>
+            friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
+              noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
+              -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
+              _NVCXX_EXPAND_PACK_RETURN(_As, __as,
+                return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
+              )
+            }
+        };
+      };
+  } // namespace __stl
+
+  template <class _Derived, class _Sender, class _Kernel>
+    using __sender_facade =
+      __stl::__sender<_Derived, _Sender, _Kernel>;
+
+  struct __default_kernel {
+    struct __no_data {};
+
+    template <class _Sender>
+      static _Sender&& transform_sender(
+          _Sender&& __sndr,
+          [[maybe_unused]] stdexec::__ignore __data,
+          [[maybe_unused]] stdexec::__ignore __rcvr) noexcept {
+        return (_Sender&&) __sndr;
+      }
+
+    template <class _Env>
+      static _Env get_env(_Env&& __env) {
+        return (_Env&&) __env;
+      }
+
+    static __no_data get_data(
+        [[maybe_unused]] stdexec::__ignore __rcvr,
+        [[maybe_unused]] void* __compl_sigs) noexcept {
+      return {};
+    }
+
+    template <class _Op>
+      static void start(
+          _Op& __op,
+          [[maybe_unused]] stdexec::__ignore __data,
+          [[maybe_unused]] stdexec::__ignore __rcvr) noexcept {
+        stdexec::start(__op);
+      }
+
+    template <class _Tag, class _Receiver, class... _As>
+      static auto set_result(
+          _Tag __tag,
+          [[maybe_unused]] stdexec::__ignore __data,
+          _Receiver& __rcvr,
+          _As&&... __as) noexcept
+        -> stdexec::completion_signatures<_Tag(_As...)>* {
+        __tag((_Receiver&&) __rcvr, (_As&&) __as...);
+        return {};
+      }
+  };
+} // namespace exec
+
+#ifdef __EDG__
+#pragma diagnostic pop
+#endif

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -17,6 +17,7 @@
 
 #include "../stdexec/execution.hpp"
 #include "env.hpp"
+#include "__detail/__sender_facade.hpp"
 
 namespace exec {
   /////////////////////////////////////////////////////////////////////////////
@@ -125,105 +126,108 @@ namespace exec {
           }
       };
 
-    template <class _Sender, class _Scheduler, class _Closure>
-      struct __continue_fn {
-        _Sender __sndr_;
+    template <class _Env, class _SchedulerId>
+      struct __with_sched_env : _Env {
+        using _Scheduler = stdexec::__t<_SchedulerId>;
         _Scheduler __sched_;
-        _Closure __closure_;
+        friend _Scheduler tag_invoke(get_scheduler_t, const __with_sched_env& __self) noexcept {
+          return __self.__sched_;
+        }
+      };
 
-        template <class _Self, class _OldSched>
-          static auto __call(_Self&& __self, _OldSched __old_sched) {
-            return ((_Self&&) __self).__sndr_
-              | exec::write(exec::with(get_scheduler, __old_sched))
-              | transfer(__self.__sched_)
-              | ((_Self&&) __self).__closure_
-              | transfer(__old_sched)
-              | exec::write(exec::with(get_scheduler, __self.__sched_))
-              ;
+    template <class _Scheduler>
+      struct __with_sched_kernel : __default_kernel {
+        _Scheduler __sched_;
+        __with_sched_kernel(_Scheduler __sched)
+          : __sched_((_Scheduler&&) __sched)
+        {}
+
+        template <class _Env>
+          __with_sched_env<_Env, __id<_Scheduler>> get_env(_Env __env) {
+            return {(_Env&&) __env, __sched_};
           }
 
-        template <scheduler _OldSched>
-          auto operator()(_OldSched __old_sched) && {
-            return __call(std::move(*this), __old_sched);
-          }
-        template <scheduler _OldSched>
-          auto operator()(_OldSched __old_sched) const & {
-            return __call(*this, __old_sched);
+        template <class _Env, class _OtherSchedulerId>
+          _Env get_env(__with_sched_env<_Env, _OtherSchedulerId> __env) {
+            return (_Env&&) __env;
           }
       };
-    template <class _Sender, class _Scheduler, class _Closure>
-      __continue_fn(_Sender, _Scheduler, _Closure)
-        -> __continue_fn<_Sender, _Scheduler, _Closure>;
 
-    template <class _SenderId, class _SchedulerId, class _ClosureId>
-      struct __continue_on_sender {
-        using _Sender = __t<_SenderId>;
-        using _Scheduler = __t<_SchedulerId>;
-        using _Closure = __t<_ClosureId>;
+    template <class _SenderId, class _Scheduler>
+      struct __with_sched
+        : __sender_facade<
+            __with_sched<_SenderId, _Scheduler>,
+            __t<_SenderId>,
+            __with_sched_kernel<_Scheduler>>
+      {};
 
-        _Sender __sndr_;
+    template <class _Scheduler, class _Closure>
+      struct __continue_on_kernel : __default_kernel {
         _Scheduler __sched_;
         _Closure __closure_;
+        __continue_on_kernel(_Scheduler __sched, _Closure __closure)
+          : __sched_((_Scheduler&&) __sched)
+          , __closure_((_Closure&&) __closure)
+        {}
 
-        template <class _Self>
-          static auto __call(_Self&& __self) {
-            return let_value(
-              stdexec::read(get_scheduler),
-              __continue_fn{
-                ((_Self&&) __self).__sndr_,
-                __self.__sched_,
-                ((_Self&&) __self).__closure_});
+        template <class... _Ts>
+          using __self_t = __make_dependent_on<__continue_on_kernel, _Ts...>;
+
+        template <class _Sender, class _OldScheduler>
+          auto transform_sender_(_Sender&& __sndr, _OldScheduler __old_sched) {
+            using __sender_t = __t<__with_sched<__id<decay_t<_Sender>>, _OldScheduler>>;
+            return __sender_t{(_Sender&&) __sndr, __old_sched}
+              | transfer(__sched_)
+              | (__member_t<_Sender, _Closure>&&) __closure_
+              | transfer(__old_sched);
           }
 
-        template <class _Self>
-          using __inner_t = decltype(__call(__declval<_Self>()));
+        template <class _Sender, class _Receiver, class... _Ts>
+          using __sender_t =
+            decltype(__declval<__self_t<_Sender, _Receiver, _Ts...>&>().transform_sender_(
+              __declval<_Sender>(),
+              __declval<__call_result_t<get_scheduler_t, env_of_t<_Receiver>>>()));
 
-        template <__decays_to<__continue_on_sender> _Self, receiver _Receiver>
-            requires constructible_from<_Sender, __member_t<_Self, _Sender>> &&
-              sender_to<__inner_t<_Self>, _Receiver>
-          friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __receiver)
-            -> connect_result_t<__inner_t<_Self>, _Receiver> {
-            return connect(__call((_Self&&) __self), (_Receiver&&) __receiver);
+        template <class _Sender, class _Receiver>
+          auto transform_sender(_Sender&& __sndr, __ignore, _Receiver& __rcvr)
+            -> __sender_t<_Sender, _Receiver> {
+            auto __sched = get_scheduler(stdexec::get_env(__rcvr));
+            return transform_sender_((_Sender&&) __sndr, __sched);
           }
 
-        template <__decays_to<__continue_on_sender> _Self, class _Env>
-          friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-            -> completion_signatures_of_t<__inner_t<_Self>, _Env>;
-
-        template <__decays_to<__continue_on_sender> _Self, __none_of<no_env> _Env>
-            requires (!__callable<get_scheduler_t, _Env>)
-          friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
-            -> _ENVIRONMENT_HAS_NO_SCHEDULER_FOR_THE_ON_ADAPTOR_TO_TRANSITION_BACK_TO<_Env, _Sender>;
-
-        // forward sender queries:
-        template <tag_category<forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
-            requires __callable<_Tag, const _Sender&, _As...>
-          friend auto tag_invoke(_Tag __tag, const __continue_on_sender& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-            _NVCXX_EXPAND_PACK_RETURN(_As, __as,
-              return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-            )
+        template <class _Env>
+          __with_sched_env<_Env, __id<_Scheduler>> get_env(_Env __env) {
+            return {(_Env&&) __env, __sched_};
           }
       };
+
+    template <class _SenderId, class _Scheduler, class _Closure>
+      struct __continue_on
+        : __sender_facade<
+            __continue_on<_SenderId, _Scheduler, _Closure>,
+            __t<_SenderId>,
+            __continue_on_kernel<_Scheduler, _Closure>>
+      {};
+
     template <class _Sender, class _Scheduler, class _Closure>
-      __continue_on_sender(_Sender, _Scheduler, _Closure)
-        -> __continue_on_sender<__x<_Sender>, __x<_Scheduler>, __x<_Closure>>;
+      using __continue_on_t =
+        __t<__continue_on<__id<decay_t<_Sender>>, _Scheduler, _Closure>>;
 
     template <>
       struct on_t<on_kind::continue_on> {
         template <sender _Sender, scheduler _Scheduler, __sender_adaptor_closure_for<_Sender> _Closure>
             requires constructible_from<decay_t<_Sender>, _Sender>
-          auto operator()(_Sender&& __sndr, _Scheduler&& __sched, _Closure __closure) const {
-            return __continue_on_sender{
+          auto operator()(_Sender&& __sndr, _Scheduler __sched, _Closure __closure) const {
+            return __continue_on_t<_Sender, _Scheduler, _Closure>{
               (_Sender&&) __sndr,
               (_Scheduler&&) __sched,
-              (_Closure&&) __closure};
+              (_Closure&&) __closure
+            };
           }
 
         template <scheduler _Scheduler, __sender_adaptor_closure _Closure>
-          auto operator()(_Scheduler&& __sched, _Closure __closure) const
-            -> __binder_back<on_t, decay_t<_Scheduler>, _Closure> {
+          auto operator()(_Scheduler __sched, _Closure __closure) const
+            -> __binder_back<on_t, _Scheduler, _Closure> {
             return {{}, {}, {(_Scheduler&&) __sched, (_Closure&&) __closure}};
           }
       };

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -93,7 +93,7 @@ namespace stdexec {
 
   template <template <class...> class _Fn, class... _Args>
     using __meval =
-      typename __i<(sizeof...(_Args) == ~0u)>::
+      typename __i<(sizeof(__types<_Args...>*) == 0)>::
         template __g<_Fn, _Args...>;
 
   template <class _Fn, class... _Args>
@@ -141,7 +141,7 @@ namespace stdexec {
 
   template <bool>
     struct __if_ {
-      template <class _True, class>
+      template <class _True, class...>
         using __f = _True;
     };
   template <>
@@ -150,14 +150,17 @@ namespace stdexec {
         using __f = _False;
     };
   #if STDEXEC_NVHPC()
-  template <class _Pred, class _True, class _False>
-    using __if = __minvoke<__if_<_Pred::value>, _True, _False>;
+  template <class _Pred, class _True, class... _False>
+      requires (sizeof...(_False) <= 1)
+    using __if = __minvoke<__if_<_Pred::value>, _True, _False...>;
   #else
-  template <class _Pred, class _True, class _False>
-    using __if = __minvoke<__if_<__v<_Pred>>, _True, _False>;
+  template <class _Pred, class _True, class... _False>
+      requires (sizeof...(_False) <= 1)
+    using __if = __minvoke<__if_<__v<_Pred>>, _True, _False...>;
   #endif
-  template <bool _Pred, class _True, class _False>
-    using __if_c = __minvoke<__if_<_Pred>, _True, _False>;
+  template <bool _Pred, class _True, class... _False>
+      requires (sizeof...(_False) <= 1)
+    using __if_c = __minvoke<__if_<_Pred>, _True, _False...>;
 
   template <class _T>
     struct __mconst {

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -2118,47 +2118,6 @@ namespace stdexec {
       /**/
     #endif
 
-    template <__class _Derived, sender _Base>
-      struct sender_adaptor {
-        class __t : __adaptor_base<_Base> {
-          _DEFINE_MEMBER(connect);
-
-          template <same_as<connect_t> _Connect, __decays_to<_Derived> _Self, receiver _Receiver>
-          friend auto tag_invoke(_Connect, _Self&& __self, _Receiver&& __rcvr)
-            noexcept(noexcept(_CALL_MEMBER(connect, (_Self&&) __self, (_Receiver&&) __rcvr)))
-            -> decltype(_CALL_MEMBER(connect, (_Self&&) __self, (_Receiver&&) __rcvr))
-          {
-            return _CALL_MEMBER(connect, (_Self&&) __self, (_Receiver&&) __rcvr);
-          }
-
-          template <same_as<connect_t> _Connect, __decays_to<_Derived> _Self, receiver _Receiver>
-            requires _MISSING_MEMBER(decay_t<_Self>, connect) &&
-              sender_to<__member_t<_Self, _Base>, _Receiver>
-          friend auto tag_invoke(_Connect, _Self&& __self, _Receiver&& __rcvr)
-            noexcept(__nothrow_connectable<__member_t<_Self, _Base>, _Receiver>)
-            -> connect_result_t<__member_t<_Self, _Base>, _Receiver> {
-            return stdexec::connect(((__t&&) __self).base(), (_Receiver&&) __rcvr);
-          }
-
-          template <tag_category<forwarding_sender_query> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
-            requires __callable<_Tag, const _Base&, _As...>
-          friend auto tag_invoke(_Tag __tag, const _Derived& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Base&, _As...>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Base&, _As...> {
-            _NVCXX_EXPAND_PACK_RETURN(_As, __as,
-              return ((_Tag&&) __tag)(__self.base(), (_As&&) __as...);
-            )
-          }
-
-         protected:
-          using __adaptor_base<_Base>::base;
-
-         public:
-          __t() = default;
-          using __adaptor_base<_Base>::__adaptor_base;
-        };
-      };
-
     template <__class _Derived, class _Base>
       struct receiver_adaptor {
         class __t : __adaptor_base<_Base> {
@@ -2256,103 +2215,11 @@ namespace stdexec {
           using __adaptor_base<_Base>::__adaptor_base;
         };
       };
-
-    template <__class _Derived, operation_state _Base>
-      struct operation_state_adaptor {
-        class __t : __adaptor_base<_Base>, __immovable {
-          _DEFINE_MEMBER(start);
-
-          template <same_as<start_t> _Start, class _D = _Derived>
-          friend auto tag_invoke(_Start, _Derived& __self) noexcept
-            -> decltype(_CALL_MEMBER(start, (_D&) __self)) {
-            static_assert(noexcept(_CALL_MEMBER(start, (_D&) __self)));
-            _CALL_MEMBER(start, (_D&) __self);
-          }
-
-          template <same_as<start_t> _Start, class _D = _Derived>
-            requires _MISSING_MEMBER(_D, start)
-          friend void tag_invoke(_Start, _Derived& __self) noexcept {
-            stdexec::start(__c_cast<__t>(__self).base());
-          }
-
-          template <__none_of<start_t> _Tag, class... _As _NVCXX_CAPTURE_PACK(_As)>
-            requires __callable<_Tag, const _Base&, _As...>
-          friend auto tag_invoke(_Tag __tag, const _Derived& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Base&, _As...>)
-            -> __call_result_if_t<__none_of<_Tag, start_t>, _Tag, const _Base&, _As...> {
-            _NVCXX_EXPAND_PACK_RETURN(_As, __as,
-              return ((_Tag&&) __tag)(__c_cast<__t>(__self).base(), (_As&&) __as...);
-            )
-          }
-
-         protected:
-          using __adaptor_base<_Base>::base;
-
-         public:
-          __t() = default;
-          using __adaptor_base<_Base>::__adaptor_base;
-        };
-      };
-
-    template <__class _Derived, scheduler _Base>
-      struct scheduler_adaptor {
-        class __t : __adaptor_base<_Base> {
-          _DEFINE_MEMBER(schedule);
-
-          template <same_as<schedule_t> _Schedule, __decays_to<_Derived> _Self>
-          friend auto tag_invoke(_Schedule, _Self&& __self)
-            noexcept(noexcept(_CALL_MEMBER(schedule, (_Self&&) __self)))
-            -> decltype(_CALL_MEMBER(schedule, (_Self&&) __self)) {
-            return _CALL_MEMBER(schedule, (_Self&&) __self);
-          }
-
-          template <same_as<schedule_t> _Schedule, __decays_to<_Derived> _Self>
-            requires _MISSING_MEMBER(decay_t<_Self>, schedule) &&
-              scheduler<__member_t<_Self, _Base>>
-          friend auto tag_invoke(_Schedule, _Self&& __self)
-            noexcept(noexcept(stdexec::schedule(__declval<__member_t<_Self, _Base>>())))
-            -> schedule_result_t<_Self> {
-            return stdexec::schedule(__c_cast<__t>((_Self&&) __self).base());
-          }
-
-          template <tag_category<forwarding_scheduler_query> _Tag, same_as<_Derived> _Self, class... _As _NVCXX_CAPTURE_PACK(_As)>
-            requires __callable<_Tag, const _Base&, _As...>
-          friend auto tag_invoke(_Tag __tag, const _Self& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Base&, _As...>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_scheduler_query>, _Tag, const _Base&, _As...> {
-            _NVCXX_EXPAND_PACK_RETURN(_As, __as,
-              return ((_Tag&&) __tag)(__c_cast<__t>(__self).base(), (_As&&) __as...);
-            )
-          }
-
-         protected:
-          using __adaptor_base<_Base>::base;
-
-         public:
-          __t() = default;
-          using __adaptor_base<_Base>::__adaptor_base;
-        };
-      };
   } // namespace __adaptors
-
-  // NOT TO SPEC
-  template <__class _Derived, sender _Base>
-    using sender_adaptor =
-      typename __adaptors::sender_adaptor<_Derived, _Base>::__t;
 
   template <__class _Derived, receiver _Base = __adaptors::__not_a_receiver>
     using receiver_adaptor =
       typename __adaptors::receiver_adaptor<_Derived, _Base>::__t;
-
-  // NOT TO SPEC
-  template <__class _Derived, operation_state _Base>
-    using operation_state_adaptor =
-      typename __adaptors::operation_state_adaptor<_Derived, _Base>::__t;
-
-  // NOT TO SPEC
-  template <__class _Derived, scheduler _Base>
-    using scheduler_adaptor =
-      typename __adaptors::scheduler_adaptor<_Derived, _Base>::__t;
 
   template <class _Receiver, class... _As>
     concept __receiver_of_maybe_void =
@@ -4670,7 +4537,6 @@ namespace stdexec {
     template <class _SenderId>
       class __sender {
         using _Sender = __t<_SenderId>;
-        friend sender_adaptor<__sender, _Sender>;
         template <class _Receiver>
           using __receiver_t = __receiver<_SenderId, __x<remove_cvref_t<_Receiver>>>;
 

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -219,8 +219,6 @@ namespace stdexec {
         constexpr auto operator()(const _EnvProvider& __with_env) const
           noexcept(nothrow_tag_invocable<get_env_t, const _EnvProvider&>)
           -> tag_invoke_result_t<get_env_t, const _EnvProvider&> {
-          using _Env = tag_invoke_result_t<get_env_t, const _EnvProvider&>;
-          static_assert(!same_as<_Env, no_env>);
           return tag_invoke(*this, __with_env);
         }
     };
@@ -1235,8 +1233,10 @@ namespace stdexec {
 
     template <class _Env>
       struct __any_debug_receiver {
-        friend void tag_invoke(set_value_t, __any_debug_receiver&&, auto&&...) noexcept;
-        friend void tag_invoke(set_error_t, __any_debug_receiver&&, auto&&) noexcept;
+        template <class... _Args>
+          friend void tag_invoke(set_value_t, __any_debug_receiver&&, _Args&&...) noexcept;
+        template <class _Error>
+          friend void tag_invoke(set_error_t, __any_debug_receiver&&, _Error&&) noexcept;
         friend void tag_invoke(set_stopped_t, __any_debug_receiver&&) noexcept;
         friend __debug_env_t<_Env> tag_invoke(get_env_t, __any_debug_receiver) noexcept;
       };


### PR DESCRIPTION
Also, add an `exec::__sender_facade` in `exec/__detail/` that eliminates the boilerplate of writing custom senders and is more powerful and flexible than the `exec::create` utility. I'm leaving it as a detail for now because it isn't well tested, but we'll probably want to promote this to be a proper member of `exec::` eventually.