### PR TITLE
Configure tests and examples in separate `CMakeLists.txt`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -30,6 +30,7 @@ CompileFlags:
   Add:
     - "-x"
     - "cuda"
+    - "-std=gnu++20"
     - "-Wno-unknown-cuda-version"
 
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "nvc++ 22.11", cuda: "11.8", cxx: "mpic++",  tag: "nvhpc22.11",       gpu: "v100", driver: "520", arch: "amd64", cxxflags: "",              }
-          - { name: "clang 16", cuda: "11.8",    cxx: "clang++", tag: "llvmdev-cuda11.8", gpu: "v100", driver: "520", arch: "amd64", cxxflags: "-stdlib=libc++" }
-        # - { name: "clang 16", cuda: "12.0",    cxx: "clang++", tag: "llvmdev-cuda12.0", gpu: "v100", driver: "525", arch: "amd64", cxxflags: "-stdlib=libc++" }
+          - { name: "nvc++ 22.11", cuda: "11.8", cxx: "mpic++",  tag: "nvhpc22.11",       gpu: "v100", driver: "520", arch: "amd64" }
+          - { name: "clang 16", cuda: "11.8",    cxx: "clang++", tag: "llvmdev-cuda11.8", gpu: "v100", driver: "520", arch: "amd64" }
+        # - { name: "clang 16", cuda: "12.0",    cxx: "clang++", tag: "llvmdev-cuda12.0", gpu: "v100", driver: "525", arch: "amd64" }
     runs-on:
       - self-hosted
       - linux
@@ -77,7 +77,6 @@ jobs:
         shell: bash
         env:
           cxx: "${{ matrix.cxx }}"
-          cxxflags: "${{ matrix.cxxflags }}"
         run: |
           source $BASH_ENV;
 
@@ -93,7 +92,6 @@ jobs:
             -DSTDEXEC_ENABLE_CUDA=ON \
             -DCMAKE_CXX_COMPILER="$cxx" \
             -DCMAKE_CUDA_COMPILER="$cxx" \
