### PR TITLE
Update devcontainer and vscode debugging launch configs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,15 @@
 {
-  "image": "ghcr.io/trxcllnt/devcontainer-images:cmake-ninja-sccache-llvmdev-cuda11.8-nvhpc22.11",
+  "image": "docker.io/pauletaylor/devcontainers:cmake-ninja-sccache-llvmdev-cuda11.8-nvhpc22.11",
   "capAdd": ["SYS_PTRACE"],
   "hostRequirements": { "gpu": true },
   "securityOpt": ["seccomp=unconfined"],
   "initializeCommand": "mkdir -p .cache",
   "updateContentCommand": "sed -i -re 's/^(HIST(FILE)?SIZE=).*$/\\1/g' ~/.bashrc",
+  "postAttachCommand": ["/opt/devcontainer/bin/post-attach-command.sh"],
   "containerEnv": {
-    "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history"
+    "CMAKE_CXX_COMPILER_LAUNCHER": "/usr/bin/sccache",
+    "CMAKE_CUDA_COMPILER_LAUNCHER": "/usr/bin/sccache",
+    "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history",
   },
   "customizations": {
     "vscode": {
@@ -16,7 +19,9 @@
         "cschlosser.doxdocgen",
         "ms-vscode.cpptools",
         "nvidia.nsight-vscode-edition",
-        "llvm-vs-code-extensions.vscode-clangd"
+        "augustocdias.tasks-shell-input",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "vadimcn.vscode-lldb"
       ],
       "settings": {
         "C_Cpp.vcpkg.enabled": false,

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build*/
 .cache
-.vscode
+.vscode/*
+!.vscode/launch.json
 .gitattributes
 compile_commands.json
 /*.cpp

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,89 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "C++ Tests (lldb)",
+            "type": "lldb",
+            "request": "launch",
+            "stdio": null,
+            "stopOnEntry": false,
+            "terminal": "console",
+            "console": "internalConsole",
+            "sourceLanguages": ["cpp", "cuda"],
+            "internalConsoleOptions": "neverOpen",
+            "cwd": "${workspaceFolder}/${input:BUILD_DIR}",
+            "relativePathBase": "${workspaceFolder}/${input:BUILD_DIR}",
+            "program": "${workspaceFolder}/${input:BUILD_DIR}/${input:CXX_TEST_SUITE}",
+            "initCommands": ["settings set target.disable-aslr false"],
+            "args": ["-v", "normal", "${input:CXX_TEST_TAGS}"],
+        },
+        {
+            "name": "CUDA Tests (cuda-gdb)",
+            "type": "cuda-gdb",
+            "request": "launch",
+            "stopAtEntry": false,
+            "breakOnLaunch": false,
+            "internalConsoleOptions": "neverOpen",
+            "program": "${workspaceFolder}/${input:BUILD_DIR}/${input:CUDA_TEST_SUITE}",
+            "cwd": "${workspaceFolder}/${input:BUILD_DIR}",
+            "args": "-v normal ${input:CUDA_TEST_TAGS}",
+        },
+    ],
+    "inputs": [
+        {
+            "type": "command",
+            "id": "BUILD_DIR",
+            "command": "shellCommand.execute",
+            "args": {
+                "cwd": "${workspaceFolder}",
+                "description": "The build directory to use",
+                "command": "find . -maxdepth 3 -type f -name CMakeCache.txt -exec dirname {} \\;"
+            }
+        },
+        {
+            "id": "CXX_TEST_SUITE",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "useFirstResult": true,
+                "description": "Path to Test Suite",
+                "cwd": "${workspaceFolder}/${input:BUILD_DIR}",
+                "command": "find . -type f -name test.stdexec"
+            }
+        },
+        {
+            "id": "CUDA_TEST_SUITE",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "useFirstResult": true,
+                "description": "Path to Test Suite",
+                "cwd": "${workspaceFolder}/${input:BUILD_DIR}",
+                "command": "find . -type f -name test.CUDA"
+            }
+        },
+        {
+            "type": "command",
+            "id": "CXX_TEST_TAGS",
+            "command": "shellCommand.execute",
+            "args": {
+                "description": "Select test tags to filter",
+                "cwd": "${workspaceFolder}/${input:BUILD_DIR}",
+                "command": "./${input:CXX_TEST_SUITE} --list-tags | tail -n +2 | head -n -2 | tr -s ' '' ' | cut -d' ' -f3",
+            }
+        },
+        {
+            "type": "command",
+            "id": "CUDA_TEST_TAGS",
+            "command": "shellCommand.execute",
+            "args": {
+                "description": "Select test tags to filter",
+                "cwd": "${workspaceFolder}/${input:BUILD_DIR}",
+                "command": "./${input:CUDA_TEST_SUITE} --list-tags | tail -n +2 | head -n -2 | tr -s ' '' ' | cut -d' ' -f3",
+            }
+        },
+    ],
+}


### PR DESCRIPTION
Merge after https://github.com/NVIDIA/stdexec/pull/734.

This PR updates the devcontainer image to a dockerhub mirror which should fix some timeouts with the GitHub CLI. The new image also automatically uses your GitHub user to authenticate with RAPIDS Vault and issue temporary S3 credentials for `sccache`.

This PR also adds VSCode debugger launch configurations for debugging C++ and CUDA tests:

<details><summary>C++ debugging example</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/213335914-5492ef71-f33a-4a34-88f8-98a36a45fae4.gif" data-target="animated-image.originalLink"><img src="https://user-images.githubusercontent.com/178183/213335914-5492ef71-f33a-4a34-88f8-98a36a45fae4.gif" alt="2023-01-18_17-23-28" style="max-width: 100%; display: inline-block;" data-target="animated-image.originalImage"></a></details>

<details><summary>CUDA debugging example</summary><a target="_blank" rel="noopener noreferrer nofollow" href="https://user-images.githubusercontent.com/178183/213335926-e4775d77-b537-43c2-9310-4a6fbbab6f51.gif" data-target="animated-image.originalLink"><img src="https://user-images.githubusercontent.com/178183/213335926-e4775d77-b537-43c2-9310-4a6fbbab6f51.gif" alt="2023-01-18_17-24-32" style="max-width: 100%; display: inline-block;" data-target="animated-image.originalImage"></a></details>
