### PR TITLE
Fix recursive constraint on GCC in __rec::__ref

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -533,7 +533,8 @@ namespace exec {
             ((_Self&&) __self).__env_.__rcvr_, (_As&&) __as...);
         }
 
-        friend const __env_t& tag_invoke(get_env_t, const __ref& __self) noexcept {
+        template <std::same_as<__ref> Self>
+        friend const __env_t& tag_invoke(get_env_t, const Self& __self) noexcept {
           return __self.__env_;
         }
       };

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -260,11 +260,9 @@ TEST_CASE("sync_wait works on any_sender_of", "[types][any_sender]") {
 
 TEST_CASE("construct any_sender_of recursively from when_all", "[types][any_sender]") {
   any_sender_of<set_value_t(), set_stopped_t(), set_error_t(std::exception_ptr)> sender = just();
-  sender = when_all(std::move(sender), just());
-  CHECK(std::same_as<
-        completion_signatures_of_t<any_sender_of<set_value_t()>>,
-        completion_signatures<set_value_t()>>);
-  sync_wait(std::move(sender));
+  using sender_t = any_sender_of<set_value_t(), set_stopped_t(), set_error_t(std::exception_ptr)>;
+  using when_all_t = decltype(when_all(std::move(sender)));
+  static_assert(std::is_constructible_v<sender_t, when_all_t&&>);
 }
 
 TEST_CASE("sync_wait returns value", "[types][any_sender]") {

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -258,6 +258,15 @@ TEST_CASE("sync_wait works on any_sender_of", "[types][any_sender]") {
   CHECK(value == 42);
 }
 
+TEST_CASE("construct any_sender_of recursively from when_all", "[types][any_sender]") {
+  any_sender_of<set_value_t(), set_stopped_t(), set_error_t(std::exception_ptr)> sender = just();
+  sender = when_all(std::move(sender), just());
+  CHECK(std::same_as<
+        completion_signatures_of_t<any_sender_of<set_value_t()>>,
+        completion_signatures<set_value_t()>>);
+  sync_wait(std::move(sender));
+}
+
 TEST_CASE("sync_wait returns value", "[types][any_sender]") {
   any_sender_of<set_value_t(int)> sender = just(21) | then([&](int v) noexcept { return 2 * v; });
   CHECK(std::same_as<


### PR DESCRIPTION
This solves the compilation issues in #492 for GCC

Here is a link to the breaking example https://godbolt.org/z/axe39vh73

I am not sure how this is triggered and why its not covered in the current tests tho. ~~Should I try to find a test?~~

Edit: I added a test that observes the change through calling `when_all`