### PR TITLE
add `__mexception` as a meta-exception type, plumb it through all meta utilities

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -686,8 +686,8 @@ namespace exec {
         }
 
         __unique_operation_storage __connect(__receiver_ref_t __receiver) {
-          return __storage_.__get_vtable()
-            ->__connect_(__storage_.__get_object_pointer(), (__receiver_ref_t&&) __receiver);
+          return __storage_.__get_vtable()->__connect_(
+            __storage_.__get_object_pointer(), (__receiver_ref_t&&) __receiver);
         }
 
         explicit operator bool() const noexcept {
@@ -753,8 +753,8 @@ namespace exec {
       template <same_as<__scheduler> _Self>
       friend __sender_t tag_invoke(schedule_t, const _Self& __self) noexcept {
         STDEXEC_ASSERT(__self.__storage_.__get_vtable()->__schedule_);
-        return __self.__storage_.__get_vtable()
-          ->__schedule_(__self.__storage_.__get_object_pointer());
+        return __self.__storage_.__get_vtable()->__schedule_(
+          __self.__storage_.__get_object_pointer());
       }
 
       template <class _Tag, same_as<__scheduler> _Self, class... _As>
@@ -762,8 +762,8 @@ namespace exec {
       friend auto tag_invoke(_Tag, const _Self& __self, _As&&... __as) noexcept(
         __nothrow_callable<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...>)
         -> __call_result_t<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...> {
-        return __self.__storage_.__get_vtable()
-          ->__queries()(_Tag{}, __self.__storage_.__get_object_pointer(), (_As&&) __as...);
+        return __self.__storage_.__get_vtable()->__queries()(
+          _Tag{}, __self.__storage_.__get_object_pointer(), (_As&&) __as...);
       }
 
       friend bool operator==(const __scheduler& __self, const __scheduler& __other) noexcept {

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -556,7 +556,7 @@ namespace exec {
       }
      private:
       template <class _Self>
-      using __completions_t = __future_completions_t<__make_dependent_on<_Sender, _Self>, _Env>;
+      using __completions_t = __future_completions_t<__mfront<_Sender, _Self>, _Env>;
 
       explicit __future(std::unique_ptr<__future_state<_Sender, _Env>> __state) noexcept
         : __state_(std::move(__state)) {

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -94,7 +94,7 @@ namespace exec {
       }
 
       template <class... _Ts>
-      using __self_t = __make_dependent_on<__start_on_kernel, _Ts...>;
+      using __self_t = __mfront<__start_on_kernel, _Ts...>;
 
       template <class _Sender, class _OldScheduler>
       auto transform_sender_(_Sender&& __sndr, _OldScheduler __old_sched) {
@@ -189,7 +189,7 @@ namespace exec {
       }
 
       template <class... _Ts>
-      using __self_t = __make_dependent_on<__continue_on_kernel, _Ts...>;
+      using __self_t = __mfront<__continue_on_kernel, _Ts...>;
 
       template <class _Sender, class _OldScheduler>
       auto transform_sender_(_Sender&& __sndr, _OldScheduler __old_sched) {

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -357,7 +357,7 @@ namespace exec {
 
         template <class Self, class Env>
         using completion_signatures = //
-          stdexec::__make_completion_signatures<
+          stdexec::__try_make_completion_signatures<
             stdexec::__copy_cvref_t<Self, Sender>,
             Env,
             with_error_invoke_t<Fun, stdexec::__copy_cvref_t<Self, Sender>, Env>,

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -106,7 +106,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <class Self, class Env>
       using completion_signatures = //
-        stdexec::__make_completion_signatures<
+        stdexec::__try_make_completion_signatures<
           stdexec::__copy_cvref_t<Self, Sender>,
           Env,
           set_error_t,
@@ -343,7 +343,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <class Self, class Env>
       using completion_signatures = //
-        stdexec::__make_completion_signatures<
+        stdexec::__try_make_completion_signatures<
           stdexec::__copy_cvref_t<Self, Sender>,
           Env,
           set_error_t,

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -31,6 +31,7 @@
 #include "../detail/variant.cuh"
 
 namespace nvexec {
+  using stdexec::operator""__csz;
 
   enum class stream_priority {
     high,

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -23,6 +23,7 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace then {
+    using stdexec::operator""__csz;
 
     template <class Fun, class... As>
     __launch_bounds__(1) __global__ void kernel(Fun fn, As... as) {
@@ -162,7 +163,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             Fun,
             stdexec::__copy_cvref_t<Self, Sender>,
             Env,
-            stdexec::__callable_error< stdexec::__mstring("In nvexec::then(Sender, Function)...")>>,
+            stdexec::__callable_error<"In nvexec::then(Sender, Function)..."__csz>>,
           stdexec::__mbind_front_q<stdexec::__set_value_invoke_t, Fun>,
           stdexec::__q<set_error>>;
 

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -153,14 +153,16 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <class Self, class Env>
       using completion_signatures = //
-        stdexec::__make_completion_signatures<
+        stdexec::__meval<
+          stdexec::__make_completion_signatures,
           stdexec::__copy_cvref_t<Self, Sender>,
           Env,
           stdexec::__with_error_invoke_t<
             stdexec::set_value_t,
             Fun,
             stdexec::__copy_cvref_t<Self, Sender>,
-            Env>,
+            Env,
+            stdexec::__callable_error< stdexec::__mstring("In nvexec::then(Sender, Function)...")>>,
           stdexec::__mbind_front_q<stdexec::__set_value_invoke_t, Fun>,
           stdexec::__q<set_error>>;
 

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -153,7 +153,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <class Self, class Env>
       using completion_signatures = //
         stdexec::__meval<
-          stdexec::__make_completion_signatures,
+          stdexec::__try_make_completion_signatures,
           stdexec::__copy_cvref_t<Self, Sender>,
           Env,
           stdexec::__with_error_invoke_t<

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -23,8 +23,6 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace then {
-    using stdexec::operator""__csz;
-
     template <class Fun, class... As>
     __launch_bounds__(1) __global__ void kernel(Fun fn, As... as) {
       ::cuda::std::move(fn)(std::move(as)...);

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -144,7 +144,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <class Self, class Env>
       using completion_signatures = //
-        stdexec::__make_completion_signatures<
+        stdexec::__try_make_completion_signatures<
           stdexec::__copy_cvref_t<Self, Sender>,
           Env,
           stdexec::completion_signatures<stdexec::set_error_t(cudaError_t)>,

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -112,14 +112,17 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <class Self, class Env>
       using completion_signatures = //
-        stdexec::__make_completion_signatures<
+        stdexec::__meval<
+          stdexec::__make_completion_signatures,
           stdexec::__copy_cvref_t<Self, Sender>,
           Env,
           stdexec::__with_error_invoke_t<
             stdexec::set_stopped_t,
             Fun,
             stdexec::__copy_cvref_t<Self, Sender>,
-            Env>,
+            Env,
+            stdexec::__callable_error< stdexec::__mstring("In nvexec::upon_stopped(Sender, "
+                                                          "Function)...")>>,
           stdexec::__q<stdexec::__compl_sigs::__default_set_value>,
           stdexec::__q<stdexec::__compl_sigs::__default_set_error>,
           stdexec::__set_value_invoke_t<Fun>>;

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -23,8 +23,6 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace upon_stopped {
-    using stdexec::operator""__csz;
-
     template <class Fun>
     __launch_bounds__(1) __global__ void kernel(Fun fn) {
       fn();

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -23,6 +23,8 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace upon_stopped {
+    using stdexec::operator""__csz;
+
     template <class Fun>
     __launch_bounds__(1) __global__ void kernel(Fun fn) {
       fn();
@@ -121,8 +123,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             Fun,
             stdexec::__copy_cvref_t<Self, Sender>,
             Env,
-            stdexec::__callable_error< stdexec::__mstring("In nvexec::upon_stopped(Sender, "
-                                                          "Function)...")>>,
+            stdexec::__callable_error<"In nvexec::upon_stopped(Sender, Function)..."__csz>>,
           stdexec::__q<stdexec::__compl_sigs::__default_set_value>,
           stdexec::__q<stdexec::__compl_sigs::__default_set_error>,
           stdexec::__set_value_invoke_t<Fun>>;

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -113,7 +113,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <class Self, class Env>
       using completion_signatures = //
         stdexec::__meval<
-          stdexec::__make_completion_signatures,
+          stdexec::__try_make_completion_signatures,
           stdexec::__copy_cvref_t<Self, Sender>,
           Env,
           stdexec::__with_error_invoke_t<

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -2712,8 +2712,8 @@ namespace stdexec {
   template <class... _Args>
   struct _WITH_ARGUMENTS_ { };
 
-  inline constexpr __mstring const
-    __not_callable_diag("The specified function is not callable with the arguments provided.");
+  inline constexpr __mstring __not_callable_diag =
+    "The specified function is not callable with the arguments provided."__csz;
 
   template <__mstring _Context, __mstring _Diagnostic = __not_callable_diag>
   struct _NOT_CALLABLE_ {
@@ -2818,7 +2818,7 @@ namespace stdexec {
       };
     };
 
-    inline constexpr __mstring __then_context("In stdexec::then(Sender, Function)...");
+    inline constexpr __mstring __then_context = "In stdexec::then(Sender, Function)..."__csz;
     using __on_not_callable = __callable_error<__then_context>;
 
     template <class _SenderId, class _Fun>
@@ -2959,7 +2959,8 @@ namespace stdexec {
       };
     };
 
-    inline constexpr __mstring __upon_error_context("In stdexec::upon_error(Sender, Function)...");
+    inline constexpr __mstring __upon_error_context =
+      "In stdexec::upon_error(Sender, Function)..."__csz;
     using __on_not_callable = __callable_error<__upon_error_context>;
 
     template <class _SenderId, class _Fun>
@@ -3091,8 +3092,8 @@ namespace stdexec {
       };
     };
 
-    inline constexpr __mstring
-      __upon_stopped_context("In stdexec::upon_stopped(Sender, Function)...");
+    inline constexpr __mstring __upon_stopped_context =
+      "In stdexec::upon_stopped(Sender, Function)..."__csz;
     using __on_not_callable = __callable_error<__upon_stopped_context>;
 
     template <class _SenderId, class _Fun>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -232,7 +232,7 @@ namespace stdexec {
       template <class _WithId>
       using __tag_of = typename _WithId::__tag_t;
       template <class _Self>
-      using __base_env_of = __make_dependent_on<_BaseEnv, _Self>;
+      using __base_env_of = __mfront<_BaseEnv, _Self>;
 
       struct __t : stdexec::__t<_WithIds>... {
         using __id = __env;
@@ -3544,7 +3544,7 @@ namespace stdexec {
             // NOT TO SPEC:
             // See https://github.com/brycelelbach/wg21_p2300_execution/issues/26
             _CvrefSender,
-            __env_t<__make_dependent_on<_Env, _Self>>,
+            __env_t<__mfront<_Env, _Self>>,
             completion_signatures<
               set_error_t(const std::exception_ptr&),
               set_stopped_t()>, // NOT TO SPEC
@@ -3864,7 +3864,7 @@ namespace stdexec {
         using __completions_t = //
           make_completion_signatures<
             _Sender&,
-            __env_t<__make_dependent_on<_Env, _Self>>,
+            __env_t<__mfront<_Env, _Self>>,
             completion_signatures<
               set_error_t(std::exception_ptr&&),
               set_stopped_t()>, // BUGBUG NOT TO SPEC
@@ -5246,12 +5246,12 @@ namespace stdexec {
           __none_of<get_completion_signatures_t, get_stop_token_t> _Tag, //
           same_as<__t> _Self,                                            //
           class... _As>
-          requires __callable<_Tag, const __make_dependent_on<_Env, _Self>&, _As...>
+          requires __callable<_Tag, const __mfront<_Env, _Self>&, _As...>
         friend auto tag_invoke(_Tag __tag, const _Self& __self, _As&&... __as) noexcept
           -> __call_result_if_t<
             same_as<_Self, __t>,
             _Tag,
-            const __make_dependent_on<_Env, _Self>&,
+            const __mfront<_Env, _Self>&,
             _As...> {
           return ((_Tag&&) __tag)(__self.__base_env_, (_As&&) __as...);
         }

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4079,16 +4079,20 @@ namespace stdexec {
   // [execution.senders.adaptors.let_stopped]
   namespace __let {
     template <class _Set>
-    inline constexpr __mstring __let_context = "In stdexec::let_value(Sender, Function)..."__csz;
+    constexpr auto __let_context() {
+      return "In stdexec::let_value(Sender, Function)..."__csz;
+    }
     template <>
-    inline constexpr __mstring __let_context<set_error_t> =
-      "In stdexec::let_error(Sender, Function)..."__csz;
+    constexpr auto __let_context<set_error_t>() {
+      return "In stdexec::let_error(Sender, Function)..."__csz;
+    }
     template <>
-    inline constexpr __mstring __let_context<set_stopped_t> =
-      "In stdexec::let_stopped(Sender, Function)..."__csz;
+    constexpr auto __let_context<set_stopped_t>() {
+      return "In stdexec::let_stopped(Sender, Function)..."__csz;
+    }
 
     template <class _Set>
-    using __on_not_callable = __callable_error<__let_context<_Set>>;
+    using __on_not_callable = __callable_error<__let_context<_Set>()>;
 
     template <class _Tp>
     using __decay_ref = __decay_t<_Tp>&;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4079,26 +4079,20 @@ namespace stdexec {
   // [execution.senders.adaptors.let_stopped]
   namespace __let {
     template <class _Set>
-    struct __let_context {
-      static constexpr auto __get() {
-        return "In stdexec::let_value(Sender, Function)..."__csz;
-      }
+    struct __on_not_callable_ {
+      using __t = __callable_error<"In stdexec::let_value(Sender, Function)..."__csz>;
     };
     template <>
-    struct __let_context<set_error_t> {
-      static constexpr auto __get() {
-        return "In stdexec::let_error(Sender, Function)..."__csz;
-      }
+    struct __on_not_callable_<set_error_t> {
+      using __t = __callable_error<"In stdexec::let_error(Sender, Function)..."__csz>;
     };
     template <>
-    struct __let_context<set_stopped_t> {
-      static constexpr auto __get() {
-        return "In stdexec::let_stopped(Sender, Function)..."__csz;
-      }
+    struct __on_not_callable_<set_stopped_t> {
+      using __t = __callable_error<"In stdexec::let_stopped(Sender, Function)..."__csz>;
     };
 
     template <class _Set>
-    using __on_not_callable = __callable_error<__let_context<_Set>::__get()>;
+    using __on_not_callable = __t<__on_not_callable_<_Set>>;
 
     template <class _Tp>
     using __decay_ref = __decay_t<_Tp>&;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4079,20 +4079,26 @@ namespace stdexec {
   // [execution.senders.adaptors.let_stopped]
   namespace __let {
     template <class _Set>
-    constexpr auto __let_context() {
-      return "In stdexec::let_value(Sender, Function)..."__csz;
-    }
+    struct __let_context {
+      static constexpr auto __get() {
+        return "In stdexec::let_value(Sender, Function)..."__csz;
+      }
+    };
     template <>
-    constexpr auto __let_context<set_error_t>() {
-      return "In stdexec::let_error(Sender, Function)..."__csz;
-    }
+    struct __let_context<set_error_t> {
+      static constexpr auto __get() {
+        return "In stdexec::let_error(Sender, Function)..."__csz;
+      }
+    };
     template <>
-    constexpr auto __let_context<set_stopped_t>() {
-      return "In stdexec::let_stopped(Sender, Function)..."__csz;
-    }
+    struct __let_context<set_stopped_t> {
+      static constexpr auto __get() {
+        return "In stdexec::let_stopped(Sender, Function)..."__csz;
+      }
+    };
 
     template <class _Set>
-    using __on_not_callable = __callable_error<__let_context<_Set>()>;
+    using __on_not_callable = __callable_error<__let_context<_Set>::__get()>;
 
     template <class _Tp>
     using __decay_ref = __decay_t<_Tp>&;

--- a/include/tbbexec/tbb_thread_pool.hpp
+++ b/include/tbbexec/tbb_thread_pool.hpp
@@ -327,7 +327,7 @@ namespace tbbexec {
             stdexec::completion_signatures<stdexec::set_value_t(stdexec::__decay_t<Tys>...)>;
 
           template <class Self, class Env>
-          using completion_signatures = stdexec::__make_completion_signatures<
+          using completion_signatures = stdexec::__try_make_completion_signatures<
             stdexec::__copy_cvref_t<Self, Sender>,
             Env,
             with_error_invoke_t<Fun, stdexec::__copy_cvref_t<Self, Sender>, Env>,

--- a/test/nvexec/bulk.cpp
+++ b/test/nvexec/bulk.cpp
@@ -72,7 +72,9 @@ TEST_CASE("bulk forwards multiple values on GPU", "[cuda][stream][adaptors][bulk
   REQUIRE(d == 4.2);
 }
 
-TEST_CASE("bulk forwards values that can be taken by reference on GPU", "[cuda][stream][adaptors][bulk]") {
+TEST_CASE(
+  "bulk forwards values that can be taken by reference on GPU",
+  "[cuda][stream][adaptors][bulk]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<1024> flags_storage{};

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -164,7 +164,7 @@ namespace detail::a_sender {
       stdexec::__id<receiver_th<Receiver>>>;
 
     template <class Self, class Env>
-    using completion_signatures = stdexec::__make_completion_signatures<
+    using completion_signatures = stdexec::__try_make_completion_signatures<
       stdexec::__copy_cvref_t<Self, Sender>,
       Env,
       stdexec::completion_signatures<>,
@@ -227,7 +227,7 @@ namespace detail::a_receiverless_sender {
       stdexec::__id<Receiver>>;
 
     template <class Self, class Env>
-    using completion_signatures = stdexec::__make_completion_signatures<
+    using completion_signatures = stdexec::__try_make_completion_signatures<
       stdexec::__copy_cvref_t<Self, Sender>,
       Env,
       stdexec::completion_signatures<>>;

--- a/test/stdexec/algos/adaptors/test_bulk.cpp
+++ b/test/stdexec/algos/adaptors/test_bulk.cpp
@@ -150,9 +150,7 @@ TEST_CASE("bulk forwards values that can be taken by reference", "[adaptors][bul
   std::iota(vals_expected.begin(), vals_expected.end(), 0);
 
   auto snd = ex::just(std::move(vals)) //
-           | ex::bulk(n, [&](int i, std::vector<int>& vals) {
-               vals[i] = i;
-             });
+           | ex::bulk(n, [&](int i, std::vector<int>& vals) { vals[i] = i; });
   auto op = ex::connect(std::move(snd), expect_value_receiver{vals_expected});
   ex::start(op);
 }
@@ -249,14 +247,8 @@ TEST_CASE("bulk works with static thread pool", "[adaptors][bulk]") {
       std::iota(vals_expected.begin(), vals_expected.end(), 1);
 
       auto snd = ex::transfer_just(sch, std::move(vals))
-               | ex::bulk(
-                   n,
-                   [](int idx, std::vector<int>& vals) {
-                     vals[idx] = idx;
-                   })
-               | ex::bulk(n, [](int idx, std::vector<int>& vals) {
-                   ++vals[idx];
-                 });
+               | ex::bulk(n, [](int idx, std::vector<int>& vals) { vals[idx] = idx; })
+               | ex::bulk(n, [](int idx, std::vector<int>& vals) { ++vals[idx]; });
       auto [vals_actual] = stdexec::sync_wait(std::move(snd)).value();
 
       CHECK(vals_actual == vals_expected);


### PR DESCRIPTION
When evaluating `__minvoke< Fn, Args... >`, if any type in `Args` is an instance of `__mexception`, the alias will name that exception type. Otherwise, it names `Fn::__f<Args...>` as always. This will make it easier to propagate custom compile-time diagnostics from deep inside the library to an interface boundary where it can be reported with a diagnostic in plain text.

The template parameters to `__mexception` are types that provide information about the error. You can use `__mstring` to embed text strings into type names.