### PR TITLE
Make `when_all` move values into `set_value`

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4866,7 +4866,7 @@ namespace stdexec {
           : __rcvr_(__rcvr)
         {}
         template <class... _Ts>
-          void operator()(_Ts&&... __ts) const noexcept {
+          void operator()(_Ts&... __ts) const noexcept {
             _Tag{}((_Receiver&&) __rcvr_, (_Ts&&) __ts...);
           }
       };

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -68,6 +68,14 @@ TEST_CASE("when_all with just one sender", "[adaptors][when_all]") {
   wait_for_value(std::move(snd), 2);
 }
 
+TEST_CASE("when_all with move-only types", "[adaptors][when_all]") {
+  ex::sender auto snd = ex::when_all( //
+      ex::just(movable(2))            //
+  );
+  auto op = ex::connect(std::move(snd), expect_error_receiver{});
+  wait_for_value(std::move(snd), movable(2));
+}
+
 TEST_CASE("when_all with no senders", "[adaptors][when_all]") {
   ex::sender auto snd = ex::when_all();
   wait_for_value(std::move(snd));


### PR DESCRIPTION
The added test fails to compile without the change in this PR. Before this change `_Ts` in `__complete_fn::operator()` is always deduced as a reference and so the `__ts`s don't get moved.