### PR TITLE
add an operator| overload to issue a diagnostic when trying to pipe into a sender

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -6193,7 +6193,28 @@ namespace stdexec {
   using __sync_wait::sync_wait_with_variant_t;
   inline constexpr sync_wait_with_variant_t sync_wait_with_variant{};
 
+  struct __ignore_sender {
+    using is_sender = void;
+
+    template <sender _Sender>
+    constexpr __ignore_sender(_Sender&&) noexcept {
+    }
+  };
+
+  template <auto _Reason = "You cannot pipe one sender into another."__csz>
+  struct _CANNOT_PIPE_INTO_A_SENDER_ { };
+
+  template <class _Sender>
+  struct _WITH_SENDER_ { };
+
+  template <class _Sender>
+  using __bad_pipe_sink_t = __mexception<_CANNOT_PIPE_INTO_A_SENDER_<>, _WITH_SENDER_<_Sender>>;
 } // namespace stdexec
+
+// For issuing a meaningful diagnostic for the erroneous `snd1 | snd2`.
+template <stdexec::sender _Sender>
+  requires stdexec::__ok<stdexec::__bad_pipe_sink_t<_Sender>>
+auto operator|(stdexec::__ignore_sender, _Sender&&) noexcept -> stdexec::__ignore_sender;
 
 #include "__detail/__p2300.hpp"
 


### PR DESCRIPTION
Fixes #708 