### PR TITLE
Store devcontainer command history

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,13 @@
 {
-  "image": "ghcr.io/trxcllnt/devcontainer-images/cmake-ninja-sccache-llvm-cuda-nvhpc:latest",
+  "image": "ghcr.io/trxcllnt/devcontainer-images:cmake-ninja-sccache-llvmdev-cuda11.8-nvhpc22.11",
   "capAdd": ["SYS_PTRACE"],
   "hostRequirements": { "gpu": true },
   "securityOpt": ["seccomp=unconfined"],
+  "initializeCommand": "mkdir -p .cache",
+  "updateContentCommand": "sed -i -re 's/^(HIST(FILE)?SIZE=).*$/\\1/g' ~/.bashrc",
+  "containerEnv": {
+    "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Build and test with nvc++ (v22.7)
+      - name: Build and test with nvc++ (v22.11)
         run: entrypoint.py
 
 #  build-clang-13:


### PR DESCRIPTION
Small PR to store the devcontainer command history in a local `._bash_history` file. Also updates to the new devcontainer base image tag and fixes a typo in the github actions `ci.yml` workflow.