### PR TITLE
[NFC] Do not use single letter names

### DIFF
--- a/include/exec/__detail/__atomic_intrusive_queue.hpp
+++ b/include/exec/__detail/__atomic_intrusive_queue.hpp
@@ -22,11 +22,11 @@ namespace exec {
   template <auto _NextPtr>
   class __atomic_intrusive_queue;
 
-  template <class _T, _T* _T::*_NextPtr>
+  template <class _Tp, _Tp* _Tp::*_NextPtr>
   class __atomic_intrusive_queue<_NextPtr> {
    public:
-    using __node_pointer = _T*;
-    using __atomic_node_pointer = std::atomic<_T*>;
+    using __node_pointer = _Tp*;
+    using __atomic_node_pointer = std::atomic<_Tp*>;
 
     [[nodiscard]] bool empty() const noexcept {
       return __head_.load(std::memory_order_relaxed) == nullptr;

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -24,10 +24,10 @@ namespace exec {
     using namespace stdexec;
 
     struct __create_vtable_t {
-      template <class _VTable, class _T>
-        requires __tag_invocable_r<const _VTable*, __create_vtable_t, __mtype<_VTable>, __mtype<_T>>
-      constexpr const _VTable* operator()(__mtype<_VTable>, __mtype<_T>) const noexcept {
-        return tag_invoke(__create_vtable_t{}, __mtype<_VTable>{}, __mtype<_T>{});
+      template <class _VTable, class _Tp>
+        requires __tag_invocable_r<const _VTable*, __create_vtable_t, __mtype<_VTable>, __mtype<_Tp>>
+      constexpr const _VTable* operator()(__mtype<_VTable>, __mtype<_Tp>) const noexcept {
+        return tag_invoke(__create_vtable_t{}, __mtype<_VTable>{}, __mtype<_Tp>{});
       }
     };
 
@@ -142,23 +142,23 @@ namespace exec {
       }
     };
 
-    template <class _Storage, class _T>
+    template <class _Storage, class _Tp>
     struct __storage_vfun_fn {
       template <class _Tag, class... _As>
-        requires __callable<_Tag, __mtype<_T>, _Storage&, _As...>
+        requires __callable<_Tag, __mtype<_Tp>, _Storage&, _As...>
       constexpr void (*operator()(_Tag (*)(void (*)(_As...))) const noexcept)(void*, _As...) {
         return +[](void* __storage, _As... __as) -> void {
-          return _Tag{}(__mtype<_T>{}, *(_Storage*) __storage, (_As&&) __as...);
+          return _Tag{}(__mtype<_Tp>{}, *(_Storage*) __storage, (_As&&) __as...);
         };
       }
 
       template <class _Tag, class... _As>
-        requires __callable<_Tag, __mtype<_T>, _Storage&, _As...>
+        requires __callable<_Tag, __mtype<_Tp>, _Storage&, _As...>
       constexpr void (
         *operator()(_Tag (*)(void (*)(_As...) noexcept)) const noexcept)(void*, _As...) noexcept {
         return +[](void* __storage, _As... __as) noexcept -> void {
-          static_assert(__nothrow_callable<_Tag, __mtype<_T>, _Storage&, _As...>);
-          return _Tag{}(__mtype<_T>{}, *(_Storage*) __storage, (_As&&) __as...);
+          static_assert(__nothrow_callable<_Tag, __mtype<_Tp>, _Storage&, _As...>);
+          return _Tag{}(__mtype<_Tp>{}, *(_Storage*) __storage, (_As&&) __as...);
         };
       }
     };
@@ -187,34 +187,34 @@ namespace exec {
     inline constexpr __get_object_pointer_t __get_object_pointer{};
 
     struct __delete_t {
-      template <class _Storage, class _T>
-        requires tag_invocable<__delete_t, __mtype<_T>, _Storage&>
-      void operator()(__mtype<_T>, _Storage& __storage) noexcept {
-        static_assert(nothrow_tag_invocable<__delete_t, __mtype<_T>, _Storage&>);
-        tag_invoke(__delete_t{}, __mtype<_T>{}, __storage);
+      template <class _Storage, class _Tp>
+        requires tag_invocable<__delete_t, __mtype<_Tp>, _Storage&>
+      void operator()(__mtype<_Tp>, _Storage& __storage) noexcept {
+        static_assert(nothrow_tag_invocable<__delete_t, __mtype<_Tp>, _Storage&>);
+        tag_invoke(__delete_t{}, __mtype<_Tp>{}, __storage);
       }
     };
 
     inline constexpr __delete_t __delete{};
 
     struct __copy_construct_t {
-      template <class _Storage, class _T>
-        requires tag_invocable<__copy_construct_t, __mtype<_T>, _Storage&, const _Storage&>
-      void operator()(__mtype<_T>, _Storage& __self, const _Storage& __from) noexcept(
-        nothrow_tag_invocable<__copy_construct_t, __mtype<_T>, _Storage&, const _Storage&>) {
-        tag_invoke(__copy_construct_t{}, __mtype<_T>{}, __self, __from);
+      template <class _Storage, class _Tp>
+        requires tag_invocable<__copy_construct_t, __mtype<_Tp>, _Storage&, const _Storage&>
+      void operator()(__mtype<_Tp>, _Storage& __self, const _Storage& __from) noexcept(
+        nothrow_tag_invocable<__copy_construct_t, __mtype<_Tp>, _Storage&, const _Storage&>) {
+        tag_invoke(__copy_construct_t{}, __mtype<_Tp>{}, __self, __from);
       }
     };
 
     inline constexpr __copy_construct_t __copy_construct{};
 
     struct __move_construct_t {
-      template <class _Storage, class _T>
-        requires tag_invocable<__move_construct_t, __mtype<_T>, _Storage&, _Storage&&>
-      void operator()(__mtype<_T>, _Storage& __self, __midentity<_Storage&&> __from) noexcept {
+      template <class _Storage, class _Tp>
+        requires tag_invocable<__move_construct_t, __mtype<_Tp>, _Storage&, _Storage&&>
+      void operator()(__mtype<_Tp>, _Storage& __self, __midentity<_Storage&&> __from) noexcept {
         static_assert(
-          nothrow_tag_invocable<__move_construct_t, __mtype<_T>, _Storage&, _Storage&&>);
-        tag_invoke(__move_construct_t{}, __mtype<_T>{}, __self, (_Storage&&) __from);
+          nothrow_tag_invocable<__move_construct_t, __mtype<_Tp>, _Storage&, _Storage&&>);
+        tag_invoke(__move_construct_t{}, __mtype<_Tp>{}, __self, (_Storage&&) __from);
       }
     };
 
@@ -249,10 +249,10 @@ namespace exec {
       return &__null_storage_vtbl<_ParentVTable, _StorageCPOs...>;
     }
 
-    template <class _Storage, class _T, class _ParentVTable, class... _StorageCPOs>
+    template <class _Storage, class _Tp, class _ParentVTable, class... _StorageCPOs>
     static const __storage_vtable<_ParentVTable, _StorageCPOs...> __storage_vtbl{
-      {*__create_vtable(__mtype<_ParentVTable>{}, __mtype<_T>{})},
-      {__storage_vfun_fn<_Storage, _T>{}((_StorageCPOs*) nullptr)}...};
+      {*__create_vtable(__mtype<_ParentVTable>{}, __mtype<_Tp>{})},
+      {__storage_vfun_fn<_Storage, _Tp>{}((_StorageCPOs*) nullptr)}...};
 
     template <
       class _Vtable,
@@ -281,21 +281,21 @@ namespace exec {
       using __with_move = __move_construct_t(void(__t&&) noexcept);
       using __with_delete = __delete_t(void() noexcept);
 
-      template <class _T>
-      static constexpr bool __is_small = sizeof(_T) <= __buffer_size && alignof(_T) <= __alignment
-                                      && std::is_nothrow_move_constructible_v<_T>;
+      template <class _Tp>
+      static constexpr bool __is_small = sizeof(_Tp) <= __buffer_size && alignof(_Tp) <= __alignment
+                                      && std::is_nothrow_move_constructible_v<_Tp>;
 
       using __vtable_t = __if_c<
         _Copyable,
         __storage_vtable<_Vtable, __with_delete, __with_move, __with_copy>,
         __storage_vtable<_Vtable, __with_delete, __with_move>>;
 
-      template <class _T>
+      template <class _Tp>
       static constexpr const __vtable_t* __get_vtable() noexcept {
         if constexpr (_Copyable) {
-          return &__storage_vtbl<__t, decay_t<_T>, _Vtable, __with_delete, __with_move, __with_copy>;
+          return &__storage_vtbl<__t, decay_t<_Tp>, _Vtable, __with_delete, __with_move, __with_copy>;
         } else {
-          return &__storage_vtbl<__t, decay_t<_T>, _Vtable, __with_delete, __with_move>;
+          return &__storage_vtbl<__t, decay_t<_Tp>, _Vtable, __with_delete, __with_move>;
         }
       }
 
@@ -304,26 +304,26 @@ namespace exec {
 
       __t() = default;
 
-      template <__none_of<__t&, const __t&> _T>
-        requires __callable<__create_vtable_t, __mtype<_Vtable>, __mtype<std::decay_t<_T>>>
-      __t(_T&& __object)
-        : __vtable_{__get_vtable<_T>()} {
-        using _D = decay_t<_T>;
-        if constexpr (__is_small<_D>) {
-          __construct_small<_D>((_T&&) __object);
+      template <__none_of<__t&, const __t&> _Tp>
+        requires __callable<__create_vtable_t, __mtype<_Vtable>, __mtype<std::decay_t<_Tp>>>
+      __t(_Tp&& __object)
+        : __vtable_{__get_vtable<_Tp>()} {
+        using _Dp = decay_t<_Tp>;
+        if constexpr (__is_small<_Dp>) {
+          __construct_small<_Dp>((_Tp&&) __object);
         } else {
-          __construct_large<_D>((_T&&) __object);
+          __construct_large<_Dp>((_Tp&&) __object);
         }
       }
 
-      template <class _T, class... _Args>
-        requires __callable<__create_vtable_t, __mtype<_Vtable>, __mtype<_T>>
-      __t(std::in_place_type_t<_T>, _Args&&... __args)
-        : __vtable_{__get_vtable<_T>()} {
-        if constexpr (__is_small<_T>) {
-          __construct_small<_T>((_Args&&) __args...);
+      template <class _Tp, class... _Args>
+        requires __callable<__create_vtable_t, __mtype<_Vtable>, __mtype<_Tp>>
+      __t(std::in_place_type_t<_Tp>, _Args&&... __args)
+        : __vtable_{__get_vtable<_Tp>()} {
+        if constexpr (__is_small<_Tp>) {
+          __construct_small<_Tp>((_Args&&) __args...);
         } else {
-          __construct_large<_T>((_Args&&) __args...);
+          __construct_large<_Tp>((_Args&&) __args...);
         }
       }
 
@@ -361,21 +361,21 @@ namespace exec {
       }
 
      private:
-      template <class _T, class... _As>
+      template <class _Tp, class... _As>
       void __construct_small(_As&&... __args) {
-        static_assert(sizeof(_T) <= __buffer_size && alignof(_T) <= __alignment);
-        _T* __pointer = static_cast<_T*>(static_cast<void*>(&__buffer_[0]));
-        using _Alloc = typename std::allocator_traits<_Allocator>::template rebind_alloc<_T>;
+        static_assert(sizeof(_Tp) <= __buffer_size && alignof(_Tp) <= __alignment);
+        _Tp* __pointer = static_cast<_Tp*>(static_cast<void*>(&__buffer_[0]));
+        using _Alloc = typename std::allocator_traits<_Allocator>::template rebind_alloc<_Tp>;
         _Alloc __alloc{__allocator_};
         std::allocator_traits<_Alloc>::construct(__alloc, __pointer, (_As&&) __args...);
         __object_pointer_ = __pointer;
       }
 
-      template <class _T, class... _As>
+      template <class _Tp, class... _As>
       void __construct_large(_As&&... __args) {
-        using _Alloc = typename std::allocator_traits<_Allocator>::template rebind_alloc<_T>;
+        using _Alloc = typename std::allocator_traits<_Allocator>::template rebind_alloc<_Tp>;
         _Alloc __alloc{__allocator_};
-        _T* __pointer = std::allocator_traits<_Alloc>::allocate(__alloc, 1);
+        _Tp* __pointer = std::allocator_traits<_Alloc>::allocate(__alloc, 1);
         try {
           std::allocator_traits<_Alloc>::construct(__alloc, __pointer, (_As&&) __args...);
         } catch (...) {
@@ -393,29 +393,29 @@ namespace exec {
         return __self.__object_pointer_;
       }
 
-      template <class _T>
-      friend void tag_invoke(__delete_t, __mtype<_T>, __t& __self) noexcept {
+      template <class _Tp>
+      friend void tag_invoke(__delete_t, __mtype<_Tp>, __t& __self) noexcept {
         if (!__self.__object_pointer_) {
           return;
         }
-        using _Alloc = typename std::allocator_traits<_Allocator>::template rebind_alloc<_T>;
+        using _Alloc = typename std::allocator_traits<_Allocator>::template rebind_alloc<_Tp>;
         _Alloc __alloc{__self.__allocator_};
-        _T* __pointer = static_cast<_T*>(std::exchange(__self.__object_pointer_, nullptr));
+        _Tp* __pointer = static_cast<_Tp*>(std::exchange(__self.__object_pointer_, nullptr));
         std::allocator_traits<_Alloc>::destroy(__alloc, __pointer);
-        if constexpr (!__is_small<_T>) {
+        if constexpr (!__is_small<_Tp>) {
           std::allocator_traits<_Alloc>::deallocate(__alloc, __pointer, 1);
         }
       }
 
-      template <class _T>
-      friend void tag_invoke(__move_construct_t, __mtype<_T>, __t& __self, __t&& __other) noexcept {
+      template <class _Tp>
+      friend void tag_invoke(__move_construct_t, __mtype<_Tp>, __t& __self, __t&& __other) noexcept {
         if (!__other.__object_pointer_) {
           return;
         }
-        _T* __pointer = static_cast<_T*>(std::exchange(__other.__object_pointer_, nullptr));
-        if constexpr (__is_small<_T>) {
-          _T& __other_object = *__pointer;
-          __self.template __construct_small<_T>((_T&&) __other_object);
+        _Tp* __pointer = static_cast<_Tp*>(std::exchange(__other.__object_pointer_, nullptr));
+        if constexpr (__is_small<_Tp>) {
+          _Tp& __other_object = *__pointer;
+          __self.template __construct_small<_Tp>((_Tp&&) __other_object);
         } else {
           __self.__object_pointer_ = __pointer;
         }
@@ -423,17 +423,17 @@ namespace exec {
           __other.__vtable_, __default_storage_vtable((__vtable_t*) nullptr));
       }
 
-      template <class _T>
+      template <class _Tp>
         requires _Copyable
-      friend void tag_invoke(__copy_construct_t, __mtype<_T>, __t& __self, const __t& __other) {
+      friend void tag_invoke(__copy_construct_t, __mtype<_Tp>, __t& __self, const __t& __other) {
         if (!__other.__object_pointer_) {
           return;
         }
-        const _T& __other_object = *static_cast<const _T*>(__other.__object_pointer_);
-        if constexpr (__is_small<_T>) {
-          __self.template __construct_small<_T>(__other_object);
+        const _Tp& __other_object = *static_cast<const _Tp*>(__other.__object_pointer_);
+        if constexpr (__is_small<_Tp>) {
+          __self.template __construct_small<_Tp>(__other_object);
         } else {
-          __self.template __construct_large<_T>(__other_object);
+          __self.template __construct_large<_Tp>(__other_object);
         }
         __self.__vtable_ = __other.__vtable_;
       }

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -62,8 +62,8 @@ namespace exec {
           }
         };
       };
-      template <class _R>
-      using __receiver = __t<__receiver_id<_R>>;
+      template <class _Rec>
+      using __receiver = __t<__receiver_id<_Rec>>;
 
       template <class _Sender>
       struct __sender_id {

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -246,15 +246,15 @@ namespace exec {
         _InitialSender __initial_sender_;
         _FinalSender __final_sender_;
 
-        template <__decays_to<__t> _Self, class _R>
+        template <__decays_to<__t> _Self, class _Rec>
           requires receiver_of<
-            _R,
-            __completion_signatures_t<_InitialSender, _FinalSender, env_of_t<_R>>>
-        friend __op_t< _Self, _R> tag_invoke(connect_t, _Self&& __self, _R&& __receiver) noexcept {
+            _Rec,
+            __completion_signatures_t<_InitialSender, _FinalSender, env_of_t<_Rec>>>
+        friend __op_t< _Self, _Rec> tag_invoke(connect_t, _Self&& __self, _Rec&& __receiver) noexcept {
           return {
             ((_Self&&) __self).__initial_sender_,
             ((_Self&&) __self).__final_sender_,
-            (_R&&) __receiver};
+            (_Rec&&) __receiver};
         }
 
         template <__decays_to<__t> _Self, class _Env>
@@ -271,21 +271,21 @@ namespace exec {
        public:
         using is_sender = void;
 
-        template <__decays_to<_InitialSender> _I, __decays_to<_FinalSender> _F>
-        __t(_I&& __initial_sender, _F&& __final_sender) noexcept(
-          __nothrow_decay_copyable<_I>&& __nothrow_decay_copyable<_F>)
-          : __initial_sender_{(_I&&) __initial_sender}
-          , __final_sender_{(_F&&) __final_sender} {
+        template <__decays_to<_InitialSender> _Is, __decays_to<_FinalSender> _Fs>
+        __t(_Is&& __initial_sender, _Fs&& __final_sender) noexcept(
+          __nothrow_decay_copyable<_Is>&& __nothrow_decay_copyable<_Fs>)
+          : __initial_sender_{(_Is&&) __initial_sender}
+          , __final_sender_{(_Fs&&) __final_sender} {
         }
       };
     };
 
     struct __finally_t {
-      template <sender _I, sender _F>
-      __t<__sender<__id<decay_t<_I>>, __id<decay_t<_F>>>>
-        operator()(_I&& __initial_sender, _F&& __final_sender) const
-        noexcept(__nothrow_decay_copyable<_I>&& __nothrow_decay_copyable<_F>) {
-        return {(_I&&) __initial_sender, (_F&&) __final_sender};
+      template <sender _Is, sender _Fs>
+      __t<__sender<__id<decay_t<_Is>>, __id<decay_t<_Fs>>>>
+        operator()(_Is&& __initial_sender, _Fs&& __final_sender) const
+        noexcept(__nothrow_decay_copyable<_Is>&& __nothrow_decay_copyable<_Fs>) {
+        return {(_Is&&) __initial_sender, (_Fs&&) __final_sender};
       }
     };
   }

--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -79,8 +79,8 @@ namespace exec {
         template <class... _Args>
         using __materialize_value = completion_signatures<set_value_t(set_value_t, _Args...)>;
 
-        template <class _E>
-        using __materialize_error = completion_signatures<set_value_t(set_error_t, _E)>;
+        template <class _Err>
+        using __materialize_error = completion_signatures<set_value_t(set_error_t, _Err)>;
 
         template <class _Env>
         using __completion_signatures_for_t = make_completion_signatures<

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -141,8 +141,8 @@ namespace exec {
           std::visit(
             [this]<class _Tuple>(_Tuple&& __result) {
               std::apply(
-                [this]<class _C, class... _As>(_C, _As&&... __args) noexcept {
-                  _C{}((_Receiver&&) __receiver_, (_As&&) __args...);
+                [this]<class _Cpo, class... _As>(_Cpo, _As&&... __args) noexcept {
+                  _Cpo{}((_Receiver&&) __receiver_, (_As&&) __args...);
                 },
                 (_Tuple&&) __result);
             },

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -28,8 +28,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       new (result) ResultSenderT(fn((As&&) as...));
     }
 
-    template <class _T>
-    using __decay_ref = stdexec::decay_t<_T>&;
+    template <class _Tp>
+    using __decay_ref = stdexec::decay_t<_Tp>&;
 
     template <class _Fun>
     using __result_sender = //

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -21,27 +21,27 @@
 
 #include <cassert>
 
-#define STDEXEC_CAT_(_X, ...) _X##__VA_ARGS__
-#define STDEXEC_CAT(_X, ...) STDEXEC_CAT_(_X, __VA_ARGS__)
+#define STDEXEC_CAT_(_Xp, ...) _Xp##__VA_ARGS__
+#define STDEXEC_CAT(_Xp, ...) STDEXEC_CAT_(_Xp, __VA_ARGS__)
 
 #define STDEXEC_EXPAND(...) __VA_ARGS__
 #define STDEXEC_EVAL(_M, ...) _M(__VA_ARGS__)
 
-#define STDEXEC_NOT(_X) STDEXEC_CAT(STDEXEC_NOT_, _X)
+#define STDEXEC_NOT(_Xp) STDEXEC_CAT(STDEXEC_NOT_, _Xp)
 #define STDEXEC_NOT_0 1
 #define STDEXEC_NOT_1 0
 
-#define STDEXEC_IIF_0(_Y, ...) __VA_ARGS__
-#define STDEXEC_IIF_1(_Y, ...) _Y
-#define STDEXEC_IIF(_X, _Y, ...) STDEXEC_EVAL(STDEXEC_CAT(STDEXEC_IIF_, _X), _Y, __VA_ARGS__)
+#define STDEXEC_IIF_0(_Yp, ...) __VA_ARGS__
+#define STDEXEC_IIF_1(_Yp, ...) _Yp
+#define STDEXEC_IIF(_Xp, _Yp, ...) STDEXEC_EVAL(STDEXEC_CAT(STDEXEC_IIF_, _Xp), _Yp, __VA_ARGS__)
 
 #define STDEXEC_COUNT(...) \
   STDEXEC_EXPAND(STDEXEC_COUNT_(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
-#define STDEXEC_COUNT_(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _N, ...) _N
+#define STDEXEC_COUNT_(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _Np, ...) _Np
 
 #define STDEXEC_CHECK(...) STDEXEC_EXPAND(STDEXEC_CHECK_N(__VA_ARGS__, 0, ))
-#define STDEXEC_CHECK_N(_X, _N, ...) _N
-#define STDEXEC_PROBE(_X) _X, 1,
+#define STDEXEC_CHECK_N(_Xp, _Np, ...) _Np
+#define STDEXEC_PROBE(_Xp) _Xp, 1,
 
 #if defined(__NVCOMPILER)
 #define STDEXEC_NVHPC() 1
@@ -93,10 +93,10 @@
 #error "Redefinition of STDEXEC_ASSERT is not permitted. Define STDEXEC_ASSERT_FN instead."
 #endif
 
-#define STDEXEC_ASSERT(_X) \
+#define STDEXEC_ASSERT(_Xp) \
   do { \
-    static_assert(noexcept(_X)); \
-    STDEXEC_ASSERT_FN(_X); \
+    static_assert(noexcept(_Xp)); \
+    STDEXEC_ASSERT_FN(_Xp); \
   } while (false)
 
 #ifndef STDEXEC_ASSERT_FN

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -34,9 +34,9 @@ namespace stdexec {
 
   // Before gcc-12, gcc really didn't like tuples or variants of immovable types
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 12)
-#define STDEXEC_IMMOVABLE(_X) _X(_X&&)
+#define STDEXEC_IMMOVABLE(_Xp) _Xp(_Xp&&)
 #else
-#define STDEXEC_IMMOVABLE(_X) _X(_X&&) = delete
+#define STDEXEC_IMMOVABLE(_Xp) _Xp(_Xp&&) = delete
 #endif
 
   // BUG (gcc PR93711): copy elision fails when initializing a
@@ -66,11 +66,11 @@ namespace stdexec {
     __move_only& operator=(const __move_only&) = delete;
   };
 
-  template <class _T>
-  using __t = typename _T::__t;
+  template <class _Tp>
+  using __t = typename _Tp::__t;
 
-  template <bool _B>
-  using __bool = std::bool_constant<_B>;
+  template <bool _Bp>
+  using __bool = std::bool_constant<_Bp>;
 
   template <class _Ty>
   struct __mtype {
@@ -84,26 +84,26 @@ namespace stdexec {
   template <class... _Ts>
   concept __typename = requires { typename __types<_Ts...>; };
 
-  template <class _T>
-  using __midentity = _T;
+  template <class _Tp>
+  using __midentity = _Tp;
 
-  template <std::size_t _N>
-  using __msize_t = char[_N + 1];
+  template <std::size_t _Np>
+  using __msize_t = char[_Np + 1];
 
-  template <class _T>
-  inline constexpr auto __v = _T::value;
+  template <class _Tp>
+  inline constexpr auto __v = _Tp::value;
 
-  template <class _T, class _U>
-  inline constexpr bool __v<std::is_same<_T, _U>> = false;
+  template <class _Tp, class _Up>
+  inline constexpr bool __v<std::is_same<_Tp, _Up>> = false;
 
-  template <class _T>
-  inline constexpr bool __v<std::is_same<_T, _T>> = true;
+  template <class _Tp>
+  inline constexpr bool __v<std::is_same<_Tp, _Tp>> = true;
 
-  template <class _T, _T _I>
-  inline constexpr _T __v<std::integral_constant<_T, _I>> = _I;
+  template <class _Tp, _Tp _Ip>
+  inline constexpr _Tp __v<std::integral_constant<_Tp, _Ip>> = _Ip;
 
-  template <std::size_t _I>
-  inline constexpr std::size_t __v<char[_I]> = _I - 1;
+  template <std::size_t _Ip>
+  inline constexpr std::size_t __v<char[_Ip]> = _Ip - 1;
 
   template <bool>
   struct __i {
@@ -147,8 +147,8 @@ namespace stdexec {
   template <class _Fn, class... _Back>
   using __mbind_back = __mbind_back_q<_Fn::template __f, _Back...>;
 
-  template <template <class...> class _T, class... _Args>
-  concept __valid = requires { typename __meval<_T, _Args...>; };
+  template <template <class...> class _Tp, class... _Args>
+  concept __valid = requires { typename __meval<_Tp, _Args...>; };
 
   template <class _Fn, class... _Args>
   concept __minvocable = __valid<_Fn::template __f, _Args...>;
@@ -196,10 +196,10 @@ namespace stdexec {
     requires(sizeof...(_False) <= 1)
   using __if_c = __minvoke<__if_<_Pred>, _True, _False...>;
 
-  template <class _T>
+  template <class _Tp>
   struct __mconst {
     template <class...>
-    using __f = _T;
+    using __f = _Tp;
   };
 
   template <class _Fn, class _Default>
@@ -242,57 +242,57 @@ namespace stdexec {
     using __t = __minvoke<_Continuation, _As...>;
   };
 
-  template <class _Continuation, template <class...> class _A, class... _As>
+  template <class _Continuation, template <class...> class _Ap, class... _As>
     requires __minvocable<_Continuation, _As...>
-  struct __mconcat_<_Continuation, _A<_As...>> {
+  struct __mconcat_<_Continuation, _Ap<_As...>> {
     using __t = __minvoke<_Continuation, _As...>;
   };
 
   template <             //
     class _Continuation, //
     template <class...>
-    class _A,
+    class _Ap,
     class... _As, //
     template <class...>
-    class _B,
+    class _Bp,
     class... _Bs>
     requires __minvocable<_Continuation, _As..., _Bs...>
-  struct __mconcat_<_Continuation, _A<_As...>, _B<_Bs...>> {
+  struct __mconcat_<_Continuation, _Ap<_As...>, _Bp<_Bs...>> {
     using __t = __minvoke<_Continuation, _As..., _Bs...>;
   };
 
   template <             //
     class _Continuation, //
     template <class...>
-    class _A,
+    class _Ap,
     class... _As, //
     template <class...>
-    class _B,
+    class _Bp,
     class... _Bs, //
     template <class...>
-    class _C,
+    class _Cp,
     class... _Cs>
     requires __minvocable<_Continuation, _As..., _Bs..., _Cs...>
-  struct __mconcat_<_Continuation, _A<_As...>, _B<_Bs...>, _C<_Cs...>> {
+  struct __mconcat_<_Continuation, _Ap<_As...>, _Bp<_Bs...>, _Cp<_Cs...>> {
     using __t = __minvoke<_Continuation, _As..., _Bs..., _Cs...>;
   };
 
   template <             //
     class _Continuation, //
     template <class...>
-    class _A,
+    class _Ap,
     class... _As, //
     template <class...>
-    class _B,
+    class _Bp,
     class... _Bs, //
     template <class...>
-    class _C,
+    class _Cp,
     class... _Cs, //
     template <class...>
-    class _D,
+    class _Dp,
     class... _Ds, //
     class... _Tail>
-  struct __mconcat_<_Continuation, _A<_As...>, _B<_Bs...>, _C<_Cs...>, _D<_Ds...>, _Tail...>
+  struct __mconcat_<_Continuation, _Ap<_As...>, _Bp<_Bs...>, _Cp<_Cs...>, _Dp<_Ds...>, _Tail...>
     : __mconcat_<_Continuation, __types<_As..., _Bs..., _Cs..., _Ds...>, _Tail...> { };
 
   template <class _Continuation = __q<__types>>
@@ -307,19 +307,19 @@ namespace stdexec {
     using __f = __minvoke<_Fn, _Ts...>;
   };
 
-  template <class _Fn, class _T>
+  template <class _Fn, class _Tp>
   struct __uncurry_;
 
-  template <class _Fn, template <class...> class _A, class... _As>
+  template <class _Fn, template <class...> class _Ap, class... _As>
     requires __minvocable<_Fn, _As...>
-  struct __uncurry_<_Fn, _A<_As...>> {
+  struct __uncurry_<_Fn, _Ap<_As...>> {
     using __t = __minvoke<_Fn, _As...>;
   };
 
   template <class _Fn>
   struct __uncurry {
-    template <class _T>
-    using __f = __t<__uncurry_<_Fn, _T>>;
+    template <class _Tp>
+    using __f = __t<__uncurry_<_Fn, _Tp>>;
   };
   template <class _Fn, class _List>
   using __mapply = __minvoke<__uncurry<_Fn>, _List>;
@@ -341,10 +341,10 @@ namespace stdexec {
     using __f = __msize_t<(bool(__v<__minvoke<_Fn, _Ts>>) + ... + 0)>;
   };
 
-  template <class _T>
+  template <class _Tp>
   struct __contains {
     template <class... _Args>
-    using __f = __bool<(__v<std::is_same<_T, _Args>> || ...)>;
+    using __f = __bool<(__v<std::is_same<_Tp, _Args>> || ...)>;
   };
 
   template <class _Continuation = __q<__types>>
@@ -418,54 +418,54 @@ namespace stdexec {
   };
 
   // A very simple std::declval replacement that doesn't handle void
-  template <class _T>
-  _T&& __declval() noexcept;
+  template <class _Tp>
+  _Tp&& __declval() noexcept;
 
   // For copying cvref from one type to another:
   struct __cp {
-    template <class _T>
-    using __f = _T;
+    template <class _Tp>
+    using __f = _Tp;
   };
 
   struct __cpc {
-    template <class _T>
-    using __f = const _T;
+    template <class _Tp>
+    using __f = const _Tp;
   };
 
   struct __cplr {
-    template <class _T>
-    using __f = _T&;
+    template <class _Tp>
+    using __f = _Tp&;
   };
 
   struct __cprr {
-    template <class _T>
-    using __f = _T&&;
+    template <class _Tp>
+    using __f = _Tp&&;
   };
 
   struct __cpclr {
-    template <class _T>
-    using __f = const _T&;
+    template <class _Tp>
+    using __f = const _Tp&;
   };
 
   struct __cpcrr {
-    template <class _T>
-    using __f = const _T&&;
+    template <class _Tp>
+    using __f = const _Tp&&;
   };
 
   template <class>
   extern __cp __cpcvr;
-  template <class _T>
-  extern __cpc __cpcvr<const _T>;
-  template <class _T>
-  extern __cplr __cpcvr<_T&>;
-  template <class _T>
-  extern __cprr __cpcvr<_T&&>;
-  template <class _T>
-  extern __cpclr __cpcvr<const _T&>;
-  template <class _T>
-  extern __cpcrr __cpcvr<const _T&&>;
-  template <class _T>
-  using __copy_cvref_fn = decltype(__cpcvr<_T>);
+  template <class _Tp>
+  extern __cpc __cpcvr<const _Tp>;
+  template <class _Tp>
+  extern __cplr __cpcvr<_Tp&>;
+  template <class _Tp>
+  extern __cprr __cpcvr<_Tp&&>;
+  template <class _Tp>
+  extern __cpclr __cpcvr<const _Tp&>;
+  template <class _Tp>
+  extern __cpcrr __cpcvr<const _Tp&&>;
+  template <class _Tp>
+  using __copy_cvref_fn = decltype(__cpcvr<_Tp>);
 
   template <class _From, class _To>
   using __copy_cvref_t = __minvoke<__copy_cvref_fn<_From>, _To>;
@@ -488,19 +488,19 @@ namespace stdexec {
 
   // For hiding a template type parameter from ADL
   template <class _Ty>
-  struct _X {
-    using __t = struct _T {
+  struct _Xp {
+    using __t = struct _Up {
       using __t = _Ty;
     };
   };
   template <class _Ty>
-  using __x = __t<_X<_Ty>>;
+  using __x = __t<_Xp<_Ty>>;
 
   template <class _Ty>
   concept __has_id = requires { typename _Ty::__id; };
 
   template <class _Ty>
-  struct _Y {
+  struct _Yp {
     using __t = _Ty;
 
     // Uncomment the line below to find any code that likely misuses the
@@ -520,7 +520,7 @@ namespace stdexec {
   template <>
   struct __id_<false> {
     template <class _Ty>
-    using __f = _Y<_Ty>;
+    using __f = _Yp<_Ty>;
   };
   template <class _Ty>
   using __id = __minvoke<__id_<__has_id<_Ty>>, _Ty>;
@@ -584,8 +584,8 @@ namespace stdexec {
   template <class _Fn>
   __conv(_Fn) -> __conv<_Fn>;
 
-  template <class _T>
-  using __cref_t = const std::remove_reference_t<_T>&;
+  template <class _Tp>
+  using __cref_t = const std::remove_reference_t<_Tp>&;
 
   template <class, class, class, class>
   struct __mzip_with2_;
@@ -594,20 +594,20 @@ namespace stdexec {
     class _Fn,           //
     class _Continuation, //
     template <class...>
-    class _C,
+    class _Cp,
     class... _Cs, //
     template <class...>
-    class _D,
+    class _Dp,
     class... _Ds>
     requires requires { typename __minvoke<_Continuation, __minvoke<_Fn, _Cs, _Ds>...>; }
-  struct __mzip_with2_<_Fn, _Continuation, _C<_Cs...>, _D<_Ds...>> {
+  struct __mzip_with2_<_Fn, _Continuation, _Cp<_Cs...>, _Dp<_Ds...>> {
     using __t = __minvoke<_Continuation, __minvoke<_Fn, _Cs, _Ds>...>;
   };
 
   template <class _Fn, class _Continuation = __q<__types>>
   struct __mzip_with2 {
-    template <class _C, class _D>
-    using __f = __t<__mzip_with2_<_Fn, _Continuation, _C, _D>>;
+    template <class _Cp, class _Dp>
+    using __f = __t<__mzip_with2_<_Fn, _Continuation, _Cp, _Dp>>;
   };
 
 #if STDEXEC_GCC() && (__GNUC__ < 12)
@@ -615,15 +615,15 @@ namespace stdexec {
   extern int __mconvert_indices;
   template <std::size_t... _Indices>
   extern __types<__msize_t<_Indices>...> __mconvert_indices<std::index_sequence<_Indices...>>;
-  template <std::size_t _N>
+  template <std::size_t _Np>
   using __mmake_index_sequence =
-    decltype(stdexec::__mconvert_indices<std::make_index_sequence<_N>>);
+    decltype(stdexec::__mconvert_indices<std::make_index_sequence<_Np>>);
 #else
   template <std::size_t... _Indices>
   __types<__msize_t<_Indices>...> __mconvert_indices(std::index_sequence<_Indices...>*);
-  template <std::size_t _N>
+  template <std::size_t _Np>
   using __mmake_index_sequence =
-    decltype(stdexec::__mconvert_indices((std::make_index_sequence<_N>*) nullptr));
+    decltype(stdexec::__mconvert_indices((std::make_index_sequence<_Np>*) nullptr));
 #endif
 
   template <class... _Ts>
@@ -685,8 +685,8 @@ namespace stdexec {
   };
 
 #if __has_builtin(__type_pack_element)
-  template <std::size_t _N, class... _Ts>
-  using __m_at = __type_pack_element<_N, _Ts...>;
+  template <std::size_t _Np, class... _Ts>
+  using __m_at = __type_pack_element<_Np, _Ts...>;
 #else
   template <std::size_t>
   using __void_ptr = void*;
@@ -699,20 +699,20 @@ namespace stdexec {
 
   template <std::size_t... _Is>
   struct __m_at_<std::index_sequence<_Is...>> {
-    template <class _U, class... _Us>
-    static _U __f_(__void_ptr<_Is>..., _U*, _Us*...);
+    template <class _Up, class... _Us>
+    static _Up __f_(__void_ptr<_Is>..., _Up*, _Us*...);
     template <class... _Ts>
     using __f = __t<decltype(__m_at_::__f_(__mtype_ptr<_Ts>()...))>;
   };
 
-  template <std::size_t _N, class... _Ts>
-  using __m_at = __minvoke<__m_at_<std::make_index_sequence<_N>>, _Ts...>;
+  template <std::size_t _Np, class... _Ts>
+  using __m_at = __minvoke<__m_at_<std::make_index_sequence<_Np>>, _Ts...>;
 #endif
 
-  template <std::size_t _N>
+  template <std::size_t _Np>
   struct __placeholder_;
-  template <std::size_t _N>
-  using __placeholder = __placeholder_<_N>*;
+  template <std::size_t _Np>
+  using __placeholder = __placeholder_<_Np>*;
 
   using __0 = __placeholder<0>;
   using __1 = __placeholder<1>;
@@ -728,8 +728,8 @@ namespace stdexec {
     }
   };
 
-  template <template <class...> class _C, class _Noexcept = __bool<true>>
-  using __mconstructor_for = __mcompose<__q<__mconstruct>, __q<_C>>;
+  template <template <class...> class _Cp, class _Noexcept = __bool<true>>
+  using __mconstructor_for = __mcompose<__q<__mconstruct>, __q<_Cp>>;
 
   template <std::size_t>
   using __ignore_t = __ignore;
@@ -739,11 +739,11 @@ namespace stdexec {
     return (_Ty&&) __t;
   }
 
-  template <std::size_t _N, class... _Ts>
+  template <std::size_t _Np, class... _Ts>
   constexpr decltype(auto) __nth_pack_element(_Ts&&... __ts) noexcept {
     return [&]<std::size_t... _Is>(std::index_sequence<_Is...>*) noexcept -> decltype(auto) {
       return stdexec::__nth_pack_element_<_Is...>((_Ts&&) __ts...);
-    }((std::make_index_sequence<_N>*) nullptr);
+    }((std::make_index_sequence<_Np>*) nullptr);
   }
 
   template <class _Ty>
@@ -754,35 +754,35 @@ namespace stdexec {
     }
   };
 
-  template <std::size_t _N>
-  struct __mdispatch_<__placeholder<_N>> {
+  template <std::size_t _Np>
+  struct __mdispatch_<__placeholder<_Np>> {
     template <class... _Ts>
     decltype(auto) operator()(_Ts&&... __ts) const noexcept {
-      return stdexec::__nth_pack_element<_N>((_Ts&&) __ts...);
+      return stdexec::__nth_pack_element<_Np>((_Ts&&) __ts...);
     }
   };
 
-  template <std::size_t _N>
-  struct __mdispatch_<__placeholder<_N>&> {
+  template <std::size_t _Np>
+  struct __mdispatch_<__placeholder<_Np>&> {
     template <class... _Ts>
     decltype(auto) operator()(_Ts&&... __ts) const noexcept {
-      return stdexec::__nth_pack_element<_N>(__ts...);
+      return stdexec::__nth_pack_element<_Np>(__ts...);
     }
   };
 
-  template <std::size_t _N>
-  struct __mdispatch_<__placeholder<_N>&&> {
+  template <std::size_t _Np>
+  struct __mdispatch_<__placeholder<_Np>&&> {
     template <class... _Ts>
     decltype(auto) operator()(_Ts&&... __ts) const noexcept {
-      return std::move(stdexec::__nth_pack_element<_N>(__ts...));
+      return std::move(stdexec::__nth_pack_element<_Np>(__ts...));
     }
   };
 
-  template <std::size_t _N>
-  struct __mdispatch_<const __placeholder<_N>&> {
+  template <std::size_t _Np>
+  struct __mdispatch_<const __placeholder<_Np>&> {
     template <class... _Ts>
     decltype(auto) operator()(_Ts&&... __ts) const noexcept {
-      return std::as_const(stdexec::__nth_pack_element<_N>(__ts...));
+      return std::as_const(stdexec::__nth_pack_element<_Np>(__ts...));
     }
   };
 
@@ -827,8 +827,8 @@ namespace stdexec {
   template <class _Signatures, class _Continuation = __q<__mfront>>
   struct __which { };
 
-  template <template <class...> class _C, class... _Signatures, class _Continuation>
-  struct __which<_C<_Signatures...>, _Continuation> {
+  template <template <class...> class _Cp, class... _Signatures, class _Continuation>
+  struct __which<_Cp<_Signatures...>, _Continuation> {
     template <class... _Args>
     using __f = //
       __minvoke<

--- a/include/stdexec/concepts.hpp
+++ b/include/stdexec/concepts.hpp
@@ -36,21 +36,21 @@
 
 namespace stdexec::__std_concepts {
 #if defined(__clang__)
-  template <class _A, class _B>
-  concept __same_as = __is_same(_A, _B);
+  template <class _Ap, class _Bp>
+  concept __same_as = __is_same(_Ap, _Bp);
 #elif defined(__GNUC__)
-  template <class _A, class _B>
-  concept __same_as = __is_same_as(_A, _B);
+  template <class _Ap, class _Bp>
+  concept __same_as = __is_same_as(_Ap, _Bp);
 #else
-  template <class _A, class _B>
+  template <class _Ap, class _Bp>
   inline constexpr bool __same_as = false;
-  template <class _A>
-  inline constexpr bool __same_as<_A, _A> = true;
+  template <class _Ap>
+  inline constexpr bool __same_as<_Ap, _Ap> = true;
 #endif
 
   // Make sure we're using a same_as concept that doesn't instantiate std::is_same
-  template <class _A, class _B>
-  concept same_as = __same_as<_A, _B> && __same_as<_B, _A>;
+  template <class _Ap, class _Bp>
+  concept same_as = __same_as<_Ap, _Bp> && __same_as<_Bp, _Ap>;
 
 #if STDEXEC_HAS_STD_CONCEPTS_HEADER()
 
@@ -64,10 +64,10 @@ namespace stdexec::__std_concepts {
   template <class T>
   concept integral = std::is_integral_v<T>;
 
-  template <class _A, class _B>
+  template <class _Ap, class _Bp>
   concept derived_from =         //
-    std::is_base_of_v<_B, _A> && //
-    std::is_convertible_v<const volatile _A*, const volatile _B*>;
+    std::is_base_of_v<_Bp, _Ap> && //
+    std::is_convertible_v<const volatile _Ap*, const volatile _Bp*>;
 
   template <class _From, class _To>
   concept convertible_to =               //
@@ -102,14 +102,14 @@ namespace stdexec {
   //   using decay_t = decltype((__decay_<_Ty>)(0));
 
   // C++20 concepts
-  template <class _Ty, class _U>
-  concept __decays_to = __same_as<decay_t<_Ty>, _U>;
+  template <class _Ty, class _Up>
+  concept __decays_to = __same_as<decay_t<_Ty>, _Up>;
 
   template <class...>
   concept __true = true;
 
-  template <class _C>
-  concept __class = __true<int _C::*> && (!__same_as<const _C, _C>);
+  template <class _Cp>
+  concept __class = __true<int _Cp::*> && (!__same_as<const _Cp, _Cp>);
 
   template <class _Ty, class... _As>
   concept __one_of = (__same_as<_Ty, _As> || ...);
@@ -140,8 +140,8 @@ namespace stdexec {
   inline constexpr bool __destructible_<_Ty&> = true;
   template <class _Ty>
   inline constexpr bool __destructible_<_Ty&&> = true;
-  template <class _Ty, std::size_t _N>
-  inline constexpr bool __destructible_<_Ty[_N]> = __destructible_<_Ty>;
+  template <class _Ty, std::size_t _Np>
+  inline constexpr bool __destructible_<_Ty[_Np]> = __destructible_<_Ty>;
 
   template <class T>
   concept destructible = __destructible_<T>;

--- a/include/stdexec/coroutine.hpp
+++ b/include/stdexec/coroutine.hpp
@@ -31,9 +31,9 @@ namespace __coro = std::experimental;
 namespace stdexec {
 #if !STDEXEC_STD_NO_COROUTINES_
   // Define some concepts and utilities for working with awaitables
-  template <class _T>
+  template <class _Tp>
   concept __await_suspend_result =
-    __one_of<_T, void, bool> || __is_instance_of<_T, __coro::coroutine_handle>;
+    __one_of<_Tp, void, bool> || __is_instance_of<_Tp, __coro::coroutine_handle>;
 
   template <class _Awaiter, class _Promise>
   concept __with_await_suspend =
@@ -82,8 +82,8 @@ namespace stdexec {
       { stdexec::__get_awaiter((_Awaitable&&) __await, __promise) } -> __awaiter<_Promise>;
     };
 
-  template <class _T>
-  _T& __as_lvalue(_T&&);
+  template <class _Tp>
+  _Tp& __as_lvalue(_Tp&&);
 
   template <class _Awaitable, class _Promise = void>
     requires __awaitable<_Awaitable, _Promise>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -142,11 +142,11 @@ namespace stdexec {
     using __cref_t = decltype(__scheduler_queries::__cref_fn(__declval<_Ty>()));
 
     struct execute_may_block_caller_t : __query<execute_may_block_caller_t> {
-      template <class _T>
-        requires tag_invocable<execute_may_block_caller_t, __cref_t<_T>>
-      constexpr bool operator()(_T&& __t) const noexcept {
-        static_assert(same_as<bool, tag_invoke_result_t<execute_may_block_caller_t, __cref_t<_T>>>);
-        static_assert(nothrow_tag_invocable<execute_may_block_caller_t, __cref_t<_T>>);
+      template <class _Tp>
+        requires tag_invocable<execute_may_block_caller_t, __cref_t<_Tp>>
+      constexpr bool operator()(_Tp&& __t) const noexcept {
+        static_assert(same_as<bool, tag_invoke_result_t<execute_may_block_caller_t, __cref_t<_Tp>>>);
+        static_assert(nothrow_tag_invocable<execute_may_block_caller_t, __cref_t<_Tp>>);
         return tag_invoke(execute_may_block_caller_t{}, std::as_const(__t));
       }
 
@@ -198,8 +198,8 @@ namespace stdexec {
           : __value_(((__with&&) __w).__value_) {
         }
 
-        template <same_as<_Tag> _T, class... _Ts>
-        friend __val_or_ref_t tag_invoke(_T, const __t& __self, _Ts&&...) //
+        template <same_as<_Tag> _Tp, class... _Ts>
+        friend __val_or_ref_t tag_invoke(_Tp, const __t& __self, _Ts&&...) //
           noexcept(std::is_nothrow_copy_constructible_v<__val_or_ref_t>) {
           return __self.__value_;
         }
@@ -217,8 +217,8 @@ namespace stdexec {
         __t(__with) {
         }
 
-        template <same_as<_Tag> _T, class... _Ts>
-        friend void tag_invoke(_T, const __t&, _Ts&&...) = delete;
+        template <same_as<_Tag> _Tp, class... _Ts>
+        friend void tag_invoke(_Tp, const __t&, _Ts&&...) = delete;
       };
     };
 
@@ -1054,11 +1054,11 @@ namespace stdexec {
     using __cref_t = decltype(__scheduler_queries::__cref_fn(__declval<_Ty>()));
 
     struct get_forward_progress_guarantee_t : __query<get_forward_progress_guarantee_t> {
-      template <class _T>
-        requires tag_invocable<get_forward_progress_guarantee_t, __cref_t<_T>>
-      constexpr auto operator()(_T&& __t) const
-        noexcept(nothrow_tag_invocable<get_forward_progress_guarantee_t, __cref_t<_T>>)
-          -> tag_invoke_result_t<get_forward_progress_guarantee_t, __cref_t<_T>> {
+      template <class _Tp>
+        requires tag_invocable<get_forward_progress_guarantee_t, __cref_t<_Tp>>
+      constexpr auto operator()(_Tp&& __t) const
+        noexcept(nothrow_tag_invocable<get_forward_progress_guarantee_t, __cref_t<_Tp>>)
+          -> tag_invoke_result_t<get_forward_progress_guarantee_t, __cref_t<_Tp>> {
         return tag_invoke(get_forward_progress_guarantee_t{}, std::as_const(__t));
       }
 
@@ -1068,13 +1068,13 @@ namespace stdexec {
     };
 
     struct __has_algorithm_customizations_t : __query<__has_algorithm_customizations_t> {
-      template <class _T>
-      using __result_t = tag_invoke_result_t<__has_algorithm_customizations_t, __cref_t<_T>>;
+      template <class _Tp>
+      using __result_t = tag_invoke_result_t<__has_algorithm_customizations_t, __cref_t<_Tp>>;
 
-      template <class _T>
-        requires tag_invocable<__has_algorithm_customizations_t, __cref_t<_T>>
-      constexpr __result_t<_T> operator()(_T&& __t) const noexcept(noexcept(__result_t<_T>{})) {
-        using _Boolean = tag_invoke_result_t<__has_algorithm_customizations_t, __cref_t<_T>>;
+      template <class _Tp>
+        requires tag_invocable<__has_algorithm_customizations_t, __cref_t<_Tp>>
+      constexpr __result_t<_Tp> operator()(_Tp&& __t) const noexcept(noexcept(__result_t<_Tp>{})) {
+        using _Boolean = tag_invoke_result_t<__has_algorithm_customizations_t, __cref_t<_Tp>>;
         static_assert(_Boolean{} ? true : true); // must be contextually convertible to bool
         return _Boolean{};
       }
@@ -1155,12 +1155,12 @@ namespace stdexec {
         return true;
       }
 
-      template <class _T>
-        requires nothrow_tag_invocable<get_delegatee_scheduler_t, __cref_t<_T>>
-              && scheduler<tag_invoke_result_t<get_delegatee_scheduler_t, __cref_t<_T>>>
-      auto operator()(_T&& __t) const
-        noexcept(nothrow_tag_invocable<get_delegatee_scheduler_t, __cref_t<_T>>)
-          -> tag_invoke_result_t<get_delegatee_scheduler_t, __cref_t<_T>> {
+      template <class _Tp>
+        requires nothrow_tag_invocable<get_delegatee_scheduler_t, __cref_t<_Tp>>
+              && scheduler<tag_invoke_result_t<get_delegatee_scheduler_t, __cref_t<_Tp>>>
+      auto operator()(_Tp&& __t) const
+        noexcept(nothrow_tag_invocable<get_delegatee_scheduler_t, __cref_t<_Tp>>)
+          -> tag_invoke_result_t<get_delegatee_scheduler_t, __cref_t<_Tp>> {
         return tag_invoke(get_delegatee_scheduler_t{}, std::as_const(__t));
       }
 
@@ -1216,8 +1216,8 @@ namespace stdexec {
   inline constexpr get_allocator_t get_allocator{};
   inline constexpr get_stop_token_t get_stop_token{};
 
-  template <class _T>
-  using stop_token_of_t = remove_cvref_t<decltype(get_stop_token(__declval<_T>()))>;
+  template <class _Tp>
+  using stop_token_of_t = remove_cvref_t<decltype(get_stop_token(__declval<_Tp>()))>;
 
   template <receiver _Receiver>
   using __current_scheduler_t = __call_result_t<get_scheduler_t, env_of_t<_Receiver>>;
@@ -1508,13 +1508,13 @@ namespace stdexec {
   namespace __connect {
     struct connect_t;
 
-    template <class _T>
+    template <class _Tp>
     STDEXEC_R5_SENDER_DEPR_WARNING //
       void
       __update_sender_type_to_p2300r7_by_adding_enable_sender_trait() {
     }
 
-    template <class _T>
+    template <class _Tp>
     STDEXEC_R5_RECEIVER_DEPR_WARNING //
       void
       __update_receiver_type_to_p2300r7_by_adding_enable_receiver_trait() {
@@ -1880,41 +1880,41 @@ namespace stdexec {
     };
 
     struct as_awaitable_t {
-      template <class _T, class _Promise>
+      template <class _Tp, class _Promise>
       static constexpr auto __select_impl_() noexcept {
-        if constexpr (tag_invocable<as_awaitable_t, _T, _Promise&>) {
-          using _Result = tag_invoke_result_t<as_awaitable_t, _T, _Promise&>;
-          constexpr bool _Nothrow = nothrow_tag_invocable<as_awaitable_t, _T, _Promise&>;
+        if constexpr (tag_invocable<as_awaitable_t, _Tp, _Promise&>) {
+          using _Result = tag_invoke_result_t<as_awaitable_t, _Tp, _Promise&>;
+          constexpr bool _Nothrow = nothrow_tag_invocable<as_awaitable_t, _Tp, _Promise&>;
           return static_cast<_Result (*)() noexcept(_Nothrow)>(nullptr);
-        } else if constexpr (__awaitable<_T, __unspecified>) { // NOT __awaitable<_T, _Promise> !!
-          return static_cast < _T && (*) () noexcept > (nullptr);
-        } else if constexpr (__awaitable_sender<_T, _Promise>) {
-          using _Result = __sender_awaitable_t<_Promise, _T>;
+        } else if constexpr (__awaitable<_Tp, __unspecified>) { // NOT __awaitable<_Tp, _Promise> !!
+          return static_cast < _Tp && (*) () noexcept > (nullptr);
+        } else if constexpr (__awaitable_sender<_Tp, _Promise>) {
+          using _Result = __sender_awaitable_t<_Promise, _Tp>;
           constexpr bool _Nothrow =
-            __nothrow_constructible_from<_Result, _T, __coro::coroutine_handle<_Promise>>;
+            __nothrow_constructible_from<_Result, _Tp, __coro::coroutine_handle<_Promise>>;
           return static_cast<_Result (*)() noexcept(_Nothrow)>(nullptr);
         } else {
-          return static_cast < _T && (*) () noexcept > (nullptr);
+          return static_cast < _Tp && (*) () noexcept > (nullptr);
         }
       }
-      template <class _T, class _Promise>
-      using __select_impl_t = decltype(__select_impl_<_T, _Promise>());
+      template <class _Tp, class _Promise>
+      using __select_impl_t = decltype(__select_impl_<_Tp, _Promise>());
 
-      template <class _T, class _Promise>
-      auto operator()(_T&& __t, _Promise& __promise) const
-        noexcept(__nothrow_callable<__select_impl_t<_T, _Promise>>)
-          -> __call_result_t<__select_impl_t<_T, _Promise>> {
-        if constexpr (tag_invocable<as_awaitable_t, _T, _Promise&>) {
-          using _Result = tag_invoke_result_t<as_awaitable_t, _T, _Promise&>;
+      template <class _Tp, class _Promise>
+      auto operator()(_Tp&& __t, _Promise& __promise) const
+        noexcept(__nothrow_callable<__select_impl_t<_Tp, _Promise>>)
+          -> __call_result_t<__select_impl_t<_Tp, _Promise>> {
+        if constexpr (tag_invocable<as_awaitable_t, _Tp, _Promise&>) {
+          using _Result = tag_invoke_result_t<as_awaitable_t, _Tp, _Promise&>;
           static_assert(__awaitable<_Result, _Promise>);
-          return tag_invoke(*this, (_T&&) __t, __promise);
-        } else if constexpr (__awaitable<_T, __unspecified>) { // NOT __awaitable<_T, _Promise> !!
-          return (_T&&) __t;
-        } else if constexpr (__awaitable_sender<_T, _Promise>) {
+          return tag_invoke(*this, (_Tp&&) __t, __promise);
+        } else if constexpr (__awaitable<_Tp, __unspecified>) { // NOT __awaitable<_Tp, _Promise> !!
+          return (_Tp&&) __t;
+        } else if constexpr (__awaitable_sender<_Tp, _Promise>) {
           auto __hcoro = __coro::coroutine_handle<_Promise>::from_promise(__promise);
-          return __sender_awaitable_t<_Promise, _T>{(_T&&) __t, __hcoro};
+          return __sender_awaitable_t<_Promise, _Tp>{(_Tp&&) __t, __hcoro};
         } else {
-          return (_T&&) __t;
+          return (_Tp&&) __t;
         }
       }
     };
@@ -2374,22 +2374,22 @@ namespace stdexec {
 
   // NOT TO SPEC:
   namespace __closure {
-    template <__class _D>
+    template <__class _Dp>
     struct sender_adaptor_closure;
   }
 
   using __closure::sender_adaptor_closure;
 
-  template <class _T>
+  template <class _Tp>
   concept __sender_adaptor_closure =
-    derived_from<remove_cvref_t<_T>, sender_adaptor_closure<remove_cvref_t<_T>>>
-    && move_constructible<remove_cvref_t<_T>> && constructible_from<remove_cvref_t<_T>, _T>;
+    derived_from<remove_cvref_t<_Tp>, sender_adaptor_closure<remove_cvref_t<_Tp>>>
+    && move_constructible<remove_cvref_t<_Tp>> && constructible_from<remove_cvref_t<_Tp>, _Tp>;
 
-  template <class _T, class _Sender>
+  template <class _Tp, class _Sender>
   concept __sender_adaptor_closure_for =
-    __sender_adaptor_closure<_T> && sender<remove_cvref_t<_Sender>>
-    && __callable<_T, remove_cvref_t<_Sender>>
-    && sender<__call_result_t<_T, remove_cvref_t<_Sender>>>;
+    __sender_adaptor_closure<_Tp> && sender<remove_cvref_t<_Sender>>
+    && __callable<_Tp, remove_cvref_t<_Sender>>
+    && sender<__call_result_t<_Tp, remove_cvref_t<_Sender>>>;
 
   namespace __closure {
     template <class _T0, class _T1>
@@ -2411,7 +2411,7 @@ namespace stdexec {
       }
     };
 
-    template <__class _D>
+    template <__class _Dp>
     struct sender_adaptor_closure { };
 
     template <sender _Sender, __sender_adaptor_closure_for<_Sender> _Closure>
@@ -2456,15 +2456,15 @@ namespace stdexec {
   namespace __adaptors {
     // A derived-to-base cast that works even when the base is not
     // accessible from derived.
-    template <class _T, class _U>
+    template <class _Tp, class _Up>
     STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      __copy_cvref_t<_U&&, _T>
-      __c_cast(_U&& u) noexcept
-      requires __decays_to<_T, _T>
+      __copy_cvref_t<_Up&&, _Tp>
+      __c_cast(_Up&& u) noexcept
+      requires __decays_to<_Tp, _Tp>
     {
-      static_assert(std::is_reference_v<__copy_cvref_t<_U&&, _T>>);
-      static_assert(std::is_base_of_v<_T, std::remove_reference_t<_U>>);
-      return (__copy_cvref_t<_U&&, _T>) (_U&&) u;
+      static_assert(std::is_reference_v<__copy_cvref_t<_Up&&, _Tp>>);
+      static_assert(std::is_base_of_v<_Tp, std::remove_reference_t<_Up>>);
+      return (__copy_cvref_t<_Up&&, _Tp>) (_Up&&) u;
     }
 
     namespace __no {
@@ -2534,14 +2534,14 @@ namespace stdexec {
 
 #if STDEXEC_CLANG()
 // Only clang gets this right.
-#define _MISSING_MEMBER(_D, _TAG) requires { typename _D::_TAG; }
+#define _MISSING_MEMBER(_Dp, _TAG) requires { typename _Dp::_TAG; }
 #define _DEFINE_MEMBER(_TAG) _DISPATCH_MEMBER(_TAG) using _TAG = void
 #else
-#define _MISSING_MEMBER(_D, _TAG) (__missing_##_TAG<_D>())
+#define _MISSING_MEMBER(_Dp, _TAG) (__missing_##_TAG<_Dp>())
 #define _DEFINE_MEMBER(_TAG) \
-  template <class _D> \
+  template <class _Dp> \
   static constexpr bool __missing_##_TAG() noexcept { \
-    return requires { requires bool(int(_D::_TAG)); }; \
+    return requires { requires bool(int(_Dp::_TAG)); }; \
   } \
   _DISPATCH_MEMBER(_TAG) \
   static constexpr int _TAG = 1 /**/
@@ -2558,23 +2558,23 @@ namespace stdexec {
 
         static constexpr bool __has_base = !derived_from<_Base, __no::__nope>;
 
-        template <class _D>
-        using __base_from_derived_t = decltype(__declval<_D>().base());
+        template <class _Dp>
+        using __base_from_derived_t = decltype(__declval<_Dp>().base());
 
         using __get_base_t =
           __if_c< __has_base, __mbind_back_q<__copy_cvref_t, _Base>, __q<__base_from_derived_t>>;
 
-        template <class _D>
-        using __base_t = __minvoke<__get_base_t, _D&&>;
+        template <class _Dp>
+        using __base_t = __minvoke<__get_base_t, _Dp&&>;
 
-        template <class _D>
+        template <class _Dp>
         STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          static __base_t<_D>
-          __get_base(_D&& __self) noexcept {
+          static __base_t<_Dp>
+          __get_base(_Dp&& __self) noexcept {
           if constexpr (__has_base) {
-            return __c_cast<__t>((_D&&) __self).base();
+            return __c_cast<__t>((_Dp&&) __self).base();
           } else {
-            return ((_D&&) __self).base();
+            return ((_Dp&&) __self).base();
           }
         }
 
@@ -2587,12 +2587,12 @@ namespace stdexec {
           _CALL_MEMBER(set_value, (_Derived&&) __self, (_As&&) __as...);
         }
 
-        template <same_as<set_value_t> _SetValue, class _D = _Derived, class... _As>
-          requires _MISSING_MEMBER(_D, set_value)
-                && tag_invocable<set_value_t, __base_t<_D>, _As...>
+        template <same_as<set_value_t> _SetValue, class _Dp = _Derived, class... _As>
+          requires _MISSING_MEMBER(_Dp, set_value)
+                && tag_invocable<set_value_t, __base_t<_Dp>, _As...>
         STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
           friend void tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept {
-          stdexec::set_value(__get_base((_D&&) __self), (_As&&) __as...);
+          stdexec::set_value(__get_base((_Dp&&) __self), (_As&&) __as...);
         }
 
         template <same_as<set_error_t> _SetError, class _Error>
@@ -2604,44 +2604,44 @@ namespace stdexec {
           _CALL_MEMBER(set_error, (_Derived&&) __self, (_Error&&) __err);
         }
 
-        template <same_as<set_error_t> _SetError, class _Error, class _D = _Derived>
-          requires _MISSING_MEMBER(_D, set_error)
-                && tag_invocable<set_error_t, __base_t<_D>, _Error>
+        template <same_as<set_error_t> _SetError, class _Error, class _Dp = _Derived>
+          requires _MISSING_MEMBER(_Dp, set_error)
+                && tag_invocable<set_error_t, __base_t<_Dp>, _Error>
         STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
           friend void tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept {
           stdexec::set_error(__get_base((_Derived&&) __self), (_Error&&) __err);
         }
 
-        template <same_as<set_stopped_t> _SetStopped, class _D = _Derived>
+        template <same_as<set_stopped_t> _SetStopped, class _Dp = _Derived>
         STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
           friend auto
           tag_invoke(_SetStopped, _Derived&& __self) noexcept
-          -> decltype(_CALL_MEMBER(set_stopped, (_D&&) __self)) {
+          -> decltype(_CALL_MEMBER(set_stopped, (_Dp&&) __self)) {
           static_assert(noexcept(_CALL_MEMBER(set_stopped, (_Derived&&) __self)));
           _CALL_MEMBER(set_stopped, (_Derived&&) __self);
         }
 
-        template <same_as<set_stopped_t> _SetStopped, class _D = _Derived>
-          requires _MISSING_MEMBER(_D, set_stopped) && tag_invocable<set_stopped_t, __base_t<_D>>
+        template <same_as<set_stopped_t> _SetStopped, class _Dp = _Derived>
+          requires _MISSING_MEMBER(_Dp, set_stopped) && tag_invocable<set_stopped_t, __base_t<_Dp>>
         STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
           friend void tag_invoke(_SetStopped, _Derived&& __self) noexcept {
           stdexec::set_stopped(__get_base((_Derived&&) __self));
         }
 
         // Pass through the get_env receiver query
-        template <same_as<get_env_t> _GetEnv, class _D = _Derived>
+        template <same_as<get_env_t> _GetEnv, class _Dp = _Derived>
         STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
           friend auto
           tag_invoke(_GetEnv, const _Derived& __self)
-            -> decltype(_CALL_MEMBER(get_env, (const _D&) __self)) {
+            -> decltype(_CALL_MEMBER(get_env, (const _Dp&) __self)) {
           return _CALL_MEMBER(get_env, __self);
         }
 
-        template <same_as<get_env_t> _GetEnv, class _D = _Derived>
-          requires _MISSING_MEMBER(_D, get_env)
+        template <same_as<get_env_t> _GetEnv, class _Dp = _Derived>
+          requires _MISSING_MEMBER(_Dp, get_env)
         STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
           friend auto tag_invoke(_GetEnv, const _Derived& __self)
-            -> __call_result_t<get_env_t, __base_t<const _D&>> {
+            -> __call_result_t<get_env_t, __base_t<const _Dp&>> {
           return stdexec::get_env(__get_base(__self));
         }
 
@@ -3960,8 +3960,8 @@ namespace stdexec {
   // [execution.senders.adaptors.let_error]
   // [execution.senders.adaptors.let_stopped]
   namespace __let {
-    template <class _T>
-    using __decay_ref = decay_t<_T>&;
+    template <class _Tp>
+    using __decay_ref = decay_t<_Tp>&;
 
     template <class _Fun>
     using __result_sender = __transform< __q<__decay_ref>, __mbind_front_q<__call_result_t, _Fun>>;
@@ -5261,8 +5261,8 @@ namespace stdexec {
     template <class _Env>
     using __env_t = __t<__if_c<same_as<_Env, no_env>, no_env, __env<__id<_Env>>>>;
 
-    template <class _T>
-    using __decay_rvalue_ref = decay_t<_T>&&;
+    template <class _Tp>
+    using __decay_rvalue_ref = decay_t<_Tp>&&;
 
     template <class _Sender, class _Env>
     concept __max1_sender =

--- a/include/stdexec/functional.hpp
+++ b/include/stdexec/functional.hpp
@@ -28,9 +28,9 @@ namespace stdexec::__std_concepts {
 #if STDEXEC_HAS_STD_CONCEPTS_HEADER()
   using std::invocable;
 #else
-  template <class _F, class... _As>
+  template <class _Fun, class... _As>
   concept invocable = //
-    requires(_F&& __f, _As&&... __as) { std::invoke((_F&&) __f, (_As&&) __as...); };
+    requires(_Fun&& __f, _As&&... __as) { std::invoke((_Fun&&) __f, (_As&&) __as...); };
 #endif
 } // stdexec::__std_concepts
 
@@ -39,11 +39,11 @@ namespace std {
 }
 
 namespace stdexec {
-  template <class _F, class... _As>
+  template <class _Fun, class... _As>
   concept __nothrow_invocable = //
-    invocable<_F, _As...> &&    //
-    requires(_F&& __f, _As&&... __as) {
-      { std::invoke((_F&&) __f, (_As&&) __as...) } noexcept;
+    invocable<_Fun, _As...> &&    //
+    requires(_Fun&& __f, _As&&... __as) {
+      { std::invoke((_Fun&&) __f, (_As&&) __as...) } noexcept;
     };
 
   template <auto _Fun>


### PR DESCRIPTION
There are platforms, where single letter macros are abundant *cough MSVC*

While it is generally not supported yet, there is no need to use those names when we can add a letter and be fine