### PR TITLE
Refactor get_completion_scheduler to work with attrs

### DIFF
--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -295,11 +295,9 @@ struct repeat_n_t {
       }
 #endif
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const repeat_n_sender_t& s)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const repeat_n_sender_t& s)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(s.sender_);
       }
     };

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -165,7 +165,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         operation_state_t(PredSender&& pred_sender, Closure closure, Receiver&& receiver, std::size_t n)
           : operation_state_base_t<ReceiverId>(
               (Receiver&&)receiver, 
-              stdexec::get_completion_scheduler<stdexec::set_value_t>(pred_sender).context_state_,
+              stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(pred_sender)).context_state_,
               false)
           , pred_sender_{(PredSender&&)pred_sender}
           , closure_(closure)
@@ -295,10 +295,12 @@ struct repeat_n_t {
       }
 #endif
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... Ts>
-        requires stdexec::tag_invocable<Tag, Sender, Ts...> friend decltype(auto)
-      tag_invoke(Tag tag, const repeat_n_sender_t &s, Ts &&...ts) noexcept {
-        return tag(s.sender_, std::forward<Ts>(ts)...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const repeat_n_sender_t& s)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(s.sender_);
       }
     };
 

--- a/include/exec/inline_scheduler.hpp
+++ b/include/exec/inline_scheduler.hpp
@@ -47,8 +47,14 @@ namespace exec {
           return {(R&&) rec};
         }
 
-      friend inline_scheduler
-      tag_invoke(stdexec::get_completion_scheduler_t<stdexec::set_value_t>, __sender) noexcept {
+      struct __attrs {
+        friend inline_scheduler
+        tag_invoke(stdexec::get_completion_scheduler_t<stdexec::set_value_t>, const __attrs&) noexcept {
+          return {};
+        }
+      };
+
+      friend __attrs tag_invoke(stdexec::get_attrs_t, const __sender&) noexcept {
         return {};
       }
     };

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -139,11 +139,9 @@ template <class SenderId, std::integral Shape, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const __t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };
@@ -377,11 +375,9 @@ template <class SenderId, std::integral Shape, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const __t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -139,12 +139,12 @@ template <class SenderId, std::integral Shape, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const __t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
     };
   };
@@ -358,7 +358,7 @@ template <class SenderId, std::integral Shape, class Fun>
           requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
         friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
           -> multi_gpu_bulk::operation_t<stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>, stdexec::__id<Receiver>, Shape, Fun> {
-          auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(self.sndr_);
+          auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(self.sndr_));
           context_state_t context_state = sch.context_state_;
           return multi_gpu_bulk::operation_t<stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>, stdexec::__id<Receiver>, Shape, Fun>(
               self.num_devices_,
@@ -377,14 +377,13 @@ template <class SenderId, std::integral Shape, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-          requires stdexec::__callable<Tag, const Sender&, As...>
-        friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-          noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-          -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, 
-                                        Tag, const Sender&, As...> {
-          return ((Tag&&) tag)(self.sndr_, (As&&) as...);
-        }
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const __t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
+      }
     };
   };
 }

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -559,7 +559,7 @@ namespace nvexec {
       concept stream_completing_sender =
         stdexec::sender<S> &&
         requires (const S& sndr) {
-          { stdexec::get_completion_scheduler<stdexec::set_value_t>(sndr).context_state_ } -> 
+          { stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(sndr)).context_state_ } ->
             stdexec::__decays_to<context_state_t>;
         };
 
@@ -585,7 +585,7 @@ namespace nvexec {
     template <stream_completing_sender Sender, class OuterReceiver, class ReceiverProvider>
       stream_op_state_t<Sender, inner_receiver_t<ReceiverProvider, OuterReceiver>, OuterReceiver>
       stream_op_state(Sender&& sndr, OuterReceiver&& out_receiver, ReceiverProvider receiver_provider) {
-        auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(sndr);
+        auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(sndr));
         context_state_t context_state = sch.context_state_;
 
         return stream_op_state_t<

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -319,11 +319,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                                           std::move(self).shared_state_};
           }
 
-        template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-          requires stdexec::__callable<_Tag, const Sender&>
-        friend auto tag_invoke(_Tag, const __t& self)
-          noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-          -> stdexec::__call_result_t<_Tag, const Sender&> {
+        friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+          noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+          -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
           return stdexec::get_attrs(self.sndr_);
         }
 

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -319,14 +319,13 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                                           std::move(self).shared_state_};
           }
 
-        template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-            requires // Always complete on GPU, so no need in (!stdexec::__is_instance_of<Tag, stdexec::get_completion_scheduler_t>) &&
-              stdexec::__callable<Tag, const Sender&, As...>
-          friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-            noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-            -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-            return ((Tag&&) tag)(self.sndr_, (As&&) as...);
-          }
+        template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+          requires stdexec::__callable<_Tag, const Sender&>
+        friend auto tag_invoke(_Tag, const __t& self)
+          noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+          -> stdexec::__call_result_t<_Tag, const Sender&> {
+          return stdexec::get_attrs(self.sndr_);
+        }
 
         template <class... Tys>
           using set_value_t = 

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -250,11 +250,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             };
           }
 
-        template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-          requires stdexec::__callable<_Tag, const _Sender&>
-        friend auto tag_invoke(_Tag, const __t& __self)
-          noexcept(stdexec::__nothrow_callable<_Tag, const _Sender&>)
-          -> stdexec::__call_result_t<_Tag, const _Sender&> {
+        friend auto tag_invoke(stdexec::get_attrs_t, const __t& __self)
+          noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const _Sender&>)
+          -> stdexec::__call_result_t<stdexec::get_attrs_t, const _Sender&> {
           return stdexec::get_attrs(__self.__sndr_);
         }
 

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -192,7 +192,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                 [this] (operation_state_base_t<stdexec::__id<_Receiver2>> &) -> __receiver_t {
                   return __receiver_t{{}, this};
                 },
-                stdexec::get_completion_scheduler<stdexec::set_value_t>(__sndr).context_state_)
+                stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(__sndr)).context_state_)
             , __fun_((_Fun&&) __fun)
           {}
         STDEXEC_IMMOVABLE(__operation);
@@ -250,13 +250,13 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             };
           }
 
