### PR TITLE
add `exec::trampoline_scheduler` to bound stack usage

### DIFF
--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -27,6 +27,8 @@ namespace exec {
   struct _FAILURE_TO_CONNECT_ {
     template <class... _Message>
     struct _WHAT_ {
+      using is_sender = void;
+
       friend _WHAT_
         tag_invoke(stdexec::get_completion_signatures_t, _WHAT_, stdexec::__ignore) noexcept {
         return {};
@@ -91,6 +93,7 @@ namespace exec {
       __declval<__receiver_placeholder<_Env>&>()));
 
     struct __dependent_sender {
+      using is_sender = void;
       using __t = __dependent_sender;
       friend auto tag_invoke(get_completion_signatures_t, __dependent_sender, no_env)
         -> dependent_completion_signatures<no_env>;

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -408,7 +408,8 @@ namespace exec {
       }
 
       template <class _Tp>
-      friend void tag_invoke(__move_construct_t, __mtype<_Tp>, __t& __self, __t&& __other) noexcept {
+      friend void
+        tag_invoke(__move_construct_t, __mtype<_Tp>, __t& __self, __t&& __other) noexcept {
         if (!__other.__object_pointer_) {
           return;
         }

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -250,7 +250,8 @@ namespace exec {
           requires receiver_of<
             _Rec,
             __completion_signatures_t<_InitialSender, _FinalSender, env_of_t<_Rec>>>
-        friend __op_t< _Self, _Rec> tag_invoke(connect_t, _Self&& __self, _Rec&& __receiver) noexcept {
+        friend __op_t< _Self, _Rec>
+          tag_invoke(connect_t, _Self&& __self, _Rec&& __receiver) noexcept {
           return {
             ((_Self&&) __self).__initial_sender_,
             ((_Self&&) __self).__final_sender_,

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -107,8 +107,7 @@ namespace exec {
         __declval<__current_scheduler_t<_Receiver>>()));
 
       template <class _Sender>
-      using __on_sender_t =
-        __copy_cvref_t<_Sender, __start_on_t<_Sender, _Scheduler>>;
+      using __on_sender_t = __copy_cvref_t<_Sender, __start_on_t<_Sender, _Scheduler>>;
 
       template <class _Sender, class _Receiver>
       using __diagnostic_t = //
@@ -204,8 +203,7 @@ namespace exec {
         __declval<__current_scheduler_t<_Receiver>>()));
 
       template <class _Sender>
-      using __on_sender_t =
-        __copy_cvref_t<_Sender, __continue_on_t<_Sender, _Scheduler, _Closure>>;
+      using __on_sender_t = __copy_cvref_t<_Sender, __continue_on_t<_Sender, _Scheduler, _Closure>>;
 
       template <class _Sender, class _Receiver>
       using __diagnostic_t = //

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -72,11 +72,18 @@ namespace exec {
           __t<_SenderId>,
           __with_sched_kernel<_Scheduler>> { };
 
-    template <class _Sender>
-    using __pretty_print = __minvoke<__with_default<__id_<>, _Sender>, _Sender>;
+    struct __dependent_sender {
+      using is_sender = void;
+      using __t = __dependent_sender;
+      friend auto tag_invoke(get_completion_signatures_t, __dependent_sender, no_env)
+        -> dependent_completion_signatures<no_env>;
+    };
 
     template <class _SenderId, class _Scheduler>
     struct __start_on;
+
+    template <class _Sender, class _Scheduler>
+    using __start_on_t = __t<__start_on<__id<decay_t<_Sender>>, _Scheduler>>;
 
     template <class _Scheduler>
     struct __start_on_kernel : __default_kernel {
@@ -101,7 +108,7 @@ namespace exec {
 
       template <class _Sender>
       using __on_sender_t =
-        __copy_cvref_t<_Sender, __start_on<__pretty_print<decay_t<_Sender>>, _Scheduler>>;
+        __copy_cvref_t<_Sender, __start_on_t<_Sender, _Scheduler>>;
 
       template <class _Sender, class _Receiver>
       using __diagnostic_t = //
@@ -111,14 +118,18 @@ namespace exec {
             __on_sender_t<_Sender>>>;
 
       template <class _Sender, class _Receiver>
-      using __result_t = //
-        __minvoke<
-          __if_c<
-            __valid<__new_sender_t, _Sender, _Receiver>,
-            __q<__new_sender_t>,
-            __q<__diagnostic_t>>,
-          _Sender,
-          _Receiver>;
+      static auto __transform_sender_result() {
+        if constexpr (__valid<__new_sender_t, _Sender, _Receiver>) {
+          return (__new_sender_t<_Sender, _Receiver>(*)()) nullptr;
+        } else if constexpr (same_as<env_of_t<_Receiver>, no_env>) {
+          return (__dependent_sender(*)()) nullptr;
+        } else {
+          return (__diagnostic_t<_Sender, _Receiver>(*)()) nullptr;
+        }
+      }
+
+      template <class _Sender, class _Receiver>
+      using __result_t = decltype(__transform_sender_result<_Sender, _Receiver>()());
 
       template <class _Sender, class _Receiver>
       auto transform_sender(_Sender&& __sndr, __ignore, _Receiver& __rcvr)
@@ -145,9 +156,6 @@ namespace exec {
       };
     };
 
-    template <class _Sender, class _Scheduler>
-    using __start_on_t = __t<__start_on<__id<decay_t<_Sender>>, _Scheduler>>;
-
     template <>
     struct on_t<on_kind::start_on> {
       template <scheduler _Scheduler, sender _Sender>
@@ -166,6 +174,9 @@ namespace exec {
 
     template <class _SenderId, class _Scheduler, class _Closure>
     struct __continue_on;
+
+    template <class _Sender, class _Scheduler, class _Closure>
+    using __continue_on_t = __t<__continue_on<__id<decay_t<_Sender>>, _Scheduler, _Closure>>;
 
     template <class _Scheduler, class _Closure>
     struct __continue_on_kernel : __default_kernel {
@@ -193,10 +204,8 @@ namespace exec {
         __declval<__current_scheduler_t<_Receiver>>()));
 
       template <class _Sender>
-      using __on_sender_t = //
-        __copy_cvref_t<
-          _Sender,
-          __continue_on<__pretty_print<decay_t<_Sender>>, _Scheduler, _Closure>>;
+      using __on_sender_t =
+        __copy_cvref_t<_Sender, __continue_on_t<_Sender, _Scheduler, _Closure>>;
 
       template <class _Sender, class _Receiver>
       using __diagnostic_t = //
@@ -206,14 +215,18 @@ namespace exec {
             __on_sender_t<_Sender>>>;
 
       template <class _Sender, class _Receiver>
-      using __result_t = //
-        __minvoke<
-          __if_c<
-            __valid<__new_sender_t, _Sender, _Receiver>,
-            __q<__new_sender_t>,
-            __q<__diagnostic_t>>,
-          _Sender,
-          _Receiver>;
+      static auto __transform_sender_result() {
+        if constexpr (__valid<__new_sender_t, _Sender, _Receiver>) {
+          return (__new_sender_t<_Sender, _Receiver>(*)()) nullptr;
+        } else if constexpr (same_as<env_of_t<_Receiver>, no_env>) {
+          return (__dependent_sender(*)()) nullptr;
+        } else {
+          return (__diagnostic_t<_Sender, _Receiver>(*)()) nullptr;
+        }
+      }
+
+      template <class _Sender, class _Receiver>
+      using __result_t = decltype(__transform_sender_result<_Sender, _Receiver>()());
 
       template <class _Sender, class _Receiver>
       auto transform_sender(_Sender&& __sndr, __ignore, _Receiver& __rcvr)
@@ -244,9 +257,6 @@ namespace exec {
         using __base::__base;
       };
     };
-
-    template <class _Sender, class _Scheduler, class _Closure>
-    using __continue_on_t = __t<__continue_on<__id<decay_t<_Sender>>, _Scheduler, _Closure>>;
 
     template <>
     struct on_t<on_kind::continue_on> {

--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/execution.hpp"
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace exec {
+  namespace __trampoline {
+    using namespace stdexec;
+
+    template <class _Operation>
+    struct __trampoline_state {
+      static thread_local __trampoline_state* __current_;
+
+      __trampoline_state() noexcept {
+        __current_ = this;
+      }
+
+      ~__trampoline_state() {
+        __current_ = nullptr;
+      }
+
+      void __drain() noexcept;
+
+      std::size_t __recursion_depth_ = 1;
+      _Operation* __head_ = nullptr;
+    };
+
+    class __scheduler {
+      std::size_t __max_recursion_depth_;
+
+     public:
+      __scheduler() noexcept
+        : __max_recursion_depth_(16) {
+      }
+
+      explicit __scheduler(std::size_t __max_recursion_depth) noexcept
+        : __max_recursion_depth_(__max_recursion_depth) {
+      }
+
+     private:
+      struct __operation_base {
+        using __execute_fn = void(__operation_base*) noexcept;
+
+        explicit __operation_base(__execute_fn* __execute, std::size_t __max_depth) noexcept
+          : __execute_(__execute)
+          , __max_recursion_depth_(__max_depth) {
+        }
+
+        void __execute() noexcept {
+          __execute_(this);
+        }
+
+        friend void tag_invoke(start_t, __operation_base& __self) noexcept {
+          auto* __current_state = __trampoline_state<__operation_base>::__current_;
+          if (__current_state == nullptr) {
+            __trampoline_state<__operation_base> __state;
+            __self.__execute();
+            __state.__drain();
+          } else if (__current_state->__recursion_depth_ < __self.__max_recursion_depth_) {
+            ++__current_state->__recursion_depth_;
+            __self.__execute();
+          } else {
+            // Exceeded recursion limit.
+            __self.__next_ = std::exchange(
+              __current_state->__head_, static_cast<__operation_base*>(&__self));
+          }
+        }
+
+        __operation_base* __next_ = nullptr;
+        __execute_fn* __execute_;
+        std::size_t __max_recursion_depth_;
+      };
+
+      template <class _ReceiverId>
+      struct __operation {
+        using _Receiver = stdexec::__t<_ReceiverId>;
+
+        struct __t : __operation_base {
+          using __id = __operation;
+          [[no_unique_address]] _Receiver __receiver_;
+
+          explicit __t(_Receiver __rcvr, std::size_t __max_depth) noexcept(
+            __nothrow_decay_copyable<_Receiver>)
+            : __operation_base(&__t::__execute_impl, __max_depth)
+            , __receiver_((_Receiver&&) __rcvr) {
+          }
+
+          static void __execute_impl(__operation_base* __op) noexcept {
+            auto& __self = *static_cast<__t*>(__op);
+            if (std::unstoppable_token<stop_token_of_t<env_of_t<_Receiver&>>>) {
+              stdexec::set_value(static_cast<_Receiver&&>(__self.__receiver_));
+            } else {
+              if (get_stop_token(get_env(__self.__receiver_)).stop_requested()) {
+                stdexec::set_stopped(static_cast<_Receiver&&>(__self.__receiver_));
+              } else {
+                stdexec::set_value(static_cast<_Receiver&&>(__self.__receiver_));
+              }
+            }
+          }
+        };
+      };
+
+      struct __schedule_sender;
+      friend __schedule_sender;
+
+      template <class _Receiver>
+      using __operation_t = stdexec::__t<__operation<__id<remove_cvref_t<_Receiver>>>>;
+
+      struct __schedule_sender {
+        using is_sender = void;
+        using completion_signatures =
+          stdexec::completion_signatures<set_value_t(), set_stopped_t()>;
+
+        explicit __schedule_sender(std::size_t __max_depth) noexcept
+          : __max_recursion_depth_(__max_depth) {
+        }
+
+        template <receiver_of<completion_signatures> _Receiver>
+        __operation_t<_Receiver> __make_operation(_Receiver __rcvr) const
+          noexcept(__nothrow_decay_copyable<_Receiver>) {
+          return __operation_t<_Receiver>{(_Receiver&&) __rcvr, __max_recursion_depth_};
+        }
+
+        template <receiver_of<completion_signatures> _Receiver>
+        friend auto tag_invoke(connect_t, __schedule_sender __self, _Receiver __rcvr) noexcept(
+          __nothrow_decay_copyable<_Receiver>) -> __operation_t<_Receiver> {
+          return __self.__make_operation((_Receiver&&) __rcvr);
+        }
+
+        friend __scheduler
+          tag_invoke(get_completion_scheduler_t<set_value_t>, __schedule_sender __self) noexcept {
+          return __scheduler{__self.__max_recursion_depth_};
+        }
+
+        friend const __schedule_sender&
+          tag_invoke(get_env_t, const __schedule_sender& __self) noexcept {
+          return __self;
+        }
+
+        std::size_t __max_recursion_depth_;
+      };
+
+      friend __schedule_sender tag_invoke(schedule_t, __scheduler __self) noexcept {
+        return __schedule_sender{__self.__max_recursion_depth_};
+      }
+
+     public:
+      bool operator==(const __scheduler&) const noexcept = default;
+    };
+
+    template <class _Operation>
+    thread_local __trampoline_state<_Operation>* __trampoline_state<_Operation>::__current_ =
+      nullptr;
+
+    template <class _Operation>
+    void __trampoline_state<_Operation>::__drain() noexcept {
+      while (__head_ != nullptr) {
+        _Operation* __op = std::exchange(__head_, __head_->__next_);
+        __recursion_depth_ = 1;
+        __op->__execute();
+      }
+    }
+  } // namespace __trampoline
+
+  using trampoline_scheduler = __trampoline::__scheduler;
+
+} // namespace exec

--- a/include/stdexec/concepts.hpp
+++ b/include/stdexec/concepts.hpp
@@ -65,7 +65,7 @@ namespace stdexec::__std_concepts {
   concept integral = std::is_integral_v<T>;
 
   template <class _Ap, class _Bp>
-  concept derived_from =         //
+  concept derived_from =           //
     std::is_base_of_v<_Bp, _Ap> && //
     std::is_convertible_v<const volatile _Ap*, const volatile _Bp*>;
 

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4763,7 +4763,7 @@ namespace stdexec {
         _Attrs __env_;
         _Sender __sndr_;
 
-        template <__decays_to<__t> _Self, class _Receiver>
+        template <__decays_to<__t> _Self, receiver _Receiver>
           requires sender_to<__copy_cvref_t<_Self, _Sender>, _Receiver>
         friend auto tag_invoke(connect_t, _Self&& __self, _Receiver __rcvr) -> stdexec::__t<
           __operation1<_SchedulerId, stdexec::__cvref_id<_Self, _Sender>, stdexec::__id<_Receiver>>> {

--- a/include/stdexec/functional.hpp
+++ b/include/stdexec/functional.hpp
@@ -41,7 +41,7 @@ namespace std {
 namespace stdexec {
   template <class _Fun, class... _As>
   concept __nothrow_invocable = //
-    invocable<_Fun, _As...> &&    //
+    invocable<_Fun, _As...> &&  //
     requires(_Fun&& __f, _As&&... __as) {
       { std::invoke((_Fun&&) __f, (_As&&) __as...) } noexcept;
     };

--- a/include/tbbexec/tbb_thread_pool.hpp
+++ b/include/tbbexec/tbb_thread_pool.hpp
@@ -315,7 +315,9 @@ namespace tbbexec {
             stdexec::__v<stdexec::__value_types_of_t<
               Sender,
               Env,
-              stdexec::__transform<stdexec::__q<__decay_ref>, stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>>,
+              stdexec::__transform<
+                stdexec::__q<__decay_ref>,
+                stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>>,
               stdexec::__q<stdexec::__mand>>>,
             stdexec::completion_signatures<>,
             stdexec::__with_exception_ptr>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #=============================================================================
 
-set(stdexec_test_sources 
+set(stdexec_test_sources
     test_main.cpp
     stdexec/cpos/test_cpo_bulk.cpp
     stdexec/cpos/test_cpo_ensure_started.cpp
@@ -78,6 +78,7 @@ set(stdexec_test_sources
     exec/test_at_coroutine_exit.cpp
     exec/test_materialize.cpp
     exec/test_io_uring_context.cpp
+    exec/test_trampoline_scheduler.cpp
     $<$<BOOL:${STDEXEC_ENABLE_TBB}>:tbbexec/test_tbb_thread_pool.cpp>
     )
 

--- a/test/exec/test_trampoline_scheduler.cpp
+++ b/test/exec/test_trampoline_scheduler.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../../include/exec/trampoline_scheduler.hpp"
+
+#include "../../include/exec/on.hpp"
+#include "../test_common/require_terminate.hpp"
+#include "../test_common/retry.hpp"
+
+#include <catch2/catch.hpp>
+#include <exception>
+#include <memory>
+
+using namespace stdexec;
+
+struct try_again { };
+
+struct fails_alot {
+  using is_sender = void;
+  using __t = fails_alot;
+  using __id = fails_alot;
+  using completion_signatures =
+    stdexec::completion_signatures<set_value_t(), set_error_t(try_again)>;
+
+  template <class Receiver>
+  struct operation {
+    Receiver rcvr_;
+    int counter_;
+
+    friend void tag_invoke(start_t, operation& self) noexcept {
+      if (self.counter_ == 0) {
+        set_value((Receiver&&) self.rcvr_);
+      } else {
+        set_error((Receiver&&) self.rcvr_, try_again{});
+      }
+    }
+  };
+
+  template <receiver_of<completion_signatures> Receiver>
+  friend operation<Receiver> tag_invoke(connect_t, fails_alot self, Receiver rcvr) {
+    return {(Receiver&&) rcvr, --*self.counter_};
+  }
+
+  std::shared_ptr<int> counter_ = std::make_shared<int>(1'000'000);
+};
+
+#if defined(REQUIRE_TERMINATE) && !STDEXEC_NVHPC()
+// For some reason, when compiling with nvc++, the forked process dies with SIGSEGV
+// but the error code returned from ::wait reports success, so this test fails.
+TEST_CASE("running deeply recursing algo blows the stack", "[schedulers][trampoline_scheduler]") {
+
+  auto recurse_deeply = retry(fails_alot{});
+  REQUIRE_TERMINATE([&] { sync_wait(std::move(recurse_deeply)); });
+}
+#endif
+
+TEST_CASE(
+  "running deeply recursing algo on trampoline_scheduler doesn't blow the stack",
+  "[schedulers][trampoline_scheduler]") {
+
+  exec::trampoline_scheduler sched;
+  auto recurse_deeply = retry(exec::on(sched, fails_alot{}));
+  sync_wait(std::move(recurse_deeply));
+}

--- a/test/exec/test_trampoline_scheduler.cpp
+++ b/test/exec/test_trampoline_scheduler.cpp
@@ -58,15 +58,15 @@ struct fails_alot {
   std::shared_ptr<int> counter_ = std::make_shared<int>(1'000'000);
 };
 
-#if defined(REQUIRE_TERMINATE) && !STDEXEC_NVHPC()
-// For some reason, when compiling with nvc++, the forked process dies with SIGSEGV
-// but the error code returned from ::wait reports success, so this test fails.
-TEST_CASE("running deeply recursing algo blows the stack", "[schedulers][trampoline_scheduler]") {
+// #if defined(REQUIRE_TERMINATE)
+// // For some reason, when compiling with nvc++, the forked process dies with SIGSEGV
+// // but the error code returned from ::wait reports success, so this test fails.
+// TEST_CASE("running deeply recursing algo blows the stack", "[schedulers][trampoline_scheduler]") {
 
-  auto recurse_deeply = retry(fails_alot{});
-  REQUIRE_TERMINATE([&] { sync_wait(std::move(recurse_deeply)); });
-}
-#endif
+//   auto recurse_deeply = retry(fails_alot{});
+//   REQUIRE_TERMINATE([&] { sync_wait(std::move(recurse_deeply)); });
+// }
+// #endif
 
 TEST_CASE(
   "running deeply recursing algo on trampoline_scheduler doesn't blow the stack",

--- a/test/test_common/require_terminate.hpp
+++ b/test/test_common/require_terminate.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#if __has_include(<unistd.h>) && __has_include(<sys/wait.h>)
+#include <unistd.h>
+#include <sys/wait.h>
+#define REQUIRE_TERMINATE __require_terminate
+#endif
+
+#include <catch2/catch.hpp>
+
+#ifdef REQUIRE_TERMINATE
+namespace {
+  template <class F, class... Args>
+  void __require_terminate(F&& f, Args&&... args) {
+    // spawn a new process
+    auto child_pid = ::fork();
+
+    // if the fork succeed
+    if (child_pid >= 0) {
+
+      // if we are in the child process
+      if (child_pid == 0) {
+
+        // call the function that we expect to abort
+        std::set_terminate([] { std::exit(EXIT_FAILURE); });
+
+        std::invoke((F&&) f, (Args&&) args...);
+
+        // if the function didn't abort, we'll exit cleanly
+        std::exit(EXIT_SUCCESS);
+      }
+    }
+
+    // determine if the child process aborted
+    int exit_status{};
+    ::wait(&exit_status);
+
+    // we check the exit status instead of a signal interrupt, because
+    // Catch is going to catch the signal and exit with an error
+    bool aborted = WEXITSTATUS(exit_status);
+    if (!aborted) {
+      INFO("He didn't fall? Inconceivable!");
+    }
+    REQUIRE(aborted);
+  }
+} // namespace
+#endif

--- a/test/test_common/retry.hpp
+++ b/test/test_common/retry.hpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021-2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Pull in the reference implementation of P2300:
+#include <stdexec/execution.hpp>
+
+template <class From, class To>
+using _copy_cvref_t = stdexec::__copy_cvref_t<From, To>;
+
+template <class From, class To>
+concept _decays_to = std::same_as<std::decay_t<From>, To>;
+
+///////////////////////////////////////////////////////////////////////////////
+// retry algorithm:
+
+// _conv needed so we can emplace construct non-movable types into
+// a std::optional.
+template <std::invocable F>
+  requires std::is_nothrow_move_constructible_v<F>
+struct _conv {
+  F f_;
+
+  explicit _conv(F f) noexcept
+    : f_((F&&) f) {
+  }
+
+  operator std::invoke_result_t<F>() && {
+    return ((F&&) f_)();
+  }
+};
+
+template <class S, class R>
+struct _op;
+
+// pass through all customizations except set_error, which retries the operation.
+template <class S, class R>
+struct _retry_receiver : stdexec::receiver_adaptor<_retry_receiver<S, R>> {
+  _op<S, R>* o_;
+
+  R&& base() && noexcept {
+    return (R&&) o_->r_;
+  }
+
+  const R& base() const & noexcept {
+    return o_->r_;
+  }
+
+  explicit _retry_receiver(_op<S, R>* o)
+    : o_(o) {
+  }
+
+  template <class Error>
+  void set_error(Error&&) && noexcept {
+    o_->_retry(); // This causes the op to be retried
+  }
+};
+
+// Hold the nested operation state in an optional so we can
+// re-construct and re-start it if the operation fails.
+template <class S, class R>
+struct _op {
+  S s_;
+  R r_;
+  std::optional< stdexec::connect_result_t<S&, _retry_receiver<S, R>>> o_;
+
+  _op(S s, R r)
+    : s_((S&&) s)
+    , r_((R&&) r)
+    , o_{_connect()} {
+  }
+
+  _op(_op&&) = delete;
+
+  auto _connect() noexcept {
+    return _conv{[this] {
+      return stdexec::connect(s_, _retry_receiver<S, R>{this});
+    }};
+  }
+
+  void _retry() noexcept {
+    try {
+      o_.emplace(_connect()); // potentially throwing
+      stdexec::start(*o_);
+    } catch (...) {
+      stdexec::set_error((R&&) r_, std::current_exception());
+    }
+  }
+
+  friend void tag_invoke(stdexec::start_t, _op& o) noexcept {
+    stdexec::start(*o.o_);
+  }
+};
+
+template <class S>
+struct _retry_sender {
+  using is_sender = void;
+  S s_;
+
+  explicit _retry_sender(S s)
+    : s_((S&&) s) {
+  }
+
+  template <class>
+  using _error = stdexec::completion_signatures<>;
+  template <class... Ts>
+  using _value = stdexec::completion_signatures<stdexec::set_value_t(Ts...)>;
+
+  template <class Env>
+  friend auto tag_invoke(stdexec::get_completion_signatures_t, const _retry_sender&, Env)
+    -> stdexec::make_completion_signatures<
+      S&,
+      Env,
+      stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>,
+      _value,
+      _error>;
+
+  template <stdexec::receiver R>
+  friend _op<S, R> tag_invoke(stdexec::connect_t, _retry_sender&& self, R r) {
+    return {(S&&) self.s_, (R&&) r};
+  }
+
+  friend auto tag_invoke(stdexec::get_env_t, const _retry_sender& self) //
+    noexcept(noexcept(stdexec::get_env(self.s_))) -> std::invoke_result_t<stdexec::get_env_t, S> {
+    return stdexec::get_env(self.s_);
+  }
+};
+
+template <stdexec::sender S>
+stdexec::sender auto retry(S s) {
+  return _retry_sender{(S&&) s};
+}


### PR DESCRIPTION
Used like:

```c++
  exec::trampoline_scheduler sched;
  auto recurse_deeply = retry(exec::on(sched, fails_alot{}));
  sync_wait(std::move(recurse_deeply));
```
