### PR TITLE
Fix `clangd` errors with `stdexec::sync_wait` in tests

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -28,9 +28,9 @@ If:
 CompileFlags:
   Compiler: clang++
   Add:
-    - -x
-    - cuda
-    - -Wno-unknown-cuda-version
+    - "-x"
+    - "cuda"
+    - "-Wno-unknown-cuda-version"
 
 ---
 
@@ -38,13 +38,13 @@ CompileFlags:
 CompileFlags:
   CompilationDatabase: .
   Add:
-    - -D_NVHPC_CUDA
+    - "-D_NVHPC_CUDA"
     # report all errors
     - "-ferror-limit=0"
     - "-fmacro-backtrace-limit=0"
     - "-ftemplate-backtrace-limit=0"
   Remove:
-    - -stdpar
+    - "-stdpar*"
     # strip CUDA fatbin args
     - "-Xfatbin*"
     - "-gpu=*"

--- a/.clangd
+++ b/.clangd
@@ -30,6 +30,7 @@ CompileFlags:
   Add:
     - "-x"
     - "cuda"
+    - "-D_NVHPC_CUDA"
     - "-Wno-unknown-cuda-version"
 
 ---
@@ -38,7 +39,6 @@ CompileFlags:
 CompileFlags:
   CompilationDatabase: .
   Add:
-    - "-D_NVHPC_CUDA"
     # report all errors
     - "-ferror-limit=0"
     - "-fmacro-backtrace-limit=0"

--- a/.clangd
+++ b/.clangd
@@ -30,7 +30,7 @@ CompileFlags:
   Add:
     - -x
     - cuda
-    - -D__NVCOMPILER
+    - -Wno-unknown-cuda-version
 
 ---
 
@@ -38,9 +38,10 @@ CompileFlags:
 CompileFlags:
   CompilationDatabase: .
   Add:
+    - -D_NVHPC_CUDA
     # report all errors
     - "-ferror-limit=0"
-    - "-D_NVHPC_CUDA=1"
+    - "-fmacro-backtrace-limit=0"
     - "-ftemplate-backtrace-limit=0"
   Remove:
     - -stdpar

--- a/examples/nvexec/maxwell/cpp.cuh
+++ b/examples/nvexec/maxwell/cpp.cuh
@@ -48,5 +48,5 @@ void run_cpp(float dt, bool write_vtk, std::size_t n_iterations,
       writer();
     };
 
-  report_performance(grid.cells, n_iterations * n_iterations, method, action);
+  report_performance(grid.cells, n_iterations, method, action);
 }