-        template <stdexec::tag_category<stdexec::forwarding_sender_query> _Tag, class... _As>
-            requires stdexec::__callable<_Tag, const _Sender&, _As...>
-          friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-            noexcept(stdexec::__nothrow_callable<_Tag, const _Sender&, _As...>)
-            -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, stdexec::forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-          }
+        template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+          requires stdexec::__callable<_Tag, const _Sender&>
+        friend auto tag_invoke(_Tag, const __t& __self)
+          noexcept(stdexec::__nothrow_callable<_Tag, const _Sender&>)
+          -> stdexec::__call_result_t<_Tag, const _Sender&> {
+          return stdexec::get_attrs(__self.__sndr_);
+        }
 
         template <stdexec::__decays_to<__t> _Self, class _Env>
           friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env)

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -219,11 +219,9 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const __t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -219,12 +219,12 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const __t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -68,11 +68,9 @@ namespace schedule_from {
           return stdexec::connect(((Self&&)self).sender_, (Receiver&&)rcvr);
         }
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const source_sender_t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const source_sender_t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         // TODO - this code is not exercised by any test
         return stdexec::get_attrs(self.sndr_);
       }

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -68,12 +68,13 @@ namespace schedule_from {
           return stdexec::connect(((Self&&)self).sender_, (Receiver&&)rcvr);
         }
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> _Tag, class... _As>
-        requires stdexec::__callable<_Tag, const Sender&, _As...>
-      friend auto tag_invoke(_Tag __tag, const source_sender_t& __self, _As&&... __as)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&, _As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, stdexec::forwarding_sender_query>, _Tag, const Sender&, _As...> {
-        return ((_Tag&&) __tag)(__self.sender_, (_As&&) __as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const source_sender_t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        // TODO - this code is not exercised by any test
+        return stdexec::get_attrs(self.sndr_);
       }
 
       template <stdexec::__decays_to<source_sender_t> _Self, class _Env>
@@ -91,9 +92,18 @@ template <class Scheduler, class SenderId>
     using Sender = stdexec::__t<SenderId>;
     using source_sender_th = schedule_from::source_sender_t<Sender>;
 
+    struct __attrs {
+      context_state_t context_state_;
+
+      template <stdexec::__one_of<stdexec::set_value_t, stdexec::set_stopped_t, stdexec::set_error_t> _Tag>
+        friend Scheduler tag_invoke(stdexec::get_completion_scheduler_t<_Tag>, const __attrs& __self) noexcept {
+          return {__self.context_state_};
+        }
+    };
+
     struct __t : stream_sender_base {
       using __id = schedule_from_sender_t;
-      context_state_t context_state_;
+      __attrs attrs_;
       source_sender_th sndr_;
 
       template <class Self, class Receiver>
@@ -113,21 +123,12 @@ template <class Scheduler, class SenderId>
               [&](operation_state_base_t<stdexec::__id<Receiver>>& stream_provider) -> receiver_t<Self, Receiver> {
                 return receiver_t<Self, Receiver>{{}, stream_provider};
               },
-              self.context_state_);
+              self.attrs_.context_state_);
       }
 
-      template <stdexec::__one_of<stdexec::set_value_t, stdexec::set_stopped_t, stdexec::set_error_t> _Tag>
-        friend Scheduler tag_invoke(stdexec::get_completion_scheduler_t<_Tag>, const __t& __self) noexcept {
-          return {__self.context_state_};
-        }
-
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> _Tag, class... _As>
-          requires stdexec::__callable<_Tag, const Sender&, _As...>
-        friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-          noexcept(stdexec::__nothrow_callable<_Tag, const Sender&, _As...>)
-          -> stdexec::__call_result_if_t<stdexec::tag_category<_Tag, stdexec::forwarding_sender_query>, _Tag, const Sender&, _As...> {
-          return ((_Tag&&) __tag)(__self.sndr_, (_As&&) __as...);
-        }
+      friend const __attrs& tag_invoke(stdexec::get_attrs_t, const __t& __self) noexcept {
+        return __self.attrs_;
+      }
 
       template <stdexec::__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env) ->
@@ -137,7 +138,7 @@ template <class Scheduler, class SenderId>
             stdexec::completion_signatures<stdexec::set_error_t(cudaError_t)>>;
 
       __t(context_state_t context_state, Sender sndr)
-        : context_state_(context_state)
+        : attrs_{context_state}
         , sndr_{{}, (Sender&&)sndr} {
       }
     };

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -310,14 +310,13 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                                           self.shared_state_};
           }
 
-        template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-            requires // Always complete on GPU, so no need in (!stdexec::__is_instance_of<Tag, stdexec::get_completion_scheduler_t>) && 
-              stdexec::__callable<Tag, const Sender&, As...>
-          friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-            noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-            -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-            return ((Tag&&) tag)(self.sndr_, (As&&) as...);
-          }
+        template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+          requires stdexec::__callable<_Tag, const Sender&>
+        friend auto tag_invoke(_Tag, const __t& self)
+          noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+          -> stdexec::__call_result_t<_Tag, const Sender&> {
+          return stdexec::get_attrs(self.sndr_);
+        }
 
         template <class... Tys>
           using set_value_t = stdexec::completion_signatures<stdexec::set_value_t(const std::decay_t<Tys>&...)>;

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -310,11 +310,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                                           self.shared_state_};
           }
 
