### PR TITLE
make sure all the tests have unique names

### DIFF
--- a/test/nvexec/bulk.cpp
+++ b/test/nvexec/bulk.cpp
@@ -8,14 +8,14 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("bulk returns a sender", "[cuda][stream][adaptors][bulk]") {
+TEST_CASE("nvexec bulk returns a sender", "[cuda][stream][adaptors][bulk]") {
   nvexec::stream_context stream_ctx{};
   auto snd = ex::bulk(ex::schedule(stream_ctx.get_scheduler()), 42, [] {});
   STATIC_REQUIRE(ex::sender<decltype(snd)>);
   (void) snd;
 }
 
-TEST_CASE("bulk executes on GPU", "[cuda][stream][adaptors][bulk]") {
+TEST_CASE("nvexec bulk executes on GPU", "[cuda][stream][adaptors][bulk]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<4> flags_storage{};
@@ -32,7 +32,7 @@ TEST_CASE("bulk executes on GPU", "[cuda][stream][adaptors][bulk]") {
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("bulk forwards values on GPU", "[cuda][stream][adaptors][bulk]") {
+TEST_CASE("nvexec bulk forwards values on GPU", "[cuda][stream][adaptors][bulk]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<1024> flags_storage{};
@@ -51,7 +51,7 @@ TEST_CASE("bulk forwards values on GPU", "[cuda][stream][adaptors][bulk]") {
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("bulk forwards multiple values on GPU", "[cuda][stream][adaptors][bulk]") {
+TEST_CASE("nvexec bulk forwards multiple values on GPU", "[cuda][stream][adaptors][bulk]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<2> flags_storage{};
@@ -92,7 +92,7 @@ TEST_CASE(
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("bulk can preceed a sender without values", "[cuda][stream][adaptors][bulk]") {
+TEST_CASE("nvexec bulk can preceed a sender without values", "[cuda][stream][adaptors][bulk]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<3> flags_storage{};
@@ -116,7 +116,7 @@ TEST_CASE("bulk can preceed a sender without values", "[cuda][stream][adaptors][
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("bulk can succeed a sender", "[cuda][stream][adaptors][bulk]") {
+TEST_CASE("nvexec bulk can succeed a sender", "[cuda][stream][adaptors][bulk]") {
   SECTION("without values") {
     nvexec::stream_context stream_ctx{};
     flags_storage_t<3> flags_storage{};

--- a/test/nvexec/ensure_started.cpp
+++ b/test/nvexec/ensure_started.cpp
@@ -12,7 +12,7 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("ensure_started is eager", "[cuda][stream][adaptors][ensure_started]") {
+TEST_CASE("nvexec ensure_started is eager", "[cuda][stream][adaptors][ensure_started]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -32,7 +32,7 @@ TEST_CASE("ensure_started is eager", "[cuda][stream][adaptors][ensure_started]")
   stdexec::sync_wait(std::move(snd));
 }
 
-TEST_CASE("ensure_started propagates values", "[cuda][stream][adaptors][ensure_started]") {
+TEST_CASE("nvexec ensure_started propagates values", "[cuda][stream][adaptors][ensure_started]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd1 = ex::ensure_started(
@@ -71,7 +71,7 @@ TEST_CASE(
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("ensure_started can succeed a sender", "[cuda][stream][adaptors][ensure_started]") {
+TEST_CASE("nvexec ensure_started can succeed a sender", "[cuda][stream][adaptors][ensure_started]") {
   SECTION("without values") {
     nvexec::stream_context stream_ctx{};
     flags_storage_t<2> flags_storage{};

--- a/test/nvexec/let_error.cpp
+++ b/test/nvexec/let_error.cpp
@@ -8,7 +8,7 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("let_error returns a sender", "[cuda][stream][adaptors][let_error]") {
+TEST_CASE("nvexec let_error returns a sender", "[cuda][stream][adaptors][let_error]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::just_error(42) | ex::transfer(stream_ctx.get_scheduler())
@@ -17,7 +17,7 @@ TEST_CASE("let_error returns a sender", "[cuda][stream][adaptors][let_error]") {
   (void) snd;
 }
 
-TEST_CASE("let_error executes on GPU", "[cuda][stream][adaptors][let_error]") {
+TEST_CASE("nvexec let_error executes on GPU", "[cuda][stream][adaptors][let_error]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -36,7 +36,7 @@ TEST_CASE("let_error executes on GPU", "[cuda][stream][adaptors][let_error]") {
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("let_error can preceed a sender without values", "[cuda][stream][adaptors][let_error]") {
+TEST_CASE("nvexec let_error can preceed a sender without values", "[cuda][stream][adaptors][let_error]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<2> flags_storage{};
@@ -61,7 +61,7 @@ TEST_CASE("let_error can preceed a sender without values", "[cuda][stream][adapt
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("let_error can succeed a sender", "[cuda][stream][adaptors][let_error]") {
+TEST_CASE("nvexec let_error can succeed a sender", "[cuda][stream][adaptors][let_error]") {
   nvexec::stream_context stream_ctx{};
   nvexec::stream_scheduler sch = stream_ctx.get_scheduler();
   flags_storage_t flags_storage{};

--- a/test/nvexec/let_stopped.cpp
+++ b/test/nvexec/let_stopped.cpp
@@ -8,7 +8,7 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("let_stopped returns a sender", "[cuda][stream][adaptors][let_stopped]") {
+TEST_CASE("nvexec let_stopped returns a sender", "[cuda][stream][adaptors][let_stopped]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::just_stopped() | ex::transfer(stream_ctx.get_scheduler())
@@ -17,7 +17,7 @@ TEST_CASE("let_stopped returns a sender", "[cuda][stream][adaptors][let_stopped]
   (void) snd;
 }
 
-TEST_CASE("let_stopped executes on GPU", "[cuda][stream][adaptors][let_stopped]") {
+TEST_CASE("nvexec let_stopped executes on GPU", "[cuda][stream][adaptors][let_stopped]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -62,7 +62,7 @@ TEST_CASE(
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("let_stopped can succeed a sender", "[cuda][stream][adaptors][let_stopped]") {
+TEST_CASE("nvexec let_stopped can succeed a sender", "[cuda][stream][adaptors][let_stopped]") {
   nvexec::stream_context stream_ctx{};
   nvexec::stream_scheduler sch = stream_ctx.get_scheduler();
   flags_storage_t flags_storage{};

--- a/test/nvexec/let_value.cpp
+++ b/test/nvexec/let_value.cpp
@@ -8,14 +8,14 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("let_value returns a sender", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE("nvexec let_value returns a sender", "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
   auto snd = ex::let_value(ex::schedule(stream_ctx.get_scheduler()), [] { return ex::just(); });
   STATIC_REQUIRE(ex::sender<decltype(snd)>);
   (void) snd;
 }
 
-TEST_CASE("let_value executes on GPU", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE("nvexec let_value executes on GPU", "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -33,7 +33,7 @@ TEST_CASE("let_value executes on GPU", "[cuda][stream][adaptors][let_value]") {
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("let_value accepts values on GPU", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE("nvexec let_value accepts values on GPU", "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -54,7 +54,7 @@ TEST_CASE("let_value accepts values on GPU", "[cuda][stream][adaptors][let_value
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("let_value accepts multiple values on GPU", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE("nvexec let_value accepts multiple values on GPU", "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -74,7 +74,7 @@ TEST_CASE("let_value accepts multiple values on GPU", "[cuda][stream][adaptors][
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("let_value returns values on GPU", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE("nvexec let_value returns values on GPU", "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::schedule(stream_ctx.get_scheduler()) //
@@ -84,7 +84,7 @@ TEST_CASE("let_value returns values on GPU", "[cuda][stream][adaptors][let_value
   REQUIRE(result == 1);
 }
 
-TEST_CASE("let_value can preceed a sender without values", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE("nvexec let_value can preceed a sender without values", "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<2> flags_storage{};
@@ -108,7 +108,7 @@ TEST_CASE("let_value can preceed a sender without values", "[cuda][stream][adapt
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("let_value can succeed a sender", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE("nvexec let_value can succeed a sender", "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
   nvexec::stream_scheduler sch = stream_ctx.get_scheduler();
   flags_storage_t flags_storage{};

--- a/test/nvexec/reduce.cpp
+++ b/test/nvexec/reduce.cpp
@@ -12,7 +12,7 @@
 
 namespace ex = stdexec;
 
-TEST_CASE("reduce returns a sender with single input", "[cuda][stream][adaptors][reduce]") {
+TEST_CASE("nvexec reduce returns a sender with single input", "[cuda][stream][adaptors][reduce]") {
   constexpr int N = 2048;
   int input[N] = {};
   std::fill_n(input, N, 1);
@@ -25,7 +25,7 @@ TEST_CASE("reduce returns a sender with single input", "[cuda][stream][adaptors]
   (void) snd;
 }
 
-TEST_CASE("reduce returns a sender with two inputs", "[cuda][stream][adaptors][reduce]") {
+TEST_CASE("nvexec reduce returns a sender with two inputs", "[cuda][stream][adaptors][reduce]") {
   constexpr int N = 2048;
   int input[N] = {};
   std::fill_n(input, N, 1);
@@ -39,7 +39,7 @@ TEST_CASE("reduce returns a sender with two inputs", "[cuda][stream][adaptors][r
   (void) snd;
 }
 
-TEST_CASE("reduce uses sum as default", "[cuda][stream][adaptors][reduce]") {
+TEST_CASE("nvexec reduce uses sum as default", "[cuda][stream][adaptors][reduce]") {
   constexpr int N = 2048;
   constexpr int init = 42;
 
@@ -56,7 +56,7 @@ TEST_CASE("reduce uses sum as default", "[cuda][stream][adaptors][reduce]") {
   REQUIRE(result == N + init);
 }
 
-TEST_CASE("reduce uses the passed function", "[cuda][stream][adaptors][reduce]") {
+TEST_CASE("nvexec reduce uses the passed function", "[cuda][stream][adaptors][reduce]") {
   constexpr int N = 2048;
   constexpr int init = 42;
 
@@ -73,7 +73,7 @@ TEST_CASE("reduce uses the passed function", "[cuda][stream][adaptors][reduce]")
   REQUIRE(result == 1);
 }
 
-TEST_CASE("reduce executes on GPU", "[cuda][stream][adaptors][reduce]") {
+TEST_CASE("nvexec reduce executes on GPU", "[cuda][stream][adaptors][reduce]") {
   constexpr int N = 2048;
   constexpr int init = 42;
 

--- a/test/nvexec/split.cpp
+++ b/test/nvexec/split.cpp
@@ -8,14 +8,14 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("split returns a sender", "[cuda][stream][adaptors][split]") {
+TEST_CASE("nvexec split returns a sender", "[cuda][stream][adaptors][split]") {
   nvexec::stream_context stream_ctx{};
   auto snd = ex::split(ex::schedule(stream_ctx.get_scheduler()));
   STATIC_REQUIRE(ex::sender<decltype(snd)>);
   (void) snd;
 }
 
-TEST_CASE("split works", "[cuda][stream][adaptors][split]") {
+TEST_CASE("nvexec split works", "[cuda][stream][adaptors][split]") {
   nvexec::stream_context stream_ctx{};
 
   auto fork = ex::schedule(stream_ctx.get_scheduler()) //
@@ -31,7 +31,7 @@ TEST_CASE("split works", "[cuda][stream][adaptors][split]") {
   REQUIRE(v2 == 42);
 }
 
-TEST_CASE("split can preceed a sender without values", "[cuda][stream][adaptors][split]") {
+TEST_CASE("nvexec split can preceed a sender without values", "[cuda][stream][adaptors][split]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -50,7 +50,7 @@ TEST_CASE("split can preceed a sender without values", "[cuda][stream][adaptors]
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("split can succeed a sender", "[cuda][stream][adaptors][split]") {
+TEST_CASE("nvexec split can succeed a sender", "[cuda][stream][adaptors][split]") {
   SECTION("without values") {
     nvexec::stream_context stream_ctx{};
     flags_storage_t<2> flags_storage{};

--- a/test/nvexec/start_detached.cpp
+++ b/test/nvexec/start_detached.cpp
@@ -12,7 +12,7 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("start_detached doesn't block", "[cuda][stream][consumers][start_detached]") {
+TEST_CASE("nvexec start_detached doesn't block", "[cuda][stream][consumers][start_detached]") {
   if (const char* env = std::getenv("CUDA_LAUNCH_BLOCKING")) {
     if (std::strlen(env) >= 1 && env[0] == '1') {
       return; // This test is unable to run when the launch is blocking

--- a/test/nvexec/then.cpp
+++ b/test/nvexec/then.cpp
@@ -8,14 +8,14 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("then returns a sender", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then returns a sender", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
   auto snd = ex::then(ex::schedule(stream_ctx.get_scheduler()), [] {});
   STATIC_REQUIRE(ex::sender<decltype(snd)>);
   (void) snd;
 }
 
-TEST_CASE("then executes on GPU", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then executes on GPU", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -32,7 +32,7 @@ TEST_CASE("then executes on GPU", "[cuda][stream][adaptors][then]") {
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("then accepts values on GPU", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then accepts values on GPU", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -51,7 +51,7 @@ TEST_CASE("then accepts values on GPU", "[cuda][stream][adaptors][then]") {
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("then accepts multiple values on GPU", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then accepts multiple values on GPU", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -70,7 +70,7 @@ TEST_CASE("then accepts multiple values on GPU", "[cuda][stream][adaptors][then]
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("then returns values on GPU", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then returns values on GPU", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::schedule(stream_ctx.get_scheduler()) //
@@ -86,7 +86,7 @@ TEST_CASE("then returns values on GPU", "[cuda][stream][adaptors][then]") {
   REQUIRE(result == 42);
 }
 
-TEST_CASE("then can preceed a sender without values", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then can preceed a sender without values", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<2> flags_storage{};
@@ -108,7 +108,7 @@ TEST_CASE("then can preceed a sender without values", "[cuda][stream][adaptors][
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("then can succeed a sender", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then can succeed a sender", "[cuda][stream][adaptors][then]") {
   SECTION("without values") {
     nvexec::stream_context stream_ctx{};
     flags_storage_t<2> flags_storage{};
@@ -148,7 +148,7 @@ TEST_CASE("then can succeed a sender", "[cuda][stream][adaptors][then]") {
   }
 }
 
-TEST_CASE("then can succeed a receiverless sender", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then can succeed a receiverless sender", "[cuda][stream][adaptors][then]") {
   SECTION("without values") {
     nvexec::stream_context stream_ctx{};
     flags_storage_t flags_storage{};
@@ -184,7 +184,7 @@ TEST_CASE("then can succeed a receiverless sender", "[cuda][stream][adaptors][th
   }
 }
 
-TEST_CASE("then can return values of non-trivial types", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then can return values of non-trivial types", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
   flags_storage_t flags_storage{};
   auto flags = flags_storage.get();
@@ -201,7 +201,7 @@ TEST_CASE("then can return values of non-trivial types", "[cuda][stream][adaptor
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("then can preceed a sender with values", "[cuda][stream][adaptors][then]") {
+TEST_CASE("nvexec then can preceed a sender with values", "[cuda][stream][adaptors][then]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::schedule(stream_ctx.get_scheduler())

--- a/test/nvexec/transfer.cpp
+++ b/test/nvexec/transfer.cpp
@@ -9,7 +9,7 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("transfer to stream context returns a sender", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE("nvexec transfer to stream context returns a sender", "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
   exec::inline_scheduler cpu{};
   nvexec::stream_scheduler gpu = stream_ctx.get_scheduler();
@@ -19,7 +19,7 @@ TEST_CASE("transfer to stream context returns a sender", "[cuda][stream][adaptor
   (void) snd;
 }
 
-TEST_CASE("transfer from stream context returns a sender", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE("nvexec transfer from stream context returns a sender", "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
 
   exec::inline_scheduler cpu{};
@@ -30,7 +30,7 @@ TEST_CASE("transfer from stream context returns a sender", "[cuda][stream][adapt
   (void) snd;
 }
 
-TEST_CASE("transfer changes context to GPU", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE("nvexec transfer changes context to GPU", "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
 
   exec::inline_scheduler cpu{};
@@ -55,7 +55,7 @@ TEST_CASE("transfer changes context to GPU", "[cuda][stream][adaptors][transfer]
   REQUIRE(result == 2);
 }
 
-TEST_CASE("transfer changes context from GPU", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE("nvexec transfer changes context from GPU", "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
 
   exec::inline_scheduler cpu{};
@@ -80,7 +80,7 @@ TEST_CASE("transfer changes context from GPU", "[cuda][stream][adaptors][transfe
   REQUIRE(result == 2);
 }
 
-TEST_CASE("transfer_just changes context to GPU", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE("nvexec transfer_just changes context to GPU", "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
   nvexec::stream_scheduler gpu = stream_ctx.get_scheduler();
 
@@ -96,7 +96,7 @@ TEST_CASE("transfer_just changes context to GPU", "[cuda][stream][adaptors][tran
   REQUIRE(result == true);
 }
 
-TEST_CASE("transfer_just supports move-only types", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE("nvexec transfer_just supports move-only types", "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
   nvexec::stream_scheduler gpu = stream_ctx.get_scheduler();
 
@@ -112,7 +112,7 @@ TEST_CASE("transfer_just supports move-only types", "[cuda][stream][adaptors][tr
   REQUIRE(result == true);
 }
 
-TEST_CASE("transfer supports move-only types", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE("nvexec transfer supports move-only types", "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
 
   exec::inline_scheduler cpu{};

--- a/test/nvexec/transfer_when_all.cpp
+++ b/test/nvexec/transfer_when_all.cpp
@@ -24,7 +24,7 @@
 
 namespace ex = stdexec;
 
-TEST_CASE("transfer_when_all returns a sender", "[cuda][stream][adaptors][transfer_when_all]") {
+TEST_CASE("nvexec transfer_when_all returns a sender", "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
   auto snd = ex::transfer_when_all(gpu, ex::just(3), ex::just(0.1415));
@@ -33,7 +33,7 @@ TEST_CASE("transfer_when_all returns a sender", "[cuda][stream][adaptors][transf
 }
 
 TEST_CASE(
-  "transfer_when_all with environment returns a sender",
+  "nvexec transfer_when_all with environment returns a sender",
   "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
@@ -42,21 +42,21 @@ TEST_CASE(
   (void) snd;
 }
 
-TEST_CASE("transfer_when_all with no senders", "[cuda][stream][adaptors][transfer_when_all]") {
+TEST_CASE("nvexec transfer_when_all with no senders", "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
   auto snd = ex::transfer_when_all(gpu);
   wait_for_value(std::move(snd));
 }
 
-TEST_CASE("transfer_when_all one sender", "[cuda][stream][adaptors][transfer_when_all]") {
+TEST_CASE("nvexec transfer_when_all one sender", "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
   auto snd = ex::transfer_when_all(gpu, ex::just(3.1415));
   wait_for_value(std::move(snd), 3.1415);
 }
 
-TEST_CASE("transfer_when_all two senders", "[cuda][stream][adaptors][transfer_when_all]") {
+TEST_CASE("nvexec transfer_when_all two senders", "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
   auto snd1 = ex::transfer_when_all(gpu, ex::just(3), ex::just(0.1415));
@@ -65,7 +65,7 @@ TEST_CASE("transfer_when_all two senders", "[cuda][stream][adaptors][transfer_wh
 }
 
 TEST_CASE(
-  "transfer_when_all two senders on same scheduler",
+  "nvexec transfer_when_all two senders on same scheduler",
   "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
@@ -75,7 +75,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-  "transfer_when_all_with_variant returns a sender",
+  "nvexec transfer_when_all_with_variant returns a sender",
   "[cuda][stream][adaptors][transfer_when_all_with_variant]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
@@ -85,7 +85,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-  "transfer_when_all_with_variant with environment returns a sender",
+  "nvexec transfer_when_all_with_variant with environment returns a sender",
   "[cuda][stream][adaptors][transfer_when_all_with_variant]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
@@ -95,7 +95,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-  "transfer_when_all_with_variant basic example",
+  "nvexec transfer_when_all_with_variant basic example",
   "[cuda][stream][adaptors][transfer_when_all_with_variant]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();

--- a/test/nvexec/upon_error.cpp
+++ b/test/nvexec/upon_error.cpp
@@ -30,7 +30,7 @@ inline void check_err_types(S snd) {
   check_types_impl<ExpectedValType, t>();
 }
 
-TEST_CASE("upon_error returns a sender", "[cuda][stream][adaptors][upon_error]") {
+TEST_CASE("nvexec upon_error returns a sender", "[cuda][stream][adaptors][upon_error]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::just_error(42) | ex::transfer(stream_ctx.get_scheduler())
@@ -39,7 +39,7 @@ TEST_CASE("upon_error returns a sender", "[cuda][stream][adaptors][upon_error]")
   (void) snd;
 }
 
-TEST_CASE("upon_error executes on GPU", "[cuda][stream][adaptors][upon_error]") {
+TEST_CASE("nvexec upon_error executes on GPU", "[cuda][stream][adaptors][upon_error]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};

--- a/test/nvexec/upon_stopped.cpp
+++ b/test/nvexec/upon_stopped.cpp
@@ -8,7 +8,7 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("upon_stopped returns a sender", "[cuda][stream][adaptors][upon_stopped]") {
+TEST_CASE("nvexec upon_stopped returns a sender", "[cuda][stream][adaptors][upon_stopped]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::just_stopped() | ex::transfer(stream_ctx.get_scheduler())
@@ -17,7 +17,7 @@ TEST_CASE("upon_stopped returns a sender", "[cuda][stream][adaptors][upon_stoppe
   (void) snd;
 }
 
-TEST_CASE("upon_stopped executes on GPU", "[cuda][stream][adaptors][upon_stopped]") {
+TEST_CASE("nvexec upon_stopped executes on GPU", "[cuda][stream][adaptors][upon_stopped]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};

--- a/test/nvexec/variant.cpp
+++ b/test/nvexec/variant.cpp
@@ -27,7 +27,7 @@
 using nvexec::variant_t;
 using nvexec::visit;
 
-TEST_CASE("variant max size is correct", "[cuda][stream][containers][variant]") {
+TEST_CASE("nvexec variant max size is correct", "[cuda][stream][containers][variant]") {
   STATIC_REQUIRE(variant_t<double>::max_size == sizeof(double));
   STATIC_REQUIRE(variant_t<int, double>::max_size == sizeof(double));
   STATIC_REQUIRE(variant_t<char, int, double>::max_size == sizeof(double));
@@ -35,7 +35,7 @@ TEST_CASE("variant max size is correct", "[cuda][stream][containers][variant]") 
   STATIC_REQUIRE(variant_t<char>::max_size == sizeof(char));
 }
 
-TEST_CASE("variant max alignment is correct", "[cuda][stream][containers][variant]") {
+TEST_CASE("nvexec variant max alignment is correct", "[cuda][stream][containers][variant]") {
   STATIC_REQUIRE(variant_t<double>::max_size == std::alignment_of_v<double>);
   STATIC_REQUIRE(variant_t<int, double>::max_size == std::alignment_of_v<double>);
   STATIC_REQUIRE(variant_t<char, int, double>::max_size == std::alignment_of_v<double>);
@@ -43,13 +43,13 @@ TEST_CASE("variant max alignment is correct", "[cuda][stream][containers][varian
   STATIC_REQUIRE(variant_t<char>::max_size == std::alignment_of_v<char>);
 }
 
-TEST_CASE("variant size is correct", "[cuda][stream][containers][variant]") {
+TEST_CASE("nvexec variant size is correct", "[cuda][stream][containers][variant]") {
   STATIC_REQUIRE(variant_t<double>::size == 1);
   STATIC_REQUIRE(variant_t<int, double>::size == 2);
   STATIC_REQUIRE(variant_t<char, int, double>::size == 3);
 }
 
-TEST_CASE("variant emplaces alternative from CPU", "[cuda][stream][containers][variant]") {
+TEST_CASE("nvexec variant emplaces alternative from CPU", "[cuda][stream][containers][variant]") {
   variant_t<int, double> v;
   REQUIRE(v.index_ == 0);
 
@@ -65,7 +65,7 @@ __global__ void kernel(V* v, T alt) {
   v->template emplace<T>(alt);
 }
 
-TEST_CASE("variant emplaces alternative from GPU", "[cuda][stream][containers][variant]") {
+TEST_CASE("nvexec variant emplaces alternative from GPU", "[cuda][stream][containers][variant]") {
   using variant_t = variant_t<int, double>;
   thrust::universal_vector<variant_t> variant_storage(1);
   variant_t* v = thrust::raw_pointer_cast(variant_storage.data());
@@ -83,7 +83,7 @@ TEST_CASE("variant emplaces alternative from GPU", "[cuda][stream][containers][v
   visit([](auto alt) { REQUIRE(alt == 42); }, *v);
 }
 
-TEST_CASE("variant works with cuda tuple", "[cuda][stream][containers][variant]") {
+TEST_CASE("nvexec variant works with cuda tuple", "[cuda][stream][containers][variant]") {
   variant_t<cuda::std::tuple<int, double>, cuda::std::tuple<char, int>> v;
   REQUIRE(v.index_ == 0);
 
@@ -112,7 +112,7 @@ TEST_CASE("variant works with cuda tuple", "[cuda][stream][containers][variant]"
     v);
 }
 
-TEST_CASE("variant internal index bypass works", "[cuda][stream][containers][variant]") {
+TEST_CASE("nvexec variant internal index bypass works", "[cuda][stream][containers][variant]") {
   variant_t<cuda::std::tuple<int, double>, cuda::std::tuple<char, int>> v;
 
   v.emplace<cuda::std::tuple<int, double>>(42, 4.2);

--- a/test/nvexec/when_all.cpp
+++ b/test/nvexec/when_all.cpp
@@ -9,7 +9,7 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("when_all returns a sender", "[cuda][stream][adaptors][when_all]") {
+TEST_CASE("nvexec when_all returns a sender", "[cuda][stream][adaptors][when_all]") {
   nvexec::stream_context stream_ctx{};
   auto snd = ex::when_all(
     ex::schedule(stream_ctx.get_scheduler()), ex::schedule(stream_ctx.get_scheduler()));
@@ -17,7 +17,7 @@ TEST_CASE("when_all returns a sender", "[cuda][stream][adaptors][when_all]") {
   (void) snd;
 }
 
-TEST_CASE("when_all works", "[cuda][stream][adaptors][when_all]") {
+TEST_CASE("nvexec when_all works", "[cuda][stream][adaptors][when_all]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<2> flags_storage{};
@@ -41,7 +41,7 @@ TEST_CASE("when_all works", "[cuda][stream][adaptors][when_all]") {
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("when_all returns values", "[cuda][stream][adaptors][when_all]") {
+TEST_CASE("nvexec when_all returns values", "[cuda][stream][adaptors][when_all]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::when_all(
@@ -53,7 +53,7 @@ TEST_CASE("when_all returns values", "[cuda][stream][adaptors][when_all]") {
   REQUIRE(v2 == 42);
 }
 
-TEST_CASE("when_all with many senders", "[cuda][stream][adaptors][when_all]") {
+TEST_CASE("nvexec when_all with many senders", "[cuda][stream][adaptors][when_all]") {
   nvexec::stream_context stream_ctx{};
 
   auto snd = ex::when_all(
@@ -71,7 +71,7 @@ TEST_CASE("when_all with many senders", "[cuda][stream][adaptors][when_all]") {
   REQUIRE(v5 == 5);
 }
 
-TEST_CASE("when_all works with unknown senders", "[cuda][stream][adaptors][when_all]") {
+TEST_CASE("nvexec when_all works with unknown senders", "[cuda][stream][adaptors][when_all]") {
   nvexec::stream_context stream_ctx{};
   auto sch = stream_ctx.get_scheduler();
 

--- a/test/stdexec/algos/adaptors/test_split.cpp
+++ b/test/stdexec/algos/adaptors/test_split.cpp
@@ -486,3 +486,15 @@ TEST_CASE("split can nest", "[adaptors][split]") {
   REQUIRE(v2 == 2);
   REQUIRE(v3 == 1);
 }
+
+TEST_CASE("split doesn't advertise completion scheduler", "[adaptors][split]") {
+  inline_scheduler sched;
+
+  auto snd = ex::transfer_just(sched, 42) | ex::split();
+  using snd_t = decltype(snd);
+  static_assert(!stdexec::__callable<stdexec::get_completion_scheduler_t<ex::set_value_t>, snd_t>);
+  static_assert(!stdexec::__callable<stdexec::get_completion_scheduler_t<ex::set_error_t>, snd_t>);
+  static_assert(
+    !stdexec::__callable<stdexec::get_completion_scheduler_t<ex::set_stopped_t>, snd_t>);
+  (void) snd;
+}

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -42,6 +42,8 @@ struct cpo_t {
 template <class CPO>
 struct free_standing_sender_t {
   using is_sender = void;
+  using __id = free_standing_sender_t;
+  using __t = free_standing_sender_t;
   using completion_signatures = ex::completion_signatures< //
     ex::set_value_t(),                                     //
     ex::set_error_t(std::exception_ptr),                   //
@@ -59,6 +61,9 @@ struct free_standing_sender_t {
 
 template <class CPO, class... CompletionSignals>
 struct scheduler_t {
+  using __id = scheduler_t;
+  using __t = scheduler_t;
+
   struct env_t {
     template <stdexec::__one_of<ex::set_value_t, CompletionSignals...> Tag>
     friend scheduler_t tag_invoke(ex::get_completion_scheduler_t<Tag>, const env_t&) noexcept {
@@ -68,6 +73,8 @@ struct scheduler_t {
 
   struct sender_t {
     using is_sender = void;
+    using __id = sender_t;
+    using __t = sender_t;
     using completion_signatures = ex::completion_signatures< //
       ex::set_value_t(),                                     //
       ex::set_error_t(std::exception_ptr),                   //

--- a/test/test_common/senders.hpp
+++ b/test/test_common/senders.hpp
@@ -63,9 +63,9 @@ struct value_env {
   int value;
 };
 
-template <class Attrs, class... Values>
+template <class Env, class... Values>
 struct just_with_env {
-  std::remove_cvref_t<Attrs> env_;
+  std::remove_cvref_t<Env> env_;
   std::tuple<Values...> values_;
   using is_sender = void;
   using completion_signatures = ex::completion_signatures<ex::set_value_t(Values...)>;
@@ -88,7 +88,7 @@ struct just_with_env {
     return {{}, std::move(self.values_), std::forward<Receiver>(rcvr)};
   }
 
-  friend Attrs tag_invoke(ex::get_env_t, const just_with_env& self) noexcept {
+  friend Env tag_invoke(ex::get_env_t, const just_with_env& self) noexcept {
     return self.env_;
   }
 };

--- a/test/test_common/type_helpers.hpp
+++ b/test/test_common/type_helpers.hpp
@@ -82,10 +82,10 @@ inline void check_val_types(S snd) {
 }
 
 //! Check that the env of a sender matches the expected type
-template <typename ExpectedAttrsType, typename S>
+template <typename ExpectedEnvType, typename S>
 inline void check_env_type(S snd) {
   using t = decltype(ex::get_env(snd));
-  static_assert(std::same_as<t, ExpectedAttrsType>);
+  static_assert(std::same_as<t, ExpectedEnvType>);
 }
 
 //! Check that the error_types of a sender matches the expected type


### PR DESCRIPTION
Some of the tests in `test/nvexec/` has the same name as those in `test/stdexec/`, causing vscode to report test failures when in fact there are none.