### PR TITLE
Initial R7 env changes

### DIFF
--- a/examples/algorithms/retry.hpp
+++ b/examples/algorithms/retry.hpp
@@ -110,9 +110,9 @@ struct _retry_sender {
     return {(S&&) self.s_, (R&&) r};
   }
 
-  friend auto tag_invoke(stdexec::get_attrs_t, const _retry_sender& self)
-    noexcept(noexcept(stdexec::get_attrs(self.s_))) -> std::invoke_result_t<stdexec::get_attrs_t, S> {
-    return stdexec::get_attrs(self.s_);
+  friend auto tag_invoke(stdexec::get_env_t, const _retry_sender& self)
+    noexcept(noexcept(stdexec::get_env(self.s_))) -> std::invoke_result_t<stdexec::get_env_t, S> {
+    return stdexec::get_env(self.s_);
   }
 };
 

--- a/examples/algorithms/then.hpp
+++ b/examples/algorithms/then.hpp
@@ -46,10 +46,14 @@ class _then_receiver
   _then_receiver(R r, F f)
    : stdexec::receiver_adaptor<_then_receiver, R>{std::move(r)}
    , f_(std::move(f)) {}
+
+  using is_receiver = void;
 };
 
 template<stdexec::sender S, class F>
 struct _then_sender {
+  using is_sender = void;
+
   S s_;
   F f_;
 

--- a/examples/algorithms/then.hpp
+++ b/examples/algorithms/then.hpp
@@ -79,9 +79,9 @@ struct _then_sender {
         (S&&) self.s_, _then_receiver<R, F>{(R&&) r, (F&&) self.f_});
   }
 
-  friend auto tag_invoke(stdexec::get_attrs_t, const _then_sender& self)
-    noexcept(noexcept(stdexec::get_attrs(self.s_))) -> std::invoke_result_t<stdexec::get_attrs_t, S> {
-    return stdexec::get_attrs(self.s_);
+  friend auto tag_invoke(stdexec::get_env_t, const _then_sender& self)
+    noexcept(noexcept(stdexec::get_env(self.s_))) -> std::invoke_result_t<stdexec::get_env_t, S> {
+    return stdexec::get_env(self.s_);
   }
 };
 

--- a/examples/algorithms/then.hpp
+++ b/examples/algorithms/then.hpp
@@ -46,8 +46,6 @@ class _then_receiver
   _then_receiver(R r, F f)
    : stdexec::receiver_adaptor<_then_receiver, R>{std::move(r)}
    , f_(std::move(f)) {}
-
-  using is_receiver = void;
 };
 
 template<stdexec::sender S, class F>

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -165,7 +165,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         operation_state_t(PredSender&& pred_sender, Closure closure, Receiver&& receiver, std::size_t n)
           : operation_state_base_t<ReceiverId>(
               (Receiver&&)receiver, 
-              stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(pred_sender)).context_state_,
+              stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(pred_sender)).context_state_,
               false)
           , pred_sender_{(PredSender&&)pred_sender}
           , closure_(closure)
@@ -295,10 +295,10 @@ struct repeat_n_t {
       }
 #endif
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const repeat_n_sender_t& s)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(s.sender_);
+      friend auto tag_invoke(stdexec::get_env_t, const repeat_n_sender_t& s)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(s.sender_);
       }
     };
 

--- a/examples/retry.cpp
+++ b/examples/retry.cpp
@@ -48,7 +48,7 @@ struct fail_some {
   }
 
   struct empty_attrs {};
-  friend empty_attrs tag_invoke(stdexec::get_attrs_t, const fail_some&) noexcept {
+  friend empty_attrs tag_invoke(stdexec::get_env_t, const fail_some&) noexcept {
     return {};
   }
 };

--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -372,10 +372,10 @@ namespace exec {
             friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
               -> __minvoke<__impl_fn<_Self, _Env>, _Self, _Env>;
 
-          friend auto tag_invoke(stdexec::get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<stdexec::get_attrs_t, const _Sender&>)
-            -> __call_result_t<stdexec::get_attrs_t, const _Sender&> {
-            return stdexec::get_attrs(__self.__sndr_);
+          friend auto tag_invoke(stdexec::get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<stdexec::get_env_t, const _Sender&>)
+            -> __call_result_t<stdexec::get_env_t, const _Sender&> {
+            return stdexec::get_env(__self.__sndr_);
           }
 
         };

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -120,7 +120,7 @@ namespace exec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> completion_signatures_of_t<__copy_cvref_t<_Self, _Constrained>, __env_t<_Env>>;
 
-        friend __empty_attrs tag_invoke(get_attrs_t, const __when_empty_sender& __self) noexcept {
+        friend __empty_env tag_invoke(get_env_t, const __when_empty_sender& __self) noexcept {
           return {};
         }
       };
@@ -226,7 +226,7 @@ namespace exec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> completion_signatures_of_t<__copy_cvref_t<_Self, _Constrained>, __env_t<_Env>>;
 
-        friend __empty_attrs tag_invoke(get_attrs_t, const __nest_sender& __self) noexcept {
+        friend __empty_env tag_invoke(get_env_t, const __nest_sender& __self) noexcept {
           return {};
         }
       };
@@ -576,7 +576,7 @@ namespace exec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _OtherEnv)
             -> __completions_t<_Self>;
 
-        friend __empty_attrs tag_invoke(get_attrs_t, const __future& __self) noexcept {
+        friend __empty_env tag_invoke(get_env_t, const __future& __self) noexcept {
           return {};
         }
 

--- a/include/exec/create.hpp
+++ b/include/exec/create.hpp
@@ -73,7 +73,7 @@ namespace exec {
           return {{(_Receiver&&) __rcvr, ((_Self&&) __self).__args_}, ((_Self&&) __self).__fun_};
         }
 
-        friend __empty_attrs tag_invoke(get_attrs_t, const __sender&) noexcept {
+        friend __empty_env tag_invoke(get_env_t, const __sender&) noexcept {
           return {};
         }
       };

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -191,10 +191,10 @@ namespace exec {
                   ((_Self&&) __self).__withs_};
         }
 
-        friend auto tag_invoke(stdexec::get_attrs_t, const __sender& __self)
-          noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const _Sender&>)
-          -> stdexec::__call_result_t<stdexec::get_attrs_t, const _Sender&> {
-          return stdexec::get_attrs(__self.__sndr_);
+        friend auto tag_invoke(stdexec::get_env_t, const __sender& __self)
+          noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const _Sender&>)
+          -> stdexec::__call_result_t<stdexec::get_env_t, const _Sender&> {
+          return stdexec::get_env(__self.__sndr_);
         }
 
         template <__decays_to<__sender> _Self, class _Env>

--- a/include/exec/inline_scheduler.hpp
+++ b/include/exec/inline_scheduler.hpp
@@ -47,14 +47,14 @@ namespace exec {
           return {(R&&) rec};
         }
 
-      struct __attrs {
+      struct __env {
         friend inline_scheduler
-        tag_invoke(stdexec::get_completion_scheduler_t<stdexec::set_value_t>, const __attrs&) noexcept {
+        tag_invoke(stdexec::get_completion_scheduler_t<stdexec::set_value_t>, const __env&) noexcept {
           return {};
         }
       };
 
-      friend __attrs tag_invoke(stdexec::get_env_t, const __sender&) noexcept {
+      friend __env tag_invoke(stdexec::get_env_t, const __sender&) noexcept {
         return {};
       }
     };

--- a/include/exec/inline_scheduler.hpp
+++ b/include/exec/inline_scheduler.hpp
@@ -54,7 +54,7 @@ namespace exec {
         }
       };
 
-      friend __attrs tag_invoke(stdexec::get_attrs_t, const __sender&) noexcept {
+      friend __attrs tag_invoke(stdexec::get_env_t, const __sender&) noexcept {
         return {};
       }
     };

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -78,13 +78,13 @@ namespace exec {
           return s.make_operation_((Receiver &&) r);
         }
 
-        struct attrs {
+        struct env {
           static_thread_pool& pool_;
 
           template <class CPO>
           friend static_thread_pool::scheduler tag_invoke(
               stdexec::get_completion_scheduler_t<CPO>,
-              const attrs& self) noexcept {
+              const env& self) noexcept {
             return self.make_scheduler_();
           }
 
@@ -93,8 +93,8 @@ namespace exec {
           }
         };
 
-        friend attrs tag_invoke(stdexec::get_env_t, const sender& self) noexcept {
-          return attrs{self.pool_};
+        friend env tag_invoke(stdexec::get_env_t, const sender& self) noexcept {
+          return env{self.pool_};
         }
 
         friend struct static_thread_pool::scheduler;

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -93,7 +93,7 @@ namespace exec {
           }
         };
 
-        friend attrs tag_invoke(stdexec::get_attrs_t, const sender& self) noexcept {
+        friend attrs tag_invoke(stdexec::get_env_t, const sender& self) noexcept {
           return attrs{self.pool_};
         }
 
@@ -383,10 +383,10 @@ namespace exec {
           friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
             -> completion_signatures<Self, Env> requires true;
 
-          friend auto tag_invoke(stdexec::get_attrs_t, const bulk_sender& self)
-            noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-            -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-            return stdexec::get_attrs(self.sndr_);
+          friend auto tag_invoke(stdexec::get_env_t, const bulk_sender& self)
+            noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+            -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+            return stdexec::get_env(self.sndr_);
       }
         };
 

--- a/include/nvexec/multi_gpu_context.cuh
+++ b/include/nvexec/multi_gpu_context.cuh
@@ -102,7 +102,7 @@ namespace nvexec {
             return operation_state_t<stdexec::__id<std::remove_cvref_t<R>>>((R&&) rec);
           }
 
-        friend const attrs& tag_invoke(stdexec::get_attrs_t, const sender_t& self) noexcept {
+        friend const attrs& tag_invoke(stdexec::get_env_t, const sender_t& self) noexcept {
           return self.attrs_;
         }
 

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -139,10 +139,10 @@ template <class SenderId, std::integral Shape, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
   };
@@ -356,7 +356,7 @@ template <class SenderId, std::integral Shape, class Fun>
           requires stdexec::receiver_of<Receiver, completion_signatures<Self, stdexec::env_of_t<Receiver>>>
         friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& rcvr)
           -> multi_gpu_bulk::operation_t<stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>, stdexec::__id<Receiver>, Shape, Fun> {
-          auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(self.sndr_));
+          auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(self.sndr_));
           context_state_t context_state = sch.context_state_;
           return multi_gpu_bulk::operation_t<stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>, stdexec::__id<Receiver>, Shape, Fun>(
               self.num_devices_,
@@ -375,10 +375,10 @@ template <class SenderId, std::integral Shape, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -559,7 +559,7 @@ namespace nvexec {
       concept stream_completing_sender =
         stdexec::sender<S> &&
         requires (const S& sndr) {
-          { stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(sndr)).context_state_ } ->
+          { stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr)).context_state_ } ->
             stdexec::__decays_to<context_state_t>;
         };
 
@@ -585,7 +585,7 @@ namespace nvexec {
     template <stream_completing_sender Sender, class OuterReceiver, class ReceiverProvider>
       stream_op_state_t<Sender, inner_receiver_t<ReceiverProvider, OuterReceiver>, OuterReceiver>
       stream_op_state(Sender&& sndr, OuterReceiver&& out_receiver, ReceiverProvider receiver_provider) {
-        auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(sndr));
+        auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr));
         context_state_t context_state = sch.context_state_;
 
         return stream_op_state_t<

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -319,10 +319,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                                           std::move(self).shared_state_};
           }
 