-        template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-          requires stdexec::__callable<_Tag, const Sender&>
-        friend auto tag_invoke(_Tag, const __t& self)
-          noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-          -> stdexec::__call_result_t<_Tag, const Sender&> {
+        friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+          noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+          -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
           return stdexec::get_attrs(self.sndr_);
         }
 

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -189,12 +189,12 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const __t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -189,11 +189,9 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const __t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -144,12 +144,12 @@ template <class SenderId>
         friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env) ->
           completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const __t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
 
       __t(context_state_t context_state, Sender sndr)

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -144,11 +144,9 @@ template <class SenderId>
         friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env) ->
           completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const __t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
 

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -176,12 +176,12 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const __t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -176,11 +176,9 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const __t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -150,12 +150,12 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const __t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const __t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -150,11 +150,9 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const __t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -5521,7 +5521,15 @@ namespace stdexec {
           (!__tag_invocable_with_completion_scheduler<
             sync_wait_t, set_value_t, _Sender>) &&
           tag_invocable<sync_wait_t, _Sender>
-      tag_invoke_result_t<sync_wait_t, _Sender>
+      // TODO - for reasons I cannot figure out, the move_only_t test in
+      // test/nvexec/then.cpp appears to instantiate this version of
+      // operator(), even though the complation scheduler overload above is
+      // what actually is called. This leads the compilation to fail when
+      // computing tag_invoke_result_t in the return type.
+      // Using decltype(auto) avoids the tag_invoke_result_t expansion.
+      // Why does the compiler not respect the requires clause and avoid
+      // expanding the tag_invoke_result_t?
+      decltype(auto)
       operator()(_Sender&& __sndr) const noexcept(
         nothrow_tag_invocable<sync_wait_t, _Sender>) {
         return tag_invoke(sync_wait_t{}, (_Sender&&) __sndr);

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -687,8 +687,8 @@ namespace stdexec {
       // NOT TO SPEC:
       // The sender related concepts are temporarily "in flight" being
       // upgraded from P2300R5 to the get_attrs aware version of P2300.
-      requires (const remove_cvref_t<_Sender>& __sender) {
-        { get_attrs(__sender) } -> queryable;
+      requires (const remove_cvref_t<_Sender>& __sndr) {
+        { get_attrs(__sndr) } -> queryable;
       } &&
       __sender<_Sender, no_env> &&
       __sender<_Sender, _Env>;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -684,6 +684,12 @@ namespace stdexec {
   // [execution.senders]
   template <class _Sender, class _Env = no_env>
     concept sender =
+      // NOT TO SPEC:
+      // The sender related concepts are temporarily "in flight" being
+      // upgraded from P2300R5 to the get_attrs aware version of P2300.
+      requires (const remove_cvref_t<_Sender>& __sender) {
+        { get_attrs(__sender) } -> queryable;
+      } &&
       __sender<_Sender, no_env> &&
       __sender<_Sender, _Env>;
 
@@ -2591,15 +2597,9 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          // TODO: Until all senders provide get_attrs, the senders returned by
-          // sender adaptors define the tag_invoke(get_attrs) as a constrainted
-          // templated function. We can remove this when all senders provide
-          // get_attrs.
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
         };
@@ -2712,11 +2712,9 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
         };
@@ -2826,11 +2824,9 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
         };
@@ -2970,11 +2966,9 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
         };
@@ -3812,11 +3806,9 @@ namespace stdexec {
               };
             }
 
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
 
