### PR TITLE
Implement on_coroutine_[completion]

### DIFF
--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -23,7 +23,6 @@
 
 #include "stdexec/execution.hpp"
 #include "exec/task.hpp"
-#include "exec/any_sender_of.hpp"
 
 namespace exec {
   namespace __at_coro_exit {

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -392,7 +392,7 @@ namespace exec {
       }
     };
 
-    struct __on_coro_error_t {
+    struct __on_coro_failed_t {
      private:
       template <class _Action, class... _Ts>
       static __task<__on_coroutine_completion::__error, _Ts...>
@@ -412,5 +412,5 @@ namespace exec {
 
   inline constexpr __on_coroutine_succeeded::__on_coro_succeeded_t on_coroutine_succeeded{};
   inline constexpr __on_coroutine_succeeded::__on_coro_stopped_t on_coroutine_stopped{};
-  inline constexpr __on_coroutine_succeeded::__on_coro_error_t on_coroutine_error{};
+  inline constexpr __on_coroutine_succeeded::__on_coro_failed_t on_coroutine_failed{};
 } // namespace exec

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -231,13 +231,13 @@ namespace exec {
   namespace __on_coroutine_succeeded {
     using namespace stdexec;
 
-    enum class __on_coroutine_completion {
+    enum class __on_coroutine_completion : int {
       __stopped,
       __value,
       __error
     };
 
-    __on_coroutine_completion __from_int(int __i) noexcept {
+    inline __on_coroutine_completion __from_int(int __i) noexcept {
       return static_cast<__on_coroutine_completion>(__i);
     }
 

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -204,10 +204,10 @@ namespace exec {
       std::variant<std::monostate, __void, std::exception_ptr> __data_{};
     };
 
-    enum class __disposition : unsigned {
-      __none,
-      __value,
-      __exception,
+    enum class disposition : unsigned {
+      stopped,
+      succeeded,
+      failed,
     };
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -259,8 +259,8 @@ namespace exec {
           return {};
         }
 
-        __task::__disposition __disposition() const noexcept {
-          return static_cast<__task::__disposition>(this->__data_.index());
+        __task::disposition disposition() const noexcept {
+          return static_cast<__task::disposition>(this->__data_.index());
         }
 
         void unhandled_exception() noexcept {
@@ -359,6 +359,8 @@ namespace exec {
       __coro::coroutine_handle<promise_type> __coro_;
     };
   } // namespace __task
+
+  using task_disposition = __task::disposition;
 
   template <class _Ty>
   using default_task_context = __task::default_task_context<_Ty>;

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -204,6 +204,12 @@ namespace exec {
       std::variant<std::monostate, __void, std::exception_ptr> __data_{};
     };
 
+    enum class __disposition : unsigned {
+      __none,
+      __value,
+      __exception,
+    };
+
     ////////////////////////////////////////////////////////////////////////////////
     // basic_task
     template <class _Ty, class _Context = default_task_context<_Ty>>
@@ -251,6 +257,10 @@ namespace exec {
 
         __final_awaitable final_suspend() noexcept {
           return {};
+        }
+
+        __task::__disposition __disposition() const noexcept {
+          return static_cast<__task::__disposition>(this->__data_.index());
         }
 
         void unhandled_exception() noexcept {

--- a/test/exec/test_at_coroutine_exit.cpp
+++ b/test/exec/test_at_coroutine_exit.cpp
@@ -109,6 +109,63 @@ namespace {
     ++result;
   }
 
+  task<void> test_on_succeeded_one_cleanup_action(int& result) {
+    ++result;
+    co_await on_coroutine_succeeded([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    ++result;
+  }
+
+  task<void> test_on_stopped_one_cleanup_action(int& result) {
+    ++result;
+    co_await on_coroutine_stopped([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    ++result;
+  }
+
+  task<void> test_on_error_one_cleanup_action(int& result) {
+    ++result;
+    co_await on_coroutine_error([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    ++result;
+  }
+
+  task<void> test_on_succeeded_one_cleanup_action_with_stop(int& result) {
+    ++result;
+    co_await on_coroutine_succeeded([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    co_await stop();
+    ++result;
+  }
+
+  task<void> test_on_stopped_one_cleanup_action_with_stop(int& result) {
+    ++result;
+    co_await on_coroutine_stopped([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    co_await stop();
+    ++result;
+  }
+
+  task<void> test_on_error_one_cleanup_action_with_stop(int& result) {
+    ++result;
+    co_await on_coroutine_error([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    throw 42;
+    ++result;
+  }
+
   task<void> test_two_cleanup_actions_with_stop(int& result) {
     ++result;
     co_await at_coroutine_exit([&result]() -> task<void> {
@@ -234,6 +291,42 @@ TEST_CASE("OneCleanupActionWithStop", "[task][at_coroutine_exit]") {
   int result = 0;
   stdexec::sync_wait(test_one_cleanup_action_with_stop(result));
   REQUIRE(result == 2);
+}
+
+TEST_CASE("OnSucceededOneCleanupAction", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_succeeded_one_cleanup_action(result));
+  REQUIRE(result == 6);
+}
+
+TEST_CASE("OnStoppedOneCleanupActionSuccess", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_stopped_one_cleanup_action(result));
+  REQUIRE(result == 2);
+}
+
+TEST_CASE("OnErrorOneCleanupActionSuccess", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_error_one_cleanup_action(result));
+  REQUIRE(result == 2);
+}
+
+TEST_CASE("OnSucceededOneCleanupActionWithStop", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_succeeded_one_cleanup_action_with_stop(result));
+  REQUIRE(result == 1);
+}
+
+TEST_CASE("OnStoppedOneCleanupActionWithStopSuccess", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_stopped_one_cleanup_action_with_stop(result));
+  REQUIRE(result == 3);
+}
+
+TEST_CASE("OnErrorOneCleanupActionWithStopSuccess", "[task][at_coroutine_exit]") {
+  int result = 0;
+  CHECK_THROWS_AS(stdexec::sync_wait(test_on_error_one_cleanup_action_with_stop(result)), int);
+  REQUIRE(result == 3);
 }
 
 TEST_CASE("TwoCleanupActionsWithStop", "[task][at_coroutine_exit]") {

--- a/test/exec/test_at_coroutine_exit.cpp
+++ b/test/exec/test_at_coroutine_exit.cpp
@@ -233,6 +233,17 @@ namespace {
     i *= i;
   }
 
+  task<void> test_on_succeeded_mutable_stateful_cleanup_action(int& result) {
+    auto&& [i] = co_await on_coroutine_succeeded(
+      [&result](int&& i) -> task<void> {
+        result += i;
+        co_return;
+      },
+      3);
+    ++result;
+    i *= i;
+  }
+
   task<void> with_continuation(int& result, task<void> next) {
     co_await std::move(next);
     result *= 3;
@@ -404,6 +415,12 @@ TEST_CASE("CleanupActionWithStatefulSender", "[task][at_coroutine_exit]") {
 TEST_CASE("CleanupActionWithMutableStateful", "[task][at_coroutine_exit]") {
   int result = 0;
   stdexec::sync_wait(test_mutable_stateful_cleanup_action(result));
+  REQUIRE(result == 10);
+}
+
+TEST_CASE("OnSuccessCleanupActionWithMutableStateful", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_succeeded_mutable_stateful_cleanup_action(result));
   REQUIRE(result == 10);
 }
 

--- a/test/exec/test_at_coroutine_exit.cpp
+++ b/test/exec/test_at_coroutine_exit.cpp
@@ -118,24 +118,6 @@ namespace {
     ++result;
   }
 
-  task<void> test_on_stopped_one_cleanup_action(int& result) {
-    ++result;
-    co_await on_coroutine_stopped([&result]() -> task<void> {
-      result *= 3;
-      co_return;
-    });
-    ++result;
-  }
-
-  task<void> test_on_error_one_cleanup_action(int& result) {
-    ++result;
-    co_await on_coroutine_error([&result]() -> task<void> {
-      result *= 3;
-      co_return;
-    });
-    ++result;
-  }
-
   task<void> test_on_succeeded_one_cleanup_action_with_stop(int& result) {
     ++result;
     co_await on_coroutine_succeeded([&result]() -> task<void> {
@@ -143,6 +125,25 @@ namespace {
       co_return;
     });
     co_await stop();
+    ++result;
+  }
+
+  task<void> test_on_succeeded_one_cleanup_action_with_error(int& result) {
+    ++result;
+    co_await on_coroutine_succeeded([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    throw 42;
+    ++result;
+  }
+
+  task<void> test_on_stopped_one_cleanup_action(int& result) {
+    ++result;
+    co_await on_coroutine_stopped([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
     ++result;
   }
 
@@ -166,9 +167,18 @@ namespace {
     ++result;
   }
 
-  task<void> test_on_error_one_cleanup_action_with_stop(int& result) {
+  task<void> test_on_failed_one_cleanup_action(int& result) {
     ++result;
-    co_await on_coroutine_error([&result]() -> task<void> {
+    co_await on_coroutine_failed([&result]() -> task<void> {
+      result *= 3;
+      co_return;
+    });
+    ++result;
+  }
+
+  task<void> test_on_failed_one_cleanup_action_with_stop(int& result) {
+    ++result;
+    co_await on_coroutine_failed([&result]() -> task<void> {
       result *= 3;
       co_return;
     });
@@ -176,9 +186,9 @@ namespace {
     ++result;
   }
 
-  task<void> test_on_error_one_cleanup_action_with_error(int& result) {
+  task<void> test_on_failed_one_cleanup_action_with_error(int& result) {
     ++result;
-    co_await on_coroutine_error([&result]() -> task<void> {
+    co_await on_coroutine_failed([&result]() -> task<void> {
       result *= 3;
       co_return;
     });
@@ -319,22 +329,22 @@ TEST_CASE("OnSucceededOneCleanupAction", "[task][at_coroutine_exit]") {
   REQUIRE(result == 6);
 }
 
-TEST_CASE("OnStoppedOneCleanupActionSuccess", "[task][at_coroutine_exit]") {
-  int result = 0;
-  stdexec::sync_wait(test_on_stopped_one_cleanup_action(result));
-  REQUIRE(result == 2);
-}
-
-TEST_CASE("OnErrorOneCleanupActionSuccess", "[task][at_coroutine_exit]") {
-  int result = 0;
-  stdexec::sync_wait(test_on_error_one_cleanup_action(result));
-  REQUIRE(result == 2);
-}
-
 TEST_CASE("OnSucceededOneCleanupActionWithStop", "[task][at_coroutine_exit]") {
   int result = 0;
   stdexec::sync_wait(test_on_succeeded_one_cleanup_action_with_stop(result));
   REQUIRE(result == 1);
+}
+
+TEST_CASE("OnSucceededOneCleanupActionWithError", "[task][at_coroutine_exit]") {
+  int result = 0;
+  CHECK_THROWS_AS(stdexec::sync_wait(test_on_succeeded_one_cleanup_action_with_error(result)), int);
+  REQUIRE(result == 1);
+}
+
+TEST_CASE("OnStoppedOneCleanupActionSuccess", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_stopped_one_cleanup_action(result));
+  REQUIRE(result == 2);
 }
 
 TEST_CASE("OnStoppedOneCleanupActionWithStop", "[task][at_coroutine_exit]") {
@@ -349,15 +359,21 @@ TEST_CASE("OnStoppedOneCleanupActionWithError", "[task][at_coroutine_exit]") {
   REQUIRE(result == 1);
 }
 
-TEST_CASE("OnErrorOneCleanupActionWithStop", "[task][at_coroutine_exit]") {
+TEST_CASE("OnFailedOneCleanupActionSuccess", "[task][at_coroutine_exit]") {
   int result = 0;
-  stdexec::sync_wait(test_on_error_one_cleanup_action_with_stop(result));
+  stdexec::sync_wait(test_on_failed_one_cleanup_action(result));
+  REQUIRE(result == 2);
+}
+
+TEST_CASE("OnFailedOneCleanupActionWithStop", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_failed_one_cleanup_action_with_stop(result));
   REQUIRE(result == 1);
 }
 
-TEST_CASE("OnErrorOneCleanupActionWithError", "[task][at_coroutine_exit]") {
+TEST_CASE("OnFailedOneCleanupActionWithError", "[task][at_coroutine_exit]") {
   int result = 0;
-  CHECK_THROWS_AS(stdexec::sync_wait(test_on_error_one_cleanup_action_with_error(result)), int);
+  CHECK_THROWS_AS(stdexec::sync_wait(test_on_failed_one_cleanup_action_with_error(result)), int);
   REQUIRE(result == 3);
 }
 

--- a/test/exec/test_at_coroutine_exit.cpp
+++ b/test/exec/test_at_coroutine_exit.cpp
@@ -99,6 +99,20 @@ namespace {
     ++result;
   }
 
+  task<void> test_on_stopped_two_cleanup_actions_with_stop(int& result) {
+    ++result;
+    co_await on_coroutine_stopped([&result]() -> task<void> {
+      result *= 2;
+      co_return;
+    });
+    co_await on_coroutine_stopped([&result]() -> task<void> {
+      result *= result;
+      co_return;
+    });
+    ++result;
+    co_await stop();
+  }
+
   task<void> test_one_cleanup_action_with_stop(int& result) {
     ++result;
     co_await at_coroutine_exit([&result]() -> task<void> {
@@ -307,6 +321,12 @@ TEST_CASE("OneCleanupAction", "[task][at_coroutine_exit]") {
 TEST_CASE("TwoCleanupActions", "[task][at_coroutine_exit]") {
   int result = 0;
   stdexec::sync_wait(test_two_cleanup_actions(result));
+  REQUIRE(result == 8);
+}
+
+TEST_CASE("OnStoppedTwoCleanupActions", "[task][at_coroutine_exit]") {
+  int result = 0;
+  stdexec::sync_wait(test_on_stopped_two_cleanup_actions_with_stop(result));
   REQUIRE(result == 8);
 }
 


### PR DESCRIPTION
Hi,

This PR addresses the feature idea #767 and shows a sample implementation. 

Opposed to what, I thought, was suggested, I did not see how to use `unhandled_{exception,stopped}` directly. Instead I type-erase the index of the `__data_` variant in the parent promise and use `any_sender` to type erase either `just()` or the `__die_on_stop((_Awaitable&&) awaitable)` sender.

What I need is some direction for the implementation:
 - Is the index approach okay?
 - `any_sender` is ok until something like variant_sender is there?
 - emulate an `if`-like sender with something like
 ```cpp
 when_any(
     completes_if(is_completion) | let_value([] { return die_on_stop }), 
     completes_if(!is_completion) | let_value([] { return just(); }))
```