-        friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-          noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-          -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-          return stdexec::get_attrs(self.sndr_);
+        friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+          noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+          -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+          return stdexec::get_env(self.sndr_);
         }
 
         template <class... Tys>

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -192,7 +192,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                 [this] (operation_state_base_t<stdexec::__id<_Receiver2>> &) -> __receiver_t {
                   return __receiver_t{{}, this};
                 },
-                stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(__sndr)).context_state_)
+                stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(__sndr)).context_state_)
             , __fun_((_Fun&&) __fun)
           {}
         STDEXEC_IMMOVABLE(__operation);
@@ -250,10 +250,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             };
           }
 
-        friend auto tag_invoke(stdexec::get_attrs_t, const __t& __self)
-          noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const _Sender&>)
-          -> stdexec::__call_result_t<stdexec::get_attrs_t, const _Sender&> {
-          return stdexec::get_attrs(__self.__sndr_);
+        friend auto tag_invoke(stdexec::get_env_t, const __t& __self)
+          noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const _Sender&>)
+          -> stdexec::__call_result_t<stdexec::get_env_t, const _Sender&> {
+          return stdexec::get_env(__self.__sndr_);
         }
 
         template <stdexec::__decays_to<__t> _Self, class _Env>

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -219,10 +219,10 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -68,11 +68,11 @@ namespace schedule_from {
           return stdexec::connect(((Self&&)self).sender_, (Receiver&&)rcvr);
         }
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const source_sender_t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
+      friend auto tag_invoke(stdexec::get_env_t, const source_sender_t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
         // TODO - this code is not exercised by any test
-        return stdexec::get_attrs(self.sndr_);
+        return stdexec::get_env(self.sndr_);
       }
 
       template <stdexec::__decays_to<source_sender_t> _Self, class _Env>
@@ -124,7 +124,7 @@ template <class Scheduler, class SenderId>
               self.attrs_.context_state_);
       }
 
-      friend const __attrs& tag_invoke(stdexec::get_attrs_t, const __t& __self) noexcept {
+      friend const __attrs& tag_invoke(stdexec::get_env_t, const __t& __self) noexcept {
         return __self.attrs_;
       }
 

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -53,7 +53,7 @@ namespace schedule_from {
           }, *storage);
         }
 
-        friend Env 
+        friend Env
         tag_invoke(stdexec::get_env_t, const __t& self) {
           return self.operation_state_.make_env();
         }
@@ -90,25 +90,25 @@ template <class Scheduler, class SenderId>
     using Sender = stdexec::__t<SenderId>;
     using source_sender_th = schedule_from::source_sender_t<Sender>;
 
-    struct __attrs {
+    struct __env {
       context_state_t context_state_;
 
       template <stdexec::__one_of<stdexec::set_value_t, stdexec::set_stopped_t, stdexec::set_error_t> _Tag>
-        friend Scheduler tag_invoke(stdexec::get_completion_scheduler_t<_Tag>, const __attrs& __self) noexcept {
+        friend Scheduler tag_invoke(stdexec::get_completion_scheduler_t<_Tag>, const __env& __self) noexcept {
           return {__self.context_state_};
         }
     };
 
     struct __t : stream_sender_base {
       using __id = schedule_from_sender_t;
-      __attrs attrs_;
+      __env env_;
       source_sender_th sndr_;
 
       template <class Self, class Receiver>
-        using receiver_t = 
+        using receiver_t =
           stdexec::__t<
             schedule_from::receiver_t<
-              stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>, 
+              stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>,
               stdexec::__id<Receiver>>>;
 
       template <stdexec::__decays_to<__t> Self, stdexec::receiver Receiver>
@@ -121,11 +121,11 @@ template <class Scheduler, class SenderId>
               [&](operation_state_base_t<stdexec::__id<Receiver>>& stream_provider) -> receiver_t<Self, Receiver> {
                 return receiver_t<Self, Receiver>{{}, stream_provider};
               },
-              self.attrs_.context_state_);
+              self.env_.context_state_);
       }
 
-      friend const __attrs& tag_invoke(stdexec::get_env_t, const __t& __self) noexcept {
-        return __self.attrs_;
+      friend const __env& tag_invoke(stdexec::get_env_t, const __t& __self) noexcept {
+        return __self.env_;
       }
 
       template <stdexec::__decays_to<__t> _Self, class _Env>
@@ -136,10 +136,9 @@ template <class Scheduler, class SenderId>
             stdexec::completion_signatures<stdexec::set_error_t(cudaError_t)>>;
 
       __t(context_state_t context_state, Sender sndr)
-        : attrs_{context_state}
+        : env_{context_state}
         , sndr_{{}, (Sender&&)sndr} {
       }
     };
   };
 }
-

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -310,10 +310,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                                           self.shared_state_};
           }
 
