### PR TITLE
Modify requirement `ensure_started` to accept move only input sender

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4029,8 +4029,7 @@ namespace stdexec {
         using is_sender = void;
 
         explicit __t(_CvrefSender __sndr, _Env __env)
-          : __sndr_((_CvrefSender&&) __sndr)
-          , __shared_state_{__make_intrusive<__sh_state_>((_CvrefSender&&)__sndr_, (_Env&&) __env)} {
+          : __shared_state_{__make_intrusive<__sh_state_>((_CvrefSender&&)__sndr, (_Env&&) __env)} {
         }
 
         ~__t() {
@@ -4065,7 +4064,6 @@ namespace stdexec {
             __q<__set_value_t>,
             __q<__set_error_t>>;
 
-        _CvrefSender __sndr_;
         __intrusive_ptr<__sh_state_> __shared_state_;
 
         template <same_as<__t> _Self, receiver_of<__completions_t<_Self>> _Receiver>

--- a/include/stdexec/functional.hpp
+++ b/include/stdexec/functional.hpp
@@ -46,6 +46,13 @@ namespace stdexec {
       { std::invoke((_Fun&&) __f, (_As&&) __as...) } noexcept;
     };
 
+  struct __first {
+    template <class _First, class _Second>
+    constexpr _First&& operator()(_First&& __first, _Second&&) const noexcept {
+      return (_First&&) __first;
+    }
+  };
+
   template <auto _Fun>
   struct __fun_c_t {
     using _FunT = decltype(_Fun);

--- a/test/stdexec/algos/adaptors/test_ensure_started.cpp
+++ b/test/stdexec/algos/adaptors/test_ensure_started.cpp
@@ -33,9 +33,11 @@ TEST_CASE("ensure_started returns a sender", "[adaptors][ensure_started]") {
   (void) snd;
 }
 
+static const auto env = exec::make_env(exec::with(ex::get_scheduler, inline_scheduler{}));
+
 TEST_CASE("ensure_started with environment returns a sender", "[adaptors][ensure_started]") {
-  auto snd = ex::ensure_started(ex::just(19));
-  static_assert(ex::sender_in<decltype(snd), empty_env>);
+  auto snd = ex::ensure_started(ex::just(19), env);
+  static_assert(ex::sender_in<decltype(snd), decltype(env)>);
   (void) snd;
 }
 

--- a/test/stdexec/algos/adaptors/test_ensure_started.cpp
+++ b/test/stdexec/algos/adaptors/test_ensure_started.cpp
@@ -283,6 +283,7 @@ TEST_CASE("Repeated ensure_started compiles", "[adaptors][ensure_started]") {
   CHECK_FALSE(called);
   auto snd2 = ex::ensure_started(std::move(snd1));
   auto snd = ex::ensure_started(std::move(snd2));
+  STATIC_REQUIRE(ex::same_as<decltype(snd2), decltype(snd)>);
   CHECK(called);
   auto op = ex::connect(std::move(snd), expect_void_receiver{});
   ex::start(op);

--- a/test/stdexec/algos/adaptors/test_ensure_started.cpp
+++ b/test/stdexec/algos/adaptors/test_ensure_started.cpp
@@ -285,3 +285,13 @@ TEST_CASE("Repeated ensure_started compiles", "[adaptors][ensure_started]") {
   auto op = ex::connect(std::move(snd), expect_void_receiver{});
   ex::start(op);
 }
+
+TEST_CASE("ensure_started with move only input sender", "[adaptors][ensure_started]") {
+  bool called{false};
+  auto snd1 = ex::just(movable(42)) | ex::then([&](movable &&) { called = true; });
+  CHECK_FALSE(called);
+  auto snd = ex::ensure_started(std::move(snd1));
+  CHECK(called);
+  auto op = ex::connect(std::move(snd), expect_void_receiver{});
+  ex::start(op);
+}


### PR DESCRIPTION
In the same way as #748 does it for `split`.
Change the environment test to use a non empty_env.