### PR TITLE
Turn when_any into when_any_value and fix issue #770

### DIFF
--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -49,8 +49,13 @@ namespace exec {
     using __all_nothrow_decay_copyable = __bool<(__nothrow_decay_copyable<_Args> && ...)>;
 
     template <class _Env, class... _SenderIds>
-    using __all_value_args_nothrow_decay_copyable =
-      __mand<value_types_of_t<__t<_SenderIds>, _Env, __all_nothrow_decay_copyable, __mand>...>;
+    using __all_value_args_nothrow_decay_copyable = __mand<
+      value_types_of_t<__t<_SenderIds>, _Env, __all_nothrow_decay_copyable, __mand>...,
+      value_types_of_t<
+        __t<_SenderIds>,
+        _Env,
+        __decayed_tuple,
+        __mall_of<__q<std::is_nothrow_move_constructible>>::__f>...>;
 
     template <class... Args>
     using __as_rvalues = set_value_t(decay_t<Args>&&...);

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -34,42 +34,56 @@ namespace exec {
     using __env_t = __make_env_t<_BaseEnv, __with<get_stop_token_t, in_place_stop_token>>;
 
     template <class _Ret, class... _Args>
-    std::tuple<_Ret, _Args...> __signature_to_tuple_(_Ret (*)(_Args...));
+    __decayed_tuple<_Args...> __signature_to_tuple_(_Ret (*)(_Args...));
 
     template <class _Sig>
     using __signature_to_tuple_t = decltype(__signature_to_tuple_((_Sig*) nullptr));
 
-    template <class _Env, class... _SenderIds>
-    using __all_nothrow_copy_constructible = //
-      __mapply<
-        __mall_of<__q<std::is_nothrow_copy_constructible>>,
-        __mapply<
-          __transform<__q<__signature_to_tuple_t>>,
-          __minvoke<__mconcat<>, __completion_signatures_of_t<__t<_SenderIds>, _Env>...>>>;
+    template <class _Tag>
+    struct __ret_equals_to {
+      template <class _Sig>
+      using __f = std::is_same<_Tag, __tag_of_sig_t<_Sig>>;
+    };
 
-    template <class _Env, class _SenderId, class... _SenderIds>
-    make_completion_signatures<
-      __t<_SenderId>,
-      _Env,
-      __minvoke<
-        __mconcat<__q<completion_signatures>>,
+    template <class... _Args>
+    using __all_nothrow_decay_copyable = __bool<(__nothrow_decay_copyable<_Args> && ...)>;
+
+    template <class _Env, class... _SenderIds>
+    using __all_value_args_nothrow_decay_copyable =
+      __mand<value_types_of_t<__t<_SenderIds>, _Env, __all_nothrow_decay_copyable, __mand>...>;
+
+    template <class... Args>
+    using __as_rvalues = set_value_t(decay_t<Args>&&...);
+
+    template <class... E>
+    using __as_error = completion_signatures<set_error_t(E)...>;
+
+    template <class _Env, class... _SenderIds>
+    using __completion_signatures_t = __concat_completion_signatures_t<
         __if<
-          __all_nothrow_copy_constructible<_Env, _SenderIds...>,
-          __types<set_stopped_t()>,
-          __types<set_stopped_t(), set_error_t(std::exception_ptr)>>,
-        completion_signatures_of_t<__t<_SenderIds>, _Env>...>>
-      __completion_signatures_(_Env*, _SenderId*, _SenderIds*...);
-
-    template <class _Env, class... _Senders>
-    using __completion_signatures_t =
-      decltype(__completion_signatures_((decay_t<_Env>*) nullptr, (_Senders*) nullptr...));
+        __all_value_args_nothrow_decay_copyable<_Env, _SenderIds...>,
+        completion_signatures<set_stopped_t()>,
+        completion_signatures<set_stopped_t(), set_error_t(std::exception_ptr)>>,
+      value_types_of_t<__t<_SenderIds>, _Env, __as_rvalues, completion_signatures>...,
+      error_types_of_t<__t<_SenderIds>, _Env, __as_error>...>;
 
     template <class _Env, class... _SenderIds>
-    using __result_type_t = //
-      __mapply<
+    using __result_type_t_ = __mapply<
         __transform<__q<__signature_to_tuple_t>, __q<std::variant>>,
-        __completion_signatures_t<_Env, _SenderIds...>>;
+      __mapply<
+        __remove_if<__mnone_of<__ret_equals_to<set_value_t>>, __q<completion_signatures>>,
+        __completion_signatures_t<_Env, _SenderIds...>>>;
 
+    struct __exception_tag { };
+
+    template <class _Env, class... _SenderIds>
+    using __result_type_t = __if<
+      __all_value_args_nothrow_decay_copyable<_Env, _SenderIds...>,
+      __result_type_t_<_Env, _SenderIds...>,
+      __minvoke<
+        __push_back<__q<std::variant>>,
+        __result_type_t_<_Env, _SenderIds...>,
+        std::tuple<__exception_tag, std::exception_ptr>>>;
 
     template <class _Variant, class... _Ts>
     concept __result_constructible_from =
@@ -103,24 +117,8 @@ namespace exec {
       _Receiver __receiver_;
       std::optional<_ResultVariant> __result_{};
 
-      template <class _CPO, class... _Args>
+      template <__one_of<set_value_t, set_error_t, set_stopped_t> _CPO, class... _Args>
       void notify(_CPO, _Args&&... __args) noexcept {
-        bool __expect = false;
-        if (__emplaced_.compare_exchange_strong(
-              __expect, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
-          // This emplacement can happen only once
-          if constexpr (__nothrow_result_constructible_from<_ResultVariant, _CPO, _Args...>) {
-            __result_.emplace(std::tuple{_CPO{}, (_Args&&) __args...});
-          } else {
-            try {
-              __result_.emplace(std::tuple{_CPO{}, (_Args&&) __args...});
-            } catch (...) {
-              __result_.emplace(set_error_t{}, std::current_exception());
-            }
-          }
-          // stop pending operations
-          __stop_source_.request_stop();
-        }
         // make __result_ emplacement visible when __count_ goes from one to zero
         // This relies on the fact that each sender will call notify() at most once
         if (__count_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
@@ -128,19 +126,51 @@ namespace exec {
           auto stop_token = get_stop_token(get_env(__receiver_));
           if (stop_token.stop_requested()) {
             set_stopped((_Receiver&&) __receiver_);
-            return;
-          }
-          STDEXEC_ASSERT(__result_.has_value());
+          } else if (!__result_.has_value()) {
+            _CPO{}((_Receiver&&) __receiver_, (_Args&&) __args...);
+          } else {
           std::visit(
             [this]<class _Tuple>(_Tuple&& __result) {
               std::apply(
-                [this]<class _C, class... _As>(_C, _As&&... __args) noexcept {
-                  _C{}((_Receiver&&) __receiver_, (_As&&) __args...);
+                  [this]<class... _As>(_As&&... __args) noexcept {
+                    if constexpr (sizeof...(_As) >= 1) {
+                      if constexpr (__decays_to<__mfront<_As...>, __exception_tag>) {
+                        [this]<class _B, class... _Bs>(_B&&, _Bs&&... __bs) {
+                          set_error((_Receiver&&) __receiver_, (_Bs&&) __bs...);
+                        }((_As&&) __args...);
+                      } else {
+                        set_value((_Receiver&&) __receiver_, (_As&&) __args...);
+                      }
+                    } else {
+                      set_value((_Receiver&&) __receiver_, (_As&&) __args...);
+                    }
                 },
                 (_Tuple&&) __result);
             },
             (_ResultVariant&&) *__result_);
+          }
         }
+      }
+
+      template <class... _Args>
+      void emplace_and_notify(_Args&&... __args) noexcept {
+        bool __expect = false;
+        if (__emplaced_.compare_exchange_strong(
+              __expect, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
+          // This emplacement can happen only once
+          if constexpr (__nothrow_result_constructible_from<_ResultVariant, _Args...>) {
+            __result_.emplace(std::tuple{(_Args&&) __args...});
+          } else {
+            try {
+              __result_.emplace(std::tuple{(_Args&&) __args...});
+            } catch (...) {
+              __result_.emplace(std::tuple{__exception_tag{}, std::current_exception()});
+            }
+          }
+          // stop pending operations
+          __stop_source_.request_stop();
+        }
+        notify(set_value, (_Args&&) __args...);
       }
     };
 
@@ -157,10 +187,15 @@ namespace exec {
        private:
         __op_base<_Receiver, _ResultVariant>* __op_;
 
-        template <__one_of<set_value_t, set_error_t, set_stopped_t> _CPO, class... _Args>
-          requires __result_constructible_from<_ResultVariant, _CPO, _Args...>
+        template <__one_of<set_error_t, set_stopped_t> _CPO, class... _Args>
         friend void tag_invoke(_CPO, __t&& __self, _Args&&... __args) noexcept {
           __self.__op_->notify(_CPO{}, (_Args&&) __args...);
+        }
+
+        template <class... _Args>
+          requires __result_constructible_from<_ResultVariant, _Args...>
+        friend void tag_invoke(set_value_t, __t&& __self, _Args&&... __args) noexcept {
+          __self.__op_->emplace_and_notify((_Args&&) __args...);
         }
 
         friend __env_t<env_of_t<_Receiver>> tag_invoke(get_env_t, const __t& __self) noexcept {
@@ -223,7 +258,6 @@ namespace exec {
 
     template <class... _SenderIds>
     struct __sender {
-
       template <class _Receiver>
       using __receiver_t =
         stdexec::__t< __receiver<_Receiver, __result_type_t<env_of_t<_Receiver>, _SenderIds...>>>;
@@ -243,12 +277,17 @@ namespace exec {
         }
 
        private:
+        using senders_tuple_t = std::tuple<stdexec::__t<_SenderIds>...>;
+
         template <__decays_to<__t> _Self, receiver _Receiver>
           requires(
-            sender_to< __copy_cvref_t<_Self, stdexec::__t<_SenderIds>>, __receiver_t<_Receiver>>
+            sender_to<__copy_cvref_t<_Self, stdexec::__t<_SenderIds>>, __receiver_t<_Receiver>>
             && ...)
         friend __op_t<_Receiver> tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr) //
-          noexcept(std::is_nothrow_constructible_v<__op_t<_Receiver>, _Self&&, _Receiver&&>) {
+          noexcept(std::is_nothrow_constructible_v<
+                   __op_t<_Receiver>,
+                   __copy_cvref_t<_Self, senders_tuple_t>,
+                   _Receiver&&>) {
           return __op_t<_Receiver>{((_Self&&) __self).__senders_, (_Receiver&&) __rcvr};
         }
 
@@ -265,7 +304,7 @@ namespace exec {
       };
     };
 
-    struct __when_any_t {
+    struct __when_any_value_t {
       template <class... _Senders>
       using __sender_t = __t<__sender<__id<decay_t<_Senders>>...>>;
 
@@ -277,8 +316,8 @@ namespace exec {
       }
     };
 
-    inline constexpr __when_any_t when_any{};
+    inline constexpr __when_any_value_t when_any_value{};
   } // namespace __when_any
 
-  using __when_any::when_any;
+  using __when_any::when_any_value;
 }

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -145,7 +145,7 @@ TEST_CASE("any_receiver_ref is connectable with when_any", "[types][any_sender]"
   sink_receiver rcvr{};
   receiver_ref ref = rcvr;
 
-  auto sndr = when_any(just(42));
+  auto sndr = when_any_value(just(42));
   CHECK(rcvr.value_.index() == 0);
   auto op = connect(std::move(sndr), std::move(ref));
   start(op);
@@ -305,7 +305,7 @@ TEST_CASE("any_sender is connectable with any_receiver_ref", "[types][any_sender
     start(op);
     CHECK(rcvr.value_.index() == 1);
   }
-  sndr = when_any(just(42));
+  sndr = when_any_value(just(42));
   {
     sink_receiver rcvr{};
     receiver_ref ref = rcvr;
@@ -356,7 +356,7 @@ static_assert(
 
 TEST_CASE("any_sender does not connect with stop token", "[types][any_sender]") {
   using unstoppable_sender = any_sender_of<set_value_t(int), set_stopped_t()>;
-  unstoppable_sender sender = when_any(just(21));
+  unstoppable_sender sender = when_any_value(just(21));
   in_place_stop_source stop_source{};
   stopped_receiver receiver{stop_source.get_token(), false};
   stop_source.request_stop();
@@ -371,7 +371,7 @@ TEST_CASE(
   using Sigs = completion_signatures<set_value_t(int), set_stopped_t()>;
   using receiver_ref = any_receiver_ref<Sigs, get_stop_token.signature<in_place_stop_token()>>;
   using stoppable_sender = receiver_ref::any_sender<>;
-  stoppable_sender sender = when_any(just(21));
+  stoppable_sender sender = when_any_value(just(21));
   in_place_stop_source stop_source{};
   stopped_receiver receiver{stop_source.get_token(), true};
   stop_source.request_stop();

--- a/test/exec/test_when_any.cpp
+++ b/test/exec/test_when_any.cpp
@@ -69,20 +69,20 @@ TEST_CASE("when_any with move-only types", "[adaptors][when_any]") {
   wait_for_value(std::move(snd), movable(42));
 }
 
-// TEST_CASE("when_any forwards stop signal", "[adaptors][when_any]") {
-//   stopped_scheduler stop;
-//   int result = 42;
-//   ex::sender auto snd =
-//     exec::when_any_value( //
-//       ex::schedule(stop), //
-//       ex::schedule(stop)  //
-//       )
-//     | ex::then([&result] { result += 1; });
-//   ex::sync_wait(std::move(snd));
-//   static_assert(ex::sender<decltype(snd)>);
-//   // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
-//   REQUIRE(result == 42);
-// }
+TEST_CASE("when_any forwards stop signal", "[adaptors][when_any]") {
+  stopped_scheduler stop;
+  int result = 42;
+  ex::sender auto snd =
+    exec::when_any_value( //
+      ex::schedule(stop), //
+      ex::schedule(stop)  //
+      )
+    | ex::then([&result] { result += 1; });
+  ex::sync_wait(std::move(snd));
+  static_assert(ex::sender<decltype(snd)>);
+  // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
+  REQUIRE(result == 42);
+}
 
 TEST_CASE("nested when_any is stoppable", "[adaptors][when_any]") {
   int result = 41;
@@ -99,15 +99,15 @@ TEST_CASE("nested when_any is stoppable", "[adaptors][when_any]") {
   REQUIRE(result == 42);
 }
 
-// TEST_CASE("stop is forwarded", "[adaptors][when_any]") {
-//   int result = 41;
-//   ex::sender auto snd = exec::when_any_value(ex::just_stopped())
-//                       | ex::upon_stopped([&result]() noexcept { result += 1; });
-//   ex::sync_wait(std::move(snd));
-//   static_assert(ex::sender<decltype(snd)>);
-//   // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
-//   REQUIRE(result == 42);
-// }
+TEST_CASE("stop is forwarded", "[adaptors][when_any]") {
+  int result = 41;
+  ex::sender auto snd = exec::when_any_value(ex::just_stopped())
+                      | ex::upon_stopped([&result]() noexcept { result += 1; });
+  ex::sync_wait(std::move(snd));
+  static_assert(ex::sender<decltype(snd)>);
+  // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
+  REQUIRE(result == 42);
+}
 
 TEST_CASE("when_any_value is thread-safe", "[adaptors][when_any]") {
   exec::single_thread_context ctx1;

--- a/test/exec/test_when_any.cpp
+++ b/test/exec/test_when_any.cpp
@@ -25,19 +25,19 @@
 namespace ex = stdexec;
 
 TEST_CASE("when_ny returns a sender", "[adaptors][when_any]") {
-  auto snd = exec::when_any(ex::just(3), ex::just(0.1415));
+  auto snd = exec::when_any_value(ex::just(3), ex::just(0.1415));
   static_assert(ex::sender<decltype(snd)>);
   (void) snd;
 }
 
 TEST_CASE("when_any with environment returns a sender", "[adaptors][when_any]") {
-  auto snd = exec::when_any(ex::just(3), ex::just(0.1415));
-  static_assert(ex::sender_in<decltype(snd), empty_env>);
+  auto snd = exec::when_any_value(ex::just(3), ex::just(0.1415));
+  static_assert(ex::sender_in<decltype(snd), ex::empty_env>);
   (void) snd;
 }
 
 TEST_CASE("when_any simple example", "[adaptors][when_any]") {
-  auto snd = exec::when_any(ex::just(3.0));
+  auto snd = exec::when_any_value(ex::just(3.0));
   auto snd1 = std::move(snd) | ex::then([](double y) { return y + 0.1415; });
   const double expected = 3.0 + 0.1415;
   auto op = ex::connect(std::move(snd1), expect_value_receiver{expected});
@@ -45,62 +45,71 @@ TEST_CASE("when_any simple example", "[adaptors][when_any]") {
 }
 
 TEST_CASE("when_any completes with only one sender", "[adaptors][when_any]") {
-  ex::sender auto snd = exec::when_any(               //
+  ex::sender auto snd = exec::when_any_value(         //
     completes_if{false} | ex::then([] { return 1; }), //
     completes_if{true} | ex::then([] { return 42; })  //
   );
+  static_assert(ex::sender<decltype(snd)>);
   wait_for_value(std::move(snd), 42);
-
-  ex::sender auto snd2 = exec::when_any(              //
+  ex::sender auto snd2 = exec::when_any_value(        //
     completes_if{true} | ex::then([] { return 1; }),  //
     completes_if{false} | ex::then([] { return 42; }) //
   );
+  //ex::__types<ex::completion_signatures_of_t<decltype(snd2)>> t;
   wait_for_value(std::move(snd2), 1);
 }
 
 TEST_CASE("when_any with move-only types", "[adaptors][when_any]") {
-  ex::sender auto snd = exec::when_any( //
+  ex::sender auto snd = exec::when_any_value( //
     completes_if{false} | ex::then([] { return movable(1); }),
-    ex::just(movable(42))               //
+    ex::just(movable(42))                     //
   );
+  static_assert(ex::sender<decltype(snd)>);
+  // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
   wait_for_value(std::move(snd), movable(42));
 }
 
-TEST_CASE("when_any forwards stop signal", "[adaptors][when_any]") {
-  stopped_scheduler stop;
-  int result = 42;
-  ex::sender auto snd =
-    exec::when_any(        //
-      completes_if{false}, //
-      ex::schedule(stop)   //
-      )
-    | ex::then([&result] { result += 1; });
-  ex::sync_wait(std::move(snd));
-  REQUIRE(result == 42);
-}
+// TEST_CASE("when_any forwards stop signal", "[adaptors][when_any]") {
+//   stopped_scheduler stop;
+//   int result = 42;
+//   ex::sender auto snd =
+//     exec::when_any_value( //
+//       ex::schedule(stop), //
+//       ex::schedule(stop)  //
+//       )
+//     | ex::then([&result] { result += 1; });
+//   ex::sync_wait(std::move(snd));
+//   static_assert(ex::sender<decltype(snd)>);
+//   // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
+//   REQUIRE(result == 42);
+// }
 
 TEST_CASE("nested when_any is stoppable", "[adaptors][when_any]") {
   int result = 41;
   ex::sender auto snd =
-    exec::when_any(
-      exec::when_any(completes_if{false}, completes_if{false}),
+    exec::when_any_value(
+      exec::when_any_value(completes_if{false}, completes_if{false}),
       completes_if{false},
       ex::just(),
       completes_if{false})
     | ex::then([&result] { result += 1; });
+  static_assert(ex::sender<decltype(snd)>);
   ex::sync_wait(std::move(snd));
+  // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
   REQUIRE(result == 42);
 }
 
-TEST_CASE("stop is forwarded", "[adaptors][when_any]") {
-  int result = 41;
-  ex::sender auto snd = exec::when_any(ex::just_stopped(), completes_if{false})
-                      | ex::upon_stopped([&result] { result += 1; });
-  ex::sync_wait(std::move(snd));
-  REQUIRE(result == 42);
-}
+// TEST_CASE("stop is forwarded", "[adaptors][when_any]") {
+//   int result = 41;
+//   ex::sender auto snd = exec::when_any_value(ex::just_stopped())
+//                       | ex::upon_stopped([&result]() noexcept { result += 1; });
+//   ex::sync_wait(std::move(snd));
+//   static_assert(ex::sender<decltype(snd)>);
+//   // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
+//   REQUIRE(result == 42);
+// }
 
-TEST_CASE("when_any is thread-safe", "[adaptors][when_any]") {
+TEST_CASE("when_any_value is thread-safe", "[adaptors][when_any]") {
   exec::single_thread_context ctx1;
   exec::single_thread_context ctx2;
   exec::single_thread_context ctx3;
@@ -111,12 +120,13 @@ TEST_CASE("when_any is thread-safe", "[adaptors][when_any]") {
 
   int result = 41;
 
-  ex::sender auto snd = exec::when_any(
-    sch1 | ex::let_value([] { return exec::when_any(completes_if{false}); }),
+  ex::sender auto snd = exec::when_any_value(
+    sch1 | ex::let_value([] { return exec::when_any_value(completes_if{false}); }),
     sch2 | ex::let_value([] { return completes_if{false}; }),
     sch3 | ex::then([&result] { result += 1; }),
     completes_if{false});
-
+  static_assert(ex::sender<decltype(snd)>);
+  // ex::__types<ex::completion_signatures_of_t<decltype(snd)>> t;
   ex::sync_wait(std::move(snd));
   REQUIRE(result == 42);
 }


### PR DESCRIPTION
Hi,

we had this discussion in Discord, where `when_any(Senders...)` could be a `dematerialize(when_any_value(materialize(Senders...)))` but I think there is no way in the other direction.

- This PR solves issue #770 
- rewrites the current `when_any` into a `when_any_value`
  - completes if all input senders completed. 
  - If a stop is requested from an upstream Receiver, then `when_any_value` will complete with `set_stopped()`
  - When any sender completes with a call to `set_value` this algorithm requests a stop for all other senders.
  - If no stop is requested, `when_any_value` completes with `set_value(decay_t<Args>&&...)` of the first call in form of `set_value(Args&&...)`
  - If all senders complete with either `set_stopped` or `set_error` the last completion will be forwarded unless a stop was requested.
  - If moving  `__decayed_tuple<Args...>` or its construction from `Args&&... args` throw, an exception will be stored and forwarded upon completion of all senders.

I plan to add better tests, especially around completion signatures and error handling. 
I also plan to add materialize and dematerialize to put `when_any` back to place. 