### PR TITLE
Enable RAPIDS ops bot

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,4 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+copy_prs: true

--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -1,0 +1,46 @@
+name: CI (CPU)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+
+  build-cpu-gcc11:
+    runs-on: ubuntu-latest
+    name: CPU (gcc 11)
+    steps:
+      - name: Checkout stdexec
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Build and test CPU schedulers
+        uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:gcc11-ubuntu20.04
+        with:
+          cc: gcc-11
+          checks: build test
+          prebuild_command: |
+            apt update && apt install -y --no-install-recommends git;
+
+  build-cpu-clang12:
+    runs-on: ubuntu-latest
+    name: CPU (clang 12)
+    steps:
+      - name: Checkout stdexec
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Build and test CPU schedulers
+        uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:clang12-ubuntu20.04
+        with:
+          cc: clang-12
+          checks: build test
+          cxxflags: "-stdlib=libc++"
+          prebuild_command: |
+            apt update && apt install -y --no-install-recommends git;

--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -1,11 +1,10 @@
----
-name: CI
+name: CI (GPU)
 
 on:
-  pull_request:
   push:
     branches:
       - main
+      - "pull-request/[0-9]+"
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
@@ -13,40 +12,8 @@ concurrency:
 
 jobs:
 
-  build-cpu-gcc11:
-    runs-on: ubuntu-latest
-    name: CPU (gcc 11)
-    steps:
-      - name: Checkout stdexec
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - name: Build and test CPU schedulers
-        uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:gcc11-ubuntu20.04
-        with:
-          cc: gcc-11
-          checks: build test
-          prebuild_command: |
-            apt update && apt install -y --no-install-recommends git;
-
-  build-cpu-clang12:
-    runs-on: ubuntu-latest
-    name: CPU (clang 12)
-    steps:
-      - name: Checkout stdexec
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-      - name: Build and test CPU schedulers
-        uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:clang12-ubuntu20.04
-        with:
-          cc: clang-12
-          checks: build test
-          cxxflags: "-stdlib=libc++"
-          prebuild_command: |
-            apt update && apt install -y --no-install-recommends git;
-
   build-gpu:
+    if: github.repository == 'nvidia/stdexec'
     name: GPU (${{ matrix.name }}, CUDA ${{ matrix.cuda }})
     strategy:
       fail-fast: false


### PR DESCRIPTION
The self-hosted runners are going to be dropping `pull_request` and `pull_request_target` events later this week for security reasons, so we need to use the [RAPIDS ops-bot](https://github.com/rapidsai/ops-bot)'s PR branch copier in order to keep using the self-hosted runners.

We can still run CPU jobs on the GitHub-hosted runners using the `pull_request` event, but need to run the GPU jobs on `push` events.

The RAPIDS ops-bot will automatically create/push a branch named `pull-request/{pr_number}` to `nvidia/stdexec` when a user with write permissions replies to the PR with an `ok to test` comment.