### PR TITLE
Don't use `_Bool` for template parameters

### DIFF
--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -525,12 +525,12 @@ namespace stdexec {
               __v<__minvoke<__mfind_if<_Fn, __mcount>, _Args...>>)>;
     };
 
-  template <class... _Bools>
-    using __mand = __bool<(__v<_Bools> &&...)>;
-  template <class... _Bools>
-    using __mor = __bool<(__v<_Bools> ||...)>;
-  template <class _Bool>
-    using __mnot = __bool<!__v<_Bool>>;
+  template <class... _Booleans>
+    using __mand = __bool<(__v<_Booleans> &&...)>;
+  template <class... _Booleans>
+    using __mor = __bool<(__v<_Booleans> ||...)>;
+  template <class _Boolean>
+    using __mnot = __bool<!__v<_Boolean>>;
 
   template <class _Fn>
     struct __mall_of {

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -852,9 +852,9 @@ namespace stdexec {
       template <class _T>
         requires tag_invocable<__has_algorithm_customizations_t, __cref_t<_T>>
       constexpr __result_t<_T> operator()(_T&& __t) const noexcept(noexcept(__result_t<_T>{})) {
-        using _Bool = tag_invoke_result_t<__has_algorithm_customizations_t, __cref_t<_T>>;
-        static_assert(_Bool{} ? true : true); // must be contextually convertible to bool
-        return _Bool{};
+        using _Boolean = tag_invoke_result_t<__has_algorithm_customizations_t, __cref_t<_T>>;
+        static_assert(_Boolean{} ? true : true); // must be contextually convertible to bool
+        return _Boolean{};
       }
       constexpr std::false_type operator()(auto&&) const noexcept {
         return {};


### PR DESCRIPTION
Since `_Bool` is the C boolean, don't use it as a template parameter name. If something somewhere happens to include `stdbool.h`/`cstdbool` it breaks the build (https://godbolt.org/z/EKErezb1P).

I renamed both `_Bool` and `_Bools` everywhere to the more verbose `_Boolean` and `_Booleans`, but I guess something like `_B` and `_Bs` could work as well.

Edit: Though to be completely fair it seems to only be a `libstdc++` thing: https://github.com/gcc-mirror/gcc/blob/0c1b0a23f1fe7db6a2e391b7cb78cff900377772/gcc/ginclude/stdbool.h#L44.