### PR TITLE
Fix data race in static thread pool specialization of bulk

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -112,9 +112,65 @@ namespace exec {
           >;
 
       template <class SenderId, class ReceiverId, class Shape, class Fun, bool MayThrow>
-        struct bulk_shared_state : task_base {
+        struct bulk_shared_state {
           using Sender = stdexec::__t<SenderId>;
           using Receiver = stdexec::__t<ReceiverId>;
+
+          struct bulk_task : task_base {
+              bulk_shared_state *sh_state_;
+
+              bulk_task(bulk_shared_state *sh_state)
+                : sh_state_(sh_state) {
+                this->__execute = [](task_base* t, std::uint32_t tid) noexcept {
+                  auto& sh_state = *static_cast<bulk_task*>(t)->sh_state_;
+                  auto total_threads = sh_state.num_agents_required();
+
+                  auto computation = [&](auto&... args) {
+                    auto [begin, end] = even_share(sh_state.shape_, tid, total_threads);
+                    for (Shape i = begin; i < end; ++i) {
+                      sh_state.fn_(i, args...);
+                    }
+                  };
+
+                  auto completion = [&](auto&... args) {
+                    stdexec::set_value((Receiver&&)sh_state.receiver_, std::move(args)...);
+                  };
+
+                  if constexpr (MayThrow) {
+                    try {
+                      sh_state.apply(computation);
+                    } catch(...) {
+                      std::uint32_t expected = total_threads;
+
+                      if (sh_state.thread_with_exception_.compare_exchange_strong(
+                              expected, tid,
+                              std::memory_order_relaxed,
+                              std::memory_order_relaxed)) {
+                        sh_state.exception_ = std::current_exception();
+                      }
+                    }
+
+                    const bool is_last_thread = sh_state.finished_threads_.fetch_add(1) == (total_threads - 1);
+
+                    if (is_last_thread) {
+                      if (sh_state.exception_) {
+                        stdexec::set_error((Receiver&&)sh_state.receiver_, sh_state.exception_);
+                      } else {
+                        sh_state.apply(completion);
+                      }
+                    }
+                  } else {
+                    sh_state.apply(computation);
+
+                    const bool is_last_thread = sh_state.finished_threads_.fetch_add(1) == (total_threads - 1);
+
+                    if (is_last_thread) {
+                      sh_state.apply(completion);
+                    }
+                  }
+                };
+              }
+          };
 
           using variant_t =
             stdexec::__value_types_of_t<
@@ -132,6 +188,7 @@ namespace exec {
           std::atomic<std::uint32_t> finished_threads_{0};
           std::atomic<std::uint32_t> thread_with_exception_{0};
           std::exception_ptr exception_;
+          std::vector<bulk_task> tasks_;
 
           // Splits `n` into `size` chunks distributing `n % size` evenly between ranks.
           // Returns `[begin, end)` range in `n` for a given `rank`.
@@ -172,60 +229,12 @@ namespace exec {
           bulk_shared_state(
               static_thread_pool& pool,
               Receiver receiver, Shape shape, Fun fn)
-            : pool_(pool)
+            : pool_{pool}
             , receiver_{(Receiver&&)receiver}
             , shape_{shape}
             , fn_{fn}
             , thread_with_exception_{num_agents_required()}
-          {
-            this->__execute = [](task_base* t, std::uint32_t tid) noexcept {
-              auto& self = *static_cast<bulk_shared_state*>(t);
-              auto total_threads = self.num_agents_required();
-
-              auto computation = [&](auto&... args) {
-                auto [begin, end] = even_share(self.shape_, tid, total_threads);
-                for (Shape i = begin; i < end; ++i) {
-                  self.fn_(i, args...);
-                }
-              };
-
-              auto completion = [&](auto&... args) {
-                stdexec::set_value((Receiver&&)self.receiver_, std::move(args)...);
-              };
-
-              if constexpr (MayThrow) {
-                try {
-                  self.apply(computation);
-                } catch(...) {
-                  std::uint32_t expected = total_threads;
-
-                  if (self.thread_with_exception_.compare_exchange_strong(
-                          expected, tid,
-                          std::memory_order_relaxed,
-                          std::memory_order_relaxed)) {
-                    self.exception_ = std::current_exception();
-                  }
-                }
-
-                const bool is_last_thread = self.finished_threads_.fetch_add(1) == (total_threads - 1);
-
-                if (is_last_thread) {
-                  if (self.exception_) {
-                    stdexec::set_error((Receiver&&)self.receiver_, self.exception_);
-                  } else {
-                    self.apply(completion);
-                  }
-                }
-              } else {
-                self.apply(computation);
-
-                const bool is_last_thread = self.finished_threads_.fetch_add(1) == (total_threads - 1);
-
-                if (is_last_thread) {
-                  self.apply(completion);
-                }
-              }
-            };
+            , tasks_{num_agents_required(), {this}} {
           }
         };
 
@@ -239,7 +248,7 @@ namespace exec {
           shared_state& shared_state_;
 
           void enqueue() noexcept {
-            shared_state_.pool_.bulk_enqueue(&shared_state_, shared_state_.num_agents_required());
+            shared_state_.pool_.bulk_enqueue(shared_state_.tasks_.data(), shared_state_.num_agents_required());
           }
 
           template <class... As>
@@ -426,7 +435,9 @@ namespace exec {
     void join() noexcept;
 
     void enqueue(task_base* task) noexcept;
-    void bulk_enqueue(task_base* task, std::uint32_t n_threads) noexcept;
+
+    template <std::derived_from<task_base> TaskT>
+      void bulk_enqueue(TaskT* task, std::uint32_t n_threads) noexcept;
 
     std::uint32_t threadCount_;
     std::vector<std::thread> threads_;
@@ -556,11 +567,12 @@ namespace exec {
     threadStates_[startIndex].push(task);
   }
 
-  inline void static_thread_pool::bulk_enqueue(task_base* task, std::uint32_t n_threads) noexcept {
-    for (std::size_t i = 0; i < n_threads; ++i) {
-      threadStates_[i % available_parallelism()].push(task);
+  template <std::derived_from<task_base> TaskT>
+    inline void static_thread_pool::bulk_enqueue(TaskT* task, std::uint32_t n_threads) noexcept {
+      for (std::size_t i = 0; i < n_threads; ++i) {
+        threadStates_[i % available_parallelism()].push(task + i);
+      }
     }
-  }
 
   inline task_base* static_thread_pool::thread_state::try_pop() {
     std::unique_lock lk{mut_, std::try_to_lock};

--- a/test/stdexec/algos/adaptors/test_let_error.cpp
+++ b/test/stdexec/algos/adaptors/test_let_error.cpp
@@ -235,21 +235,21 @@ struct int_err_transform {
 
 TEST_CASE("let_error works when changing threads", "[adaptors][let_error]") {
   exec::static_thread_pool pool{2};
-  bool called{false};
+  std::atomic<bool> called{false};
   {
     // lunch some work on the thread pool
     ex::sender auto snd = ex::on(pool.get_scheduler(), ex::just_error(7)) //
                           | ex::let_error(int_err_transform{})            //
                           | ex::then([&](auto x) -> void {
                               CHECK(x == 13);
-                              called = true;
+                              called.store(true);
                             });
     ex::start_detached(std::move(snd));
   }
   // wait for the work to be executed, with timeout
   // perform a poor-man's sync
   // NOTE: it's a shame that the `join` method in static_thread_pool is not public
-  for (int i = 0; i < 1000 && !called; i++)
+  for (int i = 0; i < 1000 && !called.load(); i++)
     std::this_thread::sleep_for(1ms);
   // the work should be executed
   REQUIRE(called);

--- a/test/stdexec/algos/adaptors/test_schedule_from.cpp
+++ b/test/stdexec/algos/adaptors/test_schedule_from.cpp
@@ -87,18 +87,19 @@ TEST_CASE("schedule_from calls the given sender when the scheduler dictates",
 
 TEST_CASE("schedule_from works when changing threads", "[adaptors][schedule_from]") {
   exec::static_thread_pool pool{2};
-  bool called{false};
+  std::atomic<bool> called{false};
   {
     // lunch some work on the thread pool
     ex::sender auto snd = ex::schedule_from(pool.get_scheduler(), ex::just()) //
-                          | ex::then([&] { called = true; });
+                          | ex::then([&] { called.store(true); });
     ex::start_detached(std::move(snd));
   }
   // wait for the work to be executed, with timeout
   // perform a poor-man's sync
   // NOTE: it's a shame that the `join` method in static_thread_pool is not public
-  for (int i = 0; i < 1000 && !called; i++)
+  for (int i = 0; i < 1000 && !called.load(); i++) {
     std::this_thread::sleep_for(1ms);
+  }
   // the work should be executed
   REQUIRE(called);
 }

--- a/test/stdexec/algos/adaptors/test_transfer.cpp
+++ b/test/stdexec/algos/adaptors/test_transfer.cpp
@@ -100,18 +100,19 @@ TEST_CASE("transfer calls the given sender when the scheduler dictates", "[adapt
 
 TEST_CASE("transfer works when changing threads", "[adaptors][transfer]") {
   exec::static_thread_pool pool{2};
-  bool called{false};
+  std::atomic<bool> called{false};
   {
     // lunch some work on the thread pool
     ex::sender auto snd = ex::transfer(ex::just(), pool.get_scheduler()) //
-                          | ex::then([&] { called = true; });
+                          | ex::then([&] { called.store(true); });
     ex::start_detached(std::move(snd));
   }
   // wait for the work to be executed, with timeout
   // perform a poor-man's sync
   // NOTE: it's a shame that the `join` method in static_thread_pool is not public
-  for (int i = 0; i < 1000 && !called; i++)
+  for (int i = 0; i < 1000 && !called.load(); i++) {
     std::this_thread::sleep_for(1ms);
+  }
   // the work should be executed
   REQUIRE(called);
 }

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -63,17 +63,17 @@ TEST_CASE("start_detached works with senders that do not complete immediately",
 
 TEST_CASE("start_detached works when changing threads", "[consumers][start_detached]") {
   exec::static_thread_pool pool{2};
-  bool called{false};
+  std::atomic<bool> called{false};
   {
     // lunch some work on the thread pool
     ex::sender auto snd = ex::transfer_just(pool.get_scheduler()) //
-                          | ex::then([&] { called = true; });
+                          | ex::then([&] { called.store(true); });
     ex::start_detached(std::move(snd));
   }
   // wait for the work to be executed, with timeout
   // perform a poor-man's sync
   // NOTE: it's a shame that the `join` method in static_thread_pool is not public
-  for (int i = 0; i < 1000 && !called; i++)
+  for (int i = 0; i < 1000 && !called.load(); i++)
     std::this_thread::sleep_for(1ms);
   // the work should be executed
   REQUIRE(called);


### PR DESCRIPTION
It is possible for data race to happen when concurrent thread enqueue a task into static thread pool while bulk receiver is running. The race happens on writing `_Next` and is addressed by separating bulk shared state and bulk tasks. I also took the liberty of fixing remeaning data races in our tests so that we can start using tsan in our CI.  

Closes #729