-        friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-          noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-          -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-          return stdexec::get_attrs(self.sndr_);
+        friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+          noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+          -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+          return stdexec::get_env(self.sndr_);
         }
 
         template <class... Tys>

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -189,10 +189,10 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -144,10 +144,10 @@ template <class SenderId>
         friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env) ->
           completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
 
       __t(context_state_t context_state, Sender sndr)

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -176,10 +176,10 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -150,10 +150,10 @@ template <class SenderId, class Fun>
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const __t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const __t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
   };

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -325,7 +325,7 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
               , child_states_{
                   stdexec::__conv{[&when_all, this]() {
                     operation_t* parent_op = this;
-                    auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_attrs(std::get<Is>(when_all.sndrs_)));
+                    auto sch = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(std::get<Is>(when_all.sndrs_)));
                     context_state_t context_state = sch.context_state_;
                     STDEXEC_DBG_ERR(cudaStreamCreate(&this->streams_[Is]));
 
@@ -417,7 +417,7 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
         friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
           -> completion_sigs<stdexec::__copy_cvref_t<Self, Env>>;
 
-      friend const attrs& tag_invoke(stdexec::get_attrs_t, const __t& __self) noexcept {
+      friend const attrs& tag_invoke(stdexec::get_env_t, const __t& __self) noexcept {
         return __self.attrs_;
       }
 

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -88,12 +88,12 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
   struct when_all_sender_t {
     struct __t : stream_sender_base {
     private:
-      struct attrs {
+      struct env {
         context_state_t context_state_;
 
       template <stdexec::__one_of<stdexec::set_value_t, stdexec::set_stopped_t> _Tag>
           requires WithCompletionScheduler
-        friend Scheduler tag_invoke(stdexec::get_completion_scheduler_t<_Tag>, const attrs& self) noexcept {
+        friend Scheduler tag_invoke(stdexec::get_completion_scheduler_t<_Tag>, const env& self) noexcept {
           return Scheduler(self.context_state_);
         }
       };
@@ -102,12 +102,12 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
 
       template <class... Sndrs>
         explicit __t(context_state_t context_state, Sndrs&&... __sndrs)
-          : attrs_{context_state}
+          : env_{context_state}
           , sndrs_((Sndrs&&) __sndrs...)
         {}
 
      private:
-      attrs attrs_;
+      env env_;
 
       template <class CvrefEnv>
         using completion_sigs =
@@ -133,9 +133,9 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
           using Receiver = stdexec::__t<std::decay_t<CvrefReceiverId>>;
           using Env = make_terminal_stream_env_t<
                         exec::make_env_t<
-                          stdexec::env_of_t<Receiver>, 
+                          stdexec::env_of_t<Receiver>,
                           exec::with_t<
-                            stdexec::get_stop_token_t, 
+                            stdexec::get_stop_token_t,
                             stdexec::in_place_stop_token>>>;
 
           struct __t : stdexec::receiver_adaptor<__t>
@@ -179,7 +179,7 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
 
                     if constexpr (stream_receiver<Receiver>) {
                       if (op_state_->status_ == cudaSuccess) {
-                        op_state_->status_ = 
+                        op_state_->status_ =
                           STDEXEC_DBG_ERR(cudaEventRecord(op_state_->events_[Index], stream));
                       }
                     }
@@ -232,7 +232,7 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
           template <class Sender, std::size_t Index>
             using child_op_state =
               exit_operation_state_t<
-                Sender&&, 
+                Sender&&,
                 stdexec::__t<receiver_t<CvrefReceiverId, Index>>>;
 
           using Indices = std::index_sequence_for<SenderIds...>;
@@ -321,7 +321,7 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
 
           template <size_t... Is>
             operation_t(WhenAll&& when_all, Receiver rcvr, std::index_sequence<Is...>)
-              : recvr_((Receiver&&) rcvr) 
+              : recvr_((Receiver&&) rcvr)
               , child_states_{
                   stdexec::__conv{[&when_all, this]() {
                     operation_t* parent_op = this;
@@ -331,7 +331,7 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
 
                     return exit_op_state<decltype(std::get<Is>(((WhenAll&&)when_all).sndrs_)),
                                          stdexec::__t<receiver_t<CvrefReceiverId, Is>>>(
-                             std::get<Is>(((WhenAll&&) when_all).sndrs_), 
+                             std::get<Is>(((WhenAll&&) when_all).sndrs_),
                              stdexec::__t<receiver_t<CvrefReceiverId, Is>>{{}, {}, parent_op},
                              context_state);
                   }}...
@@ -417,12 +417,11 @@ template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
         friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
           -> completion_sigs<stdexec::__copy_cvref_t<Self, Env>>;
 
-      friend const attrs& tag_invoke(stdexec::get_env_t, const __t& __self) noexcept {
-        return __self.attrs_;
+      friend const env& tag_invoke(stdexec::get_env_t, const __t& __self) noexcept {
+        return __self.env_;
       }
 
       std::tuple<stdexec::__t<SenderIds>...> sndrs_;
     };
   };
 }
-

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -87,7 +87,7 @@ namespace nvexec {
             cudaStream_t stream_{0};
             cudaError_t status_{cudaSuccess};
 
-            __t(Receiver&& receiver, context_state_t context_state) 
+            __t(Receiver&& receiver, context_state_t context_state)
               : operation_state_base_t<ReceiverId>((Receiver&&)receiver, context_state, false) {
             }
 
@@ -100,7 +100,7 @@ namespace nvexec {
       template <class ReceiverId>
         using operation_state_t = stdexec::__t<operation_state_<ReceiverId>>;
 
-      struct attrs {
+      struct env {
         context_state_t context_state_;
 
         stream_scheduler make_scheduler() const {
@@ -109,7 +109,7 @@ namespace nvexec {
 
         template <class CPO>
           friend stream_scheduler
-          tag_invoke(stdexec::get_completion_scheduler_t<CPO>, const attrs& self) noexcept {
+          tag_invoke(stdexec::get_completion_scheduler_t<CPO>, const env& self) noexcept {
             return self.make_scheduler();
           }
       };
@@ -126,19 +126,19 @@ namespace nvexec {
             friend auto tag_invoke(stdexec::connect_t, const __t& self, R&& rec)
               noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<R>, R>)
               -> operation_state_t<stdexec::__id<std::remove_cvref_t<R>>> {
-              return operation_state_t<stdexec::__id<std::remove_cvref_t<R>>>((R&&) rec, self.attrs_.context_state_);
+              return operation_state_t<stdexec::__id<std::remove_cvref_t<R>>>((R&&) rec, self.env_.context_state_);
             }
 
-          friend const attrs& tag_invoke(stdexec::get_env_t, const __t& self) noexcept {
-            return self.attrs_;
+          friend const env& tag_invoke(stdexec::get_env_t, const __t& self) noexcept {
+            return self.env_;
           };
 
           STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
           inline __t(context_state_t context_state) noexcept
-            : attrs_{context_state} {
+            : env_{context_state} {
           }
 
-          attrs attrs_;
+          env env_;
         };
       };
 
@@ -207,9 +207,9 @@ namespace nvexec {
       template <stream_completing_sender... Senders>
         friend auto
         tag_invoke(stdexec::transfer_when_all_with_variant_t, const stream_scheduler& sch, Senders&&... sndrs) noexcept {
-          return 
+          return
             transfer_when_all_sender_th<stream_scheduler, stdexec::tag_invoke_result_t<stdexec::into_variant_t, Senders>...>(
-                sch.context_state_, 
+                sch.context_state_,
                 stdexec::into_variant((Senders&&)sndrs)...);
         }
 
@@ -275,7 +275,7 @@ namespace nvexec {
       when_all_sender_th<stream_scheduler, stdexec::tag_invoke_result_t<stdexec::into_variant_t, Senders>...>
       tag_invoke(stdexec::when_all_with_variant_t, Senders&&... sndrs) noexcept {
         return when_all_sender_th<stream_scheduler, stdexec::tag_invoke_result_t<stdexec::into_variant_t, Senders>...>{
-          context_state_t{nullptr, nullptr, nullptr}, 
+          context_state_t{nullptr, nullptr, nullptr},
           stdexec::into_variant((Senders&&)sndrs)...
         };
       }
@@ -381,19 +381,18 @@ namespace nvexec {
     int dev_id_{};
     STDEXEC_STREAM_DETAIL_NS::queue::task_hub_t hub_;
 
-    stream_context() 
+    stream_context()
       : dev_id_(get_device())
       , hub_(dev_id_, pinned_resource_.get()) {
     }
 
     stream_scheduler get_scheduler(stream_priority priority = stream_priority::normal) {
       return {STDEXEC_STREAM_DETAIL_NS::context_state_t(
-          pinned_resource_.get(), 
-          managed_resource_.get(), 
-          // gpu_resource_.get(), 
-          &hub_, 
+          pinned_resource_.get(),
+          managed_resource_.get(),
+          // gpu_resource_.get(),
+          &hub_,
           priority)};
     }
   };
 }
-

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -129,7 +129,7 @@ namespace nvexec {
               return operation_state_t<stdexec::__id<std::remove_cvref_t<R>>>((R&&) rec, self.attrs_.context_state_);
             }
 
-          friend const attrs& tag_invoke(stdexec::get_attrs_t, const __t& self) noexcept {
+          friend const attrs& tag_invoke(stdexec::get_env_t, const __t& self) noexcept {
             return self.attrs_;
           };
 

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -626,6 +626,12 @@ namespace stdexec {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.receivers]
   template <class _Receiver>
+    inline constexpr bool enable_receiver =
+      requires {
+        typename _Receiver::is_receiver;
+      };
+
+  template <class _Receiver>
     concept receiver =
       environment_provider<__cref_t<_Receiver>> &&
       move_constructible<remove_cvref_t<_Receiver>> &&

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -342,7 +342,7 @@ namespace stdexec {
             (!tag_invocable<get_env_t, const _EnvProvider&>)
         constexpr decltype(auto) operator()(const _EnvProvider& __with_env) const
           noexcept {
-          if constexpr (__r5_sender<_EnvProvider>) {
+          if constexpr (!enable_sender<_EnvProvider>) {
             return __with_env;
           } else {
             return __empty_env{};

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -318,8 +318,7 @@ namespace stdexec {
             (!tag_invocable<get_env_t, const _EnvProvider&>) &&
             // NOT TO SPEC: Remove the R5/R7 sender checks when
             // deprecating R5 support.
-            (!__r5_sender<_EnvProvider>) &&
-            __r7_sender<_EnvProvider>
+            (!__r5_sender<_EnvProvider>)
         constexpr auto operator()(const _EnvProvider& __with_env) const
           noexcept -> __empty_env {
           return {};
@@ -2095,6 +2094,8 @@ namespace stdexec {
         struct __t {
           using __id = __basic_sender;
           using completion_signatures = __completion_signatures_<_Tag, _Ts...>;
+          using is_sender = void;
+
           std::tuple<_Ts...> __vals_;
 
           template <receiver_of<completion_signatures> _Receiver>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4191,18 +4191,18 @@ namespace stdexec {
             return {&__loop_->__head_, __loop_, (_Receiver &&) __rcvr};
           }
 
-          struct __attrs {
+          struct __env {
             run_loop* __loop_;
 
             template <class _CPO>
             friend __scheduler
-            tag_invoke(get_completion_scheduler_t<_CPO>, const __attrs& __self) noexcept {
+            tag_invoke(get_completion_scheduler_t<_CPO>, const __env& __self) noexcept {
               return __scheduler{__self.__loop_};
             }
           };
 
-          friend __attrs tag_invoke(get_env_t, const __schedule_task& __self) noexcept {
-            return __attrs{__self.__loop_};
+          friend __env tag_invoke(get_env_t, const __schedule_task& __self) noexcept {
+            return __env{__self.__loop_};
           }
 
           explicit __schedule_task(run_loop* __loop) noexcept
@@ -4480,11 +4480,11 @@ namespace stdexec {
           __mcompose<__q<completion_signatures>, __qf<_Tag>>>;
 
     template <class _SchedulerId>
-      struct __attrs {
+      struct __env {
         using _Scheduler = stdexec::__t<_SchedulerId>;
 
         struct __t {
-          using __id = __attrs;
+          using __id = __env;
 
           _Scheduler __sched_;
 
@@ -4500,22 +4500,22 @@ namespace stdexec {
       struct __sender {
         using _Scheduler = stdexec::__t<_SchedulerId>;
         using _Sender = stdexec::__t<_SenderId>;
-        using _Attrs = stdexec::__t<__attrs<_SchedulerId>>;
+        using _Attrs = stdexec::__t<__env<_SchedulerId>>;
 
         struct __t {
           using __id = __sender;
-          _Attrs __attrs_;
+          _Attrs __env_;
           _Sender __sndr_;
 
           template <__decays_to<__t> _Self, class _Receiver>
             requires sender_to<__copy_cvref_t<_Self, _Sender>, _Receiver>
           friend auto tag_invoke(connect_t, _Self&& __self, _Receiver __rcvr)
               -> stdexec::__t<__operation1<_SchedulerId, stdexec::__id<__copy_cvref_t<_Self, _Sender>>, stdexec::__id<_Receiver>>> {
-            return {__self.__attrs_.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
+            return {__self.__env_.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
           }
 
           friend const _Attrs& tag_invoke(get_env_t, const __t& __self) noexcept {
-            return __self.__attrs_;
+            return __self.__env_;
           }
 
           template <class... _Errs>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -334,7 +334,7 @@ namespace stdexec {
 
       // NOT TO SPEC: The overloads below check the non-standard
       // __r5_sender concept to determine whether to provide backwards
-      // compatibile behavior for R5 version sender types. When we
+      // compatible behavior for R5 version sender types. When we
       // deprecate R5 support, we can bring this overload in line with
       // the spec.
       template <class _EnvProvider>
@@ -655,15 +655,11 @@ namespace stdexec {
     concept receiver =
       // NOT TO SPEC:
       // As we upgrade the receiver related entities from R5 to R7,
-      // here we explicitly keep the requirement that a type still
-      // must explicitly provide a 'get_env' tag invocable friend
-      // function. Receivers in R5 world always did this, so throughout
-      // the upgrade lifecycle, we'll keep that requirement in place
-      // temporarily. This is important since in R7 world, 'get_env'
-      // provides a default version that returns empty_env. Keeping
-      // the extra constraint ensures types like 'no_env' (which are
-      // deprecated) do not automatically become receivers.
-      tag_invocable<get_env_t, __cref_t<_Receiver>> &&
+      // we allow types that do not yet satisfy enable_receiver to
+      // still satisfy the receiver concept if the type provides an
+      // explicit get_env. All R5 receivers provided an explicit get_env,
+      // so this is backwards compatible.
+      (enable_receiver<_Receiver> || tag_invocable<get_env_t, __cref_t<_Receiver>>) &&
       environment_provider<__cref_t<_Receiver>> &&
       move_constructible<remove_cvref_t<_Receiver>> &&
       constructible_from<remove_cvref_t<_Receiver>, _Receiver>;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -664,10 +664,6 @@ namespace stdexec {
       // the extra constraint ensures types like 'no_env' (which are
       // deprecated) do not automatically become receivers.
       tag_invocable<get_env_t, __cref_t<_Receiver>> &&
-      // NOT TO SPEC:
-      // This needs more investigation - I'm not sure why I had to explicitly
-      // add the check below.
-      !same_as<__env_promise<__empty_env>, _Receiver> &&
       environment_provider<__cref_t<_Receiver>> &&
       move_constructible<remove_cvref_t<_Receiver>> &&
       constructible_from<remove_cvref_t<_Receiver>, _Receiver>;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -653,6 +653,21 @@ namespace stdexec {
 
   template <class _Receiver>
     concept receiver =
+      // NOT TO SPEC:
+      // As we upgrade the receiver related entities from R5 to R7,
+      // here we explicitly keep the requirement that a type still
+      // must explicitly provide a 'get_env' tag invocable friend
+      // function. Receivers in R5 world always did this, so throughout
+      // the upgrade lifecycle, we'll keep that requirement in place
+      // temporarily. This is important since in R7 world, 'get_env'
+      // provides a default version that returns empty_env. Keeping
+      // the extra constraint ensures types like 'no_env' (which are
+      // deprecated) do not automatically become receivers.
+      tag_invocable<get_env_t, __cref_t<_Receiver>> &&
+      // NOT TO SPEC:
+      // This needs more investigation - I'm not sure why I had to explicitly
+      // add the check below.
+      !same_as<__env_promise<__empty_env>, _Receiver> &&
       environment_provider<__cref_t<_Receiver>> &&
       move_constructible<remove_cvref_t<_Receiver>> &&
       constructible_from<remove_cvref_t<_Receiver>, _Receiver>;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -56,7 +56,11 @@
 #pragma diag_suppress 497
 #endif
 
+#ifdef STDEXEC_ENABLE_R5_DEPRECATIONS
 #define R5_SENDER_DEPR_WARNING [[deprecated("Deprecated sender type detected. Please update the type for to satisfy the sender concept in P2300R7")]]
+#else
+#define R5_SENDER_DEPR_WARNING
+#endif
 
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE("-Wundefined-inline")
@@ -92,12 +96,32 @@ namespace stdexec {
   using __forwarding_query::forwarding_query_t;
 
   /////////////////////////////////////////////////////////////////////////////
+  // completion_signatures
+  namespace __compl_sigs {
+    template <class _Env>
+      struct __env_promise;
+    struct __dependent;
+  } // namespace __compl_sigs
+
+  /////////////////////////////////////////////////////////////////////////////
+  // env_of
+  namespace __env {
+    struct __empty_env {
+      using __t = __empty_env;
+      using __id = __empty_env;
+    };
+  } // namespace __env
+
+  /////////////////////////////////////////////////////////////////////////////
   // [execution.senders]
   template <class _Sender>
-    inline constexpr bool enable_sender =
-      requires {
-        typename _Sender::is_sender;
-      };
+    concept __enable_sender = requires {
+      typename _Sender::is_sender;
+    } ||
+    __awaitable<_Sender, __compl_sigs::__env_promise<__env::__empty_env>>;
+
+  template <class _Sender>
+    inline constexpr bool enable_sender = __enable_sender<_Sender>;
 
   // [execution.schedulers.queries], scheduler queries
   namespace __scheduler_queries {
@@ -134,13 +158,43 @@ namespace stdexec {
   }
   using __get_completion_signatures::get_completion_signatures_t;
 
+  namespace __r5_support {
+    // The concepts below are not to any spec. They approximate whether
+    // a type satisfies the R5 or R7 sender concept for the purpose of
+    // emitting [[deprecated]] diagnostic warning asking the user to
+    // upgrade their sender types.
+    //
+    // All R5 receivers already provide get_env, so the extra overloads
+    // of get_env would at most conflict if a receiver type also
+    // has completion signatures or the new enable_sender trait, neither
+    // of which is too likely.
+
+    template <class _Sender>
+    concept __r7_sender = enable_sender<remove_cvref_t<_Sender>>;
+
+    template <class _Sender>
+    concept __r5_sender = requires(_Sender&& __sender) {
+      __declval<get_completion_signatures_t>()((_Sender&&)__sender);
+    } && !__r7_sender<_Sender>;
+
+    template <class _T>
+    R5_SENDER_DEPR_WARNING
+    void __update_sender_type_to_p2300r7_by_adding_enable_sender_trait() { }
+
+    template <class _T>
+    void __check_sender_version() {
+      if constexpr (!enable_sender<_T>) {
+        __update_sender_type_to_p2300r7_by_adding_enable_sender_trait<_T>();
+      }
+    }
+
+  } // namespace __r5_support
+  using __r5_support::__r5_sender;
+  using __r5_support::__check_sender_version;
+
   /////////////////////////////////////////////////////////////////////////////
   // env_of
   namespace __env {
-    struct __empty_env {
-      using __t = __empty_env;
-      using __id = __empty_env;
-    };
     struct no_env {
       using __t = no_env;
       using __id = no_env;
@@ -245,47 +299,6 @@ namespace stdexec {
         }
     };
 
-    struct get_env_t;
-
-    namespace __r5_support {
-      // The concepts below are not to any spec. They are necessary but
-      // not sufficient conditions for senders in the respective versions
-      // of the spec, and allow backwards compatibility.
-      //
-      // All R5 receivers already provide get_env, so the extra overloads
-      // of get_env would at most conflict if a receiver type also
-      // has completion signatures or the new enable_sender trait, neither
-      // of which is too likely.
-
-      template <class _Sender>
-      concept __r5_sender = requires(_Sender&& __sender) {
-        __declval<get_completion_signatures_t>()((_Sender&&)__sender);
-      };
-
-      template <class _Sender>
-      concept __r7_sender = enable_sender<remove_cvref_t<_Sender>>;
-
-      template <class _T>
-      R5_SENDER_DEPR_WARNING
-      void __update_sender_type_to_p2300r7_by_adding_enable_sender_trait() { }
-
-      template <class _T>
-      R5_SENDER_DEPR_WARNING
-      void __update_sender_type_to_p2300r7_by_adding_get_env() { }
-
-      template <class _T>
-      void __check_sender_version() {
-        if constexpr (!enable_sender<_T>) {
-          __update_sender_type_to_p2300r7_by_adding_enable_sender_trait<_T>();
-        }
-        if constexpr (!tag_invocable<get_env_t, const _T&>) {
-          __update_sender_type_to_p2300r7_by_adding_get_env<_T>();
-        }
-      }
-
-    } // namespace __r5_support
-    using namespace __r5_support;
-
     // For getting an evaluation environment from a receiver
     struct get_env_t {
       template <class _EnvProvider>
@@ -294,34 +307,24 @@ namespace stdexec {
           noexcept(nothrow_tag_invocable<get_env_t, const _EnvProvider&>)
           -> tag_invoke_result_t<get_env_t, const _EnvProvider&> {
           static_assert(queryable<tag_invoke_result_t<get_env_t, const _EnvProvider&> >);
-          __check_sender_version<remove_cvref_t<_EnvProvider>>();
           return tag_invoke(*this, __with_env);
         }
 
-      // NOT TO SPEC: This overload is provided to support
-      // R5 sender types which don't yet define get_env or
-      // evaluate true for the enable_sender trait. Remove
-      // this overload when deprecating R5 support.
+      // NOT TO SPEC: The overloads below check the non-standard
+      // __r5_sender concept to determine whether to provide backwards
+      // compatibile behavior for R5 version sender types. When we
+      // deprecate R5 support, we can bring this overload in line with
+      // the spec.
       template <class _EnvProvider>
           requires
-            (!tag_invocable<get_env_t, const _EnvProvider&>) &&
-            __r5_sender<_EnvProvider> &&
-            (!__r7_sender<_EnvProvider>)
-        constexpr auto operator()(const _EnvProvider& __with_env) const
-          noexcept -> const _EnvProvider& {
-          __check_sender_version<remove_cvref_t<_EnvProvider>>();
-          return __with_env;
-        }
-
-      template <class _EnvProvider>
-          requires
-            (!tag_invocable<get_env_t, const _EnvProvider&>) &&
-            // NOT TO SPEC: Remove the R5/R7 sender checks when
-            // deprecating R5 support.
-            (!__r5_sender<_EnvProvider>)
-        constexpr auto operator()(const _EnvProvider& __with_env) const
-          noexcept -> __empty_env {
-          return {};
+            (!tag_invocable<get_env_t, const _EnvProvider&>)
+        constexpr decltype(auto) operator()(const _EnvProvider& __with_env) const
+          noexcept {
+          if constexpr (__r5_sender<_EnvProvider>) {
+            return __with_env;
+          } else {
+            return __empty_env{};
+          }
         }
     };
   } // namespace __env
@@ -1524,6 +1527,8 @@ namespace stdexec {
           tag_invocable<__is_debug_env_t, env_of_t<_Receiver>>
       auto operator()(_Sender&& __sndr, _Receiver&& __rcvr) const
           noexcept(__nothrow_connect<_Sender, _Receiver>()) {
+        __check_sender_version<_Sender>();
+        //__check_receiver_version<_Receiver>();
         if constexpr (__connectable_with_tag_invoke<_Sender, _Receiver>) {
           static_assert(
             operation_state<tag_invoke_result_t<connect_t, _Sender, _Receiver>>,

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -1035,7 +1035,7 @@ namespace stdexec {
   template <class _Scheduler>
     concept __sender_has_completion_scheduler =
       requires(_Scheduler&& __sched, const get_completion_scheduler_t<set_value_t>&& __tag) {
-        { tag_invoke(std::move(__tag), get_attrs(schedule((_Scheduler&&) __sched))) }
+        { tag_invoke(std::move(__tag), get_env(schedule((_Scheduler&&) __sched))) }
           -> same_as<remove_cvref_t<_Scheduler>>;
       };
 
@@ -1617,10 +1617,10 @@ namespace stdexec {
 
   template <class _Sender, class _CPO>
     concept __has_completion_scheduler =
-      __callable<get_completion_scheduler_t<_CPO>, __call_result_t<get_attrs_t, const _Sender&>>;
+      __callable<get_completion_scheduler_t<_CPO>, __call_result_t<get_env_t, const _Sender&>>;
 
   template <class _Sender, class _CPO>
-    using __completion_scheduler_for = __call_result_t<get_completion_scheduler_t<_CPO>, __call_result_t<get_attrs_t, const _Sender&>>;
+    using __completion_scheduler_for = __call_result_t<get_completion_scheduler_t<_CPO>, __call_result_t<get_env_t, const _Sender&>>;
 
   template <class _Fun, class _CPO, class _Sender, class... _As>
     concept __tag_invocable_with_completion_scheduler =
@@ -2048,7 +2048,7 @@ namespace stdexec {
               return {{}, ((__t&&) __sndr).__vals_, (_Receiver&&) __rcvr};
             }
 
-          friend __empty_attrs tag_invoke(get_attrs_t, const __t&) noexcept {
+          friend __empty_env tag_invoke(get_env_t, const __t&) noexcept {
             return {};
           }
         };
@@ -2574,10 +2574,10 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
         };
       };
@@ -2598,7 +2598,7 @@ namespace stdexec {
         requires __tag_invocable_with_completion_scheduler<then_t, set_value_t, _Sender, _Fun>
       sender auto operator()(_Sender&& __sndr, _Fun __fun) const
         noexcept(nothrow_tag_invocable<then_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Fun>) {
-        auto __sched = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
+        auto __sched = get_completion_scheduler<set_value_t>(get_env(__sndr));
         return tag_invoke(then_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
       }
       template <sender _Sender, __movable_value _Fun>
@@ -2689,10 +2689,10 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
         };
       };
@@ -2705,7 +2705,7 @@ namespace stdexec {
         requires __tag_invocable_with_completion_scheduler<upon_error_t, set_error_t, _Sender, _Fun>
       sender auto operator()(_Sender&& __sndr, _Fun __fun) const
         noexcept(nothrow_tag_invocable<upon_error_t, __completion_scheduler_for<_Sender, set_error_t>, _Sender, _Fun>) {
-        auto __sched = get_completion_scheduler<set_error_t>(get_attrs(__sndr)); // TODO ADD TEST!
+        auto __sched = get_completion_scheduler<set_error_t>(get_env(__sndr)); // TODO ADD TEST!
         return tag_invoke(upon_error_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
       }
       template <sender _Sender, __movable_value _Fun>
@@ -2801,10 +2801,10 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
         };
       };
@@ -2819,7 +2819,7 @@ namespace stdexec {
           __callable<_Fun>
       sender auto operator()(_Sender&& __sndr, _Fun __fun) const
         noexcept(nothrow_tag_invocable<upon_stopped_t, __completion_scheduler_for<_Sender, set_stopped_t>, _Sender, _Fun>) {
-        auto __sched = get_completion_scheduler<set_stopped_t>(get_attrs(__sndr)); // TODO ADD TEST!
+        auto __sched = get_completion_scheduler<set_stopped_t>(get_env(__sndr)); // TODO ADD TEST!
         return tag_invoke(upon_stopped_t{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
       }
       template <sender _Sender, __movable_value _Fun>
@@ -2943,10 +2943,10 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
             -> __completion_signatures<_Self, _Env> requires true;
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
         };
       };
@@ -2959,7 +2959,7 @@ namespace stdexec {
         requires __tag_invocable_with_completion_scheduler<bulk_t, set_value_t, _Sender, _Shape, _Fun>
       sender auto operator()(_Sender&& __sndr, _Shape __shape, _Fun __fun) const
         noexcept(nothrow_tag_invocable<bulk_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Shape, _Fun>) {
-        auto __sched = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
+        auto __sched = get_completion_scheduler<set_value_t>(get_env(__sndr));
         return tag_invoke(bulk_t{}, std::move(__sched), (_Sender&&) __sndr, (_Shape&&) __shape, (_Fun&&) __fun);
       }
       template <sender _Sender, integral _Shape, __movable_value _Fun>
@@ -3240,8 +3240,8 @@ namespace stdexec {
     using _Env = __1;
     using __cust_sigs =
       __types<
-        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender),
-        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender, _Env),
+        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(get_env_t(_Sender&)), _Sender),
+        tag_invoke_t(split_t, get_completion_scheduler_t<set_value_t>(get_env_t(_Sender&)), _Sender, _Env),
         tag_invoke_t(split_t, get_scheduler_t(_Env&), _Sender),
         tag_invoke_t(split_t, get_scheduler_t(_Env&), _Sender, _Env),
         tag_invoke_t(split_t, _Sender),
@@ -3551,8 +3551,8 @@ namespace stdexec {
     using _Env = __1;
     using __cust_sigs =
       __types<
-        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender),
-        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(get_attrs_t(_Sender&)), _Sender, _Env),
+        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(get_env_t(_Sender&)), _Sender),
+        tag_invoke_t(ensure_started_t, get_completion_scheduler_t<set_value_t>(get_env_t(_Sender&)), _Sender, _Env),
         tag_invoke_t(ensure_started_t, get_scheduler_t(_Env&), _Sender),
         tag_invoke_t(ensure_started_t, get_scheduler_t(_Env&), _Sender, _Env),
         tag_invoke_t(ensure_started_t, _Sender),
@@ -3790,10 +3790,10 @@ namespace stdexec {
               };
             }
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
 
           template <__decays_to<__t> _Self, class _Env>
@@ -3818,7 +3818,7 @@ namespace stdexec {
           requires __tag_invocable_with_completion_scheduler<_LetTag, set_value_t, _Sender, _Fun>
         sender auto operator()(_Sender&& __sndr, _Fun __fun) const
           noexcept(nothrow_tag_invocable<_LetTag, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Fun>) {
-          auto __sched = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
+          auto __sched = get_completion_scheduler<set_value_t>(get_env(__sndr));
           return tag_invoke(_LetTag{}, std::move(__sched), (_Sender&&) __sndr, (_Fun&&) __fun);
         }
         template <sender _Sender, __movable_value _Fun>
@@ -3944,10 +3944,10 @@ namespace stdexec {
               return {((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
             }
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
 
           template <class... _Tys>
@@ -4106,7 +4106,7 @@ namespace stdexec {
             }
           };
 
-          friend __attrs tag_invoke(get_attrs_t, const __schedule_task& __self) noexcept {
+          friend __attrs tag_invoke(get_env_t, const __schedule_task& __self) noexcept {
             return __attrs{__self.__loop_};
           }
 
@@ -4419,7 +4419,7 @@ namespace stdexec {
             return {__self.__attrs_.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
           }
 
-          friend const _Attrs& tag_invoke(get_attrs_t, const __t& __self) noexcept {
+          friend const _Attrs& tag_invoke(get_env_t, const __t& __self) noexcept {
             return __self.__attrs_;
           }
 
@@ -4481,7 +4481,7 @@ namespace stdexec {
       tag_invoke_result_t<transfer_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Scheduler>
       operator()(_Sender&& __sndr, _Scheduler&& __sched) const
         noexcept(nothrow_tag_invocable<transfer_t, __completion_scheduler_for<_Sender, set_value_t>, _Sender, _Scheduler>) {
-        auto csch = get_completion_scheduler<set_value_t>(get_attrs(__sndr));
+        auto csch = get_completion_scheduler<set_value_t>(get_env(__sndr));
         return tag_invoke(transfer_t{}, std::move(csch), (_Sender&&) __sndr, (_Scheduler&&) __sched);
       }
       template <sender _Sender, scheduler _Scheduler>
@@ -4640,10 +4640,10 @@ namespace stdexec {
                     (_Receiver&&) __rcvr};
           }
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
 
           template <class...>
@@ -4788,10 +4788,10 @@ namespace stdexec {
                 __receiver_t<_Receiver>{(_Receiver&&) __rcvr});
           }
 
-          friend auto tag_invoke(get_attrs_t, const __t& __self)
-            noexcept(__nothrow_callable<get_attrs_t, const _Sender&>)
-            -> __call_result_t<get_attrs_t, const _Sender&> {
-            return get_attrs(__self.__sndr_);
+          friend auto tag_invoke(get_env_t, const __t& __self)
+            noexcept(__nothrow_callable<get_env_t, const _Sender&>)
+            -> __call_result_t<get_env_t, const _Sender&> {
+            return get_env(__self.__sndr_);
           }
 
           template <class _Env>
@@ -5217,7 +5217,7 @@ namespace stdexec {
               -> __completions_t<_Self, _Env>
                 requires true;
 
-          friend __empty_attrs tag_invoke(get_attrs_t, const __t& __self) noexcept {
+          friend __empty_env tag_invoke(get_env_t, const __t& __self) noexcept {
             return {};
           }
 
@@ -5358,7 +5358,7 @@ namespace stdexec {
           friend auto tag_invoke(get_completion_signatures_t, __sender, _Env)
             -> __completions_t<_Env>;
 
-        friend __empty_attrs tag_invoke(get_attrs_t, const __t& __self) noexcept {
+        friend __empty_env tag_invoke(get_env_t, const __t& __self) noexcept {
           return {};
         }
       };
@@ -5499,7 +5499,7 @@ namespace stdexec {
           __completion_scheduler_for<_Sender, set_value_t>,
           _Sender>) {
         auto __sched =
-          get_completion_scheduler<set_value_t>(get_attrs(__sndr));
+          get_completion_scheduler<set_value_t>(get_env(__sndr));
         return tag_invoke(sync_wait_t{}, std::move(__sched), (_Sender&&) __sndr);
       }
 
@@ -5574,7 +5574,7 @@ namespace stdexec {
           "must be sync-wait-with-variant-type<S, sync-wait-env>");
 
         auto __sched =
-          get_completion_scheduler<set_value_t>(get_attrs(__sndr));
+          get_completion_scheduler<set_value_t>(get_env(__sndr));
         return tag_invoke(
           sync_wait_with_variant_t{}, std::move(__sched), (_Sender&&) __sndr);
       }

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -57,8 +57,8 @@
 #endif
 
 #ifdef STDEXEC_ENABLE_R5_DEPRECATIONS
-#define R5_SENDER_DEPR_WARNING [[deprecated("Deprecated sender type detected. Please update the type for to satisfy the sender concept in P2300R7")]]
-#define R5_RECEIVER_DEPR_WARNING [[deprecated("Deprecated receiver type detected. Please update the type for to satisfy the receiver concept in P2300R7")]]
+#define R5_SENDER_DEPR_WARNING [[deprecated("Deprecated sender type detected. Please update the type to satisfy the boolean stdexec::enable_sender<S> trait. Defining a member type alias named 'is_sender' is one way to do this.")]]
+#define R5_RECEIVER_DEPR_WARNING [[deprecated("Deprecated receiver type detected. Please update the type for to satisfy the boolean stdexec::enable_receiver<R> trait. Defining a member type alias named 'is_receiver' is one way to do this.")]]
 #else
 #define R5_SENDER_DEPR_WARNING
 #define R5_RECEIVER_DEPR_WARNING
@@ -2498,6 +2498,8 @@ namespace stdexec {
          public:
           __t() = default;
           using __adaptor_base<_Base>::__adaptor_base;
+
+          using is_receiver = void;
         };
       };
   } // namespace __adaptors

--- a/test/exec/async_scope/test_spawn.cpp
+++ b/test/exec/async_scope/test_spawn.cpp
@@ -28,7 +28,7 @@ struct throwing_sender {
     return {std::forward<Receiver>(rcvr)};
   }
 
-  friend empty_attrs tag_invoke(stdexec::get_attrs_t, const throwing_sender&) noexcept {
+  friend empty_attrs tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {
     return {};
   }
 };

--- a/test/exec/async_scope/test_spawn.cpp
+++ b/test/exec/async_scope/test_spawn.cpp
@@ -28,7 +28,7 @@ struct throwing_sender {
     return {std::forward<Receiver>(rcvr)};
   }
 
-  friend empty_attrs tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {
+  friend empty_env tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {
     return {};
   }
 };

--- a/test/exec/async_scope/test_spawn_future.cpp
+++ b/test/exec/async_scope/test_spawn_future.cpp
@@ -42,7 +42,7 @@ struct throwing_sender {
     return {std::forward<Receiver>(rcvr)};
   }
 
-  friend empty_attrs tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {
+  friend empty_env tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {
     return {};
   }
 };

--- a/test/exec/async_scope/test_spawn_future.cpp
+++ b/test/exec/async_scope/test_spawn_future.cpp
@@ -42,7 +42,7 @@ struct throwing_sender {
     return {std::forward<Receiver>(rcvr)};
   }
 
-  friend empty_attrs tag_invoke(stdexec::get_attrs_t, const throwing_sender&) noexcept {
+  friend empty_attrs tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {
     return {};
   }
 };

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -189,10 +189,10 @@ namespace detail::a_sender {
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const sender_t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const sender_t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
 }
@@ -248,10 +248,10 @@ namespace detail::a_receiverless_sender {
       friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
         -> completion_signatures<Self, Env> requires true;
 
-      friend auto tag_invoke(stdexec::get_attrs_t, const sender_t& self)
-        noexcept(stdexec::__nothrow_callable<stdexec::get_attrs_t, const Sender&>)
-        -> stdexec::__call_result_t<stdexec::get_attrs_t, const Sender&> {
-        return stdexec::get_attrs(self.sndr_);
+      friend auto tag_invoke(stdexec::get_env_t, const sender_t& self)
+        noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
+        -> stdexec::__call_result_t<stdexec::get_env_t, const Sender&> {
+        return stdexec::get_env(self.sndr_);
       }
     };
 }

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -128,16 +128,16 @@ TEST_CASE("then advertises completion schedulers", "[adaptors][then]") {
   }
 }
 
-TEST_CASE("then forwards attrs", "[adaptors][then]") {
-  SECTION("returns attrs by value") {
-    auto snd = just_with_attrs<value_attrs, int>{value_attrs{100}, {0}} | ex::then([]{});
-    static_assert(std::same_as<decltype(ex::get_env(snd)), value_attrs>);
+TEST_CASE("then forwards env", "[adaptors][then]") {
+  SECTION("returns env by value") {
+    auto snd = just_with_env<value_env, int>{value_env{100}, {0}} | ex::then([]{});
+    static_assert(std::same_as<decltype(ex::get_env(snd)), value_env>);
     CHECK(ex::get_env(snd).value == 100);
   }
 
-  SECTION("returns attrs by reference") {
-    auto snd = just_with_attrs<const value_attrs&, int>{value_attrs{100}, {0}} | ex::then([]{});
-    static_assert(std::same_as<decltype(ex::get_env(snd)), const value_attrs&>);
+  SECTION("returns env by reference") {
+    auto snd = just_with_env<const value_env&, int>{value_env{100}, {0}} | ex::then([]{});
+    static_assert(std::same_as<decltype(ex::get_env(snd)), const value_env&>);
     CHECK(ex::get_env(snd).value == 100);
   }
 }

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -120,25 +120,25 @@ TEST_CASE("then advertises completion schedulers", "[adaptors][then]") {
 
   SECTION("for value channel") {
     ex::sender auto snd = ex::schedule(sched) | ex::then([]{});
-    REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(snd)) == sched);
+    REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(snd)) == sched);
   }
   SECTION("for stop channel") {
     ex::sender auto snd = ex::just_stopped() | ex::transfer(sched) | ex::then([]{});
-    REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(snd)) == sched);
+    REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(snd)) == sched);
   }
 }
 
 TEST_CASE("then forwards attrs", "[adaptors][then]") {
   SECTION("returns attrs by value") {
     auto snd = just_with_attrs<value_attrs, int>{value_attrs{100}, {0}} | ex::then([]{});
-    static_assert(std::same_as<decltype(ex::get_attrs(snd)), value_attrs>);
-    CHECK(ex::get_attrs(snd).value == 100);
+    static_assert(std::same_as<decltype(ex::get_env(snd)), value_attrs>);
+    CHECK(ex::get_env(snd).value == 100);
   }
 
   SECTION("returns attrs by reference") {
     auto snd = just_with_attrs<const value_attrs&, int>{value_attrs{100}, {0}} | ex::then([]{});
-    static_assert(std::same_as<decltype(ex::get_attrs(snd)), const value_attrs&>);
-    CHECK(ex::get_attrs(snd).value == 100);
+    static_assert(std::same_as<decltype(ex::get_env(snd)), const value_attrs&>);
+    CHECK(ex::get_env(snd).value == 100);
   }
 }
 

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -317,7 +317,7 @@ struct my_string_sender_t {
     return ex::connect(ex::just(self.str_), std::forward<Recv>(recv));
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_string_sender_t&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_string_sender_t&) noexcept {
     return{};
   }
 };
@@ -368,6 +368,6 @@ TEST_CASE(
   wait_for_value(std::move(snd), std::string{"first program"});
 }
 
-TEST_CASE("when_all returns empty attrs", "[adaptors][when_all]") {
-  check_attrs_type<ex::__empty_env>(ex::when_all(ex::just(), ex::just()));
+TEST_CASE("when_all returns empty env", "[adaptors][when_all]") {
+  check_env_type<ex::__empty_env>(ex::when_all(ex::just(), ex::just()));
 }

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -317,7 +317,7 @@ struct my_string_sender_t {
     return ex::connect(ex::just(self.str_), std::forward<Recv>(recv));
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_string_sender_t&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_string_sender_t&) noexcept {
     return{};
   }
 };
@@ -369,5 +369,5 @@ TEST_CASE(
 }
 
 TEST_CASE("when_all returns empty attrs", "[adaptors][when_all]") {
-  check_attrs_type<ex::__empty_attrs>(ex::when_all(ex::just(), ex::just()));
+  check_attrs_type<ex::__empty_env>(ex::when_all(ex::just(), ex::just()));
 }

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -95,7 +95,7 @@ struct custom_sender {
     *sndr.called = true;
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const custom_sender&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const custom_sender&) noexcept {
     return {};
   }
 };
@@ -108,7 +108,7 @@ struct custom_scheduler {
           return {};
         }
     };
-    friend attrs tag_invoke(ex::get_attrs_t, const sender&) noexcept {
+    friend attrs tag_invoke(ex::get_env_t, const sender&) noexcept {
       return {};
     }
   };

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -95,20 +95,20 @@ struct custom_sender {
     *sndr.called = true;
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const custom_sender&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const custom_sender&) noexcept {
     return {};
   }
 };
 
 struct custom_scheduler {
   struct sender : ex::schedule_result_t<inline_scheduler> {
-    struct attrs {
+    struct env {
       template <class Tag>
-        friend custom_scheduler tag_invoke(ex::get_completion_scheduler_t<Tag>, const attrs&) noexcept {
+        friend custom_scheduler tag_invoke(ex::get_completion_scheduler_t<Tag>, const env&) noexcept {
           return {};
         }
     };
-    friend attrs tag_invoke(ex::get_env_t, const sender&) noexcept {
+    friend env tag_invoke(ex::get_env_t, const sender&) noexcept {
       return {};
     }
   };

--- a/test/stdexec/algos/consumers/test_sync_wait.cpp
+++ b/test/stdexec/algos/consumers/test_sync_wait.cpp
@@ -219,7 +219,7 @@ struct my_other_string_sender_t {
     return ex::connect(ex::just(self.str_), std::forward<Recv>(recv));
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_other_string_sender_t&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_other_string_sender_t&) noexcept {
     return {};
   }
 };
@@ -259,7 +259,7 @@ struct my_multi_value_sender_t {
     return ex::connect(ex::just(self.str_), std::forward<Recv>(recv));
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_multi_value_sender_t&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_multi_value_sender_t&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/algos/consumers/test_sync_wait.cpp
+++ b/test/stdexec/algos/consumers/test_sync_wait.cpp
@@ -219,7 +219,7 @@ struct my_other_string_sender_t {
     return ex::connect(ex::just(self.str_), std::forward<Recv>(recv));
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_other_string_sender_t&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_other_string_sender_t&) noexcept {
     return {};
   }
 };
@@ -259,7 +259,7 @@ struct my_multi_value_sender_t {
     return ex::connect(ex::just(self.str_), std::forward<Recv>(recv));
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_multi_value_sender_t&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_multi_value_sender_t&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/algos/factories/test_just.cpp
+++ b/test/stdexec/algos/factories/test_just.cpp
@@ -39,6 +39,7 @@ TEST_CASE("just returns a sender", "[factories][just]") {
   using t = decltype(ex::just(1));
   static_assert(ex::sender<t>, "ex::just must return a sender");
   REQUIRE(ex::sender<t>);
+  REQUIRE(ex::enable_sender<t>);
 }
 
 TEST_CASE("just can handle multiple values", "[factories][just]") {

--- a/test/stdexec/algos/factories/test_read.cpp
+++ b/test/stdexec/algos/factories/test_read.cpp
@@ -19,5 +19,5 @@
 namespace ex = stdexec;
 
 TEST_CASE("read returns empty attrs", "[factories][read]") {
-  check_attrs_type<ex::__empty_attrs>(ex::read(ex::get_allocator));
+  check_attrs_type<ex::__empty_env>(ex::read(ex::get_allocator));
 }

--- a/test/stdexec/algos/factories/test_read.cpp
+++ b/test/stdexec/algos/factories/test_read.cpp
@@ -18,6 +18,6 @@
 
 namespace ex = stdexec;
 
-TEST_CASE("read returns empty attrs", "[factories][read]") {
-  check_attrs_type<ex::__empty_env>(ex::read(ex::get_allocator));
+TEST_CASE("read returns empty env", "[factories][read]") {
+  check_env_type<ex::__empty_env>(ex::read(ex::get_allocator));
 }

--- a/test/stdexec/algos/factories/test_transfer_just.cpp
+++ b/test/stdexec/algos/factories/test_transfer_just.cpp
@@ -137,14 +137,14 @@ TEST_CASE("transfer_just advertises its completion scheduler", "[factories][tran
   error_scheduler sched2{};
   stopped_scheduler sched3{};
 
-  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(ex::transfer_just(sched1, 1))) == sched1);
-  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(ex::transfer_just(sched1, 1))) == sched1);
+  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(ex::transfer_just(sched1, 1))) == sched1);
+  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(ex::transfer_just(sched1, 1))) == sched1);
 
-  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(ex::transfer_just(sched2, 2))) == sched2);
-  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(ex::transfer_just(sched2, 2))) == sched2);
+  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(ex::transfer_just(sched2, 2))) == sched2);
+  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(ex::transfer_just(sched2, 2))) == sched2);
 
-  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_attrs(ex::transfer_just(sched3, 3))) == sched3);
-  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(ex::transfer_just(sched3, 3))) == sched3);
+  REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(ex::transfer_just(sched3, 3))) == sched3);
+  REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(ex::transfer_just(sched3, 3))) == sched3);
 }
 
 // Modify the value when we invoke this custom defined transfer_just implementation

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -31,7 +31,7 @@ template <class Sender>
   concept sender_with_attrs =
     ex::sender<Sender> &&
     requires (const Sender& s) {
-      ex::get_attrs(s);
+      ex::get_env(s);
     };
 
 template <typename Awaiter>
@@ -224,7 +224,7 @@ struct awaitable_attrs {};
 template <typename Awaiter>
 struct awaitable_with_get_attrs {
   Awaiter operator co_await();
-  friend awaitable_attrs tag_invoke(ex::get_attrs_t, const awaitable_with_get_attrs&) noexcept {
+  friend awaitable_attrs tag_invoke(ex::get_env_t, const awaitable_with_get_attrs&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -29,7 +29,7 @@
 namespace ex = stdexec;
 
 template <class Sender>
-  concept sender_with_attrs =
+  concept sender_with_env =
     ex::sender<Sender> &&
     requires (const Sender& s) {
       ex::get_env(s);
@@ -99,7 +99,7 @@ private:
 template <typename Signatures, typename Awaiter>
 void test_awaitable_sender1(Signatures*, Awaiter&&) {
   static_assert(ex::sender<awaitable_sender_1<Awaiter>>);
-  static_assert(sender_with_attrs<awaitable_sender_1<Awaiter>>);
+  static_assert(sender_with_env<awaitable_sender_1<Awaiter>>);
   static_assert(ex::__awaitable<awaitable_sender_1<Awaiter>>);
 
   static_assert(
@@ -110,7 +110,7 @@ void test_awaitable_sender1(Signatures*, Awaiter&&) {
 
 void test_awaitable_sender2() {
   static_assert(ex::sender<awaitable_sender_2>);
-  static_assert(sender_with_attrs<awaitable_sender_2>);
+  static_assert(sender_with_env<awaitable_sender_2>);
   static_assert(!ex::sender<awaitable_sender_2, ex::__empty_env>);
 
   static_assert(ex::__awaitable<awaitable_sender_2>);
@@ -126,7 +126,7 @@ void test_awaitable_sender2() {
 
 void test_awaitable_sender3() {
   static_assert(ex::sender<awaitable_sender_3>);
-  static_assert(sender_with_attrs<awaitable_sender_3>);
+  static_assert(sender_with_env<awaitable_sender_3>);
   static_assert(!ex::sender<awaitable_sender_3, ex::__empty_env>);
 
   static_assert(ex::__awaiter<awaiter>);
@@ -144,7 +144,7 @@ void test_awaitable_sender3() {
 template <class Signatures>
 void test_awaitable_sender4(Signatures*) {
   static_assert(ex::sender<awaitable_sender_4>);
-  static_assert(sender_with_attrs<awaitable_sender_4>);
+  static_assert(sender_with_env<awaitable_sender_4>);
   static_assert(ex::sender<awaitable_sender_4, ex::__empty_env>);
 
   static_assert(ex::__awaiter<awaiter>);
@@ -171,7 +171,7 @@ struct connect_awaitable_promise
 template <class Signatures>
 void test_awaitable_sender5(Signatures*) {
   static_assert(ex::sender<awaitable_sender_5>);
-  static_assert(sender_with_attrs<awaitable_sender_5>);
+  static_assert(sender_with_env<awaitable_sender_5>);
   static_assert(ex::sender<awaitable_sender_5, ex::__empty_env>);
 
   static_assert(ex::__awaiter<awaiter>);
@@ -221,31 +221,31 @@ TEST_CASE("get completion_signatures for awaitables", "[sndtraits][awaitables]")
       ex::__await_result_t<awaitable_sender_5, connect_awaitable_promise>()));
 }
 
-struct awaitable_attrs {};
+struct awaitable_env {};
 template <typename Awaiter>
-struct awaitable_with_get_attrs {
+struct awaitable_with_get_env {
   Awaiter operator co_await();
-  friend awaitable_attrs tag_invoke(ex::get_env_t, const awaitable_with_get_attrs&) noexcept {
+  friend awaitable_env tag_invoke(ex::get_env_t, const awaitable_with_get_env&) noexcept {
     return {};
   }
 };
 
-TEST_CASE("get_attrs for awaitables", "[sndtraits][awaitables]") {
-  check_attrs_type<ex::__empty_env>(awaitable_sender_1<awaiter>{});
+TEST_CASE("get_env for awaitables", "[sndtraits][awaitables]") {
+  check_env_type<ex::__empty_env>(awaitable_sender_1<awaiter>{});
 #if 0
   // NOT TO SPEC: Until we clean up all R5 sender support from stdexec
   // (specifically, the backwards compatibility layer for R5 senders
   // to satisfy get_env related requirements), get_env on dependent
   // awaitables return a const ref to self.
-  check_attrs_type<ex::__empty_env>(awaitable_sender_2{});
-  check_attrs_type<ex::__empty_env>(awaitable_sender_3{});
+  check_env_type<ex::__empty_env>(awaitable_sender_2{});
+  check_env_type<ex::__empty_env>(awaitable_sender_3{});
 #else
   // Delete these two lines when removing all remnants of R5 sender
   // support.
-  check_attrs_type<const awaitable_sender_2&>(awaitable_sender_2{});
-  check_attrs_type<const awaitable_sender_3&>(awaitable_sender_3{});
+  check_env_type<const awaitable_sender_2&>(awaitable_sender_2{});
+  check_env_type<const awaitable_sender_3&>(awaitable_sender_3{});
 #endif
-  check_attrs_type<awaitable_attrs>(awaitable_with_get_attrs<awaiter>{});
+  check_env_type<awaitable_env>(awaitable_with_get_env<awaiter>{});
 }
 
 TEST_CASE("env_promise bug when CWG 2369 is fixed", "[sndtraits][awaitables]") {

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -230,17 +230,18 @@ struct awaitable_with_get_attrs {
 };
 
 TEST_CASE("get_attrs for awaitables", "[sndtraits][awaitables]") {
-#if 0
-  // NOT TO SPEC
-  // When the __awaitable constrained get_attrs overload is enabled, enable
-  // these checks inside this path of the 'if' directive. get_attrs returns
-  // __empty_env for awaitables by default.
-
   check_attrs_type<ex::__empty_env>(awaitable_sender_1<awaiter>{});
+#if 0
+  // NOT TO SPEC: Until we clean up all R5 sender support from stdexec
+  // (specifically, the backwards compatibility layer for R5 senders
+  // to satisfy get_env related requirements), get_env on dependent
+  // awaitables return a const ref to self.
+  check_attrs_type<ex::__empty_env>(awaitable_sender_2{});
   check_attrs_type<ex::__empty_env>(awaitable_sender_3{});
 #else
-  // And delete these two lines
-  check_attrs_type<const awaitable_sender_1<awaiter>&>(awaitable_sender_1<awaiter>{});
+  // Delete these two lines when removing all remnants of R5 sender
+  // support.
+  check_attrs_type<const awaitable_sender_2&>(awaitable_sender_2{});
   check_attrs_type<const awaitable_sender_3&>(awaitable_sender_3{});
 #endif
   check_attrs_type<awaitable_attrs>(awaitable_with_get_attrs<awaiter>{});

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -234,10 +234,10 @@ TEST_CASE("get_attrs for awaitables", "[sndtraits][awaitables]") {
   // NOT TO SPEC
   // When the __awaitable constrained get_attrs overload is enabled, enable
   // these checks inside this path of the 'if' directive. get_attrs returns
-  // __empty_attrs for awaitables by default.
+  // __empty_env for awaitables by default.
 
-  check_attrs_type<ex::__empty_attrs>(awaitable_sender_1<awaiter>{});
-  check_attrs_type<ex::__empty_attrs>(awaitable_sender_3{});
+  check_attrs_type<ex::__empty_env>(awaitable_sender_1<awaiter>{});
+  check_attrs_type<ex::__empty_env>(awaitable_sender_3{});
 #else
   // And delete these two lines
   check_attrs_type<const awaitable_sender_1<awaiter>&>(awaitable_sender_1<awaiter>{});

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -20,9 +20,9 @@
 namespace ex = stdexec;
 
 template <class Scheduler>
-struct default_attrs {
+struct default_env {
   template <typename CPO>
-  friend Scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const default_attrs&) {
+  friend Scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const default_env&) {
     return {};
   }
 };
@@ -35,7 +35,7 @@ struct my_scheduler {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    friend default_attrs<my_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend default_env<my_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
 
@@ -68,7 +68,7 @@ struct my_scheduler_except {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    friend default_attrs<my_scheduler_except> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend default_env<my_scheduler_except> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -94,7 +94,7 @@ struct noeq_sched {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    friend default_attrs<noeq_sched> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend default_env<noeq_sched> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -114,14 +114,14 @@ struct sched_no_completion {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    struct attrs {
+    struct env {
       friend sched_no_completion tag_invoke(
-        ex::get_completion_scheduler_t<ex::set_error_t>, const attrs&) noexcept {
+        ex::get_completion_scheduler_t<ex::set_error_t>, const env&) noexcept {
         return {};
       }
     };
 
-    friend attrs tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend env tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
 
@@ -139,7 +139,7 @@ TEST_CASE(
   REQUIRE(!ex::scheduler<sched_no_completion>);
 }
 
-struct sched_no_attrs {
+struct sched_no_env {
 
   // P2300R5 senders defined sender queries on the sender itself.
   struct my_sender {
@@ -150,20 +150,20 @@ struct sched_no_attrs {
         ex::set_stopped_t()>;
 
     template <typename CPO>
-    friend sched_no_attrs tag_invoke(
+    friend sched_no_env tag_invoke(
                 ex::get_completion_scheduler_t<CPO>, my_sender) {
       return {};
     }
   };
 
-  friend my_sender tag_invoke(ex::schedule_t, sched_no_attrs) { return {}; }
+  friend my_sender tag_invoke(ex::schedule_t, sched_no_env) { return {}; }
 
-  friend bool operator==(sched_no_attrs, sched_no_attrs) noexcept { return true; }
-  friend bool operator!=(sched_no_attrs, sched_no_attrs) noexcept { return false; }
+  friend bool operator==(sched_no_env, sched_no_env) noexcept { return true; }
+  friend bool operator!=(sched_no_env, sched_no_env) noexcept { return false; }
 };
 
 TEST_CASE(
-    "type without sender get_attrs is still a scheduler",
+    "type without sender get_env is still a scheduler",
     "[concepts][scheduler][r5_backwards_compatibility]") {
-  REQUIRE(ex::scheduler<sched_no_attrs>);
+  REQUIRE(ex::scheduler<sched_no_env>);
 }

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -35,7 +35,7 @@ struct my_scheduler {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    friend default_attrs<my_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend default_attrs<my_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
 
@@ -68,7 +68,7 @@ struct my_scheduler_except {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    friend default_attrs<my_scheduler_except> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend default_attrs<my_scheduler_except> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -94,7 +94,7 @@ struct noeq_sched {
         ex::set_error_t(std::exception_ptr), //
         ex::set_stopped_t()>;
 
-    friend default_attrs<noeq_sched> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend default_attrs<noeq_sched> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -121,7 +121,7 @@ struct sched_no_completion {
       }
     };
 
-    friend attrs tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend attrs tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
 

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -144,6 +144,18 @@ TEST_CASE("check completion signatures for sender that also supports error codes
   check_sends_stopped<false>(ec_sender{});
   REQUIRE(ex::sender_of<ec_sender, ex::set_value_t()>);
 }
+struct my_r5_sender0 {
+  using completion_signatures =
+    ex::completion_signatures<             //
+      ex::set_value_t(),                   //
+      ex::set_error_t(std::exception_ptr), //
+      ex::set_stopped_t()>;
+
+  friend oper tag_invoke(ex::connect_t, my_r5_sender0, empty_recv::recv0&& r) { return {}; }
+};
+TEST_CASE("r5 sender emits deprecated diagnostics", "[concepts][sender]") {
+  ex::get_env(my_r5_sender0{});
+}
 
 #if !STDEXEC_NVHPC()
 // nvc++ doesn't yet implement subsumption correctly

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -155,6 +155,10 @@ struct my_r5_sender0 {
 };
 TEST_CASE("r5 sender emits deprecated diagnostics", "[concepts][sender]") {
   ex::get_env(my_r5_sender0{});
+  static_assert(ex::sender<my_r5_sender0>);
+  static_assert(std::same_as<
+      decltype(ex::get_completion_signatures(my_r5_sender0{}, ex::no_env{})),
+      my_r5_sender0::completion_signatures>);
 }
 
 #if !STDEXEC_NVHPC()

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -81,7 +81,7 @@ struct my_sender0 {
 
   friend oper tag_invoke(ex::connect_t, my_sender0, empty_recv::recv0&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender0&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_sender0&) noexcept {
     return {};
   }
 };
@@ -110,7 +110,7 @@ struct my_sender_int {
 
   friend oper tag_invoke(ex::connect_t, my_sender_int, empty_recv::recv_int&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender_int&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_sender_int&) noexcept {
     return {};
   }
 };
@@ -158,7 +158,7 @@ struct multival_sender {
 
   friend oper tag_invoke(ex::connect_t, multival_sender, empty_recv::recv_int&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const multival_sender&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const multival_sender&) noexcept {
     return {};
   }
 };
@@ -179,7 +179,7 @@ struct ec_sender {
 
   friend oper tag_invoke(ex::connect_t, ec_sender, empty_recv::recv_int&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const ec_sender&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const ec_sender&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -36,7 +36,7 @@ struct my_sender0 {
 
   friend oper tag_invoke(ex::connect_t, my_sender0, empty_recv::recv0&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_sender0&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender0&) noexcept {
     return {};
   }
 };
@@ -65,7 +65,7 @@ struct my_sender_int {
 
   friend oper tag_invoke(ex::connect_t, my_sender_int, empty_recv::recv_int&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_sender_int&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender_int&) noexcept {
     return {};
   }
 };
@@ -113,7 +113,7 @@ struct multival_sender {
 
   friend oper tag_invoke(ex::connect_t, multival_sender, empty_recv::recv_int&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const multival_sender&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const multival_sender&) noexcept {
     return {};
   }
 };
@@ -134,7 +134,7 @@ struct ec_sender {
 
   friend oper tag_invoke(ex::connect_t, ec_sender, empty_recv::recv_int&& r) { return {}; }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const ec_sender&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const ec_sender&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -30,7 +30,7 @@ struct cpo_t {
       ex::set_error_t(std::exception_ptr),                 //
       ex::set_stopped_t()>;
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const cpo_t&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const cpo_t&) noexcept {
     return {};
   }
 };
@@ -47,16 +47,16 @@ struct free_standing_sender_t {
     return cpo_t<scope_t::free_standing>{};
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const free_standing_sender_t&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const free_standing_sender_t&) noexcept {
     return {};
   }
 };
 
 template <class CPO, class... CompletionSignals>
 struct scheduler_t {
-  struct attrs_t {
+  struct env_t {
     template <stdexec::__one_of<ex::set_value_t, CompletionSignals...> Tag>
-    friend scheduler_t tag_invoke(ex::get_completion_scheduler_t<Tag>, const attrs_t&) noexcept {
+    friend scheduler_t tag_invoke(ex::get_completion_scheduler_t<Tag>, const env_t&) noexcept {
       return {};
     }
   };
@@ -66,7 +66,7 @@ struct scheduler_t {
         ex::set_error_t(std::exception_ptr),                 //
         ex::set_stopped_t()>;
 
-    friend attrs_t tag_invoke(ex::get_env_t, const sender_t&) noexcept {
+    friend env_t tag_invoke(ex::get_env_t, const sender_t&) noexcept {
       return {};
     }
   };
@@ -81,4 +81,3 @@ struct scheduler_t {
   friend bool operator==(scheduler_t, scheduler_t) noexcept { return true; }
   friend bool operator!=(scheduler_t, scheduler_t) noexcept { return false; }
 };
-

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -30,7 +30,7 @@ struct cpo_t {
       ex::set_error_t(std::exception_ptr),                 //
       ex::set_stopped_t()>;
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const cpo_t&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const cpo_t&) noexcept {
     return {};
   }
 };
@@ -47,7 +47,7 @@ struct free_standing_sender_t {
     return cpo_t<scope_t::free_standing>{};
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const free_standing_sender_t&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const free_standing_sender_t&) noexcept {
     return {};
   }
 };
@@ -66,7 +66,7 @@ struct scheduler_t {
         ex::set_error_t(std::exception_ptr),                 //
         ex::set_stopped_t()>;
 
-    friend attrs_t tag_invoke(ex::get_attrs_t, const sender_t&) noexcept {
+    friend attrs_t tag_invoke(ex::get_env_t, const sender_t&) noexcept {
       return {};
     }
   };

--- a/test/stdexec/cpos/test_cpo_connect.cpp
+++ b/test/stdexec/cpos/test_cpo_connect.cpp
@@ -42,7 +42,7 @@ struct my_sender  {
     return {{}, s.value_, (R &&) r};
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_sender&) noexcept {
     return {};
   }
 };
@@ -58,7 +58,7 @@ struct my_sender_unconstrained {
     return {{}, s.value_, (R &&) r};
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender_unconstrained&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_sender_unconstrained&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/cpos/test_cpo_connect.cpp
+++ b/test/stdexec/cpos/test_cpo_connect.cpp
@@ -42,7 +42,7 @@ struct my_sender  {
     return {{}, s.value_, (R &&) r};
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender&) noexcept {
     return {};
   }
 };
@@ -58,7 +58,7 @@ struct my_sender_unconstrained {
     return {{}, s.value_, (R &&) r};
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_sender_unconstrained&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender_unconstrained&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/cpos/test_cpo_schedule.cpp
+++ b/test/stdexec/cpos/test_cpo_schedule.cpp
@@ -29,7 +29,7 @@ struct my_sender {
 
   bool from_scheduler_{false};
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const my_sender&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/cpos/test_cpo_schedule.cpp
+++ b/test/stdexec/cpos/test_cpo_schedule.cpp
@@ -29,7 +29,7 @@ struct my_sender {
 
   bool from_scheduler_{false};
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const my_sender&) noexcept {
     return {};
   }
 };

--- a/test/stdexec/cpos/test_cpo_upon_error.cpp
+++ b/test/stdexec/cpos/test_cpo_upon_error.cpp
@@ -43,7 +43,7 @@ TEST_CASE("upon_error is customizable", "[cpo][cpo_upon_error]") {
     }
 
     {
-      ex::get_completion_scheduler<ex::set_error_t>(ex::get_attrs(snd));
+      ex::get_completion_scheduler<ex::set_error_t>(ex::get_env(snd));
       constexpr scope_t scope = decltype(ex::upon_error(snd, f))::scope;
       STATIC_REQUIRE(scope == scope_t::scheduler);
     }

--- a/test/stdexec/cpos/test_cpo_upon_stopped.cpp
+++ b/test/stdexec/cpos/test_cpo_upon_stopped.cpp
@@ -43,7 +43,7 @@ TEST_CASE("upon_stopped is customizable", "[cpo][cpo_upon_stopped]") {
     }
 
     {
-      ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_attrs(snd));
+      ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(snd));
       constexpr scope_t scope = decltype(ex::upon_stopped(snd, f))::scope;
       STATIC_REQUIRE(scope == scope_t::scheduler);
     }

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -37,14 +37,14 @@ struct uncustomized_scheduler {
       return {};
     }
 
-    struct attrs {
+    struct env {
       template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-      friend uncustomized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const attrs&) noexcept {
+      friend uncustomized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const env&) noexcept {
         return {};
       }
     };
 
-    friend attrs tag_invoke(ex::get_env_t, const sender&) noexcept {
+    friend env tag_invoke(ex::get_env_t, const sender&) noexcept {
       return {};
     }
   };
@@ -68,14 +68,14 @@ struct customized_scheduler {
       return {};
     }
 
-    struct attrs {
+    struct env {
       template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-      friend customized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const attrs&) noexcept {
+      friend customized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const env&) noexcept {
         return {};
       }
     };
 
-    friend attrs tag_invoke(ex::get_env_t, const sender&) noexcept {
+    friend env tag_invoke(ex::get_env_t, const sender&) noexcept {
       return {};
     }
   };

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -44,7 +44,7 @@ struct uncustomized_scheduler {
       }
     };
 
-    friend attrs tag_invoke(ex::get_attrs_t, const sender&) noexcept {
+    friend attrs tag_invoke(ex::get_env_t, const sender&) noexcept {
       return {};
     }
   };
@@ -75,7 +75,7 @@ struct customized_scheduler {
       }
     };
 
-    friend attrs tag_invoke(ex::get_attrs_t, const sender&) noexcept {
+    friend attrs tag_invoke(ex::get_env_t, const sender&) noexcept {
       return {};
     }
   };

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -89,7 +89,7 @@ struct impulse_scheduler {
       return {self.shared_data_, (R &&) r};
     }
 
-    friend scheduler_attrs<impulse_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend scheduler_attrs<impulse_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -143,7 +143,7 @@ struct inline_scheduler {
       return {{}, (R &&) r};
     }
 
-    friend scheduler_attrs<inline_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend scheduler_attrs<inline_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -180,7 +180,7 @@ struct error_scheduler {
       return {{}, (R &&) r, (E &&) self.err_};
     }
 
-    friend scheduler_attrs<error_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend scheduler_attrs<error_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -211,7 +211,7 @@ struct stopped_scheduler {
       return {{}, (R &&) r};
     }
 
-    friend scheduler_attrs<stopped_scheduler> tag_invoke(ex::get_attrs_t, const my_sender&) noexcept {
+    friend scheduler_attrs<stopped_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -25,9 +25,9 @@
 namespace ex = stdexec;
 
 template <class S>
-struct scheduler_attrs {
+struct scheduler_env {
   template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-  friend S tag_invoke(ex::get_completion_scheduler_t<CPO>, const scheduler_attrs&) noexcept {
+  friend S tag_invoke(ex::get_completion_scheduler_t<CPO>, const scheduler_env&) noexcept {
     return {};
   }
 };
@@ -89,7 +89,7 @@ struct impulse_scheduler {
       return {self.shared_data_, (R &&) r};
     }
 
-    friend scheduler_attrs<impulse_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend scheduler_env<impulse_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -143,7 +143,7 @@ struct inline_scheduler {
       return {{}, (R &&) r};
     }
 
-    friend scheduler_attrs<inline_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend scheduler_env<inline_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -180,7 +180,7 @@ struct error_scheduler {
       return {{}, (R &&) r, (E &&) self.err_};
     }
 
-    friend scheduler_attrs<error_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend scheduler_env<error_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };
@@ -211,7 +211,7 @@ struct stopped_scheduler {
       return {{}, (R &&) r};
     }
 
-    friend scheduler_attrs<stopped_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+    friend scheduler_env<stopped_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
       return {};
     }
   };

--- a/test/test_common/senders.hpp
+++ b/test/test_common/senders.hpp
@@ -52,7 +52,7 @@ struct fallible_just {
     return {{}, std::move(self.values_), std::forward<Receiver>(rcvr)};
   }
 
-  friend empty_attrs tag_invoke(ex::get_env_t, const fallible_just&) noexcept {
+  friend empty_env tag_invoke(ex::get_env_t, const fallible_just&) noexcept {
     return {};
   }
 };
@@ -60,13 +60,13 @@ struct fallible_just {
 template <class... Values>
 fallible_just(Values...) -> fallible_just<Values...>;
 
-struct value_attrs {
+struct value_env {
   int value;
 };
 
 template <class Attrs, class... Values>
-struct just_with_attrs {
-  std::remove_cvref_t<Attrs> attrs_;
+struct just_with_env {
+  std::remove_cvref_t<Attrs> env_;
   std::tuple<Values...> values_;
   using completion_signatures =
     ex::completion_signatures<ex::set_value_t(Values...)>;
@@ -86,12 +86,12 @@ struct just_with_attrs {
   };
 
   template <class Receiver>
-  friend auto tag_invoke(ex::connect_t, just_with_attrs&& self, Receiver&& rcvr) ->
+  friend auto tag_invoke(ex::connect_t, just_with_env&& self, Receiver&& rcvr) ->
       operation<std::decay_t<Receiver>> {
     return {{}, std::move(self.values_), std::forward<Receiver>(rcvr)};
   }
 
-  friend Attrs tag_invoke(ex::get_env_t, const just_with_attrs& self) noexcept {
-    return self.attrs_;
+  friend Attrs tag_invoke(ex::get_env_t, const just_with_env& self) noexcept {
+    return self.env_;
   }
 };

--- a/test/test_common/senders.hpp
+++ b/test/test_common/senders.hpp
@@ -52,7 +52,7 @@ struct fallible_just {
     return {{}, std::move(self.values_), std::forward<Receiver>(rcvr)};
   }
 
-  friend empty_attrs tag_invoke(ex::get_attrs_t, const fallible_just&) noexcept {
+  friend empty_attrs tag_invoke(ex::get_env_t, const fallible_just&) noexcept {
     return {};
   }
 };
@@ -91,7 +91,7 @@ struct just_with_attrs {
     return {{}, std::move(self.values_), std::forward<Receiver>(rcvr)};
   }
 
-  friend Attrs tag_invoke(ex::get_attrs_t, const just_with_attrs& self) noexcept {
+  friend Attrs tag_invoke(ex::get_env_t, const just_with_attrs& self) noexcept {
     return self.attrs_;
   }
 };

--- a/test/test_common/type_helpers.hpp
+++ b/test/test_common/type_helpers.hpp
@@ -47,9 +47,6 @@ struct type_printer;
 template <typename... Ts>
 struct type_array {};
 
-//! Used as a default empty attributes
-struct empty_attrs {};
-
 //! Used as a default empty context
 struct empty_env {};
 
@@ -60,9 +57,9 @@ inline void check_val_types(S snd) {
   static_assert(std::same_as<t, ExpectedValType>);
 }
 
-//! Check that the attrs of a sender matches the expected type
+//! Check that the env of a sender matches the expected type
 template <typename ExpectedAttrsType, typename S>
-inline void check_attrs_type(S snd) {
+inline void check_env_type(S snd) {
   using t = decltype(ex::get_env(snd));
   static_assert(std::same_as<t, ExpectedAttrsType>);
 }

--- a/test/test_common/type_helpers.hpp
+++ b/test/test_common/type_helpers.hpp
@@ -63,7 +63,7 @@ inline void check_val_types(S snd) {
 //! Check that the attrs of a sender matches the expected type
 template <typename ExpectedAttrsType, typename S>
 inline void check_attrs_type(S snd) {
-  using t = decltype(ex::get_attrs(snd));
+  using t = decltype(ex::get_env(snd));
   static_assert(std::same_as<t, ExpectedAttrsType>);
 }
 


### PR DESCRIPTION
This does not enable the trait on receivers or senders (ones returned from algos, or the ones defined in the tests or examples). The exception is stdexec::just, which now exposes `using is_sender = void` to prove out a new test.

One significant-ish change I'll need feedback on is the refactor of `get_env`, which provides forwards and backwards compatibility for R5 and R7 sender types. I also introduced a facility to emit deprecation diagnostics for sender types that are not R7 compatible, along with hints about what to change ("add get_env" or "satisfy enable_sender"). I think we'll want a compile time enablement switch/macro for this, but I'm mostly looking for feedback on whether we should introduce a deprecation notice via this strategy of guessing whether a type is R5 vs R7 with "close enough" concept checks.

The [sed -i -r get-attrs -> get_env](https://github.com/NVIDIA/stdexec/commit/af41a488731cac45ac4dc95cb082ad7b1fa4237e) commit is find/replace, and most interesting changes are in execution.hpp anyway.