### PR TITLE
Fix bug in `intrusive_queue::push_back()`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,5 +102,5 @@ jobs:
 
           # Examples
           ./build/examples/nvexec/maxwell_cpu_st --iterations=1000 --N=512 --run-cpp --run-inline-scheduler
-          ./build/examples/nvexec/maxwell_cpu_mt --iterations=1000 --N=512 --run-std --run-stdpar
+          ./build/examples/nvexec/maxwell_cpu_mt --iterations=1000 --N=512 --run-std --run-stdpar --run-thread-pool-scheduler
           ./build/examples/nvexec/maxwell_gpu_s --iterations=1000 --N=512 --run-cuda --run-stdpar --run-stream-scheduler

--- a/include/stdexec/__detail/__intrusive_queue.hpp
+++ b/include/stdexec/__detail/__intrusive_queue.hpp
@@ -69,6 +69,8 @@ namespace stdexec {
         [[nodiscard]] _Item* pop_front() noexcept {
           STDEXEC_ASSERT(!empty());
           _Item* __item = std::exchange(__head_, __head_->*_Next);
+          // This should test if __head_ == nullptr, but due to a bug in
+          // nvc++'s optimization, `__head_` isn't assigned until later.
           if (__item->*_Next == nullptr) {
             __tail_ = nullptr;
           }

--- a/include/stdexec/__detail/__intrusive_queue.hpp
+++ b/include/stdexec/__detail/__intrusive_queue.hpp
@@ -87,7 +87,7 @@ namespace stdexec {
         void push_back(_Item* __item) noexcept {
           STDEXEC_ASSERT(__item != nullptr);
           __item->*_Next = nullptr;
-          if (__tail_ == nullptr) {
+          if (empty()) {
             __head_ = __item;
           } else {
             __tail_->*_Next = __item;

--- a/include/stdexec/__detail/__intrusive_queue.hpp
+++ b/include/stdexec/__detail/__intrusive_queue.hpp
@@ -71,6 +71,7 @@ namespace stdexec {
           _Item* __item = std::exchange(__head_, __head_->*_Next);
           // This should test if __head_ == nullptr, but due to a bug in
           // nvc++'s optimization, `__head_` isn't assigned until later.
+          // Filed as NVBug#3952534.
           if (__item->*_Next == nullptr) {
             __tail_ = nullptr;
           }

--- a/include/stdexec/__detail/__intrusive_queue.hpp
+++ b/include/stdexec/__detail/__intrusive_queue.hpp
@@ -69,7 +69,7 @@ namespace stdexec {
         [[nodiscard]] _Item* pop_front() noexcept {
           STDEXEC_ASSERT(!empty());
           _Item* __item = std::exchange(__head_, __head_->*_Next);
-          if (__head_ == nullptr) {
+          if (__item->*_Next == nullptr) {
             __tail_ = nullptr;
           }
           return __item;
@@ -87,7 +87,7 @@ namespace stdexec {
         void push_back(_Item* __item) noexcept {
           STDEXEC_ASSERT(__item != nullptr);
           __item->*_Next = nullptr;
-          if (empty()) {
+          if (__tail_ == nullptr) {
             __head_ = __item;
           } else {
             __tail_->*_Next = __item;


### PR DESCRIPTION
This PR fixes the deadlock in `maxwell_cpu_mt --run-thread-pool-scheduler`.