### PR TITLE
finally: Fix use-after-free 

### DIFF
--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -123,7 +123,7 @@ namespace exec {
                 __visitor<_Receiver>{(_Receiver&&) __self.__op_->__receiver_},
                 (_ResultType&&) __result);
             } catch (...) {
-              std::set_error((_Receiver&&) __self.__op_->__receiver_, std::current_exception());
+              stdexec::set_error((_Receiver&&) __self.__op_->__receiver_, std::current_exception());
             }
           }
         }


### PR DESCRIPTION
`__self` could be destroyed after issuing a completion signal. This commits moves the `result` in a local variable, destroys the the `__manual_lifetime` object and then signals completion. In case of throwing move constructors we forward an exception. 

This fixes a TSAN issue, which I encountered using finally in an I/O example.