### PR TITLE
Fix ADL isolation for cvref forwarding

### DIFF
--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -578,7 +578,7 @@ namespace nvexec {
           operation_state_base_t<stdexec::__id<OuterReceiver>>&>;
 
     template <class Sender, class InnerReceiver, class OuterReceiver>
-      using stream_op_state_t = operation_state_t<stdexec::__cvref_id<Sender, Sender>,
+      using stream_op_state_t = operation_state_t<stdexec::__cvref_id<Sender, std::remove_cvref_t<Sender>>,
                                                   stdexec::__id<InnerReceiver>,
                                                   stdexec::__id<OuterReceiver>>;
 

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -538,7 +538,7 @@ namespace nvexec {
         requires stream_receiver<OuterReceiver>
       using exit_operation_state_t 
         = operation_state_t<
-            stdexec::__cvref_id<Sender, Sender>, 
+            stdexec::__cvref_id<Sender, std::remove_cvref_t<Sender>>,
             stdexec::__id<stdexec::__t<propagate_receiver_t<stdexec::__id<OuterReceiver>>>>, 
             stdexec::__id<OuterReceiver>>;
 

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -446,11 +446,11 @@ namespace nvexec {
         };
       };
 
-    template <class SenderId, class InnerReceiverId, class OuterReceiverId>
+    template <class CvrefSenderId, class InnerReceiverId, class OuterReceiverId>
       struct operation_state_ {
         struct __t : operation_state_base_t<OuterReceiverId> {
           using __id = operation_state_;
-          using sender_t = stdexec::__t<SenderId>;
+          using sender_t = stdexec::__cvref_t<CvrefSenderId>;
           using inner_receiver_t = stdexec::__t<InnerReceiverId>;
           using outer_receiver_t = stdexec::__t<OuterReceiverId>;
           using typename operation_state_base_t<OuterReceiverId>::env_t;
@@ -531,14 +531,14 @@ namespace nvexec {
         };
       };
 
-    template <class SenderId, class InnerReceiverId, class OuterReceiverId>
-      using operation_state_t = stdexec::__t<operation_state_<SenderId, InnerReceiverId, OuterReceiverId>>;
+    template <class CvrefSenderId, class InnerReceiverId, class OuterReceiverId>
+      using operation_state_t = stdexec::__t<operation_state_<CvrefSenderId, InnerReceiverId, OuterReceiverId>>;
 
     template <class Sender, class OuterReceiver>
         requires stream_receiver<OuterReceiver>
       using exit_operation_state_t 
         = operation_state_t<
-            stdexec::__id<Sender>, 
+            stdexec::__cvref_id<Sender, Sender>, 
             stdexec::__id<stdexec::__t<propagate_receiver_t<stdexec::__id<OuterReceiver>>>>, 
             stdexec::__id<OuterReceiver>>;
 
@@ -578,7 +578,7 @@ namespace nvexec {
           operation_state_base_t<stdexec::__id<OuterReceiver>>&>;
 
     template <class Sender, class InnerReceiver, class OuterReceiver>
-      using stream_op_state_t = operation_state_t<stdexec::__id<Sender>,
+      using stream_op_state_t = operation_state_t<stdexec::__cvref_id<Sender, Sender>,
                                                   stdexec::__id<InnerReceiver>,
                                                   stdexec::__id<OuterReceiver>>;
 

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -534,11 +534,11 @@ namespace nvexec {
     template <class CvrefSenderId, class InnerReceiverId, class OuterReceiverId>
       using operation_state_t = stdexec::__t<operation_state_<CvrefSenderId, InnerReceiverId, OuterReceiverId>>;
 
-    template <class Sender, class OuterReceiver>
+    template <class CvrefSender, class OuterReceiver>
         requires stream_receiver<OuterReceiver>
       using exit_operation_state_t 
         = operation_state_t<
-            stdexec::__cvref_id<Sender, std::remove_cvref_t<Sender>>,
+            stdexec::__cvref_id<CvrefSender, std::remove_cvref_t<CvrefSender>>,
             stdexec::__id<stdexec::__t<propagate_receiver_t<stdexec::__id<OuterReceiver>>>>, 
             stdexec::__id<OuterReceiver>>;
 
@@ -577,8 +577,8 @@ namespace nvexec {
           InnerReceiverProvider,
           operation_state_base_t<stdexec::__id<OuterReceiver>>&>;
 
-    template <class Sender, class InnerReceiver, class OuterReceiver>
-      using stream_op_state_t = operation_state_t<stdexec::__cvref_id<Sender, std::remove_cvref_t<Sender>>,
+    template <class CvrefSender, class InnerReceiver, class OuterReceiver>
+      using stream_op_state_t = operation_state_t<stdexec::__cvref_id<CvrefSender, std::remove_cvref_t<CvrefSender>>,
                                                   stdexec::__id<InnerReceiver>,
                                                   stdexec::__id<OuterReceiver>>;
 

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -24,9 +24,9 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
 namespace schedule_from {
-  template <class SenderId, class ReceiverId>
+  template <class CvrefSenderId, class ReceiverId>
     struct receiver_t {
-      using Sender = stdexec::__t<SenderId>;
+      using Sender = stdexec::__cvref_t<CvrefSenderId>;
       using Receiver = stdexec::__t<ReceiverId>;
       using Env = typename operation_state_base_t<ReceiverId>::env_t;
 
@@ -108,7 +108,7 @@ template <class Scheduler, class SenderId>
         using receiver_t =
           stdexec::__t<
             schedule_from::receiver_t<
-              stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>,
+              stdexec::__cvref_id<Self, Sender>,
               stdexec::__id<Receiver>>>;
 
       template <stdexec::__decays_to<__t> Self, stdexec::receiver Receiver>
@@ -142,3 +142,4 @@ template <class Scheduler, class SenderId>
     };
   };
 }
+

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -23,9 +23,9 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
  
 namespace transfer {
-  template <class SenderId, class ReceiverId>
+  template <class CvrefSenderId, class ReceiverId>
     struct operation_state_t {
-      using Sender = stdexec::__t<SenderId>;
+      using Sender = stdexec::__cvref_t<CvrefSenderId>;
       using Receiver = stdexec::__t<ReceiverId>;
       using Env = typename operation_state_base_t<ReceiverId>::env_t;
 
@@ -110,7 +110,7 @@ template <class SenderId>
         using op_state_th = 
           stdexec::__t<
             transfer::operation_state_t<
-              stdexec::__id<stdexec::__copy_cvref_t<Self, Sender>>, 
+              stdexec::__cvref_id<Self, Sender>,
               stdexec::__id<Receiver>>>;
 
       context_state_t context_state_;

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -468,15 +468,22 @@ namespace stdexec {
     using __x = __t<_X<_Ty>>;
 
   template <class _Ty>
-    struct _Y {
-      using __t = _Ty;
-    };
-
-  template <class _Ty>
     concept __has_id =
       requires {
         typename _Ty::__id;
       };
+
+  template <class _Ty>
+    struct _Y {
+      using __t = _Ty;
+
+      // Uncomment the line below to find any code that likely misuses the
+      // ADL isolation mechanism. In particular, '__id<T>' when T is a
+      // reference is a likely misuse. The static_assert below will trigger
+      // when the type passed to the __id alias template is a reference to
+      // a type that is setup to use ADL isolation.
+      //static_assert(!__has_id<std::remove_cvref_t<_Ty>>);
+    };
   template <bool = true>
     struct __id_ {
       template <class _Ty>

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -490,6 +490,12 @@ namespace stdexec {
   template <class _Ty>
     using __id = __minvoke<__id_<__has_id<_Ty>>, _Ty>;
 
+  template <class _Ty>
+    using __cvref_t = __copy_cvref_t<_Ty, __t<std::remove_cvref_t<_Ty>>>;
+
+  template <class _From, class _To>
+    using __cvref_id = __copy_cvref_t<_From, __id<std::remove_cvref_t<_To>>>;
+
   template <class _Fun, class... _As>
     concept __callable =
       requires (_Fun&& __fun, _As&&... __as) {

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -501,7 +501,7 @@ namespace stdexec {
     using __cvref_t = __copy_cvref_t<_Ty, __t<std::remove_cvref_t<_Ty>>>;
 
   template <class _From, class _To>
-    using __cvref_id = __copy_cvref_t<_From, __id<std::remove_cvref_t<_To>>>;
+    using __cvref_id = __copy_cvref_t<_From, __id<_To>>;
 
   template <class _Fun, class... _As>
     concept __callable =

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4017,9 +4017,9 @@ namespace stdexec {
         };
       };
 
-    template <class _CvrefSenderId>
+    template <class _SenderId>
       struct __sender {
-        using _Sender = stdexec::__cvref_t<_CvrefSenderId>;
+        using _Sender = stdexec::__t<_SenderId>;
 
         struct __t {
           using __id = __sender;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -3805,28 +3805,28 @@ namespace stdexec {
         };
       };
 
-    template <class _SenderId, class _ReceiverId, class _Fun, class _Let>
+    template <class _CvrefSenderId, class _ReceiverId, class _Fun, class _Let>
       using __receiver =
         stdexec::__t<
           __gather_completions_for<
             _Let,
-            __t<_SenderId>,
+            __cvref_t<_CvrefSenderId>,
             env_of_t<__t<_ReceiverId>>,
             __q<__decayed_tuple>,
             __munique<__mbind_front_q<__receiver_, _ReceiverId, _Fun, _Let>>>>;
 
-    template <class _SenderId, class _ReceiverId, class _Fun, class _Let>
+    template <class _CvrefSenderId, class _ReceiverId, class _Fun, class _Let>
       using __operation_base =
-        typename __receiver<_SenderId, _ReceiverId, _Fun, _Let>::__operation_base_t;
+        typename __receiver<_CvrefSenderId, _ReceiverId, _Fun, _Let>::__operation_base_t;
 
-    template <class _SenderId, class _ReceiverId, class _Fun, class _Let>
+    template <class _CvrefSenderId, class _ReceiverId, class _Fun, class _Let>
       struct __operation {
-        using _Sender = stdexec::__t<_SenderId>;
+        using _Sender = stdexec::__cvref_t<_CvrefSenderId>;
 
-        struct __t : __operation_base<_SenderId, _ReceiverId, _Fun, _Let> {
+        struct __t : __operation_base<_CvrefSenderId, _ReceiverId, _Fun, _Let> {
           using __id = __operation;
-          using __op_base_t = __operation_base<_SenderId, _ReceiverId, _Fun, _Let>;
-          using __receiver_t = __receiver<_SenderId, _ReceiverId, _Fun, _Let>;
+          using __op_base_t = __operation_base<_CvrefSenderId, _ReceiverId, _Fun, _Let>;
+          using __receiver_t = __receiver<_CvrefSenderId, _ReceiverId, _Fun, _Let>;
 
           friend void tag_invoke(start_t, __t& __self) noexcept {
             start(__self.__op_state2_);
@@ -3853,14 +3853,14 @@ namespace stdexec {
           template <class _Self, class _Receiver>
             using __operation_t =
               stdexec::__t<__operation<
-                stdexec::__id<__copy_cvref_t<_Self, _Sender>>,
+                stdexec::__cvref_id<_Self, _Sender>,
                 stdexec::__id<_Receiver>,
                 _Fun,
                 _Set>>;
           template <class _Self, class _Receiver>
             using __receiver_t =
               __receiver<
-                stdexec::__id<__copy_cvref_t<_Self, _Sender>>,
+                stdexec::__cvref_id<_Self, _Sender>,
                 stdexec::__id<_Receiver>,
                 _Fun,
                 _Set>;
@@ -3959,12 +3959,12 @@ namespace stdexec {
   // [execution.senders.adaptors.stopped_as_optional]
   // [execution.senders.adaptors.stopped_as_error]
   namespace __stopped_as_xxx {
-    template <class _SenderId, class _ReceiverId>
+    template <class _CvrefSenderId, class _ReceiverId>
       struct __operation;
 
-    template <class _SenderId, class _ReceiverId>
+    template <class _CvrefSenderId, class _ReceiverId>
       struct __receiver {
-        using _Sender = stdexec::__t<_SenderId>;
+        using _Sender = stdexec::__t<_CvrefSenderId>;
         using _Receiver = stdexec::__t<_ReceiverId>;
 
         struct __t : receiver_adaptor<__t> {
@@ -3990,15 +3990,15 @@ namespace stdexec {
             stdexec::set_value(((__t&&) *this).base(), std::optional<_Value>{std::nullopt});
           }
 
-          stdexec::__t<__operation<_SenderId, _ReceiverId>>* __op_;
+          stdexec::__t<__operation<_CvrefSenderId, _ReceiverId>>* __op_;
         };
       };
 
-    template <class _SenderId, class _ReceiverId>
+    template <class _CvrefSenderId, class _ReceiverId>
       struct __operation {
-        using _Sender = stdexec::__t<_SenderId>;
+        using _Sender = stdexec::__t<_CvrefSenderId>;
         using _Receiver = stdexec::__t<_ReceiverId>;
-        using __receiver_t = stdexec::__t<__receiver<_SenderId, _ReceiverId>>;
+        using __receiver_t = stdexec::__t<__receiver<_CvrefSenderId, _ReceiverId>>;
 
         struct __t {
           using __id = __operation;
@@ -4017,19 +4017,19 @@ namespace stdexec {
         };
       };
 
-    template <class _SenderId>
+    template <class _CvrefSenderId>
       struct __sender {
-        using _Sender = stdexec::__t<_SenderId>;
+        using _Sender = stdexec::__cvref_t<_CvrefSenderId>;
 
         struct __t {
           using __id = __sender;
 
           template <class _Self, class _Receiver>
             using __operation_t =
-              stdexec::__t<__operation<stdexec::__id<__copy_cvref_t<_Self, _Sender>>, stdexec::__id<_Receiver>>>;
+              stdexec::__t<__operation<stdexec::__cvref_id<_Self, _Sender>, stdexec::__id<_Receiver>>>;
           template <class _Self, class _Receiver>
             using __receiver_t =
-              stdexec::__t<__receiver<stdexec::__id<__copy_cvref_t<_Self, _Sender>>, stdexec::__id<_Receiver>>>;
+              stdexec::__t<__receiver<stdexec::__cvref_id<_Self, _Sender>, stdexec::__id<_Receiver>>>;
 
           template <__decays_to<__t> _Self, receiver _Receiver>
               requires __single_typed_sender<__copy_cvref_t<_Self, _Sender>, env_of_t<_Receiver>> &&
@@ -4384,7 +4384,6 @@ namespace stdexec {
     template <class _SchedulerId, class _CvrefSenderId, class _ReceiverId>
       struct __receiver1 {
         using _Scheduler = stdexec::__t<_SchedulerId>;
-        using _CvrefSender = stdexec::__t<_CvrefSenderId>;
         using _Receiver = stdexec::__t<_ReceiverId>;
         using __receiver2_t =
           stdexec::__t<__receiver2<_SchedulerId, _CvrefSenderId, _ReceiverId>>;
@@ -4428,7 +4427,7 @@ namespace stdexec {
     template <class _SchedulerId, class _CvrefSenderId, class _ReceiverId>
       struct __operation1 {
         using _Scheduler = stdexec::__t<_SchedulerId>;
-        using _CvrefSender = stdexec::__t<_CvrefSenderId>;
+        using _CvrefSender = stdexec::__cvref_t<_CvrefSenderId>;
         using _Receiver = stdexec::__t<_ReceiverId>;
         using __receiver1_t =
           stdexec::__t<__receiver1<_SchedulerId, _CvrefSenderId, _ReceiverId>>;
@@ -4510,7 +4509,7 @@ namespace stdexec {
           template <__decays_to<__t> _Self, class _Receiver>
             requires sender_to<__copy_cvref_t<_Self, _Sender>, _Receiver>
           friend auto tag_invoke(connect_t, _Self&& __self, _Receiver __rcvr)
-              -> stdexec::__t<__operation1<_SchedulerId, stdexec::__id<__copy_cvref_t<_Self, _Sender>>, stdexec::__id<_Receiver>>> {
+              -> stdexec::__t<__operation1<_SchedulerId, stdexec::__cvref_id<_Self, _Sender>, stdexec::__id<_Receiver>>> {
             return {__self.__env_.__sched_, ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr};
           }
 


### PR DESCRIPTION
These were instances of where `__id` could be passed a reference