@@ -3968,11 +3960,9 @@ namespace stdexec {
               return {((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
             }
 
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
 
@@ -4666,11 +4656,9 @@ namespace stdexec {
                     (_Receiver&&) __rcvr};
           }
 
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
 
@@ -4816,11 +4804,9 @@ namespace stdexec {
                 __receiver_t<_Receiver>{(_Receiver&&) __rcvr});
           }
 
-          template <same_as<get_attrs_t> _Tag>
-              requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_t<_Tag, const _Sender&> {
+          friend auto tag_invoke(get_attrs_t, const __t& __self)
+            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
+            -> __call_result_t<get_attrs_t, const _Sender&> {
             return get_attrs(__self.__sndr_);
           }
 

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -1609,6 +1609,10 @@ namespace stdexec {
   namespace __sender_queries {
     template <__one_of<set_value_t, set_error_t, set_stopped_t> _CPO>
       struct get_completion_scheduler_t {
+        // NOT TO SPEC:
+        friend constexpr bool tag_invoke(forwarding_sender_query_t, const get_completion_scheduler_t&) noexcept {
+          return true;
+        }
         friend constexpr bool tag_invoke(forwarding_query_t, const get_completion_scheduler_t&) noexcept {
           return true;
         }

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -655,6 +655,11 @@ namespace stdexec {
           return tag_invoke(*this, __sender);
         }
 
+      // NOT TO SPEC
+      // This overload is subsumed by the __sender constrained overload
+      // below, which is provided for backwards compatibility. We'll enable
+      // this one when removing the compatibility overload.
+#if 0
       template <class _Sender>
         requires (!tag_invocable<get_attrs_t, const _Sender&>) &&
           __awaitable<_Sender, no_env_promise>
@@ -662,6 +667,7 @@ namespace stdexec {
           noexcept -> __empty_attrs {
           return {};
         }
+#endif
 
       // NOT TO SPEC
       // For backwards compatibility, get_attrs returns a reference
@@ -669,7 +675,7 @@ namespace stdexec {
       // of all sender types defining get_attrs.
       template <class _Sender>
         requires (!tag_invocable<get_attrs_t, const _Sender&>) &&
-          (!__awaitable<_Sender, no_env_promise>) && __sender<_Sender, no_env>
+          __sender<_Sender, no_env>
         constexpr auto operator()(const _Sender& __sender) const
           noexcept -> const _Sender& {
           return __sender;
@@ -684,7 +690,7 @@ namespace stdexec {
   // [execution.senders]
   template <class _Sender, class _Env = no_env>
     concept sender =
-      // NOT TO SPEC:
+      // NOT TO SPEC
       // The sender related concepts are temporarily "in flight" being
       // upgraded from P2300R5 to the get_attrs aware version of P2300.
       requires (const remove_cvref_t<_Sender>& __sndr) {

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -1042,7 +1042,7 @@ namespace stdexec {
   template <class _Scheduler>
     concept __sender_has_completion_scheduler =
       requires(_Scheduler&& __sched, const get_completion_scheduler_t<set_value_t>&& __tag) {
-        { tag_invoke(std::move(__tag), schedule((_Scheduler&&) __sched)) }
+        { tag_invoke(std::move(__tag), get_attrs(schedule((_Scheduler&&) __sched))) }
           -> same_as<remove_cvref_t<_Scheduler>>;
       };
 
@@ -1595,23 +1595,20 @@ namespace stdexec {
   namespace __sender_queries {
     template <__one_of<set_value_t, set_error_t, set_stopped_t> _CPO>
       struct get_completion_scheduler_t {
-        friend constexpr bool tag_invoke(forwarding_sender_query_t, const get_completion_scheduler_t &) noexcept {
-          return true;
-        }
         friend constexpr bool tag_invoke(forwarding_query_t, const get_completion_scheduler_t&) noexcept {
           return true;
         }
 
-        template <sender _Sender>
-          requires tag_invocable<get_completion_scheduler_t, const _Sender&> &&
-            scheduler<tag_invoke_result_t<get_completion_scheduler_t, const _Sender&>>
-        auto operator()(const _Sender& __sndr) const noexcept
-            -> tag_invoke_result_t<get_completion_scheduler_t, const _Sender&> {
+        template <queryable _Queryable>
+          requires tag_invocable<get_completion_scheduler_t, const _Queryable&> &&
+            scheduler<tag_invoke_result_t<get_completion_scheduler_t, const _Queryable&>>
+        auto operator()(const _Queryable& __queryable) const noexcept
+            -> tag_invoke_result_t<get_completion_scheduler_t, const _Queryable&> {
           // NOT TO SPEC:
           static_assert(
-            nothrow_tag_invocable<get_completion_scheduler_t, const _Sender&>,
+            nothrow_tag_invocable<get_completion_scheduler_t, const _Queryable&>,
             "get_completion_scheduler<_CPO> should be noexcept");
-          return tag_invoke(*this, __sndr);
+          return tag_invoke(*this, __queryable);
         }
       };
   } // namespace __sender_queries
@@ -1623,11 +1620,10 @@ namespace stdexec {
 
   template <class _Sender, class _CPO>
     concept __has_completion_scheduler =
-      __callable<get_completion_scheduler_t<_CPO>, _Sender>;
+      __callable<get_completion_scheduler_t<_CPO>, __call_result_t<get_attrs_t, const _Sender&>>;
 
   template <class _Sender, class _CPO>
-    using __completion_scheduler_for =
-      __call_result_t<get_completion_scheduler_t<_CPO>, _Sender>;
+    using __completion_scheduler_for = __call_result_t<get_completion_scheduler_t<_CPO>, __call_result_t<get_attrs_t, const _Sender&>>;
 
   template <class _Fun, class _CPO, class _Sender, class... _As>
     concept __tag_invocable_with_completion_scheduler =
@@ -1923,11 +1919,6 @@ namespace stdexec {
         template <typename _Receiver>
         friend __op<_Receiver> tag_invoke(connect_t, __sender, _Receiver __rcvr) {
           return {{}, (_Receiver &&) __rcvr};
-        }
-
-        template <class CPO>
-        friend __scheduler tag_invoke(get_completion_scheduler_t<CPO>, __sender) noexcept {
-          return {};
         }
       };
 
@@ -2582,15 +2573,6 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          // forward sender queries:
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-            requires __callable<_Tag, const _Sender&, _As...>
-          friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-          }
-
           // TODO: Until all senders provide get_attrs, the senders returned by
           // sender adaptors define the tag_invoke(get_attrs) as a constrainted
           // templated function. We can remove this when all senders provide
@@ -2621,7 +2603,7 @@ namespace stdexec {
         requires __tag_invocable_with_completion_scheduler<then_t, set_value_t, _Sender, _Fun>
       sender auto operator()(_Sender&& __sndr, _Fun __fun) const
         noexcept(nothrow_tag_invocable<then_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Fun>) {
-        auto __sched = get_completion_scheduler<set_value_t>(__sndr);
+        auto __sched = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
         return tag_invoke(then_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
       }
       template <sender _Sender, __movable_value _Fun>
@@ -2712,13 +2694,6 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          template <tag_category<forwarding_sender_query> _Tag, class _Error>
-            requires __callable<_Tag, const _Sender&, _Error>
-          friend auto tag_invoke(_Tag __tag, const __t& __self, _Error&& __err)
-            noexcept(__nothrow_callable<_Tag, const _Sender&, _Error>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _Error> {
-            return ((_Tag&&) __tag)(__self.__sndr_, (_Error&&) __err);
-          }
           template <same_as<get_attrs_t> _Tag>
               requires __callable<_Tag, const _Sender&>
           friend auto tag_invoke(_Tag, const __t& __self)
@@ -2737,7 +2712,7 @@ namespace stdexec {
         requires __tag_invocable_with_completion_scheduler<upon_error_t, set_error_t, _Sender, _Fun>
       sender auto operator()(_Sender&& __sndr, _Fun __fun) const
         noexcept(nothrow_tag_invocable<upon_error_t, __completion_scheduler_for<_Sender, set_error_t>, _Sender, _Fun>) {
-        auto __sched = get_completion_scheduler<set_error_t>(__sndr);
+        auto __sched = get_completion_scheduler<set_error_t>(get_attrs(__sndr)); // TODO ADD TEST!
         return tag_invoke(upon_error_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
       }
       template <sender _Sender, __movable_value _Fun>
@@ -2833,13 +2808,6 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          template <tag_category<forwarding_sender_query> _Tag>
-            requires __callable<_Tag, const _Sender&>
-          friend auto tag_invoke(_Tag __tag, const __t& __self)
-            noexcept(__nothrow_callable<_Tag, const _Sender&>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&> {
-            return ((_Tag&&) __tag)(__self.__sndr_);
-          }
           template <same_as<get_attrs_t> _Tag>
               requires __callable<_Tag, const _Sender&>
           friend auto tag_invoke(_Tag, const __t& __self)
@@ -2860,7 +2828,7 @@ namespace stdexec {
           __callable<_Fun>
       sender auto operator()(_Sender&& __sndr, _Fun __fun) const
         noexcept(nothrow_tag_invocable<upon_stopped_t, __completion_scheduler_for<_Sender, set_stopped_t>, _Sender, _Fun>) {
-        auto __sched = get_completion_scheduler<set_stopped_t>(__sndr);
+        auto __sched = get_completion_scheduler<set_stopped_t>(get_attrs(__sndr)); // TODO ADD TEST!
         return tag_invoke(upon_stopped_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
       }
       template <sender _Sender, __movable_value _Fun>
@@ -2984,13 +2952,6 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-            requires __callable<_Tag, const _Sender&, _As...>
-          friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-          }
           template <same_as<get_attrs_t> _Tag>
               requires __callable<_Tag, const _Sender&>
           friend auto tag_invoke(_Tag, const __t& __self)
@@ -3009,7 +2970,7 @@ namespace stdexec {
         requires __tag_invocable_with_completion_scheduler<bulk_t, set_value_t, _Sender, _Shape, _Fun>
       sender auto operator()(_Sender&& __sndr, _Shape __shape, _Fun __fun) const
         noexcept(nothrow_tag_invocable<bulk_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Shape, _Fun>) {
-        auto __sched = get_completion_scheduler<set_value_t>(__sndr);
+        auto __sched = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
         return tag_invoke(bulk_t{}, std::move(__sched), (_Sender&&) __sndr, (_Shape&&) __shape, (_Fun&&) __fun);
       }
       template <sender _Sender, integral _Shape, __movable_value _Fun>
@@ -3271,15 +3232,6 @@ namespace stdexec {
                                             __self.__shared_state_};
             }
 
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-              requires (!__is_instance_of<_Tag, get_completion_scheduler_t>) &&
-                __callable<_Tag, const _Sender&, _As...>
-            friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-              noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-              -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-              return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-            }
-
           template <__decays_to<__t> _Self, class _OtherEnv>
             friend auto tag_invoke(get_completion_signatures_t, _Self&&, _OtherEnv)
               -> __completions_t<_Self>;
@@ -3299,8 +3251,8 @@ namespace stdexec {
     using _Env = __1;
     using __cust_sigs =
       __types<
-        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(_Sender&), _Sender),
-        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(_Sender&), _Sender, _Env),
+        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender),
+        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender, _Env),
         tag_invoke_t(split_t, get_scheduler_t(_Env&), _Sender),
         tag_invoke_t(split_t, get_scheduler_t(_Env&), _Sender, _Env),
         tag_invoke_t(split_t, _Sender),
@@ -3581,15 +3533,6 @@ namespace stdexec {
                                             std::move(__self).__shared_state_};
             }
 
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-              requires (!__is_instance_of<_Tag, get_completion_scheduler_t>) &&
-                __callable<_Tag, const _Sender&, _As...>
-            friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-              noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-              -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-              return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-            }
-
           template <same_as<__t> _Self, class _OtherEnv>
             friend auto tag_invoke(get_completion_signatures_t, _Self&&, _OtherEnv)
               -> __completions_t<_Self>;
@@ -3619,8 +3562,8 @@ namespace stdexec {
     using _Env = __1;
     using __cust_sigs =
       __types<
-        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(_Sender&), _Sender),
-        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(_Sender&), _Sender, _Env),
+        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender),
+        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender, _Env),
         tag_invoke_t(ensure_started_t, get_scheduler_t(_Env&), _Sender),
         tag_invoke_t(ensure_started_t, get_scheduler_t(_Env&), _Sender, _Env),
         tag_invoke_t(ensure_started_t, _Sender),
@@ -3851,13 +3794,6 @@ namespace stdexec {
               };
             }
 
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-              requires __callable<_Tag, const _Sender&, _As...>
-            friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-              noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-              -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-              return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-            }
           template <same_as<get_attrs_t> _Tag>
               requires __callable<_Tag, const _Sender&>
           friend auto tag_invoke(_Tag, const __t& __self)
@@ -3888,7 +3824,7 @@ namespace stdexec {
           requires __tag_invocable_with_completion_scheduler<_LetTag, set_value_t, _Sender, _Fun>
         sender auto operator()(_Sender&& __sndr, _Fun __fun) const
           noexcept(nothrow_tag_invocable<_LetTag, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Fun>) {
-          auto __sched = get_completion_scheduler<set_value_t>(__sndr);
+          auto __sched = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
           return tag_invoke(_LetTag{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
         }
         template <sender _Sender, __movable_value _Fun>
@@ -4014,13 +3950,6 @@ namespace stdexec {
               return {((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
             }
 
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-              requires __callable<_Tag, const _Sender&, _As...>
-            friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-              noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-              -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-              return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-            }
           template <same_as<get_attrs_t> _Tag>
               requires __callable<_Tag, const _Sender&>
           friend auto tag_invoke(_Tag, const __t& __self)
@@ -4175,10 +4104,18 @@ namespace stdexec {
             return {&__loop_->__head_, __loop_, (_Receiver &&) __rcvr};
           }
 
-          template <class _CPO>
-          friend __scheduler
-          tag_invoke(get_completion_scheduler_t<_CPO>, const __schedule_task& __self) noexcept {
-            return __scheduler{__self.__loop_};
+          struct __attrs {
+            run_loop* __loop_;
+
+            template <class _CPO>
+            friend __scheduler
+            tag_invoke(get_completion_scheduler_t<_CPO>, const __attrs& __self) noexcept {
+              return __scheduler{__self.__loop_};
+            }
+          };
+
+          friend __attrs tag_invoke(get_attrs_t, const __schedule_task& __self) noexcept {
+            return __attrs{__self.__loop_};
           }
 
           explicit __schedule_task(run_loop* __loop) noexcept
@@ -4455,34 +4392,43 @@ namespace stdexec {
           __q<decay_t>,
           __mcompose<__q<completion_signatures>, __qf<_Tag>>>;
 
+    template <class _SchedulerId>
+      struct __attrs {
+        using _Scheduler = stdexec::__t<_SchedulerId>;
+
+        struct __t {
+          using __id = __attrs;
+
+          _Scheduler __sched_;
+
+          template <__one_of<set_value_t, set_stopped_t> _Tag>
+          friend _Scheduler tag_invoke(get_completion_scheduler_t<_Tag>, const __t& __self) noexcept {
+            return __self.__sched_;
+          }
+        };
+      };
+
+
     template <class _SchedulerId, class _SenderId>
       struct __sender {
         using _Scheduler = stdexec::__t<_SchedulerId>;
         using _Sender = stdexec::__t<_SenderId>;
+        using _Attrs = stdexec::__t<__attrs<_SchedulerId>>;
 
         struct __t {
           using __id = __sender;
-          _Scheduler __sched_;
+          _Attrs __attrs_;
           _Sender __sndr_;
 
           template <__decays_to<__t> _Self, class _Receiver>
             requires sender_to<__copy_cvref_t<_Self, _Sender>, _Receiver>
           friend auto tag_invoke(connect_t, _Self&& __self, _Receiver __rcvr)
               -> stdexec::__t<__operation1<_SchedulerId, stdexec::__id<__copy_cvref_t<_Self, _Sender>>, stdexec::__id<_Receiver>>> {
-            return {__self.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
+            return {__self.__attrs_.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
           }
 
-          template <__one_of<set_value_t, set_stopped_t> _Tag>
-          friend _Scheduler tag_invoke(get_completion_scheduler_t<_Tag>, const __t& __self) noexcept {
-            return __self.__sched_;
-          }
-
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-            requires __callable<_Tag, const _Sender&, _As...>
-          friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
+          friend const _Attrs& tag_invoke(get_attrs_t, const __t& __self) noexcept {
+            return __self.__attrs_;
           }
 
           template <class... _Errs>
@@ -4527,7 +4473,7 @@ namespace stdexec {
       template <scheduler _Scheduler, sender _Sender>
       auto operator()(_Scheduler&& __sched, _Sender&& __sndr) const
         -> stdexec::__t<__sender<stdexec::__id<decay_t<_Scheduler>>, stdexec::__id<decay_t<_Sender>>>> {
-        return {(_Scheduler&&) __sched, (_Sender&&) __sndr};
+        return {{(_Scheduler&&) __sched}, (_Sender&&) __sndr};
       }
     };
   } // namespace __schedule_from
@@ -4543,7 +4489,7 @@ namespace stdexec {
       tag_invoke_result_t<transfer_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Scheduler>
       operator()(_Sender&& __sndr, _Scheduler&& __sched) const
         noexcept(nothrow_tag_invocable<transfer_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Scheduler>) {
-        auto csch = get_completion_scheduler<set_value_t>(__sndr);
+        auto csch = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
         return tag_invoke(transfer_t{}, std::move(csch), (_Sender&&) __sndr, (_Scheduler&&) __sched);
       }
       template <sender _Sender, scheduler _Scheduler>
@@ -4702,13 +4648,6 @@ namespace stdexec {
                     (_Receiver&&) __rcvr};
           }
 
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-            requires __callable<_Tag, const _Sender&, _As...>
-          friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-            noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-            -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-            return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-          }
           template <same_as<get_attrs_t> _Tag>
               requires __callable<_Tag, const _Sender&>
           friend auto tag_invoke(_Tag, const __t& __self)
@@ -4859,13 +4798,6 @@ namespace stdexec {
                 __receiver_t<_Receiver>{(_Receiver&&) __rcvr});
           }
 
-          template <tag_category<forwarding_sender_query> _Tag, class... _As>
-              requires __callable<_Tag, const _Sender&, _As...>
-            friend auto tag_invoke(_Tag __tag, const __t& __self, _As&&... __as)
-              noexcept(__nothrow_callable<_Tag, const _Sender&, _As...>)
-              -> __call_result_if_t<tag_category<_Tag, forwarding_sender_query>, _Tag, const _Sender&, _As...> {
-              return ((_Tag&&) __tag)(__self.__sndr_, (_As&&) __as...);
-            }
           template <same_as<get_attrs_t> _Tag>
               requires __callable<_Tag, const _Sender&>
           friend auto tag_invoke(_Tag, const __t& __self)
@@ -5579,7 +5511,7 @@ namespace stdexec {
           __completion_scheduler_for<_Sender, set_value_t>,
           _Sender>) {
         auto __sched =
-          get_completion_scheduler<set_value_t>(__sndr);
+          get_completion_scheduler<set_value_t>(get_attrs(__sndr));
         return tag_invoke(sync_wait_t{}, std::move(__sched), (_Sender&&) __sndr);
       }
 
@@ -5654,7 +5586,7 @@ namespace stdexec {
           "must be sync-wait-with-variant-type<S, sync-wait-env>");
 
         auto __sched =
-          get_completion_scheduler<set_value_t>(__sndr);
+          get_completion_scheduler<set_value_t>(get_attrs(__sndr));
         return tag_invoke(
           sync_wait_with_variant_t{}, std::move(__sched), (_Sender&&) __sndr);
       }

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -5525,15 +5525,7 @@ namespace stdexec {
           (!__tag_invocable_with_completion_scheduler<
             sync_wait_t, set_value_t, _Sender>) &&
           tag_invocable<sync_wait_t, _Sender>
-      // TODO - for reasons I cannot figure out, the move_only_t test in
-      // test/nvexec/then.cpp appears to instantiate this version of
-      // operator(), even though the complation scheduler overload above is
-      // what actually is called. This leads the compilation to fail when
-      // computing tag_invoke_result_t in the return type.
-      // Using decltype(auto) avoids the tag_invoke_result_t expansion.
-      // Why does the compiler not respect the requires clause and avoid
-      // expanding the tag_invoke_result_t?
-      decltype(auto)
+      tag_invoke_result_t<sync_wait_t, _Sender>
       operator()(_Sender&& __sndr) const noexcept(
         nothrow_tag_invocable<sync_wait_t, _Sender>) {
         return tag_invoke(sync_wait_t{}, (_Sender&&) __sndr);

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -189,12 +189,12 @@ namespace detail::a_sender {
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const sender_t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const sender_t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
     };
 }
@@ -250,12 +250,12 @@ namespace detail::a_receiverless_sender {
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::tag_category<stdexec::forwarding_sender_query> Tag, class... As>
-        requires stdexec::__callable<Tag, const Sender&, As...>
-      friend auto tag_invoke(Tag tag, const sender_t& self, As&&... as)
-        noexcept(stdexec::__nothrow_callable<Tag, const Sender&, As...>)
-        -> stdexec::__call_result_if_t<stdexec::tag_category<Tag, stdexec::forwarding_sender_query>, Tag, const Sender&, As...> {
-        return ((Tag&&) tag)(self.sndr_, (As&&) as...);
+      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
+        requires stdexec::__callable<_Tag, const Sender&>
+      friend auto tag_invoke(_Tag, const sender_t& self)
+        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
+        -> stdexec::__call_result_t<_Tag, const Sender&> {
+        return stdexec::get_attrs(self.sndr_);
       }
     };
 }

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -189,11 +189,9 @@ namespace detail::a_sender {
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const sender_t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const sender_t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };
@@ -250,11 +248,9 @@ namespace detail::a_receiverless_sender {
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      template <stdexec::same_as<stdexec::get_attrs_t> _Tag>
-        requires stdexec::__callable<_Tag, const Sender&>
-      friend auto tag_invoke(_Tag, const sender_t& self)
-        noexcept(stdexec::__nothrow_callable<_Tag, const Sender&>)
-        -> stdexec::__call_result_t<_Tag, const Sender&> {
+      friend auto tag_invoke(stdexec::get_attrs_t, const sender_t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
         return stdexec::get_attrs(self.sndr_);
       }
     };

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -120,11 +120,11 @@ TEST_CASE("then advertises completion schedulers", "[adaptors][then]") {
 
   SECTION("for value channel") {
     ex::sender auto snd = ex::schedule(sched) | ex::then([]{});
-    REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(snd) == sched);
+    REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(snd)) == sched);
   }
   SECTION("for stop channel") {
     ex::sender auto snd = ex::just_stopped() | ex::transfer(sched) | ex::then([]{});
-    REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(snd) == sched);
+    REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(snd)) == sched);
   }
 }
 

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -97,10 +97,15 @@ struct custom_sender {
 
 struct custom_scheduler {
   struct sender : ex::schedule_result_t<inline_scheduler> {
-    template <class Tag>
-      friend custom_scheduler tag_invoke(ex::get_completion_scheduler_t<Tag>, sender) noexcept {
-        return {};
-      }
+    struct attrs {
+      template <class Tag>
+        friend custom_scheduler tag_invoke(ex::get_completion_scheduler_t<Tag>, const attrs&) noexcept {
+          return {};
+        }
+    };
+    friend attrs tag_invoke(ex::get_attrs_t, const sender&) noexcept {
+      return {};
+    }
   };
   friend sender tag_invoke(ex::schedule_t, custom_scheduler) noexcept {
     return {};

--- a/test/stdexec/algos/factories/test_transfer_just.cpp
+++ b/test/stdexec/algos/factories/test_transfer_just.cpp
@@ -137,14 +137,14 @@ TEST_CASE("transfer_just advertises its completion scheduler", "[factories][tran
   error_scheduler sched2{};
   stopped_scheduler sched3{};
 
-  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::transfer_just(sched1, 1)) == sched1);
-  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::transfer_just(sched1, 1)) == sched1);
+  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(ex::transfer_just(sched1, 1))) == sched1);
+  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(ex::transfer_just(sched1, 1))) == sched1);
 
-  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::transfer_just(sched2, 2)) == sched2);
-  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::transfer_just(sched2, 2)) == sched2);
+  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(ex::transfer_just(sched2, 2))) == sched2);
+  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(ex::transfer_just(sched2, 2))) == sched2);
 
