### PR TITLE
Check that bulk callables can take values by reference

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -108,11 +108,11 @@ namespace exec {
       }
 
       template <class Fun, class Shape, class... Args>
-        requires stdexec::__callable<Fun, Shape, Args...>
+        requires stdexec::__callable<Fun, Shape, Args&...>
       using bulk_non_throwing = //
         stdexec::__mbool<
           // If function invocation doesn't throw
-          stdexec::__nothrow_callable<Fun, Shape, Args...> &&
+          stdexec::__nothrow_callable<Fun, Shape, Args&...> &&
           // and emplacing a tuple doesn't throw
           noexcept(stdexec::__decayed_tuple<Args...>(std::declval<Args>()...))
           // there's no need to advertise completion with `exception_ptr`

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -48,7 +48,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
         template <class... As>
         friend void tag_invoke(stdexec::set_value_t, __t&& self, As&&... as) noexcept
-          requires stdexec::__callable<Fun, Shape, As...>
+          requires stdexec::__callable<Fun, Shape, As&...>
         {
           operation_state_base_t<ReceiverId>& op_state = self.op_state_;
 
@@ -187,7 +187,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
         template <class... As>
         friend void tag_invoke(stdexec::set_value_t, __t&& self, As&&... as) noexcept
-          requires stdexec::__callable<Fun, Shape, As...>
+          requires stdexec::__callable<Fun, Shape, As&...>
         {
           operation_t<CvrefSenderId, ReceiverId, Shape, Fun>& op_state = self.op_state_;
 

--- a/test/nvexec/bulk.cpp
+++ b/test/nvexec/bulk.cpp
@@ -72,6 +72,24 @@ TEST_CASE("bulk forwards multiple values on GPU", "[cuda][stream][adaptors][bulk
   REQUIRE(d == 4.2);
 }
 
+TEST_CASE("bulk forwards values that can be taken by reference on GPU", "[cuda][stream][adaptors][bulk]") {
+  nvexec::stream_context stream_ctx{};
+
+  flags_storage_t<1024> flags_storage{};
+  using flags_t = decltype(flags_storage)::flags_t;
+  auto flags = flags_storage.get();
+
+  auto snd = ex::transfer_just(stream_ctx.get_scheduler(), flags) //
+           | ex::bulk(1024, [](int idx, flags_t& flags) {
+               if (is_on_gpu()) {
+                 flags.set(idx);
+               }
+             });
+  auto [flags_actual] = stdexec::sync_wait(std::move(snd)).value();
+
+  REQUIRE(flags_storage.all_set_once());
+}
+
 TEST_CASE("bulk can preceed a sender without values", "[cuda][stream][adaptors][bulk]") {
   nvexec::stream_context stream_ctx{};
 

--- a/test/stdexec/algos/adaptors/test_bulk.cpp
+++ b/test/stdexec/algos/adaptors/test_bulk.cpp
@@ -143,6 +143,20 @@ TEST_CASE("bulk forwards values", "[adaptors][bulk]") {
   }
 }
 
+TEST_CASE("bulk forwards values that can be taken by reference", "[adaptors][bulk]") {
+  constexpr int n = 9;
+  std::vector<int> vals(n, 0);
+  std::vector<int> vals_expected(n);
+  std::iota(vals_expected.begin(), vals_expected.end(), 0);
+
+  auto snd = ex::just(std::move(vals)) //
+           | ex::bulk(n, [&](int i, std::vector<int>& vals) {
+               vals[i] = i;
+             });
+  auto op = ex::connect(std::move(snd), expect_value_receiver{vals_expected});
+  ex::start(op);
+}
+
 TEST_CASE("bulk cannot be used to change the value type", "[adaptors][bulk]") {
   constexpr int magic_number = 42;
   constexpr int n = 2;
@@ -225,6 +239,27 @@ TEST_CASE("bulk works with static thread pool", "[adaptors][bulk]") {
       const std::size_t expected = n;
 
       CHECK(expected == actual);
+    }
+  }
+
+  SECTION("With values in the set_value channel that can be taken by reference") {
+    for (int n = 0; n < 9; n++) {
+      std::vector<int> vals(n, 0);
+      std::vector<int> vals_expected(n);
+      std::iota(vals_expected.begin(), vals_expected.end(), 1);
+
+      auto snd = ex::transfer_just(sch, std::move(vals))
+               | ex::bulk(
+                   n,
+                   [](int idx, std::vector<int>& vals) {
+                     vals[idx] = idx;
+                   })
+               | ex::bulk(n, [](int idx, std::vector<int>& vals) {
+                   ++vals[idx];
+                 });
+      auto [vals_actual] = stdexec::sync_wait(std::move(snd)).value();
+
+      CHECK(vals_actual == vals_expected);
     }
   }
 


### PR DESCRIPTION
This was already done for the default implementation of `bulk`, but not for the `static_thread_pool` and `stream_context` customizations.