### PR TITLE
Remove CPOs __get_vtable and __get_object_pointer

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -163,29 +163,6 @@ namespace exec {
       }
     };
 
-    struct __get_vtable_t {
-      template <class _Storage>
-        requires tag_invocable<__get_vtable_t, const _Storage&>
-      const tag_invoke_result_t<__get_vtable_t, const _Storage&>
-        operator()(const _Storage& __storage) const noexcept {
-        static_assert(nothrow_tag_invocable<__get_vtable_t, const _Storage&>);
-        return tag_invoke(__get_vtable_t{}, __storage);
-      }
-    };
-
-    inline constexpr __get_vtable_t __get_vtable{};
-
-    struct __get_object_pointer_t {
-      template <class _Storage>
-        requires __tag_invocable_r<void*, __get_object_pointer_t, const _Storage&>
-      void* operator()(const _Storage& __storage) const noexcept {
-        static_assert(nothrow_tag_invocable<__get_object_pointer_t, const _Storage&>);
-        return tag_invoke(__get_object_pointer_t{}, __storage);
-      }
-    };
-
-    inline constexpr __get_object_pointer_t __get_object_pointer{};
-
     struct __delete_t {
       template <class _Storage, class _Tp>
         requires tag_invocable<__delete_t, __mtype<_Tp>, _Storage&>
@@ -291,7 +268,7 @@ namespace exec {
         __storage_vtable<_Vtable, __with_delete, __with_move>>;
 
       template <class _Tp>
-      static constexpr const __vtable_t* __get_vtable() noexcept {
+      static constexpr const __vtable_t* __get_vtable_of_type() noexcept {
         if constexpr (_Copyable) {
           return &__storage_vtbl<
             __t,
@@ -313,7 +290,7 @@ namespace exec {
       template <__not_decays_to<__t> _Tp>
         requires __callable<__create_vtable_t, __mtype<_Vtable>, __mtype<__decay_t<_Tp>>>
       __t(_Tp&& __object)
-        : __vtable_{__get_vtable<_Tp>()} {
+        : __vtable_{__get_vtable_of_type<_Tp>()} {
         using _Dp = __decay_t<_Tp>;
         if constexpr (__is_small<_Dp>) {
           __construct_small<_Dp>((_Tp&&) __object);
@@ -325,7 +302,7 @@ namespace exec {
       template <class _Tp, class... _Args>
         requires __callable<__create_vtable_t, __mtype<_Vtable>, __mtype<_Tp>>
       __t(std::in_place_type_t<_Tp>, _Args&&... __args)
-        : __vtable_{__get_vtable<_Tp>()} {
+        : __vtable_{__get_vtable_of_type<_Tp>()} {
         if constexpr (__is_small<_Tp>) {
           __construct_small<_Tp>((_Args&&) __args...);
         } else {
@@ -366,6 +343,14 @@ namespace exec {
         __vtable_ = __default_storage_vtable((__vtable_t*) nullptr);
       }
 
+      const _Vtable* __get_vtable() const noexcept {
+        return __vtable_;
+      }
+
+      void* __get_object_pointer() const noexcept {
+        return __object_pointer_;
+      }
+
      private:
       template <class _Tp, class... _As>
       void __construct_small(_As&&... __args) {
@@ -389,14 +374,6 @@ namespace exec {
           throw;
         }
         __object_pointer_ = __pointer;
-      }
-
-      friend const _Vtable* tag_invoke(__get_vtable_t, const __t& __self) noexcept {
-        return __self.__vtable_;
-      }
-
-      friend void* tag_invoke(__get_object_pointer_t, const __t& __self) noexcept {
-        return __self.__object_pointer_;
       }
 
       template <class _Tp>
@@ -616,8 +593,8 @@ namespace exec {
         __unique_operation_storage __storage_{};
 
         friend void tag_invoke(start_t, __t& __self) noexcept {
-          STDEXEC_ASSERT(__get_vtable(__self.__storage_)->__start_);
-          __get_vtable(__self.__storage_)->__start_(__get_object_pointer(__self.__storage_));
+          STDEXEC_ASSERT(__self.__storage_.__get_vtable()->__start_);
+          __self.__storage_.__get_vtable()->__start_(__self.__storage_.__get_object_pointer());
         }
       };
     };
@@ -709,8 +686,8 @@ namespace exec {
         }
 
         __unique_operation_storage __connect(__receiver_ref_t __receiver) {
-          return __get_vtable(__storage_)
-            ->__connect_(__get_object_pointer(__storage_), (__receiver_ref_t&&) __receiver);
+          return __storage_.__get_vtable()
+            ->__connect_(__storage_.__get_object_pointer(), (__receiver_ref_t&&) __receiver);
         }
 
         explicit operator bool() const noexcept {
@@ -727,7 +704,7 @@ namespace exec {
         }
 
         friend __env_t tag_invoke(get_env_t, const __t& __self) noexcept {
-          return {__get_vtable(__self.__storage_), __get_object_pointer(__self.__storage_)};
+          return {__self.__storage_.__get_vtable(), __self.__storage_.__get_object_pointer()};
         }
       };
     };
@@ -775,9 +752,9 @@ namespace exec {
 
       template <same_as<__scheduler> _Self>
       friend __sender_t tag_invoke(schedule_t, const _Self& __self) noexcept {
-        STDEXEC_ASSERT(__get_vtable(__self.__storage_)->__schedule_);
-        return __get_vtable(__self.__storage_)
-          ->__schedule_(__get_object_pointer(__self.__storage_));
+        STDEXEC_ASSERT(__self.__storage_.__get_vtable()->__schedule_);
+        return __self.__storage_.__get_vtable()
+          ->__schedule_(__self.__storage_.__get_object_pointer());
       }
 
       template <class _Tag, same_as<__scheduler> _Self, class... _As>
@@ -785,18 +762,18 @@ namespace exec {
       friend auto tag_invoke(_Tag, const _Self& __self, _As&&... __as) noexcept(
         __nothrow_callable<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...>)
         -> __call_result_t<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...> {
-        return __get_vtable(__self.__storage_)
-          ->__queries()(_Tag{}, __get_object_pointer(__self.__storage_), (_As&&) __as...);
+        return __self.__storage_.__get_vtable()
+          ->__queries()(_Tag{}, __self.__storage_.__get_object_pointer(), (_As&&) __as...);
       }
 
       friend bool operator==(const __scheduler& __self, const __scheduler& __other) noexcept {
-        if (__get_vtable(__self.__storage_) != __get_vtable(__other.__storage_)) {
+        if (__self.__storage_.__get_vtable() != __other.__storage_.__get_vtable()) {
           return false;
         }
-        void* __p = __get_object_pointer(__self.__storage_);
-        void* __o = __get_object_pointer(__other.__storage_);
+        void* __p = __self.__storage_.__get_object_pointer();
+        void* __o = __other.__storage_.__get_object_pointer();
         // if both object pointers are not null, use the virtual equal_to function
-        return (__p && __o && __get_vtable(__self.__storage_)->__equal_to_(__p, __o))
+        return (__p && __o && __self.__storage_.__get_vtable()->__equal_to_(__p, __o))
             // if both object pointers are nullptrs, they are equal
             || (!__p && !__o);
       }

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -175,24 +175,24 @@ TEST_CASE("empty storage is movable", "[types][any_sender]") {
   static_assert(std::is_move_assignable_v<any_unique>);
   static_assert(!std::is_copy_assignable_v<any_unique>);
 
-  CHECK(__any::__get_vtable(s2));
-  CHECK(__any::__get_vtable(s1) != __any::__get_vtable(s2));
-  CHECK(__any::__get_object_pointer(s1) == nullptr);
-  CHECK(__any::__get_object_pointer(s2) != nullptr);
+  CHECK(s2.__get_vtable());
+  CHECK(s1.__get_vtable() != s2.__get_vtable());
+  CHECK(s1.__get_object_pointer() == nullptr);
+  CHECK(s2.__get_object_pointer() != nullptr);
   // Test SBO
-  std::intptr_t obj_ptr = reinterpret_cast<std::intptr_t>(__any::__get_object_pointer(s2));
+  std::intptr_t obj_ptr = reinterpret_cast<std::intptr_t>(s2.__get_object_pointer());
   std::intptr_t s2_ptr = reinterpret_cast<std::intptr_t>(&s2);
   CHECK(std::abs(s2_ptr - obj_ptr) < std::intptr_t(sizeof(any_unique)));
 
   s1 = std::move(s2);
-  CHECK(__any::__get_vtable(s2));
-  CHECK(__any::__get_vtable(s1) != __any::__get_vtable(s2));
-  CHECK(__any::__get_object_pointer(s1) != nullptr);
-  CHECK(__any::__get_object_pointer(s2) == nullptr);
+  CHECK(s2.__get_vtable());
+  CHECK(s1.__get_vtable() != s2.__get_vtable());
+  CHECK(s1.__get_object_pointer() != nullptr);
+  CHECK(s2.__get_object_pointer() == nullptr);
 
   s1 = std::move(s2);
-  CHECK(__any::__get_object_pointer(s1) == nullptr);
-  CHECK(__any::__get_object_pointer(s2) == nullptr);
+  CHECK(s1.__get_object_pointer() == nullptr);
+  CHECK(s2.__get_object_pointer() == nullptr);
 }
 
 TEST_CASE("empty storage is movable, throwing moves will allocate", "[types][any_sender]") {
@@ -213,24 +213,24 @@ TEST_CASE("empty storage is movable, throwing moves will allocate", "[types][any
   static_assert(std::is_move_assignable_v<any_unique>);
   static_assert(!std::is_copy_assignable_v<any_unique>);
 
-  CHECK(__any::__get_vtable(s2));
-  CHECK(__any::__get_vtable(s1) != __any::__get_vtable(s2));
-  CHECK(__any::__get_object_pointer(s1) == nullptr);
-  CHECK(__any::__get_object_pointer(s2) != nullptr);
+  CHECK(s2.__get_vtable());
+  CHECK(s1.__get_vtable() != s2.__get_vtable());
+  CHECK(s1.__get_object_pointer() == nullptr);
+  CHECK(s2.__get_object_pointer() != nullptr);
   // Test SBO
-  std::intptr_t obj_ptr = reinterpret_cast<std::intptr_t>(__any::__get_object_pointer(s2));
+  std::intptr_t obj_ptr = reinterpret_cast<std::intptr_t>(s2.__get_object_pointer());
   std::intptr_t s2_ptr = reinterpret_cast<std::intptr_t>(&s2);
   CHECK(std::abs(s2_ptr - obj_ptr) >= std::intptr_t(sizeof(any_unique)));
 
   s1 = std::move(s2);
-  CHECK(__any::__get_vtable(s2));
-  CHECK(__any::__get_vtable(s1) != __any::__get_vtable(s2));
-  CHECK(__any::__get_object_pointer(s1) != nullptr);
-  CHECK(__any::__get_object_pointer(s2) == nullptr);
+  CHECK(s2.__get_vtable());
+  CHECK(s1.__get_vtable() != s2.__get_vtable());
+  CHECK(s1.__get_object_pointer() != nullptr);
+  CHECK(s2.__get_object_pointer() == nullptr);
 
   s1 = std::move(s2);
-  CHECK(__any::__get_object_pointer(s1) == nullptr);
-  CHECK(__any::__get_object_pointer(s2) == nullptr);
+  CHECK(s1.__get_object_pointer() == nullptr);
+  CHECK(s2.__get_object_pointer() == nullptr);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi,

this PR removes the CPOs for `__get_vtable` and `__get_object_pointer` and replaces them with normal member functions on the storage type. I had them originally inplace in case I want to try different the storage type implementations. This change saves one function call stack in debug mode.