-  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::transfer_just(sched3, 3)) == sched3);
-  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::transfer_just(sched3, 3)) == sched3);
+  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(ex::transfer_just(sched3, 3))) == sched3);
+  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(ex::transfer_just(sched3, 3))) == sched3);
 }
 
 // Modify the value when we invoke this custom defined transfer_just implementation

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -230,8 +230,19 @@ struct awaitable_with_get_attrs {
 };
 
 TEST_CASE("get_attrs for awaitables", "[sndtraits][awaitables]") {
+#if 0
+  // NOT TO SPEC
+  // When the __awaitable constrained get_attrs overload is enabled, enable
+  // these checks inside this path of the 'if' directive. get_attrs returns
+  // __empty_attrs for awaitables by default.
+
   check_attrs_type<ex::__empty_attrs>(awaitable_sender_1<awaiter>{});
   check_attrs_type<ex::__empty_attrs>(awaitable_sender_3{});
+#else
+  // And delete these two lines
+  check_attrs_type<const awaitable_sender_1<awaiter>&>(awaitable_sender_1<awaiter>{});
+  check_attrs_type<const awaitable_sender_3&>(awaitable_sender_3{});
+#endif
   check_attrs_type<awaitable_attrs>(awaitable_with_get_attrs<awaiter>{});
 }
 

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -140,6 +140,8 @@ TEST_CASE(
 }
 
 struct sched_no_attrs {
+
+  // P2300R5 senders defined sender queries on the sender itself.
   struct my_sender {
     using completion_signatures =
       ex::completion_signatures<             //
@@ -147,6 +149,11 @@ struct sched_no_attrs {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
+    template <typename CPO>
+    friend sched_no_attrs tag_invoke(
+                ex::get_completion_scheduler_t<CPO>, my_sender) {
+      return {};
+    }
   };
 
   friend my_sender tag_invoke(ex::schedule_t, sched_no_attrs) { return {}; }
@@ -156,7 +163,7 @@ struct sched_no_attrs {
 };
 
 TEST_CASE(
-    "not a scheduler if the returned object is not a sender (missing get_attr)",
-    "[concepts][scheduler]") {
-  REQUIRE(!ex::scheduler<sched_no_attrs>);
+    "type without sender get_attrs is still a scheduler",
+    "[concepts][scheduler][r5_backwards_compatibility]") {
+  REQUIRE(ex::scheduler<sched_no_attrs>);
 }

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -19,6 +19,14 @@
 
 namespace ex = stdexec;
 
+template <class Scheduler>
+struct default_attrs {
+  template <typename CPO>
+  friend Scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const default_attrs&) {
+    return {};
+  }
+};
+
 struct my_scheduler {
   struct my_sender  {
     using completion_signatures =
@@ -27,10 +35,10 @@ struct my_scheduler {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    template <typename CPO>
-    friend my_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, my_sender) {
+    friend default_attrs<my_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
+
   };
 
   friend my_sender tag_invoke(ex::schedule_t, my_scheduler) { return {}; }
@@ -60,8 +68,7 @@ struct my_scheduler_except {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    template <typename CPO>
-    friend my_scheduler_except tag_invoke(ex::get_completion_scheduler_t<CPO>, my_sender) {
+    friend default_attrs<my_scheduler_except> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -87,8 +94,7 @@ struct noeq_sched {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    template <typename CPO>
-    friend noeq_sched tag_invoke(ex::get_completion_scheduler_t<CPO>, my_sender) {
+    friend default_attrs<noeq_sched> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -108,10 +114,17 @@ struct sched_no_completion {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    friend sched_no_completion tag_invoke(
-        ex::get_completion_scheduler_t<ex::set_error_t>, my_sender) {
+    struct attrs {
+      friend sched_no_completion tag_invoke(
+        ex::get_completion_scheduler_t<ex::set_error_t>, const attrs&) noexcept {
+        return {};
+      }
+    };
+
+    friend attrs tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
+
   };
 
   friend my_sender tag_invoke(ex::schedule_t, sched_no_completion) { return {}; }
@@ -123,5 +136,27 @@ struct sched_no_completion {
 TEST_CASE(
     "not a scheduler if the returned sender doesn't have get_completion_scheduler of set_value",
     "[concepts][scheduler]") {
-  REQUIRE(!ex::scheduler<noeq_sched>);
+  REQUIRE(!ex::scheduler<sched_no_completion>);
+}
+
+struct sched_no_attrs {
+  struct my_sender {
+    using completion_signatures =
+      ex::completion_signatures<             //
+        ex::set_value_t(),                   //
+        ex::set_error_t(std::exception_ptr), //
+        ex::set_stopped_t()>;
+
+  };
+
+  friend my_sender tag_invoke(ex::schedule_t, sched_no_attrs) { return {}; }
+
+  friend bool operator==(sched_no_attrs, sched_no_attrs) noexcept { return true; }
+  friend bool operator!=(sched_no_attrs, sched_no_attrs) noexcept { return false; }
+};
+
+TEST_CASE(
+    "not a scheduler if the returned object is not a sender (missing get_attr)",
+    "[concepts][scheduler]") {
+  REQUIRE(!ex::scheduler<sched_no_attrs>);
 }

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -45,15 +45,19 @@ struct free_standing_sender_t {
 
 template <class CPO, class... CompletionSignals>
 struct scheduler_t {
+  struct attrs_t {
+    template <stdexec::__one_of<ex::set_value_t, CompletionSignals...> Tag>
+    friend scheduler_t tag_invoke(ex::get_completion_scheduler_t<Tag>, const attrs_t&) noexcept {
+      return {};
+    }
+  };
   struct sender_t {
     using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                   //
         ex::set_error_t(std::exception_ptr),                 //
         ex::set_stopped_t()>;
 
-    template <stdexec::__one_of<ex::set_value_t, CompletionSignals...> Tag>
-    friend scheduler_t tag_invoke(
-        ex::get_completion_scheduler_t<Tag>, const sender_t&) noexcept {
+    friend attrs_t tag_invoke(ex::get_attrs_t, const sender_t&) noexcept {
       return {};
     }
   };

--- a/test/stdexec/cpos/test_cpo_upon_error.cpp
+++ b/test/stdexec/cpos/test_cpo_upon_error.cpp
@@ -43,7 +43,7 @@ TEST_CASE("upon_error is customizable", "[cpo][cpo_upon_error]") {
     }
 
     {
-      ex::get_completion_scheduler<ex::set_error_t>(snd);
+      ex::get_completion_scheduler<ex::set_error_t>(ex::get_attrs(snd));
       constexpr scope_t scope = decltype(ex::upon_error(snd, f))::scope;
       STATIC_REQUIRE(scope == scope_t::scheduler);
     }

--- a/test/stdexec/cpos/test_cpo_upon_stopped.cpp
+++ b/test/stdexec/cpos/test_cpo_upon_stopped.cpp
@@ -43,7 +43,7 @@ TEST_CASE("upon_stopped is customizable", "[cpo][cpo_upon_stopped]") {
     }
 
     {
-      ex::get_completion_scheduler<ex::set_stopped_t>(snd);
+      ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(snd));
       constexpr scope_t scope = decltype(ex::upon_stopped(snd, f))::scope;
       STATIC_REQUIRE(scope == scope_t::scheduler);
     }

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -37,8 +37,14 @@ struct uncustomized_scheduler {
       return {};
     }
 
-    template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-    friend uncustomized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, sender) noexcept {
+    struct attrs {
+      template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
+      friend uncustomized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const attrs&) noexcept {
+        return {};
+      }
+    };
+
+    friend attrs tag_invoke(ex::get_attrs_t, const sender&) noexcept {
       return {};
     }
   };
@@ -62,8 +68,14 @@ struct customized_scheduler {
       return {};
     }
 
-    template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-    friend customized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, sender) noexcept {
+    struct attrs {
+      template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
+      friend customized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const attrs&) noexcept {
+        return {};
+      }
+    };
+
+    friend attrs tag_invoke(ex::get_attrs_t, const sender&) noexcept {
       return {};
     }
   };

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -24,6 +24,14 @@
 
 namespace ex = stdexec;
 
+template <class S>
+struct scheduler_attrs {
+  template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
+  friend S tag_invoke(ex::get_completion_scheduler_t<CPO>, const scheduler_attrs&) noexcept {
+    return {};
+  }
+};
+
 //! Scheduler that will send impulses on user's request.
 //! One can obtain senders from this, connect them to receivers and start the operation states.
 //! Until the scheduler is told to start the next operation, the actions in the operation states are
@@ -81,8 +89,7 @@ struct impulse_scheduler {
       return {self.shared_data_, (R &&) r};
     }
 
-    friend impulse_scheduler tag_invoke(
-        ex::get_completion_scheduler_t<ex::set_value_t>, my_sender) {
+    friend scheduler_attrs<impulse_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -136,8 +143,7 @@ struct inline_scheduler {
       return {{}, (R &&) r};
     }
 
-    template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-    friend inline_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, my_sender) noexcept {
+    friend scheduler_attrs<inline_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -174,7 +180,7 @@ struct error_scheduler {
       return {{}, (R &&) r, (E &&) self.err_};
     }
 
-    friend error_scheduler tag_invoke(ex::get_completion_scheduler_t<ex::set_value_t>, my_sender) {
+    friend scheduler_attrs<error_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -205,8 +211,7 @@ struct stopped_scheduler {
       return {{}, (R &&) r};
     }
 
-    template <typename CPO>
-    friend stopped_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, my_sender) {
+    friend scheduler_attrs<stopped_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
       return {};
     }
   };


### PR DESCRIPTION
One open question,

 - How should we handle backwards compatibility for any users outside of this repository? Assuming I can get the nvexec/test.CUDA code to compile cleanly, the changes I have in this branch change the `stdexec::scheduler` concept to require that `get_completion_scheduler(get_attrs(schedule(scheduler)))` is valid. Types which satisfied the scheduler concept will no longer satisfy without updating the type. If we need backwards compatibility, I could keep the concept(s) forwards and backwards compatible, e.g., by checking whether the completion scheduler comes from the sender itself, or the senders attributes.
 - ~I'm not sure how I can build or run test.CUDA. I managed to get the code to compile with the [gcc11-cuda11.8-nvhpc22.11-ubuntu22.04](https://github.com/NVIDIA/stdexec/blob/main/.github/workflows/ci.yml#L54) container, although I'm not always able to compile successfully (in one case, the compilation appears to succeed, but nvc++ bails with the error pasted below. In any case, I'm not sure if have a sufficient hardware setup to run test.CUDA (I'm on an intel macbook pro, or a redhat VM). I've never worked with GPUs before. Is github code spaces a viable option (mirroring what CI is doing)?~