### PR TITLE
Fix CI GPU job permissions issue

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,11 @@
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history"
   },
 
+  "mounts": [
+    "source=${localWorkspaceFolder}/.cache/.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/.cache/.config,target=/home/coder/.config,type=bind,consistency=consistent"
+  ],
+
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 
   "hostRequirements": { "gpu": true },
 
-  "initializeCommand": "mkdir -p .cache",
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -p .cache/.{aws,config}"],
 
   "containerEnv": {
     "SCCACHE_REGION": "us-east-2",

--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -27,7 +27,7 @@ jobs:
       - gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1
       - ${{ matrix.arch }}
     container:
-      options: -u coder
+      options: -u root
       image: rapidsai/devcontainers:23.04-cpp-${{ matrix.tag }}-ubuntu22.04
       env:
         CUDA_VERSION: "${{ matrix.cuda }}"

--- a/include/exec/__detail/__bit_cast.hpp
+++ b/include/exec/__detail/__bit_cast.hpp
@@ -23,6 +23,8 @@
 #endif
 #endif
 
+#include <cstring>
+
 namespace exec {
 
 #if defined(STDEXEC_HAS_BIT_CAST)


### PR DESCRIPTION
Container jobs need to run as root because the host volume mounts can be owned by any user.