### PR TITLE
Implement the finally algorithm

### DIFF
--- a/include/exec/__detail/__manual_lifetime.hpp
+++ b/include/exec/__detail/__manual_lifetime.hpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <type_traits>
+
+namespace exec {
+
+  template <class _Ty>
+  class __manual_lifetime {
+   public:
+    __manual_lifetime() noexcept {
+    }
+
+    ~__manual_lifetime() {
+    }
+
+    __manual_lifetime(const __manual_lifetime&) = delete;
+    __manual_lifetime& operator=(const __manual_lifetime&) = delete;
+
+    __manual_lifetime(__manual_lifetime&&) = delete;
+    __manual_lifetime& operator=(__manual_lifetime&&) = delete;
+
+    template <class... _Args>
+    _Ty& __construct(_Args&&... __args) noexcept(std::is_nothrow_constructible_v<_Ty, _Args...>) {
+      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty((_Args&&) __args...);
+    }
+
+    void __destruct() noexcept {
+      __value_.~_Ty();
+    }
+
+    _Ty& __get() & noexcept {
+      return __value_;
+    }
+
+    _Ty&& __get() && noexcept {
+      return (_Ty&&) __value_;
+    }
+
+    const _Ty& __get() const & noexcept {
+      return __value_;
+    }
+
+    const _Ty&& __get() const && noexcept {
+      return (const _Ty&&) __value_;
+    }
+
+   private:
+    union {
+      _Ty __value_;
+    };
+  };
+}

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -19,7 +19,7 @@
 #include "../stdexec/execution.hpp"
 
 #include "__detail/__manual_lifetime.hpp"