-            -DCMAKE_CXX_FLAGS="$cxxflags" \
             -DCMAKE_CUDA_ARCHITECTURES=native;
 
           # Compile

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,7 +40,7 @@
             "args": {
                 "cwd": "${workspaceFolder}",
                 "description": "The build directory to use",
-                "command": "find . -maxdepth 3 -type f -name CMakeCache.txt -exec dirname {} \\;"
+                "command": "find . -type f -name CMakeCache.txt ! -wholename '*/test_package/*' ! -wholename '*/_deps/*' -exec dirname {} \\;"
             }
         },
         {
@@ -62,7 +62,7 @@
                 "useFirstResult": true,
                 "description": "Path to Test Suite",
                 "cwd": "${workspaceFolder}/${input:BUILD_DIR}",
-                "command": "find . -type f -name test.CUDA"
+                "command": "find . -type f -name test.nvexec"
             }
         },
         {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,12 @@ rapids_find_package(Threads REQUIRED
 ##############################################################################
 # - Main library targets -----------------------------------------------------
 
+set(stdexec_export_targets)
+
 # Define the main library
 add_library(stdexec INTERFACE)
+
+list(APPEND stdexec_export_targets stdexec)
 
 # Set library version
 set_target_properties(stdexec PROPERTIES
@@ -200,6 +204,7 @@ if(STDEXEC_ENABLE_CUDA)
 
     file(GLOB_RECURSE nvexec_sources include/nvexec/*.cuh)
     add_library(nvexec INTERFACE ${nvexec_sources})
+    list(APPEND stdexec_export_targets nvexec)
     add_library(STDEXEC::nvexec ALIAS nvexec)
 
     target_compile_features(nvexec INTERFACE cuda_std_20)
@@ -292,18 +297,18 @@ set(code_string "")
 
 # Install side of the export set
 rapids_export(
-  INSTALL stdexec
+  INSTALL ${stdexec_export_targets}
   EXPORT_SET stdexec-exports
-  GLOBAL_TARGETS stdexec
+  GLOBAL_TARGETS ${stdexec_export_targets}
   NAMESPACE STDEXEC::
   FINAL_CODE_BLOCK code_string
 )
 
 # Build side of the export set so a user can use the build dir as a CMake package root
 rapids_export(
-  BUILD stdexec
+  BUILD ${stdexec_export_targets}
   EXPORT_SET stdexec-exports
-  GLOBAL_TARGETS stdexec
+  GLOBAL_TARGETS ${stdexec_export_targets}
   NAMESPACE STDEXEC::
   FINAL_CODE_BLOCK code_string
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ target_compile_features(stdexec INTERFACE cxx_std_20)
 
 # Enable coroutines for GCC
 target_compile_options(stdexec INTERFACE
-                       $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU>>:-fcoroutines>
+                       $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fcoroutines>
                        )
 
 add_library(STDEXEC::stdexec ALIAS stdexec)
@@ -181,12 +181,12 @@ target_compile_options(stdexec_executable_flags INTERFACE
 
 # Clang CUDA options
 target_compile_options(stdexec_executable_flags INTERFACE
-                       $<$<AND:$<CUDA_COMPILER_ID:Clang>,$<COMPILE_LANGUAGE:CUDA>>:
+                       $<$<COMPILE_LANG_AND_ID:CUDA,Clang>:
                        -Wno-unknown-cuda-version
                        -Xclang=-fcuda-allow-variadic-functions>
                        )
 
-# Set up CUDASchedulers library
+# Set up nvexec library
 option(STDEXEC_ENABLE_CUDA "Enable CUDA targets for non-nvc++ compilers" OFF)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
     set(STDEXEC_ENABLE_CUDA ON)
@@ -198,13 +198,16 @@ endif()
 
 if(STDEXEC_ENABLE_CUDA)
 
-    file(GLOB_RECURSE SCHED_SOURCES include/nvexec/*.cuh)
-    add_library(CUDASchedulers INTERFACE ${SCHED_SOURCES})
-    target_link_libraries(CUDASchedulers INTERFACE stdexec stdexec_executable_flags)
+    file(GLOB_RECURSE nvexec_sources include/nvexec/*.cuh)
+    add_library(nvexec INTERFACE ${nvexec_sources})
+    add_library(STDEXEC::nvexec ALIAS nvexec)
 
-    target_compile_options(CUDASchedulers INTERFACE
+    target_compile_features(nvexec INTERFACE cuda_std_20)
+    target_link_libraries(nvexec INTERFACE STDEXEC::stdexec)
+
+    target_compile_options(nvexec INTERFACE
       $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-stdpar -gpu=nomanaged>)
-    target_link_options(CUDASchedulers INTERFACE
+    target_link_options(nvexec INTERFACE
       $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-stdpar -gpu=nomanaged>)
 
     if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
@@ -222,7 +225,7 @@ if(STDEXEC_ENABLE_CUDA)
         # because the former works with clangd intellisense
         set(CMAKE_INCLUDE_SYSTEM_FLAG_CUDA "-isystem ")
 
-        set_source_files_properties(${SCHED_SOURCES} PROPERTIES LANGUAGE CUDA)
+        set_source_files_properties(${nvexec_sources} PROPERTIES LANGUAGE CUDA)
 
         include(rapids-find)
         rapids_find_package(
@@ -231,7 +234,7 @@ if(STDEXEC_ENABLE_CUDA)
             INSTALL_EXPORT_SET stdexec-exports
         )
 
-        target_link_libraries(CUDASchedulers INTERFACE CUDA::cudart)
+        target_link_libraries(nvexec INTERFACE CUDA::cudart)
 
         include(${rapids-cmake-dir}/cpm/libcudacxx.cmake)
         rapids_cpm_libcudacxx(
@@ -242,93 +245,27 @@ if(STDEXEC_ENABLE_CUDA)
     endif()
 endif()
 
-# Now, set up test executable
-enable_testing()
+option(STDEXEC_BUILD_EXAMPLES "Build stdexec examples" ON)
+option(STDEXEC_BUILD_TESTS "Build stdexec tests" ON)
+option(BUILD_TESTING "" ${STDEXEC_BUILD_TESTS})
 
-set(test_sourceFiles
-    test/test_main.cpp
-    test/stdexec/cpos/test_cpo_bulk.cpp
-    test/stdexec/cpos/test_cpo_ensure_started.cpp
-    test/stdexec/cpos/test_cpo_receiver.cpp
-    test/stdexec/cpos/test_cpo_start.cpp
-    test/stdexec/cpos/test_cpo_connect.cpp
-    test/stdexec/cpos/test_cpo_schedule.cpp
-    test/stdexec/cpos/test_cpo_split.cpp
-    test/stdexec/cpos/test_cpo_upon_error.cpp
-    test/stdexec/cpos/test_cpo_upon_stopped.cpp
-    test/stdexec/concepts/test_concept_scheduler.cpp
-    test/stdexec/concepts/test_concepts_receiver.cpp
-    test/stdexec/concepts/test_concept_operation_state.cpp
-    test/stdexec/concepts/test_concepts_sender.cpp
-    test/stdexec/concepts/test_awaitables.cpp
-    test/stdexec/algos/factories/test_just.cpp
-    test/stdexec/algos/factories/test_transfer_just.cpp
-    test/stdexec/algos/factories/test_just_error.cpp
-    test/stdexec/algos/factories/test_just_stopped.cpp
-    test/stdexec/algos/factories/test_read.cpp
-    test/stdexec/algos/adaptors/test_on.cpp
-    test/stdexec/algos/adaptors/test_transfer.cpp
-    test/stdexec/algos/adaptors/test_schedule_from.cpp
-    test/stdexec/algos/adaptors/test_then.cpp
-    test/stdexec/algos/adaptors/test_upon_error.cpp
-    test/stdexec/algos/adaptors/test_upon_stopped.cpp
-    test/stdexec/algos/adaptors/test_let_value.cpp
-    test/stdexec/algos/adaptors/test_let_error.cpp
-    test/stdexec/algos/adaptors/test_let_stopped.cpp
-    test/stdexec/algos/adaptors/test_bulk.cpp
-    test/stdexec/algos/adaptors/test_split.cpp
-    test/stdexec/algos/adaptors/test_when_all.cpp
-    test/stdexec/algos/adaptors/test_transfer_when_all.cpp
-    test/stdexec/algos/adaptors/test_into_variant.cpp
-    test/stdexec/algos/adaptors/test_stopped_as_optional.cpp
-    test/stdexec/algos/adaptors/test_stopped_as_error.cpp
-    test/stdexec/algos/adaptors/test_ensure_started.cpp
-    test/stdexec/algos/consumers/test_start_detached.cpp
-    test/stdexec/algos/consumers/test_sync_wait.cpp
-    test/stdexec/algos/other/test_execute.cpp
-    test/stdexec/detail/test_completion_signatures.cpp
-    test/stdexec/detail/test_utility.cpp
-    test/stdexec/queries/test_get_forward_progress_guarantee.cpp
-    test/stdexec/queries/test_forwarding_queries.cpp
-    test/exec/test_type_async_scope.cpp
-    test/exec/test_create.cpp
-    test/exec/test_env.cpp
-    test/exec/test_on.cpp
-    test/exec/test_on2.cpp
-    test/exec/test_on3.cpp
-    test/exec/async_scope/test_dtor.cpp
-    test/exec/async_scope/test_spawn.cpp
-    test/exec/async_scope/test_spawn_future.cpp
-    test/exec/async_scope/test_empty.cpp
-    test/exec/async_scope/test_stop.cpp
-    )
+# Don't build tests if configuring stdexec as a submodule of another
+# CMake project, unless they explicitly set STDEXEC_BUILD_TESTS=TRUE
+if((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) OR STDEXEC_BUILD_TESTS)
+    # CTest automatically calls enable_testing() if BUILD_TESTING is ON
+    # https://cmake.org/cmake/help/latest/module/CTest.html#module:CTest
+    include(CTest)
+endif()
 
-add_executable(test.stdexec ${test_sourceFiles})
+# Configure test executables
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 
-target_include_directories(test.stdexec PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test)
-target_link_libraries(test.stdexec PUBLIC STDEXEC::stdexec stdexec_executable_flags Catch2::Catch2)
-
-# Discover the Catch2 test built by the application
-include(CTest)
-include(${Catch2_SOURCE_DIR}/contrib/Catch.cmake)
-catch_discover_tests(test.stdexec)
-
-# Set up examples
-function(def_example target sourceFile)
-    add_executable(${target} ${sourceFile})
-    target_link_libraries(${target} PRIVATE STDEXEC::stdexec stdexec_executable_flags)
-endfunction()
-
-def_example(clangd.helper "examples/_clangd_helper_file.cpp")
-def_example(example.hello_world "examples/hello_world.cpp")
-def_example(example.hello_coro "examples/hello_coro.cpp")
-def_example(example.scope "examples/scope.cpp")
-def_example(example.retry "examples/retry.cpp")
-def_example(example.then "examples/then.cpp")
-def_example(example.server_theme.let_value "examples/server_theme/let_value.cpp")
-def_example(example.server_theme.on_transfer "examples/server_theme/on_transfer.cpp")
-def_example(example.server_theme.then_upon "examples/server_theme/then_upon.cpp")
-def_example(example.server_theme.split_bulk "examples/server_theme/split_bulk.cpp")
+# Configure example executables
+if(STDEXEC_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
 
 ##############################################################################
 # Install targets ------------------------------------------------------------
@@ -370,7 +307,3 @@ rapids_export(
   NAMESPACE STDEXEC::
   FINAL_CODE_BLOCK code_string
 )
-
-# TODO
-add_subdirectory(examples/nvexec)
-add_subdirectory(test/nvexec)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,55 @@
+#=============================================================================
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+function(split pair name_out path_out)
+    string(STRIP "${pair}" pair)
+    string(REPLACE ":" ";" pair "${pair}")
+    list(POP_FRONT pair _name)
+    list(POP_FRONT pair _path)
+    string(STRIP "${_name}" _name)
+    string(STRIP "${_path}" _path)
+    set(${name_out} "${_name}" PARENT_SCOPE)
+    set(${path_out} "${_path}" PARENT_SCOPE)
+endfunction()
+
+function(def_example example)
+    split(${example} target source)
+    add_executable(${target} ${source})
+    target_link_libraries(${target}
+        PRIVATE STDEXEC::stdexec
+                stdexec_executable_flags)
+endfunction()
+
+set(stdexec_examples
+               "example.clangd.helper : _clangd_helper_file.cpp"
+                 "example.hello_world : hello_world.cpp"
+                  "example.hello_coro : hello_coro.cpp"
+                       "example.scope : scope.cpp"
+                       "example.retry : retry.cpp"
+                        "example.then : then.cpp"
+      "example.server_theme.let_value : server_theme/let_value.cpp"
+    "example.server_theme.on_transfer : server_theme/on_transfer.cpp"
+      "example.server_theme.then_upon : server_theme/then_upon.cpp"
+     "example.server_theme.split_bulk : server_theme/split_bulk.cpp"
+)
+
+foreach(example ${stdexec_examples})
+    def_example(${example})
+endforeach()
+
+if(STDEXEC_ENABLE_CUDA)
+    add_subdirectory(nvexec)
+endif()

--- a/examples/nvexec/CMakeLists.txt
+++ b/examples/nvexec/CMakeLists.txt
@@ -1,47 +1,148 @@
-if(STDEXEC_ENABLE_CUDA)
-    file(GLOB_RECURSE EXAMPLES
-         RELATIVE "${CMAKE_CURRENT_LIST_DIR}"
-         CONFIGURE_DEPENDS
-         *.cpp)
+#=============================================================================
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
 
-    set(compiler_name "")
-    get_filename_component(compiler_name "${CMAKE_CXX_COMPILER}" NAME)
+function(split pair name_out path_out)
+    string(STRIP "${pair}" pair)
+    string(REPLACE ":" ";" pair "${pair}")
+    list(POP_FRONT pair _name)
+    list(POP_FRONT pair _path)
+    string(STRIP "${_name}" _name)
+    string(STRIP "${_path}" _path)
+    set(${name_out} "${_name}" PARENT_SCOPE)
+    set(${path_out} "${_path}" PARENT_SCOPE)
+endfunction()
 
-    foreach(example ${EXAMPLES})
-        file(TO_CMAKE_PATH "${example}" example_prefix)
-        string(REPLACE "/" "." example_prefix "${example_prefix}")
-        get_filename_component(example_name "${example_prefix}" NAME_WLE)
+set(_lang_cxx CXX)
+set(_lang_gpu CXX)
 
-        if("${example}" STREQUAL "maxwell_cpu_mt.cpp")
-            add_executable(${example_name} ${example})
-            target_link_libraries(${example_name} PRIVATE stdexec stdexec_executable_flags)
-            if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
-                target_compile_options(${example_name} PRIVATE -stdpar=multicore)
-                target_link_options(${example_name} PRIVATE -stdpar=multicore)
-            else()
-                set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/${example}" PROPERTIES LANGUAGE CUDA)
-            endif()
-        elseif("${example}" STREQUAL "maxwell_distributed.cpp")
-            if("${compiler_name}" STREQUAL "mpic++")
-                add_executable(maxwell_distributed_ov ${example})
-                target_link_libraries(maxwell_distributed_ov PRIVATE CUDASchedulers)
-                target_include_directories(maxwell_distributed_ov PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
-                target_compile_definitions(maxwell_distributed_ov PRIVATE OVERLAP)
+if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
+    set(_lang_gpu CUDA)
+endif()
 
-                add_executable(maxwell_distributed ${example})
-                target_link_libraries(maxwell_distributed PRIVATE CUDASchedulers)
-                target_include_directories(maxwell_distributed PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
-                if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
-                    set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/${example}" PROPERTIES LANGUAGE CUDA)
-                endif()
-            endif()
-        else()
-            add_executable(${example_name} ${example})
-            target_link_libraries(${example_name} PRIVATE CUDASchedulers)
-            target_include_directories(${example_name} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
-            if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
-                set_source_files_properties("${CMAKE_CURRENT_LIST_DIR}/${example}" PROPERTIES LANGUAGE CUDA)
-            endif()
-        endif()
-    endforeach()
+###############################################################################
+# Define targets for common properties
+###############################################################################
+
+add_library(nvexec_example INTERFACE)
+target_include_directories(nvexec_example
+    INTERFACE ${CMAKE_CURRENT_LIST_DIR}
+)
+
+add_library(stdpar_multicore INTERFACE)
+target_include_directories(stdpar_multicore
+    SYSTEM
+    INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Clang>:${CUDAToolkit_INCLUDE_DIRS}>
+)
+
+target_compile_options(stdpar_multicore
+    INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,NVHPC>:-stdpar=multicore>
+              $<$<COMPILE_LANG_AND_ID:CXX,Clang>:
+                # libc++ doesn't include stdpar yet
+                -stdlib=libstdc++
+                # Silence Thrust -Wdeprecated-builtins warnings
+                -Wno-deprecated-builtins>
+)
+
+target_link_options(stdpar_multicore
+    INTERFACE $<$<LINK_LANG_AND_ID:CXX,NVHPC>:-stdpar=multicore>
+)
+
+function(set_executable_output_name target)
+    string(LENGTH "${target}" str_len)
+    string(FIND "${target}" "." last_dot REVERSE)
+    math(EXPR last_dot "${last_dot} + 1")
+    math(EXPR str_len "${str_len} - ${last_dot}")
+    string(SUBSTRING "${target}" ${last_dot} ${str_len} exe_name)
+    set_target_properties(${target} PROPERTIES OUTPUT_NAME ${exe_name})
+endfunction()
+
+###############################################################################
+# CPU examples
+###############################################################################
+set(nvexec_cpu_examples
+    " example.nvexec.clangd_helper : _clangd_helper_file.cpp"
+    "example.nvexec.maxwell_cpu_mt : maxwell_cpu_mt.cpp"
+    "example.nvexec.maxwell_cpu_st : maxwell_cpu_st.cpp"
+)
+
+function(def_cpu_example example)
+    split(${example} target source)
+    add_executable(${target} ${source})
+    set_executable_output_name(${target})
+    target_link_libraries(${target}
+        PRIVATE nvexec_example
+                stdpar_multicore
+                STDEXEC::stdexec
+                stdexec_executable_flags
+    )
+    set_source_files_properties(${source} PROPERTIES LANGUAGE ${_lang_cxx})
+endfunction()
+
+foreach(example ${nvexec_cpu_examples})
+    def_cpu_example(${example})
+endforeach()
+
+###############################################################################
+# GPU examples
+###############################################################################
+set(nvexec_gpu_examples
+    "         example.nvexec.bulk : bulk.cpp"
+    "       example.nvexec.reduce : reduce.cpp"
+    "        example.nvexec.split : split.cpp"
+    "example.nvexec.maxwell_gpu_s : maxwell_gpu_s.cpp"
+    "example.nvexec.maxwell_gpu_m : maxwell_gpu_m.cpp"
+)
+
+function(def_gpu_example example)
+    split(${example} target source)
+    add_executable(${target} ${source})
+    set_executable_output_name(${target})
+    target_link_libraries(${target}
+        PRIVATE nvexec_example
+                STDEXEC::nvexec
+                stdexec_executable_flags
+    )
+    set_source_files_properties(${source} PROPERTIES LANGUAGE ${_lang_gpu})
+endfunction()
+
+foreach(example ${nvexec_gpu_examples})
+    def_gpu_example(${example})
+endforeach()
+
+###############################################################################
+# MPI examples
+###############################################################################
+
+set(compiler_name "")
+get_filename_component(compiler_name "${CMAKE_CXX_COMPILER}" NAME)
+
+if((CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC") AND (compiler_name STREQUAL "mpic++"))
+
+    function(def_mpi_example target source)
+        add_executable(${target} ${source})
+        set_executable_output_name(${target})
+        target_link_libraries(${target}
+            PRIVATE nvexec_example
+                    STDEXEC::nvexec
+                    stdexec_executable_flags
+        )
+        target_compile_definitions(${target} PRIVATE ${ARGN})
+        set_source_files_properties(${source} PROPERTIES LANGUAGE ${_lang_gpu})
+    endfunction()
+
+    def_mpi_example(example.nvexec.maxwell_distributed    maxwell_distributed.cpp)
+    def_mpi_example(example.nvexec.maxwell_distributed_ov maxwell_distributed.cpp OVERLAP)
 endif()

--- a/examples/nvexec/maxwell/common.cuh
+++ b/examples/nvexec/maxwell/common.cuh
@@ -51,6 +51,7 @@ struct deleter_t {
 };
 
 template <class T>
+STDEXEC_DETAIL_CUDACC_HOST_DEVICE
 inline std::unique_ptr<T, deleter_t>
 allocate_on(bool gpu, std::size_t elements = 1) {
   T *ptr{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,87 @@
+#=============================================================================
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+set(stdexec_test_sources
+    test_main.cpp
+    stdexec/cpos/test_cpo_bulk.cpp
+    stdexec/cpos/test_cpo_ensure_started.cpp
+    stdexec/cpos/test_cpo_receiver.cpp
+    stdexec/cpos/test_cpo_start.cpp
+    stdexec/cpos/test_cpo_connect.cpp
+    stdexec/cpos/test_cpo_schedule.cpp
+    stdexec/cpos/test_cpo_split.cpp
+    stdexec/cpos/test_cpo_upon_error.cpp
+    stdexec/cpos/test_cpo_upon_stopped.cpp
+    stdexec/concepts/test_concept_scheduler.cpp
+    stdexec/concepts/test_concepts_receiver.cpp
+    stdexec/concepts/test_concept_operation_state.cpp
+    stdexec/concepts/test_concepts_sender.cpp
+    stdexec/concepts/test_awaitables.cpp
+    stdexec/algos/factories/test_just.cpp
+    stdexec/algos/factories/test_transfer_just.cpp
+    stdexec/algos/factories/test_just_error.cpp
+    stdexec/algos/factories/test_just_stopped.cpp
+    stdexec/algos/factories/test_read.cpp
+    stdexec/algos/adaptors/test_on.cpp
+    stdexec/algos/adaptors/test_transfer.cpp
+    stdexec/algos/adaptors/test_schedule_from.cpp
+    stdexec/algos/adaptors/test_then.cpp
+    stdexec/algos/adaptors/test_upon_error.cpp
+    stdexec/algos/adaptors/test_upon_stopped.cpp
+    stdexec/algos/adaptors/test_let_value.cpp
+    stdexec/algos/adaptors/test_let_error.cpp
+    stdexec/algos/adaptors/test_let_stopped.cpp
+    stdexec/algos/adaptors/test_bulk.cpp
+    stdexec/algos/adaptors/test_split.cpp
+    stdexec/algos/adaptors/test_when_all.cpp
+    stdexec/algos/adaptors/test_transfer_when_all.cpp
+    stdexec/algos/adaptors/test_into_variant.cpp
+    stdexec/algos/adaptors/test_stopped_as_optional.cpp
+    stdexec/algos/adaptors/test_stopped_as_error.cpp
+    stdexec/algos/adaptors/test_ensure_started.cpp
+    stdexec/algos/consumers/test_start_detached.cpp
+    stdexec/algos/consumers/test_sync_wait.cpp
+    stdexec/algos/other/test_execute.cpp
+    stdexec/detail/test_completion_signatures.cpp
+    stdexec/detail/test_utility.cpp
+    stdexec/queries/test_get_forward_progress_guarantee.cpp
+    stdexec/queries/test_forwarding_queries.cpp
+    exec/test_type_async_scope.cpp
+    exec/test_create.cpp
+    exec/test_env.cpp
+    exec/test_on.cpp
+    exec/test_on2.cpp
+    exec/test_on3.cpp
+    exec/async_scope/test_dtor.cpp
+    exec/async_scope/test_spawn.cpp
+    exec/async_scope/test_spawn_future.cpp
+    exec/async_scope/test_empty.cpp
+    exec/async_scope/test_stop.cpp
+    )
+
+add_executable(test.stdexec ${stdexec_test_sources})
+
+target_include_directories(test.stdexec PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(test.stdexec PUBLIC STDEXEC::stdexec stdexec_executable_flags Catch2::Catch2)
+
+# Discover the Catch2 test built by the application
+include(${Catch2_SOURCE_DIR}/contrib/Catch.cmake)
+
+catch_discover_tests(test.stdexec)
+
+if(STDEXEC_ENABLE_CUDA)
+    add_subdirectory(nvexec)
+endif()

--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -1,14 +1,44 @@
-if(STDEXEC_ENABLE_CUDA)
-    file(GLOB_RECURSE TEST_SOURCES
-            RELATIVE "${CMAKE_CURRENT_LIST_DIR}"
-            CONFIGURE_DEPENDS
-            *.cpp)
+#=============================================================================
+# Copyright 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
 
-    add_executable(test.CUDA ${TEST_SOURCES})
-    if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
-        set_source_files_properties(${TEST_SOURCES} PROPERTIES LANGUAGE CUDA)
-    endif()
-    target_include_directories(test.CUDA PRIVATE ${STDEXEC_SOURCE_DIR}/test)
-    target_link_libraries(test.CUDA CUDASchedulers Catch2::Catch2)
-    catch_discover_tests(test.CUDA)
+set(nvexec_test_sources
+    ensure_started.cpp
+    start_detached.cpp
+    variant.cpp
+    split.cpp
+    upon_stopped.cpp
+    transfer.cpp
+    let_stopped.cpp
+    test_main.cpp
+    then.cpp
+    bulk.cpp
+    when_all.cpp
+    transfer_when_all.cpp
+    let_value.cpp
+    let_error.cpp
+    upon_error.cpp
+)
+
+if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
+    set_source_files_properties(${nvexec_test_sources} PROPERTIES LANGUAGE CUDA)
 endif()
+
+add_executable(test.nvexec ${nvexec_test_sources})
+
+target_include_directories(test.nvexec PRIVATE ${CMAKE_CURRENT_LIST_DIR}/..)
+target_link_libraries(test.nvexec STDEXEC::nvexec stdexec_executable_flags Catch2::Catch2)
+
+catch_discover_tests(test.nvexec)


### PR DESCRIPTION
This PR moves test and example configuration into separate `CMakeLists.txt` files.

It also moves tests and examples behind flags (which default to `ON`). This allows other CMake projects to add stdexec as a subdirectory and skip building our tests and examples.