### PR TITLE
Fix Any scheduler leak

### DIFF
--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -61,6 +61,22 @@ jobs:
           cxxflags: "-fsanitize=thread"
           prebuild_command: |
             apt update && apt install -y --no-install-recommends git;
+  build-cpu-gcc11-ubuntu2204-asan:
+    runs-on: ubuntu-22.04
+    name: CPU (gcc 11, ubuntu 22.04, ASAN)
+    steps:
+      - name: Checkout stdexec
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Build and test CPU schedulers
+        uses: docker://ghcr.io/trxcllnt/action-cxx-toolkit:gcc11-ubuntu22.04
+        with:
+          cc: gcc-11
+          checks: build test
+          cxxflags: "-fsanitize=address"
+          prebuild_command: |
+            apt update && apt install -y --no-install-recommends git;
 
   ci-cpu:
     runs-on: ubuntu-latest

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -417,6 +417,9 @@ namespace exec {
         if constexpr (__is_small<_Tp>) {
           _Tp& __other_object = *__pointer;
           __self.template __construct_small<_Tp>((_Tp&&) __other_object);
+          using _Alloc = typename std::allocator_traits<_Allocator>::template rebind_alloc<_Tp>;
+          _Alloc __alloc{__self.__allocator_};
+          std::allocator_traits<_Alloc>::destroy(__alloc, __pointer);
         } else {
           __self.__object_pointer_ = __pointer;
         }


### PR DESCRIPTION
Hi Eric, this is a PR into your "Any scheduler leak" branch. I didn't have the rights to push directly on your branch. The problem was indeed that I forgot to destroy the moved-from object in the SBO case. 

I've also added a CI job uses ASAN on gcc.

