### PR TITLE
Fix move-only test for `when_all`

### DIFF
--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -72,7 +72,6 @@ TEST_CASE("when_all with move-only types", "[adaptors][when_all]") {
   ex::sender auto snd = ex::when_all( //
       ex::just(movable(2))            //
   );
-  auto op = ex::connect(std::move(snd), expect_error_receiver{});
   wait_for_value(std::move(snd), movable(2));
 }
 


### PR DESCRIPTION
Apologies, I only checked that the new test in #714 compiles (and doesn't compile before the change), but didn't run it. The test that I added had a superfluous copy-paste `connect` in it... This fixes that.