### PR TITLE
Conditionally call `set_error` on receiver connected to `schedule_from`

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4701,7 +4701,7 @@ namespace stdexec {
         using __all_nothrow_decay_copyable = __bool<(__nothrow_decay_copyable<_Errs> && ...)>;
 
         template <class _Env>
-        using __with_error_t = //
+        using __scheduler_with_error_t = //
           __if_c<
             __v<error_types_of_t<schedule_result_t<_Scheduler>, _Env, __all_nothrow_decay_copyable>>,
             completion_signatures<>,
@@ -4712,15 +4712,25 @@ namespace stdexec {
           __make_completion_signatures<
             schedule_result_t<_Scheduler>,
             _Env,
-            __with_error_t<_Env>,
+            __scheduler_with_error_t<_Env>,
             __mconst<completion_signatures<>>>;
+
+        template <class _Env>
+        using __input_sender_with_error_t = //
+          __if_c<
+            __v<value_types_of_t<_Sender, _Env, __all_nothrow_decay_copyable, __mand>> &&
+            __v<error_types_of_t<_Sender, _Env, __all_nothrow_decay_copyable>>,
+            completion_signatures<>,
+            __with_exception_ptr>;
 
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env)
           -> __make_completion_signatures<
             __copy_cvref_t<_Self, _Sender>,
             _Env,
-            __scheduler_completions_t<_Env>,
+            __concat_completion_signatures_t<
+              __scheduler_completions_t<_Env>,
+              __input_sender_with_error_t<_Env>>,
             __decay_signature<set_value_t>,
             __decay_signature<set_error_t>>;
       };

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4634,7 +4634,8 @@ namespace stdexec {
           start(__op_state.__state1_);
         }
 
-        void __complete() noexcept try {
+        void __complete() noexcept {
+          STDEXEC_ASSERT(!__data_.valueless_by_exception());
           std::visit(
             [&]<class _Tup>(_Tup& __tupl) -> void {
               if constexpr (same_as<_Tup, std::monostate>) {
@@ -4642,15 +4643,13 @@ namespace stdexec {
               } else {
                 std::apply(
                   [&]<class... _Args>(auto __tag, _Args&... __args) -> void {
-                    __tag((_Receiver&&) __rcvr_, (_Args&&) __args...);
+                    __try_call(
+                      (_Receiver &&) __rcvr_, __tag, (_Receiver &&) __rcvr_, (_Args &&) __args...);
                   },
                   __tupl);
               }
             },
             __data_);
-        } catch (...) {
-
-          set_error((_Receiver&&) __rcvr_, std::current_exception());
         }
       };
     };

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4643,8 +4643,7 @@ namespace stdexec {
               } else {
                 std::apply(
                   [&]<class... _Args>(auto __tag, _Args&... __args) -> void {
-                    __try_call(
-                      (_Receiver &&) __rcvr_, __tag, (_Receiver &&) __rcvr_, (_Args &&) __args...);
+                    __tag((_Receiver &&) __rcvr_, (_Args &&) __args...);
                   },
                   __tupl);
               }

--- a/test/stdexec/algos/adaptors/test_schedule_from.cpp
+++ b/test/stdexec/algos/adaptors/test_schedule_from.cpp
@@ -197,6 +197,12 @@ TEST_CASE("schedule_from keeps error_types from scheduler's sender", "[adaptors]
   check_err_types<type_array<int>>(ex::schedule_from(sched3, ex::just(3)));
 }
 
+TEST_CASE("schedule_from sends an exception_ptr if value types are potentially throwing when copied", "[adaptors][schedule_from]") {
+  inline_scheduler sched{};
+
+  check_err_types<type_array<std::exception_ptr>>(ex::schedule_from(sched, ex::just(potentially_throwing{})));
+}
+
 TEST_CASE(
   "schedule_from keeps sends_stopped from scheduler's sender",
   "[adaptors][schedule_from]") {

--- a/test/stdexec/algos/adaptors/test_transfer.cpp
+++ b/test/stdexec/algos/adaptors/test_transfer.cpp
@@ -188,6 +188,12 @@ TEST_CASE("transfer keeps error_types from scheduler's sender", "[adaptors][tran
   check_err_types<type_array<int>>(ex::transfer(ex::just(3), sched3));
 }
 
+TEST_CASE("transfer sends an exception_ptr if value types are potentially throwing when copied", "[adaptors][transfer]") {
+  inline_scheduler sched{};
+
+  check_err_types<type_array<std::exception_ptr>>(ex::transfer(ex::just(potentially_throwing{}), sched));
+}
+
 TEST_CASE("transfer keeps sends_stopped from scheduler's sender", "[adaptors][transfer]") {
   inline_scheduler sched1{};
   error_scheduler sched2{};

--- a/test/stdexec/algos/factories/test_transfer_just.cpp
+++ b/test/stdexec/algos/factories/test_transfer_just.cpp
@@ -133,6 +133,12 @@ TEST_CASE("transfer_just keeps error_types from scheduler's sender", "[factories
   check_err_types<type_array<int>>(ex::transfer_just(sched3, 3));
 }
 
+TEST_CASE("transfer_just sends an exception_ptr if value types are potentially throwing when copied", "[factories][transfer_just]") {
+  inline_scheduler sched{};
+
+  check_err_types<type_array<std::exception_ptr>>(ex::transfer_just(sched, potentially_throwing{}));
+}
+
 TEST_CASE(
   "transfer_just keeps sends_stopped from scheduler's sender",
   "[factories][transfer_just]") {

--- a/test/test_common/type_helpers.hpp
+++ b/test/test_common/type_helpers.hpp
@@ -44,6 +44,15 @@ struct movable {
   int value_;
 };
 
+//! A type with potentially throwing move/copy constructors
+struct potentially_throwing {
+  potentially_throwing() = default;
+  potentially_throwing(potentially_throwing&&) noexcept(false) {}
+  potentially_throwing(const potentially_throwing &) noexcept(false) {}
+  potentially_throwing& operator=(potentially_throwing&&) noexcept(false) { return *this; }
+  potentially_throwing& operator=(const potentially_throwing &) noexcept(false) { return *this; }
+};
+
 //! Used for debugging, to generate errors to the console
 template <typename T>
 struct type_printer;


### PR DESCRIPTION
I think there's more to be done here, and I'm not 100% sure about this, hence still a draft. I'd appreciate confirmation on a few questions.

This intends to fix `schedule_from` advertising itself as not sending `std::exception_ptr` in its completion signatures, but still instantiating `set_error(receiver, exception_ptr)` unconditionally. This is of course problematic if the receiver needs to store the `exception_ptr`.

This PR currently wraps signaling the connected receiver into the `__try_call` helper so that `set_error` isn't unnecessarily instantiated with `exception_ptr`.

Questions:
- As far as I can tell the variant can never be valueless by exception here. If emplacing into the variant fails earlier `set_error` will be called elsewhere and we won't even reach this `__complete` function. Does this sound correct? I've got an assertion there for this which isn't triggered by tests, but I'd appreciate someone else checking if this makes sense.
- I see there's a conditional `set_error_t(std::exception_ptr)` added if any of the _error_ types sent by the scheduler are potentially throwing when copied. Shouldn't the value and error types sent by the input senders be checked for that as well, or is that already handled somewhere where I'm not seeing it? (cf. https://github.com/NVIDIA/stdexec/blob/caaf7e2cab6a5429ebeff7aa3500ec7646f44fc1/include/stdexec/execution.hpp#L4701-L4717).

Still to do: add a test case (this failure was triggered by a simple `transfer(...) | then(...) | transfer(...)` so I'll add at least that as a test).