### PR TITLE
Update `when_all` `completion_signatures` to match spec

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4638,6 +4638,8 @@ namespace stdexec {
                 _Env,
                 completion_signatures<>,
                 __swallow_values>...>;
+          template <class _T>
+            using __decay_rvalue_ref = decay_t<_T>&&;
           using __values =
             __minvoke<
               __concat<__qf<set_value_t>>,
@@ -4645,7 +4647,8 @@ namespace stdexec {
                 _Senders,
                 _Env,
                 __q<__types>,
-                __single_or<__types<>>>...>;
+                __mcompose<__uncurry<__transform<__q<__decay_rvalue_ref>>>, __single_or<__types<>>>>...>;
+
           using __t =
             __if_c<
               (__sends<set_value_t, _Senders, _Env> &&...),

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -222,29 +222,37 @@ TEST_CASE("when_all cancels remaining children if cancel is detected", "[adaptor
   CHECK(cancelled);
 }
 
-TEST_CASE("when_all has the values_type based on the children", "[adaptors][when_all]") {
-  check_val_types<type_array<type_array<int>>>(ex::when_all(ex::just(13)));
-  check_val_types<type_array<type_array<double>>>(ex::when_all(ex::just(3.14)));
-  check_val_types<type_array<type_array<int, double>>>(ex::when_all(ex::just(3, 0.14)));
+TEST_CASE("when_all has the values_type based on the children, decayed and as rvalue references", "[adaptors][when_all]") {
+  check_val_types<type_array<type_array<int&&>>>(ex::when_all(ex::just(13)));
+  check_val_types<type_array<type_array<double&&>>>(ex::when_all(ex::just(3.14)));
+  check_val_types<type_array<type_array<int&&, double&&>>>(ex::when_all(ex::just(3, 0.14)));
 
   check_val_types<type_array<type_array<>>>(ex::when_all(ex::just()));
 
-  check_val_types<type_array<type_array<int, double>>>(ex::when_all(ex::just(3), ex::just(0.14)));
-  check_val_types<type_array<type_array<int, double, int, double>>>( //
-      ex::when_all(                                                  //
-          ex::just(3),                                               //
-          ex::just(0.14),                                            //
-          ex::just(1, 0.4142)                                        //
-          )                                                          //
+  check_val_types<type_array<type_array<int&&, double&&>>>(ex::when_all(ex::just(3),
+  ex::just(0.14))); check_val_types<type_array<type_array<int&&, double&&, int&&, double&&>>>( //
+      ex::when_all(                                                                            //
+          ex::just(3),                                                                         //
+          ex::just(0.14),                                                                      //
+          ex::just(1, 0.4142)                                                                  //
+          )                                                                                    //
   );
 
   // if one child returns void, then the value is simply missing
-  check_val_types<type_array<type_array<int, double>>>( //
-      ex::when_all(                                     //
-          ex::just(3),                                  //
-          ex::just(),                                   //
-          ex::just(0.14)                                //
-          )                                             //
+  check_val_types<type_array<type_array<int&&, double&&>>>( //
+      ex::when_all(                                         //
+          ex::just(3),                                      //
+          ex::just(),                                       //
+          ex::just(0.14)                                    //
+          )                                                 //
+  );
+
+  // if children send references, they get decayed
+  check_val_types<type_array<type_array<int&&, double&&>>>( //
+      ex::when_all(                                         //
+          ex::split(ex::just(3)),                           //
+          ex::split(ex::just(0.14))                         //
+          )                                                 //
   );
 }
 


### PR DESCRIPTION
The spec transforms types as `std::decay_t<T>&&`. Previously types from children were sent unchanged.

Please excuse my metaprogramming, I'm sure there's a shorter way to express the same transformation.

I've changed the checked types in the existing types to be rvalue references and I've added another test case with `split` senders (i.e. something which sends reference types).