### PR TITLE
Make repeated `ensure_started` calls compile

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -3601,6 +3601,14 @@ namespace stdexec {
       using __dispatcher_for =
         __make_dispatcher<__cust_sigs, __mconstructor_for<__sender_t>, _Sender, _Env>;
 
+    template <class _SenderId, class _EnvId>
+    void __test_ensure_started_sender(__sender<_SenderId, _EnvId> const& __sndr2){};
+
+    template <class _Sender>
+    concept __ensure_started_sender = requires(typename _Sender::__id __sndr1) {
+      __test_ensure_started_sender(__sndr1);
+    };
+
     struct ensure_started_t {
       template <sender _Sender, class _Env = __empty_env>
           requires
@@ -3613,9 +3621,8 @@ namespace stdexec {
           return __dispatcher_for<_Sender, _Env>{}((_Sender&&) __sndr, (_Env&&) __env);
         }
 
-      // BUGBUG this will never match
-      template <class _SenderId, class _EnvId>
-        __t<__sender<_SenderId, _EnvId>> operator()(__t<__sender<_SenderId, _EnvId>> __sndr) const {
+      template <__ensure_started_sender _Sender>
+        _Sender operator()(_Sender __sndr) const {
           return std::move(__sndr);
         }
 

--- a/test/stdexec/algos/adaptors/test_ensure_started.cpp
+++ b/test/stdexec/algos/adaptors/test_ensure_started.cpp
@@ -276,3 +276,14 @@ TEST_CASE("Dropping the opstate without starting it calls set_stopped", "[adapto
   // make sure the logging_receiver was never called
   CHECK(state == -1);
 }
+
+TEST_CASE("Repeated ensure_started compiles", "[adaptors][ensure_started]") {
+  bool called{false};
+  auto snd1 = ex::just() | ex::then([&] { called = true; });
+  CHECK_FALSE(called);
+  auto snd2 = ex::ensure_started(std::move(snd1));
+  auto snd = ex::ensure_started(std::move(snd2));
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_void_receiver{});
+  ex::start(op);
+}


### PR DESCRIPTION
Constrains the `ensure_started` overload supposed to take an existing `ensure_started` sender with a custom concept to allow deduction to happen. `__test_ensure_started_sender` is not an inline lambda because of missing support in earlier clang versions.

Ideally I'd like a test to ensure that this overload is really picked, and that a new shared state isn't actually created. Would something like a public `__get_shared_state` member function on the `ensure_started` `__sender` be fair game to add for testing purposes?

Fixes #715.