-#include "any_sender_of.hpp"
+#include "materialize.hpp"
 
 namespace exec {
   namespace __finally {
@@ -29,12 +29,32 @@ namespace exec {
     using __nonempty_decayed_tuple = __decayed_tuple<_Arg, _Args...>;
 
     template <class _Sigs>
-    using __result_type_ =
-      __gather_signal<set_value_t, _Sigs, __q<__nonempty_decayed_tuple>, __q<__variant>>;
+    using __value_types_ = __gather_signal<
+      set_value_t,
+      _Sigs,
+      __mbind_front_q<__decayed_tuple, set_value_t>,
+      __q<__types>>;
 
     template <class _Sigs>
-    using __result_type =
-      __if<std::is_same<__result_type_<_Sigs>, __not_a_variant>, __ignore, __result_type_<_Sigs>>;
+    using __error_types_ = __gather_signal<
+      set_error_t,
+      _Sigs,
+      __mbind_front_q<__decayed_tuple, set_error_t>,
+      __q<__types>>;
+
+    template <class _Sigs>
+    using __stopped_types_ = __gather_signal<
+      set_stopped_t,
+      _Sigs,
+      __mbind_front_q<__decayed_tuple, set_stopped_t>,
+      __q<__types>>;
+
+    template <class _Sigs>
+    using __result_variant = __minvoke<
+      __mconcat<__q<__variant>>,
+      __value_types_<_Sigs>,
+      __error_types_<_Sigs>,
+      __stopped_types_<_Sigs>>;
 
     template <class _ResultType, class _ReceiverId>
     struct __final_operation_base {
@@ -44,126 +64,35 @@ namespace exec {
       __manual_lifetime<_ResultType> __result_{};
     };
 
-    namespace __rec {
-      template <class _Sig>
-      struct __rcvr_vfun;
-
-      template <class _Sigs>
-      struct __vtable {
-        struct __t;
-      };
-
-      template <class _Sigs, class _Env>
-      struct __ref;
-
-      template <class _Tag, class... _As>
-      struct __rcvr_vfun<_Tag(_As...)> {
-        void (*__fn_)(void*, _As...) noexcept;
-      };
-
-      template <class _Rcvr>
-      struct __rcvr_vfun_fn {
-        template <class _Tag, class... _As>
-        constexpr void (*operator()(_Tag (*)(_As...)) const noexcept)(void*, _As...) noexcept {
-          return +[](void* __rcvr, _As... __as) noexcept -> void {
-            _Tag{}((_Rcvr&&) *(_Rcvr*) __rcvr, (_As&&) __as...);
-          };
-        }
-      };
-
-      template <class... _Sigs>
-      struct __vtable<completion_signatures<_Sigs...>> {
-        struct __t : __rcvr_vfun<_Sigs>... {
-          template <class _Rcvr>
-            requires receiver_of<_Rcvr, completion_signatures<_Sigs...>>
-          friend const __t*
-            tag_invoke(__any::__create_vtable_t, __mtype<__t>, __mtype<_Rcvr>) noexcept {
-            static const __t __vtable_{{__rcvr_vfun_fn<_Rcvr>{}((_Sigs*) nullptr)}...};
-            return &__vtable_;
-          }
-        };
-      };
-
-      template <class... _Sigs, class _Env>
-      struct __ref<completion_signatures<_Sigs...>, _Env> {
-        using __vtable_t = stdexec::__t<__vtable<completion_signatures<_Sigs...>>>;
-
-        class __t {
-          void* __receiver_;
-          _Env __env_;
-          const __vtable_t* __vtable_;
-
-          template <std::same_as<__t> _Self>
-          friend _Env tag_invoke(get_env_t, const _Self& __self) noexcept {
-            return __self.__env_;
-          }
-
-          template <__completion_tag _Tag, __decays_to<__t> _Self, class... _As>
-            requires __one_of<_Tag(_As...), _Sigs...>
-          friend void tag_invoke(_Tag, _Self&& __self, _As&&... __as) noexcept {
-            (*static_cast<const __rcvr_vfun<_Tag(_As...)>*>(__self.__vtable_)->__fn_)(
-              __self.__receiver_, (_As&&) __as...);
-          }
-
-         public:
-          template <__none_of<__t, const __t> _Rcvr>
-            requires receiver_of<_Rcvr, completion_signatures<_Sigs...>>
-          __t(_Rcvr& __rcvr) noexcept
-            : __receiver_{std::addressof(__rcvr)}
-            , __env_{get_env(__rcvr)}
-            , __vtable_{__any::__create_vtable(__mtype<__vtable_t>{}, __mtype<_Rcvr>{})} {
-          }
-        };
-      };
-    } // __rec
-
-    template <class _Sigs, class __ReceiverId>
-    using __receiver_ref = __t<__rec::__ref<_Sigs, env_of_t<__t<__ReceiverId>>>>;
-
-    template <class... _Args>
-    using __all_nothrow_decay_copyable = __bool<(__nothrow_decay_copyable<_Args> && ...)>;
-
-    template <class _Sender, class _Receiver>
-    static const bool __is_nothrow_connectable_v =
-      noexcept(connect(std::declval<_Sender>(), std::declval<_Receiver>()));
-
-    template <class _Sender, class _Receiver, class... _Args>
-    using __nothrow_store_and_connect = __mand<
-      __all_nothrow_decay_copyable<_Args...>,
-      __bool<__nothrow_connectable<_Sender, _Receiver>>>;
-
-    template <class _Sender, class _Receiver, class _Sigs>
-    using __nothrow_store_and_connect_sigs = __mand<
-      __gather_signal<set_value_t, _Sigs, __q<__all_nothrow_decay_copyable>, __q<__mand>>,
-      __bool<__nothrow_connectable<_Sender, _Receiver>>>;
-
-    template <class _Sender, class _Receiver, class... _Args>
-    inline constexpr bool __nothrow_store_and_connect_v =
-      __v<__nothrow_store_and_connect<_Sender, _Receiver, _Args...>>;
-
     template <class... _Args>
     using __as_rvalues = completion_signatures<set_value_t(decay_t<_Args> && ...)>;
-
-    template <class... _Errors>
-    using __error_sigs = completion_signatures<set_error_t(_Errors)...>;
-
-    template <class _Sigs, class _FinalSender, class _Env>
-    using __additional_error_types = __concat_completion_signatures_t<
-      error_types_of_t<_FinalSender, _Env, __error_sigs>,
-      __if<
-        __nothrow_store_and_connect_sigs<
-          _FinalSender,
-          __t<__rec::__ref<completion_signatures_of_t<_FinalSender>, _Env>>,
-          _Sigs>,
-        completion_signatures<>,
-        completion_signatures<set_error_t(std::exception_ptr)>>>;
 
     template <class _InitialSender, class _FinalSender, class _Env>
     using __completion_signatures_t = make_completion_signatures<
       _InitialSender,
       _Env,
-      __additional_error_types<completion_signatures_of_t<_InitialSender>, _FinalSender, _Env>,
+      completion_signatures<set_error_t(std::exception_ptr)>,
       __as_rvalues>;
+
+    template <class _Receiver>
+    struct __applier {
+      _Receiver __receiver_;
+
+      template <class _Tag, class... _Args>
+      void operator()(_Tag __tag, _Args&&... __args) const noexcept {
+        __tag((_Receiver&&) __receiver_, (_Args&&) __args...);
+      }
+    };
+
+    template <class _Receiver>
+    struct __visitor {
+      _Receiver __receiver_;
+
+      template <class _Tuple>
+      void operator()(_Tuple&& __tuple) const noexcept {
+        std::apply(__applier<_Receiver>{(_Receiver&&) __receiver_}, (_Tuple&&) __tuple);
+      }
+    };
 
     template <class _ResultType, class _ReceiverId>
     struct __final_receiver {
@@ -180,19 +109,9 @@ namespace exec {
 
         template <__decays_to<__t> _Self>
         friend void tag_invoke(set_value_t, _Self&& __self) noexcept {
-          if constexpr (!std::same_as<_ResultType, __ignore>) {
-            std::visit(
-              [&]<class _Tuple>(_Tuple&& __tuple) noexcept {
-                std::apply(
-                  [&]<class... _Args>(_Args&&... __args) noexcept {
-                    set_value((_Receiver&&) __self.__op_->__receiver_, (_Args&&) __args...);
-                  },
-                  (_Tuple&&) __tuple);
-              },
-              (_ResultType&&) __self.__op_->__result_);
-          } else {
-            set_value((_Receiver&&) __self.__op_->__receiver_);
-          }
+          std::visit(
+            __visitor<_Receiver>{(_Receiver&&) __self.__op_->__receiver_},
+            (_ResultType&&) __self.__op_->__result_);
           __self.__op_->__result_.__destruct();
         }
 
@@ -200,76 +119,6 @@ namespace exec {
           requires __callable<_Tag, _Receiver&&, _Error...>
         friend void tag_invoke(_Tag __tag, _Self&& __self, _Error&&... __error) noexcept {
           __self.__op_->__result_.__destruct();
-          __tag((_Receiver&&) __self.__op_->__receiver_, (_Error&&) __error...);
-        }
-
-        template <std::same_as<__t> _Self>
-        friend env_of_t<_Receiver> tag_invoke(get_env_t, const _Self& __self) noexcept {
-          return get_env(__self.__op_->__receiver_);
-        }
-      };
-    };
-
-    template <class _FinalSenderId, class _Sigs, class _ReceiverId>
-    struct __initial_operation_base : __final_operation_base<__result_type<_Sigs>, _ReceiverId> {
-      using _FinalSender = __t<_FinalSenderId>;
-      using __final_receiver_ref_t =
-        __receiver_ref<completion_signatures_of_t<_FinalSender>, _ReceiverId>;
-      using __final_receiver_t = __t<__final_receiver<__result_type<_Sigs>, _ReceiverId>>;
-      using __final_operation_t = connect_result_t<_FinalSender, __final_receiver_ref_t>;
-
-      _FinalSender __final_sender_;
-      __final_receiver_t __final_receiver_{this};
-      __manual_lifetime<__final_operation_t> __final_operation_{};
-
-      template <class... _Args>
-        requires std::is_constructible_v<__result_type<_Sigs>, __decayed_tuple<_Args...>>
-      void __store_result_and_start_next_op(_Args&&... __args) noexcept(
-        __nothrow_store_and_connect_v<_FinalSender, __final_receiver_ref_t, _Args...>) {
-        this->__result_.__construct(std::tuple{(_Args&&) __args...});
-        __final_operation_.__construct(__conv{[&] {
-          return connect(
-            (_FinalSender&&) __final_sender_, __final_receiver_ref_t{__final_receiver_});
-        }});
-        start(__final_operation_.__get());
-      }
-    };
-
-    template <class _FinalSenderId, class _Sigs, class _ReceiverId>
-    struct __initial_receiver {
-      using _Receiver = stdexec::__t<_ReceiverId>;
-      using _FinalSender = stdexec::__t<_FinalSenderId>;
-
-      using __final_receiver_ref_t =
-        __receiver_ref<completion_signatures_of_t<_FinalSender>, _ReceiverId>;
-
-      class __t {
-       public:
-        explicit __t(__initial_operation_base<_FinalSenderId, _Sigs, _ReceiverId>* __op) noexcept
-          : __op_(__op) {
-        }
-
-       private:
-        __initial_operation_base<_FinalSenderId, _Sigs, _ReceiverId>* __op_;
-
-        template <__decays_to<__t> _Self, class... _Args>
-          requires __callable<set_value_t, _Receiver&&, _Args...>
-        friend void tag_invoke(set_value_t, _Self&& __self, _Args&&... __args) noexcept {
-          if constexpr (
-            __nothrow_store_and_connect_v<_FinalSender, __final_receiver_ref_t, _Args...>) {
-            __self.__op_->__store_result_and_start_next_op((_Args&&) __args...);
-          } else {
-            try {
-              __self.__op_->__store_result_and_start_next_op((_Args&&) __args...);
-            } catch (...) {
-              set_error((_Receiver&&) __self.__op_->__receiver_, std::current_exception());
-            }
-          }
-        }
-
-        template <__one_of<set_error_t, set_stopped_t> _Tag, __decays_to<__t> _Self, class... _Error>
-          requires __callable<_Tag, _Receiver&&, _Error...>
-        friend void tag_invoke(_Tag __tag, _Self&& __self, _Error&&... __error) noexcept {
           __tag((_Receiver&&) __self.__op_->__receiver_, (_Error&&) __error...);
         }
 
@@ -281,31 +130,92 @@ namespace exec {
     };
 
     template <class _InitialSenderId, class _FinalSenderId, class _ReceiverId>
-    struct operation_state {
+    struct __operation_state {
       using _InitialSender = stdexec::__t<_InitialSenderId>;
       using _FinalSender = stdexec::__t<_FinalSenderId>;
       using _Receiver = stdexec::__t<_ReceiverId>;
-      using _Sigs = completion_signatures_of_t<_InitialSender>;
-      using __initial_receiver_t =
-        stdexec::__t<__initial_receiver<_FinalSenderId, _Sigs, _ReceiverId>>;
+      using __signatures = completion_signatures_of_t<_InitialSender, env_of_t<_Receiver>>;
+      using __base_t = __final_operation_base<__result_variant<__signatures>, _ReceiverId>;
+      using __final_receiver_t =
+        stdexec::__t<__final_receiver<__result_variant<__signatures>, _ReceiverId>>;
+      using __final_op_t = connect_result_t<_FinalSender, __final_receiver_t>;
+      class __t;
+    };
 
-      using __base_t = __initial_operation_base<_FinalSenderId, _Sigs, _ReceiverId>;
+    template <class _InitialSenderId, class _FinalSenderId, class _ReceiverId>
+    struct __initial_receiver {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+      using _FinalSender = stdexec::__t<_FinalSenderId>;
 
-      class __t : __base_t {
-        connect_result_t<_InitialSender, __initial_receiver_t> __initial_operation_;
+      using __base_op_t =
+        stdexec::__t<__operation_state<_InitialSenderId, _FinalSenderId, _ReceiverId>>;
+
+      class __t {
+       public:
+        explicit __t(__base_op_t* __op) noexcept
+          : __op_(__op) {
+        }
+
+       private:
+        __base_op_t* __op_;
+
+        template <class _Tag, __decays_to<__t> _Self, class... _Args>
+          requires __callable<_Tag, _Receiver&&, _Args...>
+        friend void tag_invoke(_Tag __tag, _Self&& __self, _Args&&... __args) noexcept {
+          try {
+            __self.__op_->__store_result_and_start_next_op(__tag, (_Args&&) __args...);
+          } catch (...) {
+            set_error((_Receiver&&) __self.__op_->__receiver_, std::current_exception());
+          }
+        }
 
         template <std::same_as<__t> _Self>
-        friend void tag_invoke(start_t, _Self& __self) noexcept {
-          start(__self.__initial_operation_);
-        }
-
-       public:
-        __t(_InitialSender&& __initial_sender, _FinalSender&& __final_sender, _Receiver __receiver)
-          : __base_t{{(_Receiver&&) __receiver}, (_FinalSender&&) __final_sender}
-          , __initial_operation_(
-              connect((_InitialSender&&) __initial_sender, __initial_receiver_t{this})) {
+        friend env_of_t<_Receiver> tag_invoke(get_env_t, const _Self& __self) noexcept {
+          return get_env(__self.__op_->__receiver_);
         }
       };
+    };
+
+    template <class _InitialSenderId, class _FinalSenderId, class _ReceiverId>
+    class __operation_state<_InitialSenderId, _FinalSenderId, _ReceiverId>::__t : public __base_t {
+      using __initial_receiver_t =
+        stdexec::__t<__initial_receiver<_InitialSenderId, _FinalSenderId, _ReceiverId>>;
+
+      struct __initial_op_t {
+        _FinalSender __sender_;
+        connect_result_t<_InitialSender, __initial_receiver_t> __initial_operation_;
+      };
+
+      std::variant<__initial_op_t, __final_op_t> __op_;
+
+      template <std::same_as<__t> _Self>
+      friend void tag_invoke(start_t, _Self& __self) noexcept {
+        STDEXEC_ASSERT(__self.__op_.index() == 0);
+        start(std::get_if<0>(&__self.__op_)->__initial_operation_);
+      }
+
+     public:
+      template <class... _Args>
+        requires std::is_constructible_v<__result_variant<__signatures>, __decayed_tuple<_Args...>>
+      void __store_result_and_start_next_op(_Args&&... __args) {
+        this->__result_.__construct(
+          std::in_place_type<__decayed_tuple<_Args...>>, (_Args&&) __args...);
+        STDEXEC_ASSERT(__op_.index() == 0);
+        _FinalSender& __final_sender = std::get_if<0>(&__op_)->__sender_;
+        __final_op_t& __final_op = __op_.template emplace<1>(__conv{[&] {
+          return connect((_FinalSender&&) __final_sender, __final_receiver_t{this});
+        }});
+        start(__final_op);
+      }
+
+      __t(_InitialSender&& __initial_sender, _FinalSender&& __final_sender, _Receiver __receiver)
+        : __base_t{{(_Receiver&&) __receiver}}
+        , __op_(std::in_place_index<0>, __conv{[&] {
+                  return __initial_op_t{
+                    (_FinalSender&&) __final_sender,
+                    connect((_InitialSender&&) __initial_sender, __initial_receiver_t{this})};
+                }}) {
+      }
     };
 
     template <class _InitialSenderId, class _FinalSenderId>
@@ -314,7 +224,7 @@ namespace exec {
       using _FinalSender = stdexec::__t<_FinalSenderId>;
 
       template <class _Self, class _Receiver>
-      using __op_t = stdexec::__t<operation_state<
+      using __op_t = stdexec::__t<__operation_state<
         __x<__copy_cvref_t<_Self, _InitialSender>>,
         __x<__copy_cvref_t<_Self, _FinalSender>>,
         __x<_Receiver>>>;

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/execution.hpp"
+
+#include "__detail/__manual_lifetime.hpp"
+#include "any_sender_of.hpp"
+
+namespace exec {
+  namespace __finally {
+    using namespace stdexec;
+
+    template <class _Arg, class... _Args>
+    using __nonempty_decayed_tuple = __decayed_tuple<_Arg, _Args...>;
+
+    template <class _Sigs>
+    using __result_type_ =
+      __gather_signal<set_value_t, _Sigs, __q<__nonempty_decayed_tuple>, __q<__variant>>;
+
+    template <class _Sigs>
+    using __result_type =
+      __if<std::is_same<__result_type_<_Sigs>, __not_a_variant>, __ignore, __result_type_<_Sigs>>;
+
+    template <class _ResultType, class _ReceiverId>
+    struct __final_operation_base {
+      using _Receiver = __t<_ReceiverId>;
+
+      _Receiver __receiver_{};
+      __manual_lifetime<_ResultType> __result_{};
+    };
+
+    namespace __rec {
+      template <class _Sig>
+      struct __rcvr_vfun;
+
+      template <class _Sigs>
+      struct __vtable {
+        struct __t;
+      };
+
+      template <class _Sigs, class _Env>
+      struct __ref;
+
+      template <class _Tag, class... _As>
+      struct __rcvr_vfun<_Tag(_As...)> {
+        void (*__fn_)(void*, _As...) noexcept;
+      };
+
+      template <class _Rcvr>
+      struct __rcvr_vfun_fn {
+        template <class _Tag, class... _As>
+        constexpr void (*operator()(_Tag (*)(_As...)) const noexcept)(void*, _As...) noexcept {
+          return +[](void* __rcvr, _As... __as) noexcept -> void {
+            _Tag{}((_Rcvr&&) *(_Rcvr*) __rcvr, (_As&&) __as...);
+          };
+        }
+      };
+
+      template <class... _Sigs>
+      struct __vtable<completion_signatures<_Sigs...>> {
+        struct __t : __rcvr_vfun<_Sigs>... {
+          template <class _Rcvr>
+            requires receiver_of<_Rcvr, completion_signatures<_Sigs...>>
+          friend const __t*
+            tag_invoke(__any::__create_vtable_t, __mtype<__t>, __mtype<_Rcvr>) noexcept {
+            static const __t __vtable_{{__rcvr_vfun_fn<_Rcvr>{}((_Sigs*) nullptr)}...};
+            return &__vtable_;
+          }
+        };
+      };
+
+      template <class... _Sigs, class _Env>
+      struct __ref<completion_signatures<_Sigs...>, _Env> {
+        using __vtable_t = stdexec::__t<__vtable<completion_signatures<_Sigs...>>>;
+
+        class __t {
+          void* __receiver_;
+          _Env __env_;
+          const __vtable_t* __vtable_;
+
+          template <std::same_as<__t> _Self>
+          friend _Env tag_invoke(get_env_t, const _Self& __self) noexcept {
+            return __self.__env_;
+          }
+
+          template <__completion_tag _Tag, __decays_to<__t> _Self, class... _As>
+            requires __one_of<_Tag(_As...), _Sigs...>
+          friend void tag_invoke(_Tag, _Self&& __self, _As&&... __as) noexcept {
+            (*static_cast<const __rcvr_vfun<_Tag(_As...)>*>(__self.__vtable_)->__fn_)(
+              __self.__receiver_, (_As&&) __as...);
+          }
+
+         public:
+          template <__none_of<__t, const __t> _Rcvr>
+            requires receiver_of<_Rcvr, completion_signatures<_Sigs...>>
+          __t(_Rcvr& __rcvr) noexcept
+            : __receiver_{std::addressof(__rcvr)}
+            , __env_{get_env(__rcvr)}
+            , __vtable_{__any::__create_vtable(__mtype<__vtable_t>{}, __mtype<_Rcvr>{})} {
+          }
+        };
+      };
+    } // __rec
+
+    template <class _Sigs, class __ReceiverId>
+    using __receiver_ref = __t<__rec::__ref<_Sigs, env_of_t<__t<__ReceiverId>>>>;
+
+    template <class... _Args>
+    using __all_nothrow_decay_copyable = __bool<(__nothrow_decay_copyable<_Args> && ...)>;
+
+    template <class _Sender, class _Receiver>
+    static const bool __is_nothrow_connectable_v =
+      noexcept(connect(std::declval<_Sender>(), std::declval<_Receiver>()));
+
+    template <class _Sender, class _Receiver, class... _Args>
+    using __nothrow_store_and_connect = __mand<
+      __all_nothrow_decay_copyable<_Args...>,
+      __bool<__nothrow_connectable<_Sender, _Receiver>>>;
+
+    template <class _Sender, class _Receiver, class _Sigs>
+    using __nothrow_store_and_connect_sigs = __mand<
+      __gather_signal<set_value_t, _Sigs, __q<__all_nothrow_decay_copyable>, __q<__mand>>,
+      __bool<__nothrow_connectable<_Sender, _Receiver>>>;
+
+    template <class _Sender, class _Receiver, class... _Args>
+    inline constexpr bool __nothrow_store_and_connect_v =
+      __v<__nothrow_store_and_connect<_Sender, _Receiver, _Args...>>;
+
+    template <class... _Args>
+    using __as_rvalues = completion_signatures<set_value_t(decay_t<_Args> && ...)>;
+
+    template <class... _Errors>
+    using __error_sigs = completion_signatures<set_error_t(_Errors)...>;
+
+    template <class _Sigs, class _FinalSender, class _Env>
+    using __additional_error_types = __concat_completion_signatures_t<
+      error_types_of_t<_FinalSender, _Env, __error_sigs>,
+      __if<
+        __nothrow_store_and_connect_sigs<
+          _FinalSender,
+          __t<__rec::__ref<completion_signatures_of_t<_FinalSender>, _Env>>,
+          _Sigs>,
+        completion_signatures<>,
+        completion_signatures<set_error_t(std::exception_ptr)>>>;
+
+    template <class _InitialSender, class _FinalSender, class _Env>
+    using __completion_signatures_t = make_completion_signatures<
+      _InitialSender,
+      _Env,
+      __additional_error_types<completion_signatures_of_t<_InitialSender>, _FinalSender, _Env>,
+      __as_rvalues>;
+
+    template <class _ResultType, class _ReceiverId>
+    struct __final_receiver {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      class __t {
+       public:
+        explicit __t(__final_operation_base<_ResultType, _ReceiverId>* __op) noexcept
+          : __op_{__op} {
+        }
+
+       private:
+        __final_operation_base<_ResultType, _ReceiverId>* __op_;
+
+        template <__decays_to<__t> _Self>
+        friend void tag_invoke(set_value_t, _Self&& __self) noexcept {
+          if constexpr (!std::same_as<_ResultType, __ignore>) {
+            std::visit(
+              [&]<class _Tuple>(_Tuple&& __tuple) noexcept {
+                std::apply(
+                  [&]<class... _Args>(_Args&&... __args) noexcept {
+                    set_value((_Receiver&&) __self.__op_->__receiver_, (_Args&&) __args...);
+                  },
+                  (_Tuple&&) __tuple);
+              },
+              (_ResultType&&) __self.__op_->__result_);
+          } else {
+            set_value((_Receiver&&) __self.__op_->__receiver_);
+          }
+          __self.__op_->__result_.__destruct();
+        }
+
+        template <__one_of<set_error_t, set_stopped_t> _Tag, __decays_to<__t> _Self, class... _Error>
+        friend void tag_invoke(_Tag __tag, _Self&& __self, _Error&&... __error) noexcept {
+          __self.__op_->__result_.__destruct();
+          __tag((_Receiver&&) __self.__op_->__receiver_, (_Error&&) __error...);
+        }
+
+        template <std::same_as<__t> _Self>
+        friend env_of_t<_Receiver> tag_invoke(get_env_t, const _Self& __self) noexcept {
+          return get_env(__self.__op_->__receiver_);
+        }
+      };
+    };
+
+    template <class _FinalSenderId, class _Sigs, class _ReceiverId>
+    struct __initial_operation_base : __final_operation_base<__result_type<_Sigs>, _ReceiverId> {
+      using _FinalSender = __t<_FinalSenderId>;
+      using __final_receiver_ref_t =
+        __receiver_ref<completion_signatures_of_t<_FinalSender>, _ReceiverId>;
+      using __final_receiver_t = __t<__final_receiver<__result_type<_Sigs>, _ReceiverId>>;
+      using __final_operation_t = connect_result_t<_FinalSender, __final_receiver_ref_t>;
+
+      _FinalSender __final_sender_;
+      __final_receiver_t __final_receiver_{this};
+      __manual_lifetime<__final_operation_t> __final_operation_{};
+
+      template <class... _Args>
+      void __store_result_and_start_next_op(_Args&&... __args) noexcept(
+        __nothrow_store_and_connect_v<_FinalSender, __final_receiver_ref_t, _Args...>) {
+        this->__result_.__construct(std::tuple{(_Args&&) __args...});
+        __final_operation_.__construct(__conv{[&] {
+          return connect(
+            (_FinalSender&&) __final_sender_, __final_receiver_ref_t{__final_receiver_});
+        }});
+        start(__final_operation_.__get());
+      }
+    };
+
+    template <class _FinalSenderId, class _Sigs, class _ReceiverId>
+    struct __initial_receiver {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+      using _FinalSender = stdexec::__t<_FinalSenderId>;
+
+      using __final_receiver_ref_t =
+        __receiver_ref<completion_signatures_of_t<_FinalSender>, _ReceiverId>;
+
+      class __t {
+       public:
+        explicit __t(__initial_operation_base<_FinalSenderId, _Sigs, _ReceiverId>* __op) noexcept
+          : __op_(__op) {
+        }
+
+       private:
+        __initial_operation_base<_FinalSenderId, _Sigs, _ReceiverId>* __op_;
+
+        template <__decays_to<__t> _Self, class... _Args>
+        friend void tag_invoke(set_value_t, _Self&& __self, _Args&&... __args) noexcept {
+          if constexpr (
+            __nothrow_store_and_connect_v<_FinalSender, __final_receiver_ref_t, _Args...>) {
+            __self.__op_->__store_result_and_start_next_op((_Args&&) __args...);
+          } else {
+            try {
+              __self.__op_->__store_result_and_start_next_op((_Args&&) __args...);
+            } catch (...) {
+              set_error((_Receiver&&) __self.__op_->__receiver_, std::current_exception());
+            }
+          }
+        }
+
+        template <__one_of<set_error_t, set_stopped_t> _Tag, __decays_to<__t> _Self, class... _Error>
+        friend void tag_invoke(_Tag __tag, _Self&& __self, _Error&&... __error) noexcept {
+          __tag((_Receiver&&) __self.__op_->__receiver_, (_Error&&) __error...);
+        }
+
+        template <std::same_as<__t> _Self>
+        friend env_of_t<_Receiver> tag_invoke(get_env_t, const _Self& __self) noexcept {
+          return get_env(__self.__op_->__receiver_);
+        }
+      };
+    };
+
+    template <class _InitialSenderId, class _FinalSenderId, class _ReceiverId>
+    struct operation_state {
+      using _InitialSender = stdexec::__t<_InitialSenderId>;
+      using _FinalSender = stdexec::__t<_FinalSenderId>;
+      using _Receiver = stdexec::__t<_ReceiverId>;
+      using _Sigs = completion_signatures_of_t<_InitialSender>;
+      using __initial_receiver_t =
+        stdexec::__t<__initial_receiver<_FinalSenderId, _Sigs, _ReceiverId>>;
+
+      using __base_t = __initial_operation_base<_FinalSenderId, _Sigs, _ReceiverId>;
+
+      class __t : __base_t {
+        connect_result_t<_InitialSender, __initial_receiver_t> __initial_operation_;
+
+        template <std::same_as<__t> _Self>
+        friend void tag_invoke(start_t, _Self& __self) noexcept {
+          start(__self.__initial_operation_);
+        }
+
+       public:
+        __t(_InitialSender&& __initial_sender, _FinalSender&& __final_sender, _Receiver __receiver)
+          : __base_t{{(_Receiver&&) __receiver}, (_FinalSender&&) __final_sender}
+          , __initial_operation_(
+              connect((_InitialSender&&) __initial_sender, __initial_receiver_t{this})) {
+        }
+      };
+    };
+
+    template <class _InitialSenderId, class _FinalSenderId>
+    struct __sender {
+      using _InitialSender = stdexec::__t<_InitialSenderId>;
+      using _FinalSender = stdexec::__t<_FinalSenderId>;
+
+      template <class _Self, class _Receiver>
+      using __op_t = stdexec::__t<operation_state<
+        __x<__copy_cvref_t<_Self, _InitialSender>>,
+        __x<__copy_cvref_t<_Self, _FinalSender>>,
+        __x<_Receiver>>>;
+
+      class __t {
+        _InitialSender __initial_sender_;
+        _FinalSender __final_sender_;
+
+        template <__decays_to<__t> _Self, class _R>
+          requires receiver_of<
+            _R,
+            __completion_signatures_t<_InitialSender, _FinalSender, env_of_t<_R>>>
+        friend __op_t< _Self, _R> tag_invoke(connect_t, _Self&& __self, _R&& __receiver) noexcept {
+          return {
+            ((_Self&&) __self).__initial_sender_,
+            ((_Self&&) __self).__final_sender_,
+            (_R&&) __receiver};
+        }
+
+        template <__decays_to<__t> _Self, class _Env>
+        friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env) noexcept
+          -> dependent_completion_signatures<_Env>;
+
+        template <__decays_to<__t> _Self, __none_of<no_env> _Env>
+        friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env) noexcept
+          -> __completion_signatures_t<
+            __copy_cvref_t<_Self, _InitialSender>,
+            __copy_cvref_t<_Self, _FinalSender>,
+            _Env>;
+
+       public:
+        using is_sender = void;
+
+        template <__decays_to<_InitialSender> _I, __decays_to<_FinalSender> _F>
+        __t(_I&& __initial_sender, _F&& __final_sender) noexcept(
+          __nothrow_decay_copyable<_I>&& __nothrow_decay_copyable<_F>)
+          : __initial_sender_{(_I&&) __initial_sender}
+          , __final_sender_{(_F&&) __final_sender} {
+        }
+      };
+    };
+
+    struct __finally_t {
+      template <sender _I, sender _F>
+      __t<__sender<__id<decay_t<_I>>, __id<decay_t<_F>>>>
+        operator()(_I&& __initial_sender, _F&& __final_sender) const
+        noexcept(__nothrow_decay_copyable<_I>&& __nothrow_decay_copyable<_F>) {
+        return {(_I&&) __initial_sender, (_F&&) __final_sender};
+      }
+    };
+  }
+
+  inline constexpr __finally ::__finally_t finally{};
+}

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -197,6 +197,7 @@ namespace exec {
         }
 
         template <__one_of<set_error_t, set_stopped_t> _Tag, __decays_to<__t> _Self, class... _Error>
+          requires __callable<_Tag, _Receiver&&, _Error...>
         friend void tag_invoke(_Tag __tag, _Self&& __self, _Error&&... __error) noexcept {
           __self.__op_->__result_.__destruct();
           __tag((_Receiver&&) __self.__op_->__receiver_, (_Error&&) __error...);
@@ -222,6 +223,7 @@ namespace exec {
       __manual_lifetime<__final_operation_t> __final_operation_{};
 
       template <class... _Args>
+        requires std::is_constructible_v<__result_type<_Sigs>, __decayed_tuple<_Args...>>
       void __store_result_and_start_next_op(_Args&&... __args) noexcept(
         __nothrow_store_and_connect_v<_FinalSender, __final_receiver_ref_t, _Args...>) {
         this->__result_.__construct(std::tuple{(_Args&&) __args...});
@@ -251,6 +253,7 @@ namespace exec {
         __initial_operation_base<_FinalSenderId, _Sigs, _ReceiverId>* __op_;
 
         template <__decays_to<__t> _Self, class... _Args>
+          requires __callable<set_value_t, _Receiver&&, _Args...>
         friend void tag_invoke(set_value_t, _Self&& __self, _Args&&... __args) noexcept {
           if constexpr (
             __nothrow_store_and_connect_v<_FinalSender, __final_receiver_ref_t, _Args...>) {
@@ -265,6 +268,7 @@ namespace exec {
         }
 
         template <__one_of<set_error_t, set_stopped_t> _Tag, __decays_to<__t> _Self, class... _Error>
+          requires __callable<_Tag, _Receiver&&, _Error...>
         friend void tag_invoke(_Tag __tag, _Self&& __self, _Error&&... __error) noexcept {
           __tag((_Receiver&&) __self.__op_->__receiver_, (_Error&&) __error...);
         }

--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -69,7 +69,7 @@ namespace exec {
 
         template <__decays_to<__t> _Self, class _Receiver>
           requires sender_to<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>
-        friend connect_result_t<_Sender, __receiver_t<_Receiver>>
+        friend connect_result_t<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>
           tag_invoke(connect_t, _Self&& __self, _Receiver&& __receiver) noexcept(
             __nothrow_connectable<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>) {
           return connect(
@@ -168,7 +168,7 @@ namespace exec {
 
         template <__decays_to<__t> _Self, class _Receiver>
           requires sender_to<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>
-        friend connect_result_t<_Sender, __receiver_t<_Receiver>>
+        friend connect_result_t<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>
           tag_invoke(connect_t, _Self&& __self, _Receiver&& __receiver) noexcept(
             __nothrow_connectable<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>) {
           return connect(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(stdexec_test_sources
     exec/test_type_async_scope.cpp
     exec/test_create.cpp
     exec/test_env.cpp
+    exec/test_finally.cpp
     exec/test_on.cpp
     exec/test_on2.cpp
     exec/test_on3.cpp

--- a/test/exec/test_finally.cpp
+++ b/test/exec/test_finally.cpp
@@ -1,0 +1,86 @@
+#include "exec/finally.hpp"
+#include "exec/materialize.hpp"
+
+#include <catch2/catch.hpp>
+
+using namespace stdexec;
+
+template <class Haystack>
+struct __mall_contained_in {
+  template <class... Needles>
+  using __f = __mand<__mapply<__contains<Needles>, Haystack>...>;
+};
+
+template <class Needles, class Haystack>
+using __all_contained_in = __mapply<__mall_contained_in<Haystack>, Needles>;
+
+template <class Needles, class Haystack>
+using __equivalent = __mand<
+  __all_contained_in<Needles, Haystack>,
+  std::is_same<__mapply<__msize, Needles>, __mapply<__msize, Haystack>>>;
+
+TEST_CASE("finally is a sender", "[adaptors][finally]") {
+  auto s = exec::finally(just(), just());
+  static_assert(sender<decltype(s)>);
+}
+
+TEST_CASE("finally is a sender in empty env", "[adaptors][finally]") {
+  auto s = exec::finally(just(), just());
+  static_assert(sender_in<decltype(s), empty_env>);
+  static_assert(__v<__equivalent<
+                  completion_signatures_of_t<decltype(s), empty_env>,
+                  completion_signatures<set_value_t()>>>);
+}
+
+TEST_CASE("finally executes the final action", "[adaptors][finally]") {
+  bool called = false;
+  auto s = exec::finally(just(), just() | then([&called]() noexcept { called = true; }));
+  static_assert(__v<__equivalent<
+                  completion_signatures_of_t<decltype(s), empty_env>,
+                  completion_signatures<set_value_t()>>>);
+  sync_wait(s);
+  CHECK(called);
+}
+
+TEST_CASE("finally executes the final action and returns integer", "[adaptors][finally]") {
+  bool called = false;
+  auto s = exec::finally(just(42), just() | then([&called]() noexcept { called = true; }));
+  static_assert(__v<__equivalent<
+                  completion_signatures_of_t<decltype(s), empty_env>,
+                  completion_signatures<set_value_t(int&&)>>>);
+  auto [i] = *sync_wait(s);
+  CHECK(called);
+  CHECK(i == 42);
+}
+
+TEST_CASE("finally does not execute the final action and throws integer", "[adaptors][finally]") {
+  bool called = false;
+
+  auto s = exec::finally(
+    just(21) | then([](int x) {
+      throw 42;
+      return x;
+    }),
+    just() | then([&called]() noexcept { called = true; }));
+  static_assert(__v<__equivalent<
+                  completion_signatures_of_t<decltype(s), empty_env>,
+                  completion_signatures<set_error_t(std::exception_ptr), set_value_t(int&&)>>>);
+  CHECK_THROWS_AS(sync_wait(s), int);
+  CHECK(!called);
+}
+
+TEST_CASE("finally executes the final action and throws integer", "[adaptors][finally]") {
+  bool called = false;
+
+  auto s = exec::dematerialize(exec::finally(
+    exec::materialize(just(21) | then([](int x) {
+                        throw 42;
+                        return x;
+                      })),
+    just() | then([&called]() noexcept { called = true; })));
+  static_assert(__v<__equivalent<
+                  completion_signatures_of_t<decltype(s), empty_env>,
+                  completion_signatures<set_error_t(std::exception_ptr&&), set_value_t(int&&)>>>);
+  CHECK_THROWS_AS(sync_wait(s), int);
+  CHECK(called);
+}

--- a/test/exec/test_finally.cpp
+++ b/test/exec/test_finally.cpp
@@ -21,23 +21,23 @@ using __equivalent = __mand<
 
 TEST_CASE("finally is a sender", "[adaptors][finally]") {
   auto s = exec::finally(just(), just());
-  static_assert(sender<decltype(s)>);
+  STATIC_REQUIRE(sender<decltype(s)>);
 }
 
 TEST_CASE("finally is a sender in empty env", "[adaptors][finally]") {
   auto s = exec::finally(just(), just());
-  static_assert(sender_in<decltype(s), empty_env>);
-  static_assert(__v<__equivalent<
-                  completion_signatures_of_t<decltype(s), empty_env>,
-                  completion_signatures<set_value_t()>>>);
+  STATIC_REQUIRE(sender_in<decltype(s), empty_env>);
+  STATIC_REQUIRE(__v<__equivalent<
+                   completion_signatures_of_t<decltype(s), empty_env>,
+                   completion_signatures<set_error_t(std::exception_ptr), set_value_t()>>>);
 }
 
 TEST_CASE("finally executes the final action", "[adaptors][finally]") {
   bool called = false;
   auto s = exec::finally(just(), just() | then([&called]() noexcept { called = true; }));
-  static_assert(__v<__equivalent<
-                  completion_signatures_of_t<decltype(s), empty_env>,
-                  completion_signatures<set_value_t()>>>);
+  STATIC_REQUIRE(__v<__equivalent<
+                   completion_signatures_of_t<decltype(s), empty_env>,
+                   completion_signatures<set_error_t(std::exception_ptr), set_value_t()>>>);
   sync_wait(s);
   CHECK(called);
 }
@@ -45,9 +45,9 @@ TEST_CASE("finally executes the final action", "[adaptors][finally]") {
 TEST_CASE("finally executes the final action and returns integer", "[adaptors][finally]") {
   bool called = false;
   auto s = exec::finally(just(42), just() | then([&called]() noexcept { called = true; }));
-  static_assert(__v<__equivalent<
-                  completion_signatures_of_t<decltype(s), empty_env>,
-                  completion_signatures<set_value_t(int&&)>>>);
+  STATIC_REQUIRE(__v<__equivalent<
+                   completion_signatures_of_t<decltype(s), empty_env>,
+                   completion_signatures<set_error_t(std::exception_ptr), set_value_t(int&&)>>>);
   auto [i] = *sync_wait(s);
   CHECK(called);
   CHECK(i == 42);
@@ -62,25 +62,9 @@ TEST_CASE("finally does not execute the final action and throws integer", "[adap
       return x;
     }),
     just() | then([&called]() noexcept { called = true; }));
-  static_assert(__v<__equivalent<
-                  completion_signatures_of_t<decltype(s), empty_env>,
-                  completion_signatures<set_error_t(std::exception_ptr), set_value_t(int&&)>>>);
-  CHECK_THROWS_AS(sync_wait(s), int);
-  CHECK(!called);
-}
-
-TEST_CASE("finally executes the final action and throws integer", "[adaptors][finally]") {
-  bool called = false;
-
-  auto s = exec::dematerialize(exec::finally(
-    exec::materialize(just(21) | then([](int x) {
-                        throw 42;
-                        return x;
-                      })),
-    just() | then([&called]() noexcept { called = true; })));
-  static_assert(__v<__equivalent<
-                  completion_signatures_of_t<decltype(s), empty_env>,
-                  completion_signatures<set_error_t(std::exception_ptr&&), set_value_t(int&&)>>>);
+  STATIC_REQUIRE(__v<__equivalent<
+                   completion_signatures_of_t<decltype(s), empty_env>,
+                   completion_signatures<set_error_t(std::exception_ptr), set_value_t(int&&)>>>);
   CHECK_THROWS_AS(sync_wait(s), int);
   CHECK(called);
 }


### PR DESCRIPTION
Hey,

here I implement the `finally` algorithm. I have done this such that the algorithm lazily connects the final sender and detects whether the second call to `connect` will throw or not and omits `set_error_t(std::exception_ptr)` in case it doesnt.

This flavor of the algorithm starts the final operation only if the first op completed through a value channel, which I think is different to `libunifex`, so beware. I thought the original behaviour can be achieved through the marvelous `materialize`.

Unfortunately, this PR contains two little more things: I found a bug in `materialize` / `dematerialize`. I also added `noexcept` specifier to the `then_t` operation.

I did this to experiment, whether the suggestion in issue #472 is viable and I would like to change the `let_xxx` algorithms similarily to how it is done in this implementation. But that would mean to change the spec, too. 

Any feedback welcome
