### PR TITLE
Implement repeat_effect_until

### DIFF
--- a/include/exec/__detail/__manual_lifetime.hpp
+++ b/include/exec/__detail/__manual_lifetime.hpp
@@ -37,12 +37,12 @@ namespace exec {
 
     template <class... _Args>
     _Ty& __construct(_Args&&... __args) noexcept(std::is_nothrow_constructible_v<_Ty, _Args...>) {
-      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty((_Args &&) __args...);
+      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty((_Args&&) __args...);
     }
 
-    template <typename _Func>
+    template <class _Func>
     _Ty& __construct_with(_Func&& func) {
-      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty(((_Func &&) func)());
+      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty(((_Func&&) func)());
     }
 
     void __destruct() noexcept {
@@ -54,7 +54,7 @@ namespace exec {
     }
 
     _Ty&& __get() && noexcept {
-      return (_Ty &&) __value_;
+      return (_Ty&&) __value_;
     }
 
     const _Ty& __get() const & noexcept {

--- a/include/exec/__detail/__manual_lifetime.hpp
+++ b/include/exec/__detail/__manual_lifetime.hpp
@@ -37,7 +37,12 @@ namespace exec {
 
     template <class... _Args>
     _Ty& __construct(_Args&&... __args) noexcept(std::is_nothrow_constructible_v<_Ty, _Args...>) {
-      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty((_Args&&) __args...);
+      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty((_Args &&) __args...);
+    }
+
+    template <typename _Func>
+    _Ty& __construct_with(_Func&& func) {
+      return *::new (static_cast<void*>(std::addressof(__value_))) _Ty(((_Func &&) func)());
     }
 
     void __destruct() noexcept {
@@ -49,7 +54,7 @@ namespace exec {
     }
 
     _Ty&& __get() && noexcept {
-      return (_Ty&&) __value_;
+      return (_Ty &&) __value_;
     }
 
     const _Ty& __get() const & noexcept {

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Runner-2019
  * Copyright (c) 2023 NVIDIA Corporation
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -43,7 +43,7 @@ namespace exec {
         using __id = __operation;
         using __receiver_t = stdexec::__t<__receiver<_SourceId, _ReceiverId>>;
         using __source_on_scheduler_sender =
-          __call_result_t<stdexec::on_t, trampoline_scheduler, _Source&>;
+          __call_result_t<stdexec::on_t, trampoline_scheduler, _Source &>;
         using __source_op_t = stdexec::connect_result_t<__source_on_scheduler_sender, __receiver_t>;
 
         [[no_unique_address]] _Source __source_;
@@ -166,7 +166,7 @@ namespace exec {
           return {};
         }
 
-        template <class _Source2>
+        template <__decays_to<_Source> _Source2>
         explicit __t(_Source2 &&__source) noexcept(__nothrow_decay_copyable<_Source2>)
           : __source_((_Source2 &&) __source) {
         }

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/execution.hpp"
+#include "__detail/__manual_lifetime.hpp"
+#include "stdexec/concepts.hpp"
+#include <concepts>
+
+namespace exec {
+  namespace __repeat_effect_until {
+    using namespace stdexec;
+
+    template <typename _SourceId, typename _ReceiverId>
+    struct __receiver {
+      struct __t;
+    };
+
+    template <typename _SourceId, typename _ReceiverId>
+    struct __operation {
+      using _Source = stdexec::__t<_SourceId>;
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      struct __t : stdexec::__immovable {
+        using __id = __operation;
+        using __receiver_t = stdexec::__t<__receiver<_SourceId, _ReceiverId>>;
+        using __source_op_t = stdexec::connect_result_t<_Source, __receiver_t>;
+
+        [[no_unique_address]] _Source __source_;
+        [[no_unique_address]] _Receiver __receiver_;
+        __manual_lifetime<__source_op_t> __source_op_;
+
+        template <typename _Source2, typename _Receiver2>
+        __t(_Source2 &&__source, _Receiver2 &&__receiver) noexcept(
+          std::is_nothrow_constructible_v<_Source, _Source2>
+            &&std::is_nothrow_constructible_v<_Receiver, _Receiver2>
+              &&__nothrow_connectable<_Source, __receiver_t>)
+          : __source_((_Source2 &&) __source)
+          , __receiver_((_Receiver2 &&) __receiver) {
+          __source_op_.__construct_with([&] {
+            return stdexec::connect((_Source2 &&) __source_, __receiver_t{this});
+          });
+        }
+
+        ~__t() {
+          __source_op_.__destruct();
+        }
+
+        friend void tag_invoke(stdexec::start_t, __t &__self) noexcept {
+          stdexec::start(__self.__source_op_.__get());
+        }
+      };
+    };
+
+    template <typename _SourceId, typename _ReceiverId>
+    struct __receiver<_SourceId, _ReceiverId>::__t {
+      using __id = __receiver;
+      using _Source = stdexec::__t<_SourceId>;
+      using _Receiver = stdexec::__t<_ReceiverId>;
+      using __op_t = stdexec::__t<__operation<_SourceId, _ReceiverId>>;
+
+      __op_t *__op_;
+
+      explicit __t(__op_t *op) noexcept
+        : __op_(op) {
+      }
+
+      __t(__t &&__other) noexcept
+        : __op_(std::exchange(__other.__op_, {})) {
+      }
+
+      template <__decays_to<__t> _Self, convertible_to<bool> _Arg>
+      friend void tag_invoke(set_value_t, _Self &&__self, _Arg &&__flag) noexcept {
+        __self.__op_->__source_op_.__destruct();
+
+        if constexpr (__nothrow_connectable<_Source &, __t>) {
+          // call __predicate and complete with void if it returns true
+          if (__flag) {
+            stdexec::set_value((_Receiver &&) __self.__op_->__receiver_);
+            return;
+          }
+
+          auto &__source_op = __self.__op_->__source_op_.__construct_with([&]() {
+            return stdexec::connect((_Source &&) __self.__op_->__source_, __t{__self.__op_});
+          });
+          stdexec::start(__source_op);
+        } else {
+          try {
+            // call __predicate and complete with void if it returns true
+            if (__flag) {
+              stdexec::set_value((_Receiver &&) __self.__op_->__receiver_);
+              return;
+            }
+
+            auto &__source_op = __self.__op_->__source_op_.__construct_with([&]() {
+              return stdexec::connect((_Source &&) __self.__op_->__source_, __t{__self.__op_});
+            });
+            stdexec::start(__source_op);
+          } catch (...) {
+            stdexec::set_error((_Receiver &&) __self.__op_->__receiver_, std::current_exception());
+          }
+        }
+      }
+
+      template <__decays_to<__t> _Self>
+      friend void tag_invoke(set_stopped_t, _Self &&__self) noexcept {
+        stdexec::set_stopped((_Receiver &&) __self.__op_->__receiver_);
+      }
+
+      template <__decays_to<__t> _Self, typename _Error>
+      friend void tag_invoke(set_error_t, _Self &&__self, _Error &&__error) noexcept {
+        stdexec::set_error((_Receiver &&) __self.__op_->__receiver_, (_Error &&) __error);
+      }
+
+      friend env_of_t<const _Receiver &> tag_invoke(get_env_t, const __t &__self) noexcept {
+        return get_env(__self.__op_->__receiver_);
+      }
+    };
+
+    template <typename _SourceId>
+    struct __sender {
+      using _Source = stdexec::__t<_SourceId>;
+
+      template <class _Receiver>
+      using __op_t =
+        stdexec::__t< __operation<_SourceId, stdexec::__id<std::remove_cvref_t<_Receiver>>>>;
+
+      template <class _Receiver>
+      using __receiver_t =
+        stdexec::__t< __receiver<_SourceId, stdexec::__id<std::remove_cvref_t<_Receiver>>>>;
+
+      struct __t {
+        using __id = __sender;
+        [[no_unique_address]] _Source __source_;
+
+        template <class... Ts>
+        using _Value = stdexec::completion_signatures<stdexec::set_value_t()>;
+
+        template <class _Self, class _Env>
+        using __completion_signatures = //
+          stdexec::make_completion_signatures<
+            __copy_cvref_t<_Self, _Source>,
+            _Env,
+            completion_signatures<set_error_t(std::exception_ptr)>,
+            _Value >;
+
+        template <__decays_to<__t> _Self, class _Env>
+        friend auto tag_invoke(get_completion_signatures_t, _Self &&, _Env)
+          -> __completion_signatures<_Self, _Env> {
+          return {};
+        }
+
+        template <typename _Source2>
+        explicit __t(_Source2 &&__source) noexcept(
+          std::is_nothrow_constructible_v<_Source, _Source2>)
+          : __source_((_Source2 &&) __source) {
+        }
+
+        template <__decays_to<__t> _Sender, receiver _Receiver>
+          requires sender_to<_Source, __receiver_t<_Receiver>>
+        friend __op_t<_Receiver> tag_invoke(connect_t, _Sender &&__s, _Receiver &&__r) noexcept {
+          return {((_Sender &&) __s).__source_, (_Receiver &&) __r};
+        }
+
+        friend env_of_t<const _Source &> tag_invoke(get_env_t, const __t &__self) noexcept {
+          return get_env(__self.__source_);
+        }
+      };
+    };
+
+    template <typename _Source>
+    using __sender_t = __t< __sender<stdexec::__id<std::remove_cvref_t<_Source>>>>;
+
+    inline const struct repeat_effect_until_t {
+      template <sender _Source>
+      auto operator()(_Source &&__source) const
+        noexcept(nothrow_tag_invocable<repeat_effect_until_t, _Source>)
+          -> tag_invoke_result_t<repeat_effect_until_t, _Source> {
+        return tag_invoke(*this, (_Source &&) __source);
+      }
+
+      template <sender _Source>
+        requires(!tag_invocable<repeat_effect_until_t, _Source>)
+      auto operator()(_Source &&__source) const
+        noexcept(std::is_nothrow_constructible_v< __sender_t<_Source>, _Source>)
+          -> __sender_t<_Source> {
+        return __sender_t<_Source>{(_Source &&) __source};
+      }
+
+      constexpr auto operator()() const -> __binder_back<repeat_effect_until_t> {
+        return {{}, {}, {}};
+      }
+    } repeat_effect_until{};
+
+  } // namespace __repeat_effect
+
+  inline constexpr __repeat_effect_until::repeat_effect_until_t repeat_effect_until{};
+} // namespace exec

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -181,8 +181,9 @@ namespace exec {
           return {((_Self &&) __self).__source_, (_Receiver &&) __rcvr};
         }
 
-        friend env_of_t<const _Source &> tag_invoke(get_env_t, const __t &__self) noexcept(
-          __nothrow_callable<get_env_t, const _Source &>) {
+        friend auto tag_invoke(get_env_t, const __t &__self) //
+          noexcept(__nothrow_callable<get_env_t, const _Source &>)
+            -> __call_result_t<get_env_t, const _Source &> {
           return get_env(__self.__source_);
         }
       };

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -79,10 +79,10 @@ namespace exec {
         STDEXEC_ASSERT(__op_ != nullptr);
       }
 
-      template <convertible_to<bool> _Done>
+      template <same_as<__t> _Self, convertible_to<bool> _Done>
         requires __callable<set_value_t, _Receiver>
               && __callable<set_error_t, _Receiver, std::exception_ptr>
-      friend void tag_invoke(set_value_t, __t &&__self, _Done &&__done_ish) noexcept {
+      friend void tag_invoke(set_value_t, _Self &&__self, _Done &&__done_ish) noexcept {
         bool __done = static_cast<bool>(__done_ish); // BUGBUG potentially throwing.
         auto *__op = __self.__op_;
 
@@ -104,17 +104,17 @@ namespace exec {
         }
       }
 
-      friend void tag_invoke(set_stopped_t, __t &&__self) noexcept
+      template <same_as<__t> _Self>
         requires __callable<set_stopped_t, _Receiver>
-      {
+      friend void tag_invoke(set_stopped_t, _Self &&__self) noexcept {
         auto *__op = __self.__op_;
         __op->__source_op_.__destruct();
         stdexec::set_stopped((_Receiver &&) __op->__rcvr_);
       }
 
-      template <class _Error>
+      template <same_as<__t> _Self, class _Error>
         requires __callable<set_error_t, _Receiver, _Error>
-      friend void tag_invoke(set_error_t, __t &&__self, _Error __error) noexcept {
+      friend void tag_invoke(set_error_t, _Self &&__self, _Error __error) noexcept {
         auto *__op = __self.__op_;
         __op->__source_op_.__destruct();
         stdexec::set_error((_Receiver &&) __op->__rcvr_, (_Error &&) __error);

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -43,7 +43,7 @@ namespace exec {
         using __id = __operation;
         using __receiver_t = stdexec::__t<__receiver<_SourceId, _ReceiverId>>;
         using __source_on_scheduler_sender =
-          __call_result_t<stdexec::on_t, trampoline_scheduler, _Source>;
+          __call_result_t<stdexec::on_t, trampoline_scheduler, _Source&>;
         using __source_op_t = stdexec::connect_result_t<__source_on_scheduler_sender, __receiver_t>;
 
         [[no_unique_address]] _Source __source_;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -2769,8 +2769,8 @@ namespace stdexec {
         connect_result_t<_Sender, __receiver_t> __op_;
 
         __t(_Sender&& __sndr, _Receiver __rcvr, _Fun __fun) //
-          noexcept(__nothrow_decay_copyable<_Receiver&&>    //
-                     && __nothrow_decay_copyable<_Fun&&>    //
+          noexcept(__nothrow_decay_copyable<_Receiver>      //
+                     && __nothrow_decay_copyable<_Fun>      //
                        && __nothrow_connectable<_Sender, __receiver_t>)
           : __data_{(_Receiver&&) __rcvr, (_Fun&&) __fun}
           , __op_(connect((_Sender&&) __sndr, __receiver_t{&__data_})) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ set(stdexec_test_sources
     exec/test_on.cpp
     exec/test_on2.cpp
     exec/test_on3.cpp
+    exec/test_repeat_effect_until.cpp
     exec/async_scope/test_dtor.cpp
     exec/async_scope/test_spawn.cpp
     exec/async_scope/test_spawn_future.cpp

--- a/test/exec/test_repeat_effect_until.cpp
+++ b/test/exec/test_repeat_effect_until.cpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 Runner-2019
  * Copyright (c) 2023 NVIDIA Corporation
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions

--- a/test/exec/test_repeat_effect_until.cpp
+++ b/test/exec/test_repeat_effect_until.cpp
@@ -91,17 +91,17 @@ TEST_CASE(
   stdexec::sync_wait(exec::repeat_effect_until(std::move(input_snd)));
 }
 
-TEST_CASE("simple example for repeat_effect_until", "[adaptors][repeat_effect_until]") {
-  // Run 1'000'000 times
-  int n = 1;
-  sender auto snd = exec::repeat_effect_until(just() | then([&n] {
-                                                ++n;
-                                                return n == 1'000'000;
-                                              }));
+// TEST_CASE("simple example for repeat_effect_until", "[adaptors][repeat_effect_until]") {
+//   // Run 1'000'000 times
+//   int n = 1;
+//   sender auto snd = exec::repeat_effect_until(just() | then([&n] {
+//                                                 ++n;
+//                                                 return n == 1'000'000;
+//                                               }));
 
-  stdexec::sync_wait(std::move(snd));
-  CHECK(n == 1'000'000);
-}
+//   stdexec::sync_wait(std::move(snd));
+//   CHECK(n == 1'000'000);
+// }
 
 TEST_CASE("repeat_effect_until with pipeline operator", "[adaptors][repeat_effect_until]") {
   bool should_stopped = true;

--- a/test/exec/test_repeat_effect_until.cpp
+++ b/test/exec/test_repeat_effect_until.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/repeat_effect_until.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
+#include <exception>
+#include <system_error>
+#include <test_common/schedulers.hpp>
+#include <test_common/receivers.hpp>
+#include <test_common/senders.hpp>
+#include <test_common/type_helpers.hpp>
+#include <iostream>
+
+#include <catch2/catch.hpp>
+#include <type_traits>
+
+using namespace stdexec;
+
+TEST_CASE("repeat_effect_until returns a sender", "[adaptors][repeat_effect_until]") {
+  auto snd = exec::repeat_effect_until(ex::just() | then([] { return false; }));
+  static_assert(ex::sender<decltype(snd)>);
+  (void) snd;
+}
+
+TEST_CASE(
+  "repeat_effect_until with environment returns a sender",
+  "[adaptors][repeat_effect_until]") {
+  auto snd = exec::repeat_effect_until(just() | then([] { return true; }));
+  static_assert(ex::sender_in<decltype(snd), empty_env>);
+  (void) snd;
+}
+
+TEST_CASE("test connect cpo of repeat_effect_until", "[adaptors][repeat_effect_until]") {
+  sender auto source = just(1) | then([](int n) { return true; });
+  sender auto snd = exec::repeat_effect_until(std::move(source));
+  auto op = stdexec::connect(std::move(snd), expect_void_receiver{});
+  start(op);
+}
+
+TEST_CASE(
+  "Input sender produces a int value that can be converted to bool",
+  "[adaptors][repeat_effect_until]") {
+  sender auto snd = exec::repeat_effect_until(just(1));
+  auto op = stdexec::connect(std::move(snd), expect_value_receiver{});
+  start(op);
+}
+
+TEST_CASE(
+  "Input sender produces a object value that can be converted to bool",
+  "[adaptors][repeat_effect_until]") {
+  struct pred {
+    operator bool() {
+      return --n <= 100;
+    }
+
+    int n = 100;
+  };
+
+  pred p;
+  auto input_snd = just() | then([&p] { return p; });
+  stdexec::sync_wait(exec::repeat_effect_until(std::move(input_snd)));
+}
+
+TEST_CASE(
+  "repeat effect will pass error signal of input sender to downstream' receiver",
+  "[adaptors][repeat_effect_until]") {
+  struct pred {
+    operator bool() {
+      return --n <= 100;
+    }
+
+    int n = 100;
+  };
+
+  pred p;
+  auto input_snd = just() | then([&p] { return p; });
+  stdexec::sync_wait(exec::repeat_effect_until(std::move(input_snd)));
+}
+
+TEST_CASE("simple example for repeat_effect_until", "[adaptors][repeat_effect_until]") {
+  // Run 1'000'000 times
+  int n = 1;
+  sender auto snd = exec::repeat_effect_until(just() | then([&n] {
+                                                ++n;
+                                                return n == 1'000'000;
+                                              }));
+
+  stdexec::sync_wait(std::move(snd));
+  CHECK(n == 1'000'000);
+}
+
+TEST_CASE("repeat_effect_until with pipeline operator", "[adaptors][repeat_effect_until]") {
+  bool should_stopped = true;
+  ex::sender auto snd = just(should_stopped) | exec::repeat_effect_until() | then([] { return 1; });
+  wait_for_value(std::move(snd), 1);
+}

--- a/test/exec/test_repeat_effect_until.cpp
+++ b/test/exec/test_repeat_effect_until.cpp
@@ -18,6 +18,7 @@
 #include "exec/repeat_effect_until.hpp"
 #include "exec/on.hpp"
 #include "exec/trampoline_scheduler.hpp"
+#include "exec/static_thread_pool.hpp"
 #include "stdexec/concepts.hpp"
 #include "stdexec/execution.hpp"
 #include <exception>
@@ -33,6 +34,33 @@
 
 using namespace stdexec;
 
+struct boolean_sender {
+  using __t = boolean_sender;
+  using __id = boolean_sender;
+  using completion_signatures = stdexec::completion_signatures<set_value_t(bool)>;
+
+  template <class Receiver>
+  struct operation {
+    Receiver rcvr_;
+    int counter_;
+
+    friend void tag_invoke(start_t, operation &self) noexcept {
+      if (self.counter_ == 0) {
+        set_value((Receiver &&) self.rcvr_, true);
+      } else {
+        set_value((Receiver &&) self.rcvr_, false);
+      }
+    }
+  };
+
+  template <receiver_of<completion_signatures> Receiver>
+  friend operation<Receiver> tag_invoke(connect_t, boolean_sender self, Receiver rcvr) {
+    return {(Receiver &&) rcvr, --*self.counter_};
+  }
+
+  std::shared_ptr<int> counter_ = std::make_shared<int>(1000);
+};
+
 TEST_CASE("repeat_effect_until returns a sender", "[adaptors][repeat_effect_until]") {
   auto snd = exec::repeat_effect_until(ex::just() | then([] { return false; }));
   static_assert(ex::sender<decltype(snd)>);
@@ -47,69 +75,89 @@ TEST_CASE(
   (void) snd;
 }
 
-TEST_CASE("test connect cpo of repeat_effect_until", "[adaptors][repeat_effect_until]") {
+TEST_CASE(
+  "repeat_effect_until produces void value to downstream receiver",
+  "[adaptors][repeat_effect_until]") {
   sender auto source = just(1) | then([](int n) { return true; });
   sender auto snd = exec::repeat_effect_until(std::move(source));
+  // The receiver checks if we receive the void value
+  auto op = stdexec::connect(std::move(snd), expect_void_receiver{});
+  start(op);
+}
+
+TEST_CASE("simple example for repeat_effect_until", "[adaptors][repeat_effect_until]") {
+  sender auto snd = exec::repeat_effect_until(boolean_sender{});
+  stdexec::sync_wait(std::move(snd));
+}
+
+TEST_CASE("repeat_effect_until works with pipeline operator", "[adaptors][repeat_effect_until]") {
+  bool should_stopped = true;
+  ex::sender auto snd = just(should_stopped) | exec::repeat_effect_until() | then([] { return 1; });
+  wait_for_value(std::move(snd), 1);
+}
+
+TEST_CASE(
+  "repeat_effect_until works when input sender produces an int value",
+  "[adaptors][repeat_effect_until]") {
+  sender auto snd = exec::repeat_effect_until(just(1));
   auto op = stdexec::connect(std::move(snd), expect_void_receiver{});
   start(op);
 }
 
 TEST_CASE(
-  "Input sender produces a int value that can be converted to bool",
+  "repeat_effect_until works when input sender produces an object that can be converted to bool"
   "[adaptors][repeat_effect_until]") {
-  sender auto snd = exec::repeat_effect_until(just(1));
-  auto op = stdexec::connect(std::move(snd), expect_value_receiver{});
+  struct pred {
+    operator bool() {
+      return --n <= 100;
+    }
+
+    int n = 100;
+  };
+
+  pred p;
+  auto input_snd = just() | then([&p] { return p; });
+  stdexec::sync_wait(exec::repeat_effect_until(std::move(input_snd)));
+}
+
+TEST_CASE(
+  "repeat_effect_until forwards set_error calls of other types",
+  "[adaptors][repeat_effect_until]") {
+  auto snd = just_error(std::string("error")) | exec::repeat_effect_until();
+  auto op = ex::connect(std::move(snd), expect_error_receiver{std::string("error")});
+  start(op);
+}
+
+TEST_CASE("repeat_effect_until forwards set_stopped calls", "[adaptors][repeat_effect_until]") {
+  auto snd = just_stopped() | exec::repeat_effect_until();
+  auto op = ex::connect(std::move(snd), expect_stopped_receiver{});
   start(op);
 }
 
 TEST_CASE(
-  "Input sender produces a object value that can be converted to bool",
+  "running deeply recursing algo on repeat_effect_until doesn't blow the stack",
   "[adaptors][repeat_effect_until]") {
-  struct pred {
-    operator bool() {
-      return --n <= 100;
-    }
-
-    int n = 100;
-  };
-
-  pred p;
-  auto input_snd = just() | then([&p] { return p; });
-  stdexec::sync_wait(exec::repeat_effect_until(std::move(input_snd)));
-}
-
-TEST_CASE(
-  "repeat effect will pass error signal of input sender to downstream' receiver",
-  "[adaptors][repeat_effect_until]") {
-  struct pred {
-    operator bool() {
-      return --n <= 100;
-    }
-
-    int n = 100;
-  };
-
-  pred p;
-  auto input_snd = just() | then([&p] { return p; });
-  stdexec::sync_wait(exec::repeat_effect_until(std::move(input_snd)));
-}
-
-TEST_CASE("simple example for repeat_effect_until", "[adaptors][repeat_effect_until]") {
-  // Run 1'000'000 times
   int n = 1;
-  exec::trampoline_scheduler sched;
-  auto source = exec::on(sched, just() | then([&n] {
-                                  ++n;
-                                  return n == 1'000'000;
-                                }));
-  sender auto snd = exec::repeat_effect_until(std::move(source));
-
+  sender auto snd = exec::repeat_effect_until(just() | then([&n] {
+                                                ++n;
+                                                return n == 1'000'000;
+                                              }));
   stdexec::sync_wait(std::move(snd));
   CHECK(n == 1'000'000);
 }
 
-TEST_CASE("repeat_effect_until with pipeline operator", "[adaptors][repeat_effect_until]") {
-  bool should_stopped = true;
-  ex::sender auto snd = just(should_stopped) | exec::repeat_effect_until() | then([] { return 1; });
-  wait_for_value(std::move(snd), 1);
+TEST_CASE("repeat_effect_until works when changing threads", "[adaptors][repeat_effect_until]") {
+  exec::static_thread_pool pool{2};
+  bool called{false};
+  sender auto snd = exec::on(
+    pool.get_scheduler(), //
+    ex::just()            //
+      | ex::then([&] {
+          called = true;
+          return called;
+        })
+      | exec::repeat_effect_until());
+  stdexec::sync_wait(std::move(snd));
+
+  REQUIRE(called);
 }

--- a/test/exec/test_repeat_effect_until.cpp
+++ b/test/exec/test_repeat_effect_until.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "exec/repeat_effect_until.hpp"
+#include "exec/on.hpp"
+#include "exec/trampoline_scheduler.hpp"
 #include "stdexec/concepts.hpp"
 #include "stdexec/execution.hpp"
 #include <exception>
@@ -91,17 +93,19 @@ TEST_CASE(
   stdexec::sync_wait(exec::repeat_effect_until(std::move(input_snd)));
 }
 
-// TEST_CASE("simple example for repeat_effect_until", "[adaptors][repeat_effect_until]") {
-//   // Run 1'000'000 times
-//   int n = 1;
-//   sender auto snd = exec::repeat_effect_until(just() | then([&n] {
-//                                                 ++n;
-//                                                 return n == 1'000'000;
-//                                               }));
+TEST_CASE("simple example for repeat_effect_until", "[adaptors][repeat_effect_until]") {
+  // Run 1'000'000 times
+  int n = 1;
+  exec::trampoline_scheduler sched;
+  auto source = exec::on(sched, just() | then([&n] {
+                                  ++n;
+                                  return n == 1'000'000;
+                                }));
+  sender auto snd = exec::repeat_effect_until(std::move(source));
 
-//   stdexec::sync_wait(std::move(snd));
-//   CHECK(n == 1'000'000);
-// }
+  stdexec::sync_wait(std::move(snd));
+  CHECK(n == 1'000'000);
+}
 
 TEST_CASE("repeat_effect_until with pipeline operator", "[adaptors][repeat_effect_until]") {
   bool should_stopped = true;


### PR DESCRIPTION
I implemented 'repeat_effect_until' customization point object  for repeat doing something. This cpo requires an boolean sender as loop body. If the input sender produces a true value, the repeat operation will stop, and the void signal will be generated to the downstream receiver. Otherwise, the input sender will be repeated.

Note that if the input sender sends an error signal to repeat_effect_until, the repeated operation will stop, and the error 
generated by the input sender will be transparently transmitted to the downstream receiver

e.g.
```
  int n = 1;
  sender auto snd = repeat_effect_until(just() | then([&n]() {
                                                ++n;
                                                return n == 10000;
                                              }));
  sync_wait(std::move(snd));
```
In above example, we simply increased 1 to 10000. Let's look at another example that echoes what the client sent.

```
  sender auto snd = 
    ...
    | let_value(async_read_some(...))
    | then(echo_content())
    | upon_error(error_handler(...))
    | then([](...){return !peer_close;})
    | repeat_effect_until();

  stdexec::start_detached(std::move(snd));
```

This example needs a little bit of explanation. Firstly we read the content sent by the user and perform the echo operation. After handling possible errors, determine whether the customer is disconnected and whether to repeat the next read operation.

This is just simply work now. Some suggestions are needed to make some improvements to it. Thank you.