--- a/examples/nvexec/reduce.cpp
+++ b/examples/nvexec/reduce.cpp
@@ -31,7 +31,7 @@ int main() {
 
   nvexec::stream_context stream_ctx{};
 
-  auto snd = ex::transfer_just(stream_ctx.get_scheduler(), simple_range{first, last})
+  auto snd = ex::transfer_just(stream_ctx.get_scheduler(), simple_range<int*>{first, last})
            | nvexec::reduce();
 
   auto [result] = stdexec::sync_wait(std::move(snd)).value();

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -299,7 +299,7 @@ namespace exec {
 
         // Make this task awaitable within a particular context:
         template <class _ParentPromise>
-            requires std::constructible_from<
+            requires stdexec::constructible_from<
                 awaiter_context_t<__promise, _ParentPromise>, __promise&, _ParentPromise&>
           friend __task_awaitable<_ParentPromise>
           tag_invoke(stdexec::as_awaitable_t, basic_task&& __self, _ParentPromise&) noexcept {

--- a/include/nvexec/detail/config.cuh
+++ b/include/nvexec/detail/config.cuh
@@ -24,7 +24,7 @@
 #define STDEXEC_STREAM_DETAIL_NS _strm
 
 #if STDEXEC_CLANG()
-#define STDEXEC_CLANG_HOST_DEVICE __host__ __device__
+#define STDEXEC_CUDACC_HOST_DEVICE __host__ __device__
 #else
-#define STDEXEC_CLANG_HOST_DEVICE
+#define STDEXEC_CUDACC_HOST_DEVICE
 #endif

--- a/include/nvexec/detail/config.cuh
+++ b/include/nvexec/detail/config.cuh
@@ -15,8 +15,16 @@
  */
 #pragma once
 
+#include "../../stdexec/__detail/__config.hpp"
+
 #if !defined(_NVHPC_CUDA) && !defined(__CUDACC__)
 #error The NVIDIA schedulers and utilities require CUDA support
 #endif
 
 #define STDEXEC_STREAM_DETAIL_NS _strm
+
+#if STDEXEC_CLANG()
+#define STDEXEC_CLANG_HOST_DEVICE __host__ __device__
+#else
+#define STDEXEC_CLANG_HOST_DEVICE
+#endif

--- a/include/nvexec/detail/config.cuh
+++ b/include/nvexec/detail/config.cuh
@@ -24,7 +24,7 @@
 #define STDEXEC_STREAM_DETAIL_NS _strm
 
 #if STDEXEC_CLANG()
-#define STDEXEC_CUDACC_HOST_DEVICE __host__ __device__
+#define STDEXEC_DETAIL_CUDACC_HOST_DEVICE __host__ __device__
 #else
-#define STDEXEC_CUDACC_HOST_DEVICE
+#define STDEXEC_DETAIL_CUDACC_HOST_DEVICE
 #endif

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -106,7 +106,7 @@ namespace nvexec {
     };
 
     template <class VisitorT, class V>
-      STDEXEC_CUDACC_HOST_DEVICE
+      STDEXEC_DETAIL_CUDACC_HOST_DEVICE
       void visit_impl(std::integral_constant<std::size_t, 0>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (0 == index) {
           ((VisitorT&&)visitor)(v.template get<0>());
@@ -114,7 +114,7 @@ namespace nvexec {
       }
 
     template <std::size_t I, class VisitorT, class V>
-      STDEXEC_CUDACC_HOST_DEVICE
+      STDEXEC_DETAIL_CUDACC_HOST_DEVICE
       void visit_impl(std::integral_constant<std::size_t, I>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (I == index) {
           ((VisitorT&&)visitor)(v.template get<I>());
@@ -126,7 +126,7 @@ namespace nvexec {
   }
 
   template <class VisitorT, class V>
-    STDEXEC_CUDACC_HOST_DEVICE
+    STDEXEC_DETAIL_CUDACC_HOST_DEVICE
     void visit(VisitorT&& visitor, V&& v) {
       detail::visit_impl(
           std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
@@ -136,7 +136,7 @@ namespace nvexec {
     }
 
   template <class VisitorT, class V>
-    STDEXEC_CUDACC_HOST_DEVICE
+    STDEXEC_DETAIL_CUDACC_HOST_DEVICE
     void visit(VisitorT&& visitor, V&& v, std::size_t index) {
       detail::visit_impl(
           std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
@@ -162,14 +162,14 @@ namespace nvexec {
           detail::find_index<index_t, T, Ts...>()>;
 
     template <detail::one_of<Ts...> T>
-      STDEXEC_CUDACC_HOST_DEVICE
+      STDEXEC_DETAIL_CUDACC_HOST_DEVICE
       T& get() noexcept {
         void* data = storage_.data_;
         return *static_cast<T*>(data);
       }
 
     template <std::size_t I>
-      STDEXEC_CUDACC_HOST_DEVICE
+      STDEXEC_DETAIL_CUDACC_HOST_DEVICE
       detail::nth_type<I, Ts...>& get() noexcept {
         return get<detail::nth_type<I, Ts...>>();
       }
@@ -182,26 +182,26 @@ namespace nvexec {
       destroy();
     }
 
-    STDEXEC_CUDACC_HOST_DEVICE
+    STDEXEC_DETAIL_CUDACC_HOST_DEVICE
     bool holds_alternative() const {
       return index_ != detail::npos<index_t>();
     }
 
     template <detail::one_of<Ts...> T, class... As>
-      STDEXEC_CUDACC_HOST_DEVICE
+      STDEXEC_DETAIL_CUDACC_HOST_DEVICE
       void emplace(As&&... as) {
         destroy();
         construct<T>((As&&)as...);
       }
 
     template <detail::one_of<Ts...> T, class... As>
-      STDEXEC_CUDACC_HOST_DEVICE
+      STDEXEC_DETAIL_CUDACC_HOST_DEVICE
       void construct(As&&... as) {
         ::new(storage_.data_) T((As&&)as...);
         index_ = index_of<T>();
       }
 
-    STDEXEC_CUDACC_HOST_DEVICE
+    STDEXEC_DETAIL_CUDACC_HOST_DEVICE
     void destroy() {
       if (holds_alternative()) {
         visit([](auto& val) noexcept {

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -106,7 +106,7 @@ namespace nvexec {
     };
 
     template <class VisitorT, class V>
-      STDEXEC_CLANG_HOST_DEVICE
+      STDEXEC_CUDACC_HOST_DEVICE
       void visit_impl(std::integral_constant<std::size_t, 0>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (0 == index) {
           ((VisitorT&&)visitor)(v.template get<0>());
@@ -114,7 +114,7 @@ namespace nvexec {
       }
 
     template <std::size_t I, class VisitorT, class V>
-      STDEXEC_CLANG_HOST_DEVICE
+      STDEXEC_CUDACC_HOST_DEVICE
       void visit_impl(std::integral_constant<std::size_t, I>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (I == index) {
           ((VisitorT&&)visitor)(v.template get<I>());
@@ -126,7 +126,7 @@ namespace nvexec {
   }
 
   template <class VisitorT, class V>
-    STDEXEC_CLANG_HOST_DEVICE
+    STDEXEC_CUDACC_HOST_DEVICE
     void visit(VisitorT&& visitor, V&& v) {
       detail::visit_impl(
           std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
@@ -136,7 +136,7 @@ namespace nvexec {
     }
 
   template <class VisitorT, class V>
-    STDEXEC_CLANG_HOST_DEVICE
+    STDEXEC_CUDACC_HOST_DEVICE
     void visit(VisitorT&& visitor, V&& v, std::size_t index) {
       detail::visit_impl(
           std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
@@ -162,14 +162,14 @@ namespace nvexec {
           detail::find_index<index_t, T, Ts...>()>;
 
     template <detail::one_of<Ts...> T>
-      STDEXEC_CLANG_HOST_DEVICE
+      STDEXEC_CUDACC_HOST_DEVICE
       T& get() noexcept {
         void* data = storage_.data_;
         return *static_cast<T*>(data);
       }
 
     template <std::size_t I>
-      STDEXEC_CLANG_HOST_DEVICE
+      STDEXEC_CUDACC_HOST_DEVICE
       detail::nth_type<I, Ts...>& get() noexcept {
         return get<detail::nth_type<I, Ts...>>();
       }
@@ -182,26 +182,26 @@ namespace nvexec {
       destroy();
     }
 
-    STDEXEC_CLANG_HOST_DEVICE
+    STDEXEC_CUDACC_HOST_DEVICE
     bool holds_alternative() const {
       return index_ != detail::npos<index_t>();
     }
 
     template <detail::one_of<Ts...> T, class... As>
-      STDEXEC_CLANG_HOST_DEVICE
+      STDEXEC_CUDACC_HOST_DEVICE
       void emplace(As&&... as) {
         destroy();
         construct<T>((As&&)as...);
       }
 
     template <detail::one_of<Ts...> T, class... As>
-      STDEXEC_CLANG_HOST_DEVICE
+      STDEXEC_CUDACC_HOST_DEVICE
       void construct(As&&... as) {
         ::new(storage_.data_) T((As&&)as...);
         index_ = index_of<T>();
       }
 
-    STDEXEC_CLANG_HOST_DEVICE
+    STDEXEC_CUDACC_HOST_DEVICE
     void destroy() {
       if (holds_alternative()) {
         visit([](auto& val) noexcept {

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -126,8 +126,8 @@ namespace nvexec {
   template <class VisitorT, class V>
     void visit(VisitorT&& visitor, V&& v) {
       detail::visit_impl(
-          std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{}, 
-          (VisitorT&&)visitor, 
+          std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
+          (VisitorT&&)visitor,
           (V&&)v,
           v.index_);
     }
@@ -135,8 +135,8 @@ namespace nvexec {
   template <class VisitorT, class V>
     void visit(VisitorT&& visitor, V&& v, std::size_t index) {
       detail::visit_impl(
-          std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{}, 
-          (VisitorT&&)visitor, 
+          std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
+          (VisitorT&&)visitor,
           (V&&)v,
           index);
     }
@@ -152,9 +152,9 @@ namespace nvexec {
     using union_t = detail::static_storage_t<max_alignment, max_size>;
 
     template <detail::one_of<Ts...> T>
-      using index_of = 
+      using index_of =
         std::integral_constant<
-          index_t, 
+          index_t,
           detail::find_index<index_t, T, Ts...>()>;
 
     template <detail::one_of<Ts...> T>
@@ -181,11 +181,11 @@ namespace nvexec {
     }
 
     template <detail::one_of<Ts...> T, class... As>
-      void emplace(As&&... as) {
+      __host__ __device__ void emplace(As&&... as) {
         destroy();
         construct<T>((As&&)as...);
       }
-      
+
     template <detail::one_of<Ts...> T, class... As>
       void construct(As&&... as) {
         ::new(storage_.data_) T((As&&)as...);

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -106,14 +106,16 @@ namespace nvexec {
     };
 
     template <class VisitorT, class V>
-      __host__ __device__ void visit_impl(std::integral_constant<std::size_t, 0>, VisitorT&& visitor, V&& v, std::size_t index) {
+      STDEXEC_CLANG_HOST_DEVICE
+      void visit_impl(std::integral_constant<std::size_t, 0>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (0 == index) {
           ((VisitorT&&)visitor)(v.template get<0>());
         }
       }
 
     template <std::size_t I, class VisitorT, class V>
-      __host__ __device__ void visit_impl(std::integral_constant<std::size_t, I>, VisitorT&& visitor, V&& v, std::size_t index) {
+      STDEXEC_CLANG_HOST_DEVICE
+      void visit_impl(std::integral_constant<std::size_t, I>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (I == index) {
           ((VisitorT&&)visitor)(v.template get<I>());
           return;
@@ -124,7 +126,8 @@ namespace nvexec {
   }
 
   template <class VisitorT, class V>
-    __host__ __device__ void visit(VisitorT&& visitor, V&& v) {
+    STDEXEC_CLANG_HOST_DEVICE
+    void visit(VisitorT&& visitor, V&& v) {
       detail::visit_impl(
           std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
           (VisitorT&&)visitor,
@@ -133,6 +136,7 @@ namespace nvexec {
     }
 
   template <class VisitorT, class V>
+    STDEXEC_CLANG_HOST_DEVICE
     void visit(VisitorT&& visitor, V&& v, std::size_t index) {
       detail::visit_impl(
           std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
@@ -158,13 +162,15 @@ namespace nvexec {
           detail::find_index<index_t, T, Ts...>()>;
 
     template <detail::one_of<Ts...> T>
-      __host__ __device__ T& get() noexcept {
+      STDEXEC_CLANG_HOST_DEVICE
+      T& get() noexcept {
         void* data = storage_.data_;
         return *static_cast<T*>(data);
       }
 
     template <std::size_t I>
-      __host__ __device__ detail::nth_type<I, Ts...>& get() noexcept {
+      STDEXEC_CLANG_HOST_DEVICE
+      detail::nth_type<I, Ts...>& get() noexcept {
         return get<detail::nth_type<I, Ts...>>();
       }
 
@@ -176,23 +182,27 @@ namespace nvexec {
       destroy();
     }
 
-    __host__ __device__ bool holds_alternative() const {
+    STDEXEC_CLANG_HOST_DEVICE
+    bool holds_alternative() const {
       return index_ != detail::npos<index_t>();
     }
 
     template <detail::one_of<Ts...> T, class... As>
-      __host__ __device__ void emplace(As&&... as) {
+      STDEXEC_CLANG_HOST_DEVICE
+      void emplace(As&&... as) {
         destroy();
         construct<T>((As&&)as...);
       }
 
     template <detail::one_of<Ts...> T, class... As>
-      __host__ __device__ void construct(As&&... as) {
+      STDEXEC_CLANG_HOST_DEVICE
+      void construct(As&&... as) {
         ::new(storage_.data_) T((As&&)as...);
         index_ = index_of<T>();
       }
 
-    __host__ __device__ void destroy() {
+    STDEXEC_CLANG_HOST_DEVICE
+    void destroy() {
       if (holds_alternative()) {
         visit([](auto& val) noexcept {
           using val_t = std::decay_t<decltype(val)>;

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -106,14 +106,14 @@ namespace nvexec {
     };
 
     template <class VisitorT, class V>
-      void visit_impl(std::integral_constant<std::size_t, 0>, VisitorT&& visitor, V&& v, std::size_t index) {
+      __host__ __device__ void visit_impl(std::integral_constant<std::size_t, 0>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (0 == index) {
           ((VisitorT&&)visitor)(v.template get<0>());
         }
       }
 
     template <std::size_t I, class VisitorT, class V>
-      void visit_impl(std::integral_constant<std::size_t, I>, VisitorT&& visitor, V&& v, std::size_t index) {
+      __host__ __device__ void visit_impl(std::integral_constant<std::size_t, I>, VisitorT&& visitor, V&& v, std::size_t index) {
         if (I == index) {
           ((VisitorT&&)visitor)(v.template get<I>());
           return;
@@ -124,7 +124,7 @@ namespace nvexec {
   }
 
   template <class VisitorT, class V>
-    void visit(VisitorT&& visitor, V&& v) {
+    __host__ __device__ void visit(VisitorT&& visitor, V&& v) {
       detail::visit_impl(
           std::integral_constant<std::size_t, std::decay_t<V>::size - 1>{},
           (VisitorT&&)visitor,
@@ -158,13 +158,13 @@ namespace nvexec {
           detail::find_index<index_t, T, Ts...>()>;
 
     template <detail::one_of<Ts...> T>
-      T& get() noexcept {
+      __host__ __device__ T& get() noexcept {
         void* data = storage_.data_;
         return *static_cast<T*>(data);
       }
 
     template <std::size_t I>
-      detail::nth_type<I, Ts...>& get() noexcept {
+      __host__ __device__ detail::nth_type<I, Ts...>& get() noexcept {
         return get<detail::nth_type<I, Ts...>>();
       }
 
@@ -176,7 +176,7 @@ namespace nvexec {
       destroy();
     }
 
-    bool holds_alternative() const {
+    __host__ __device__ bool holds_alternative() const {
       return index_ != detail::npos<index_t>();
     }
 
@@ -187,12 +187,12 @@ namespace nvexec {
       }
 
     template <detail::one_of<Ts...> T, class... As>
-      void construct(As&&... as) {
+      __host__ __device__ void construct(As&&... as) {
         ::new(storage_.data_) T((As&&)as...);
         index_ = index_of<T>();
       }
 
-    void destroy() {
+    __host__ __device__ void destroy() {
       if (holds_alternative()) {
         visit([](auto& val) noexcept {
           using val_t = std::decay_t<decltype(val)>;

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -131,7 +131,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             sync_wait_t, stdexec::set_value_t, Sender>) &&
           (!stdexec::tag_invocable<sync_wait_t, Sender>) &&
           stdexec::sender<Sender, __impl::__env> &&
-          stdexec::sender_to<Sender, receiver_t<Sender>>
+          stdexec::__receiver_from<receiver_t<Sender>, Sender>
       auto operator()(context_state_t context_state, Sender&& __sndr) const
         -> std::optional<__impl::sync_wait_result_t<Sender>> {
         using state_t = __impl::state_t<stdexec::__id<Sender>>;
@@ -140,8 +140,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
         exit_operation_state_t<Sender, receiver_t<Sender>> __op_state =
           exit_op_state(
-              (Sender&&)__sndr, 
-              receiver_t<Sender>{{}, &state, &loop}, 
+              (Sender&&)__sndr,
+              receiver_t<Sender>{{}, &state, &loop},
               context_state);
         state.stream_ = __op_state.get_stream();
 
@@ -161,4 +161,3 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     };
   } // namespace stream_sync_wait
 }
-


### PR DESCRIPTION
* https://github.com/NVIDIA/stdexec/commit/41d56d4a21484cc796d14c12689d3792531640b3 fixes `clangd` errors in `test/nvexec/variant.cpp`:
  * `clangd` requires[1] `variant_t#emplace()` is annotated as a device function when called from a kernel
  * `clangd` complains[2] about the non-allocating placement new expression (and the recommended fix doesn't work)
* https://github.com/NVIDIA/stdexec/commit/f013cc394a19cb00b8008eddd13fffce84cee65b fixes a `clangd` error[3] in GPU tests that call `stdexec::sync_wait()`
* https://github.com/NVIDIA/stdexec/commit/1b8fa33e308cdf14529b3a38488dd1238a581f89 fixes the `maxwell_cpu_st --run-cpp` bandwidth calculation[4].
* https://github.com/NVIDIA/stdexec/commit/dcdc9af7e096f96a6829588338c2179a7f3da5aa fixes a few[5] more[6] small `clangd` errors in the `examples/nvexec` demos.


<!--<details><summary>0. Click to expand screenshot</summary></details>-->

<details><summary>1. Click to expand screenshot</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/201803920-8400d32a-f627-47e7-aa43-578a10f0d33d.png"><img src="https://user-images.githubusercontent.com/178183/201803920-8400d32a-f627-47e7-aa43-578a10f0d33d.png" alt="image" style="max-width: 100%;"></a></details>
<details><summary>2. Click to expand screenshot</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/201804043-27ef8065-e9f2-420f-98b5-c43cfdfbf92d.png"><img src="https://user-images.githubusercontent.com/178183/201804043-27ef8065-e9f2-420f-98b5-c43cfdfbf92d.png" alt="image" style="max-width: 100%;"></a></details>
<details><summary>3. Click to expand screenshot</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/201801912-2eca06bb-b712-4e27-b44f-370fb3e89ce8.png"><img src="https://user-images.githubusercontent.com/178183/201801912-2eca06bb-b712-4e27-b44f-370fb3e89ce8.png" alt="image" style="max-width: 100%;"></a></details>
<details><summary>4. Click to expand maxwell_cpu_st output</summary><pre>$ ./build/examples/nvexec/maxwell_cpu_st --run-cpp --run-inline-scheduler --iterations=1000 -N=1024
                  method, elapsed [s],   BW [GB/s]
        CPU (snr inline),      16.174,       2.898
               CPU (cpp),      10.426,    4496.173</pre></details>
<details><summary>5. Click to expand screenshot</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/201804859-9a4dbe49-9da5-46f5-a985-4a84972c7065.png"><img src="https://user-images.githubusercontent.com/178183/201804859-9a4dbe49-9da5-46f5-a985-4a84972c7065.png" alt="image" style="max-width: 100%;"></a></details>
<details><summary>6. Click to expand screenshot</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/201804752-1817211a-3333-4bf7-92ec-63b57969b9ff.png"><img src="https://user-images.githubusercontent.com/178183/201804752-1817211a-3333-4bf7-92ec-63b57969b9ff.png" alt="image" style="max-width: 100%;"></a></details>
