### PR TITLE
switch to a lambda-based tuple for internal implementation details

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -82,6 +82,8 @@ IndentWrappedFunctionNames: true
 InsertTrailingCommas: None
 KeepEmptyLinesAtTheStartOfBlocks: true
 LambdaBodyIndentation: Signature
+MacroBlockBegin: 'STDEXEC_BEGIN_NAMESPACE_STD'
+MacroBlockEnd: 'STDEXEC_END_NAMESPACE_STD'
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: All
 PackConstructorInitializers: Never

--- a/examples/hello_world.cpp
+++ b/examples/hello_world.cpp
@@ -25,17 +25,17 @@ using stdexec::sync_wait;
 
 int main() {
   exec::static_thread_pool ctx{8};
-  scheduler auto sch = ctx.get_scheduler();                              // 1
+  scheduler auto sch = ctx.get_scheduler(); // 1
 
-  sender auto begin = schedule(sch);                                     // 2
-  sender auto hi_again = then(begin, [] {                                // 3
-    std::cout << "Hello world! Have an int.\n";                          // 3
-    return 13;                                                           // 3
-  });                                                                    // 3
+  sender auto begin = schedule(sch);            // 2
+  sender auto hi_again = then(begin, [] {       // 3
+    std::cout << "Hello world! Have an int.\n"; // 3
+    return 13;                                  // 3
+  });                                           // 3
 
   sender auto add_42 = then(hi_again, [](int arg) { return arg + 42; }); // 4
 
-  auto [i] = sync_wait(std::move(add_42)).value();                       // 5
+  auto [i] = sync_wait(std::move(add_42)).value(); // 5
   std::cout << "Result: " << i << std::endl;
 
   // Sync_wait provides a run_loop scheduler

--- a/examples/io_uring.cpp
+++ b/examples/io_uring.cpp
@@ -60,16 +60,16 @@ int main() {
     exec::finally(
       exec::schedule_after(scheduler, 4s),
       stdexec::just() | stdexec::then([&] { context2.request_stop(); })),
-    exec::schedule_after(scheduler, 10s)    //
-      | stdexec::then([] {                  //
-          std::cout << "Hello, world!\n";   //
+    exec::schedule_after(scheduler, 10s)  //
+      | stdexec::then([] {                //
+          std::cout << "Hello, world!\n"; //
         })
       | stdexec::upon_stopped([] {          //
           std::cout << "Hello, stopped.\n"; //
         }),
-    exec::schedule_after(scheduler2, 10s)   //
-      | stdexec::then([] {                  //
-          std::cout << "Hello, world!\n";   //
+    exec::schedule_after(scheduler2, 10s) //
+      | stdexec::then([] {                //
+          std::cout << "Hello, world!\n"; //
         })
       | stdexec::upon_stopped([] {          //
           std::cout << "Hello, stopped.\n"; //

--- a/examples/scope.cpp
+++ b/examples/scope.cpp
@@ -50,9 +50,9 @@ int main() {
   exec::static_thread_pool ctx{1};
   exec::async_scope scope;
 
-  scheduler auto sch = ctx.get_scheduler();                                 // 1
+  scheduler auto sch = ctx.get_scheduler(); // 1
 
-  sender auto begin = schedule(sch);                                        // 2
+  sender auto begin = schedule(sch); // 2
 
   sender auto printVoid = then(begin, []() noexcept { printf("void\n"); }); // 3
 
@@ -76,9 +76,9 @@ int main() {
 
   sender auto fortyTwo = then(begin, []() noexcept { return 42; }); // 6
 
-  scope.spawn(printVoid);                                           // 7
+  scope.spawn(printVoid); // 7
 
-  sender auto fortyTwoFuture = scope.spawn_future(fortyTwo);        // 8
+  sender auto fortyTwoFuture = scope.spawn_future(fortyTwo); // 8
 
   sender auto printFortyTwo = then(std::move(fortyTwoFuture), [](int fortyTwo) noexcept {
     printf("%d\n", fortyTwo);
@@ -88,7 +88,8 @@ int main() {
     when_all(printEmpty, std::move(printFortyTwo)),
     [](auto&&...) noexcept { printf("\nall done\n"); }); // 10
 
-  sync_wait(std::move(allDone));
+  //sync_wait(std::move(allDone));
+  __debug_sender(std::move(allDone));
 
   {
     sender auto nest = scope.nest(begin);

--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -387,7 +387,7 @@ namespace exec {
     }
 
     template <class _Tag, class _Receiver, class... _As>
-    static auto set_result(                      //
+    static auto set_result( //
       _Tag __tag,
       [[maybe_unused]] stdexec::__ignore __data, //
       _Receiver& __rcvr,                         //

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -295,7 +295,7 @@ namespace exec {
                 if constexpr (same_as<_Tup, std::monostate>) {
                   std::terminate();
                 } else {
-                  std::apply(
+                  stdexec::apply(
                     [this, &__guard]<class... _As>(auto tag, _As&... __as) {
                       __guard.unlock();
                       tag((_Receiver&&) __rcvr_, (_As&&) __as...);
@@ -367,7 +367,7 @@ namespace exec {
 
     template <class _Tag, class... _Ts>
     struct __completion_as_tuple2_<_Tag(_Ts&&...)> {
-      using __t = std::tuple<_Tag, _Ts...>;
+      using __t = stdexec::tuple<_Tag, _Ts...>;
     };
     template <class _Fn>
     using __completion_as_tuple_t = __t<__completion_as_tuple2_<_Fn>>;
@@ -375,7 +375,7 @@ namespace exec {
 #else
 
     template <class _Tag, class... _Ts>
-    std::tuple<_Tag, _Ts...> __completion_as_tuple_(_Tag (*)(_Ts&&...));
+    stdexec::tuple<_Tag, _Ts...> __completion_as_tuple_(_Tag (*)(_Ts&&...));
     template <class _Fn>
     using __completion_as_tuple_t = decltype(__scope::__completion_as_tuple_((_Fn*) nullptr));
 #endif
@@ -502,7 +502,7 @@ namespace exec {
           __guard.unlock();
           __self.__dispatch_result_();
         } catch (...) {
-          using _Tuple = std::tuple<set_error_t, std::exception_ptr>;
+          using _Tuple = stdexec::tuple<set_error_t, std::exception_ptr>;
           __state.__data_.template emplace<_Tuple>(set_error_t{}, std::current_exception());
         }
       }

--- a/include/exec/create.hpp
+++ b/include/exec/create.hpp
@@ -83,9 +83,10 @@ namespace exec {
     template <__completion_signature... _Sigs>
     struct __create_t {
       template <class _Fun, class... _Args>
-        requires move_constructible<_Fun> && constructible_from<__decayed_tuple<_Args...>, _Args...>
+        requires move_constructible<_Fun>
+              && constructible_from<__decayed_std_tuple<_Args...>, _Args...>
       auto operator()(_Fun __fun, _Args&&... __args) const
-        -> __sender<_Fun, __x<__decayed_tuple<_Args...>>, _Sigs...> {
+        -> __sender<_Fun, __x<__decayed_std_tuple<_Args...>>, _Sigs...> {
         return {(_Fun&&) __fun, {(_Args&&) __args...}};
       }
     };

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -123,7 +123,7 @@ namespace exec {
     struct __operation_base {
       using _Receiver = __t<_ReceiverId>;
       _Receiver __rcvr_;
-      std::tuple<_Withs...> __withs_;
+      stdexec::tuple<_Withs...> __withs_;
     };
 
     template <class _ReceiverId, class... _Withs>
@@ -139,7 +139,7 @@ namespace exec {
       }
 
       auto get_env() const -> make_env_t<env_of_t<_Receiver>, _Withs...> {
-        return std::apply(
+        return stdexec::apply(
           [this](auto&... __withs) { return make_env(stdexec::get_env(base()), __withs...); },
           __op_->__withs_);
       }
@@ -176,7 +176,7 @@ namespace exec {
         __operation<__x<__copy_cvref_t<_Self, _Sender>>, _ReceiverId, _Withs...>;
 
       _Sender __sndr_;
-      std::tuple<_Withs...> __withs_;
+      stdexec::tuple<_Withs...> __withs_;
 
       template <__decays_to<__sender> _Self, receiver _Receiver>
         requires sender_to<__copy_cvref_t<_Self, _Sender>, __receiver_t<__x<_Receiver>>>
@@ -201,13 +201,13 @@ namespace exec {
         requires sender<_Sender>
       auto operator()(_Sender&& __sndr, __env::__with<_Tags, _Values>... __withs) const
         -> __sender<__x<__decay_t<_Sender>>, __env::__with<_Tags, _Values>...> {
-        return {(_Sender&&) __sndr, {std::move(__withs)...}};
+        return {(_Sender&&) __sndr, stdexec::make_tuple(std::move(__withs)...)};
       }
 
       template <class... _Tags, class... _Values>
       auto operator()(__env::__with<_Tags, _Values>... __withs) const
         -> __binder_back<__write_t, __env::__with<_Tags, _Values>...> {
-        return {{}, {}, {std::move(__withs)...}};
+        return {{}, {}, stdexec::make_tuple(std::move(__withs)...)};
       }
     };
   } // namespace __write

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -90,7 +90,7 @@ namespace exec {
 
       template <class _Tuple>
       void operator()(_Tuple&& __tuple) const noexcept {
-        std::apply(__applier<_Receiver>{(_Receiver&&) __receiver_}, (_Tuple&&) __tuple);
+        stdexec::apply(__applier<_Receiver>{(_Receiver&&) __receiver_}, (_Tuple&&) __tuple);
       }
     };
 

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -229,7 +229,7 @@ namespace exec {
         void apply(F f) {
           std::visit(
             [&](auto& tupl) -> void {
-              std::apply([&](auto&... args) -> void { f(args...); }, tupl);
+              stdexec::apply([&](auto&... args) -> void { f(args...); }, tupl);
             },
             data_);
         }

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -117,10 +117,10 @@ namespace exec {
               __expect, true, std::memory_order_relaxed, std::memory_order_relaxed)) {
           // This emplacement can happen only once
           if constexpr (__nothrow_result_constructible_from<_ResultVariant, _CPO, _Args...>) {
-            __result_.emplace(std::tuple{_CPO{}, (_Args&&) __args...});
+            __result_.emplace(stdexec::make_tuple(_CPO{}, (_Args&&) __args...));
           } else {
             try {
-              __result_.emplace(std::tuple{_CPO{}, (_Args&&) __args...});
+              __result_.emplace(stdexec::make_tuple(_CPO{}, (_Args&&) __args...));
             } catch (...) {
               __result_.emplace(set_error_t{}, std::current_exception());
             }
@@ -140,7 +140,7 @@ namespace exec {
           STDEXEC_ASSERT(__result_.has_value());
           std::visit(
             [this]<class _Tuple>(_Tuple&& __result) {
-              std::apply(
+              stdexec::apply(
                 [this]<class _Cpo, class... _As>(_Cpo, _As&&... __args) noexcept {
                   _Cpo{}((_Receiver&&) __receiver_, (_As&&) __args...);
                 },
@@ -213,7 +213,7 @@ namespace exec {
           }}...} {
         }
 
-        std::tuple<connect_result_t<stdexec::__t<_SenderIds>, __receiver_t>...> __ops_;
+        stdexec::tuple<connect_result_t<stdexec::__t<_SenderIds>, __receiver_t>...> __ops_;
 
         friend void tag_invoke(start_t, __t& __self) noexcept {
           __self.__on_stop_.emplace(
@@ -222,7 +222,7 @@ namespace exec {
           if (__self.__stop_source_.stop_requested()) {
             set_stopped((_Receiver&&) __self.__receiver_);
           } else {
-            std::apply([](auto&... __ops) { (start(__ops), ...); }, __self.__ops_);
+            stdexec::apply([](auto&... __ops) { (start(__ops), ...); }, __self.__ops_);
           }
         }
       };

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -135,7 +135,7 @@ namespace nvexec {
         return {
           {},
           {},
-          {(InitT&&) init, (Fun&&) fun}
+          stdexec::make_tuple((InitT&&) init, (Fun&&) fun)
         };
       }
     };

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -37,7 +37,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
   // What should sync_wait(just_stopped()) return?
   template <class Sender>
     requires sender_in<Sender, __env>
-  using sync_wait_result_t = value_types_of_t< Sender, __env, __decayed_tuple, __msingle>;
+  using sync_wait_result_t = value_types_of_t< Sender, __env, __decayed_std_tuple, __msingle>;
 
   template <class SenderId>
   struct state_t;

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -123,7 +123,7 @@ namespace nvexec {
         struct __t : stream_sender_base {
           using __id = sender_;
           using completion_signatures =
-            completion_signatures< set_value_t(), set_error_t(cudaError_t)>;
+            stdexec::completion_signatures< set_value_t(), set_error_t(cudaError_t)>;
 
           template <class R>
           friend auto tag_invoke(connect_t, const __t& self, R&& rec) //

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -137,5 +137,16 @@
 #define STDEXEC_ASSERT_FN assert
 #endif
 
+#if __has_include(<__config>)
+#include <__config>
+#endif
+#ifdef _LIBCPP_BEGIN_NAMESPACE_STD
+#define STDEXEC_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_NAMESPACE_STD
+#define STDEXEC_END_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
+#else
+#define STDEXEC_BEGIN_NAMESPACE_STD namespace std {
+#define STDEXEC_END_NAMESPACE_STD }
+#endif
+
 namespace stdexec {
 }

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -85,7 +85,7 @@
 
 // Before gcc-12, gcc really didn't like tuples or variants of immovable types
 #if STDEXEC_GCC() && (__GNUC__ < 12)
-#define STDEXEC_IMMOVABLE(_XP) _XP(_XP&&)
+#define STDEXEC_IMMOVABLE(_XP) _XP(_XP&&);
 #else
 #define STDEXEC_IMMOVABLE(_XP) _XP(_XP&&) = delete
 #endif

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -156,4 +156,9 @@ namespace stdexec {
   using __as_awaitable::as_awaitable_t;
   extern const as_awaitable_t as_awaitable;
 
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  namespace __read {
+    template <class _Tag>
+    struct __sender;
+  }
 }

--- a/include/stdexec/__detail/__p2300.hpp
+++ b/include/stdexec/__detail/__p2300.hpp
@@ -293,8 +293,8 @@ namespace std {
     using completion_signatures STDEXEC_STD_DEPRECATED = stdexec::completion_signatures<_Sigs...>;
 
     // [exec.utils.mkcmplsigs]
-    template <                                                                          //
-      class _Sender,                                                                    //
+    template <       //
+      class _Sender, //
       class _Env = stdexec::no_env,
       class _Sigs = stdexec::completion_signatures<>,                                   //
       template <class...> class _SetValue = stdexec::__compl_sigs::__default_set_value, //

--- a/include/stdexec/__detail/__tuple.hpp
+++ b/include/stdexec/__detail/__tuple.hpp
@@ -246,23 +246,35 @@ namespace stdexec {
         __tup::__decay_copy(__move_capture(__w));
       };
 
-    template <class... _Ts>
-    constexpr auto
-      __make_impl(_Ts&&... __ts) noexcept((__nothrow_decay_copyable<__rvalue_t<_Ts>> && ...)) {
-      return [... __ts = __move_capture(__ts)]                                           //
-            <class _Self, class _Fun>(_Self&&, _Fun && __fn) constexpr mutable           //
-             noexcept(__nothrow_callable<__unconst_t<_Fun>, __element_t<_Self, _Ts>...>) //
-             -> __call_result_t<__unconst_t<_Fun>, __element_t<_Self, _Ts>...> {
-               return const_cast<__unconst_t<_Fun>&&>(__fn)(
-                 static_cast<__element_t<_Self, _Ts>&&>(__ts)...);
-             };
-    }
+    inline constexpr auto __make_impl =
+      []<class... _Ts>(_Ts&&... __ts) noexcept((__nothrow_decay_copyable<__rvalue_t<_Ts>> && ...)) {
+        return [... __ts = __move_capture(__ts)]                                           //
+              <class _Self, class _Fun>(_Self&&, _Fun && __fn) constexpr mutable           //
+               noexcept(__nothrow_callable<__unconst_t<_Fun>, __element_t<_Self, _Ts>...>) //
+               -> __call_result_t<__unconst_t<_Fun>, __element_t<_Self, _Ts>...> {
+                 return const_cast<__unconst_t<_Fun>&&>(__fn)(
+                   static_cast<__element_t<_Self, _Ts>&&>(__ts)...);
+               };
+      };
 
-    template <class _Ret, class... _Args>
-    _Ret __impl_for_(_Ret (*)(_Args...));
+    template <class _Ret, class _Impl, class... _Args>
+    _Ret __impl_for_(_Ret (_Impl::*__p)(_Args...) const);
 
     template <class... _Ts>
-    using __impl_for = decltype(__tup::__impl_for_(&__make_impl<__param_t<_Ts>...>));
+    using __impl_for =
+      decltype(__tup::__impl_for_(&decltype(__make_impl)::operator()<__param_t<_Ts>...>));
+
+    template <class... _Ts>
+    struct __construct_impl {
+      template <class... _Us>
+        requires(__decay_convertible_to<_Us, _Ts> && ...)
+      constexpr auto operator()(_Us&&... us) const
+        noexcept(noexcept(__tup::__make_impl.operator()<__param_t<_Ts>...>(
+          static_cast<__value_t<_Ts, _Us>>((_Us&&) us)...))) -> __impl_for<_Ts...> {
+        return __tup::__make_impl.operator()<__param_t<_Ts>...>(
+          static_cast<__value_t<_Ts, _Us>>((_Us&&) us)...);
+      };
+    };
 
     template <class... _Ts>
     using __tuple_for = __tuple<sizeof...(_Ts), __impl_for<_Ts...>>;
@@ -284,18 +296,6 @@ namespace stdexec {
 
     template <class _Ty>
     using __default_init_for = __if_c<move_constructible<_Ty>, _Ty, __make_default<_Ty>>;
-
-    template <class... _Ts>
-    struct __construct_impl {
-      template <class... _Us>
-        requires(__decay_convertible_to<_Us, _Ts> && ...)
-      constexpr auto operator()(_Us&&... us) const noexcept(noexcept(
-        __tup::__make_impl<__param_t<_Ts>...>(static_cast<__value_t<_Ts, _Us>>((_Us&&) us)...)))
-        -> __impl_for<_Ts...> {
-        return __tup::__make_impl<__param_t<_Ts>...>(
-          static_cast<__value_t<_Ts, _Us>>((_Us&&) us)...);
-      };
-    };
 
     template <class... _Ts>
     struct __default_init_impl {

--- a/include/stdexec/__detail/__tuple.hpp
+++ b/include/stdexec/__detail/__tuple.hpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "__config.hpp"
+#include "../concepts.hpp"
+#include "__type_traits.hpp"
+
+#include <bit>
+
+// nvc++ cannot yet handle lambda-based tuples
+#if STDEXEC_NVHPC()
+
+#include <tuple>
+
+namespace stdexec {
+  using std::tuple;
+  using std::get;
+  using std::apply;
+  using std::make_tuple;
+}
+
+#else // STDEXEC_NVHPC()
+
+namespace stdexec {
+
+  template <std::size_t _Ny, class _Impl>
+  struct __tuple;
+
+  namespace __tup {
+    template <std::size_t _Ny, class _Impl, class _Ty>
+      requires same_as<__tuple<_Ny, _Impl>, _Ty>
+    void __is_tuple_(const __tuple<_Ny, _Impl>&, const _Ty&);
+
+    template <class _Ty>
+    concept __is_tuple = requires(_Ty&& t) { __tup::__is_tuple_(t, t); };
+  }
+
+  template <__tup::__is_tuple _Tuple>
+  extern const std::size_t tuple_size_v;
+
+  template <std::size_t _Ny, class _Impl>
+  struct __mexpand<__tuple<_Ny, _Impl>>;
+
+  namespace __tup {
+    struct __base { };
+
+    template <class _Ty>
+    struct __wrapper;
+
+    template <class _Ty>
+    struct __wrapper<_Ty&> {
+      using type = _Ty;
+      using reference_wrapper = __wrapper;
+      _Ty& __val_;
+
+      /*implicit*/ constexpr __wrapper(_Ty& t) noexcept
+        : __val_(t) {
+      }
+
+      constexpr operator _Ty&() const noexcept {
+        return __val_;
+      }
+    };
+
+    // Also works with std::reference_wrapper:
+    template <class _Ty>
+    using __unwrapped_t = typename _Ty::reference_wrapper::type;
+
+    struct __wrap_fn {
+      template <class _Ty>
+        requires __invalid<__unwrapped_t, _Ty>
+      constexpr auto operator()(const _Ty&&) const = delete;
+
+      template <class _Ty>
+        requires __invalid<__unwrapped_t, _Ty>
+      constexpr auto operator()(_Ty& __ty) const noexcept -> __wrapper<_Ty&> {
+        return __ty;
+      }
+
+      template <class _Ty>
+        requires __valid<__unwrapped_t, _Ty>
+      constexpr auto operator()(_Ty __ty) const noexcept -> __wrapper<__unwrapped_t<_Ty>&> {
+        return static_cast<__unwrapped_t<_Ty>&>(__ty);
+      }
+    };
+
+    template <class _Ty>
+    struct __any_convertible_to {
+      virtual constexpr operator _Ty() = 0;
+
+      friend constexpr _Ty __move(__any_convertible_to& __self) {
+        return static_cast<_Ty>(__self);
+      }
+    };
+    template <class _Ty>
+    struct __any_convertible_to<__any_convertible_to<_Ty>>;
+
+    template <class _Ty, class _Uy>
+      requires convertible_to<_Uy, _Ty>
+    struct __convertible_from : __any_convertible_to<_Ty> {
+      _Uy&& __src_;
+
+      constexpr __convertible_from(_Uy&& __src) noexcept
+        : __src_((_Uy&&) __src) {
+      }
+
+      constexpr operator _Ty() override {
+        return static_cast<_Ty>(static_cast<_Uy&&>(__src_));
+      }
+    };
+
+    struct __self_fn {
+      template <class _Ty, class _Uy>
+      using __value = __if_c<same_as<_Ty&&, _Uy&&>, _Uy&&, _Ty>;
+      template <class _Ty>
+      using __param = _Ty;
+    };
+
+    struct __tie_fn {
+      template <class _Ty, class>
+      using __value = __wrapper<_Ty>;
+      template <class _Ty>
+      using __param = __wrapper<_Ty>;
+    };
+
+    struct __convert_fn {
+      template <class _Ty, class _Uy>
+      using __value = __convertible_from<_Ty, _Uy>;
+      template <class _Ty>
+      using __param = __any_convertible_to<_Ty>&&;
+    };
+
+    template <class _Ty>
+    extern const __self_fn __wrap;
+    template <class _Ty>
+    extern const __tie_fn __wrap<_Ty&>;
+    template <class _Ty>
+      requires(!move_constructible<_Ty>)
+    extern const __convert_fn __wrap<_Ty>;
+
+    template <class _Ty, class _Uy>
+    using __value_t = typename decltype(__wrap<_Ty>)::template __value<_Ty, _Uy>;
+    template <class _Ty>
+    using __param_t = typename decltype(__wrap<_Ty>)::template __param<_Ty>;
+
+    template <class _Ty>
+    auto __unwrap(_Ty&&, long) -> _Ty&&;
+    template <class _Ty>
+    auto __unwrap(_Ty, int) -> __unwrapped_t<_Ty>&;
+    template <class _Ty>
+    using __unwrap_t = decltype(__tup::__unwrap(__declval<_Ty>(), 0));
+
+    template <class _Ty>
+    auto __unconst(_Ty&&) -> _Ty;
+    template <class _Ty>
+    auto __unconst(_Ty&) -> _Ty&;
+    template <class _Ty>
+    auto __unconst(const _Ty&&) -> _Ty;
+    template <class _Ty>
+    auto __unconst(const _Ty&) -> _Ty&;
+    template <class _Ty>
+    using __unconst_t = decltype(__tup::__unconst(__declval<_Ty>()));
+
+    struct __access {
+      template <__is_tuple _Tuple>
+      static constexpr decltype(auto) __get_impl(_Tuple&& __tup) noexcept {
+        return (((_Tuple&&) __tup).__fn_);
+      }
+    };
+
+    template <class _Tuple>
+    using __impl_of = decltype(__access::__get_impl(__declval<_Tuple>()));
+
+    struct __apply_impl {
+      template <class _Fun, class _Impl>
+      constexpr auto operator()(_Fun&& __fn, _Impl&& __impl) const
+        noexcept(__nothrow_callable<__unconst_t<_Impl>, _Impl, __unconst_t<_Fun>>)
+          -> __call_result_t<__unconst_t<_Impl>, _Impl, _Fun> {
+        return const_cast<__unconst_t<_Impl>&&>(__impl)((_Impl&&) __impl, (_Fun&&) __fn);
+      }
+    };
+
+    template <class _Fun, __is_tuple _Tuple>
+    constexpr auto apply(_Fun&& __fn, _Tuple&& __self) noexcept(
+      __nothrow_callable<__apply_impl, _Fun, __impl_of<_Tuple>>)
+      -> __call_result_t<__apply_impl, _Fun, __impl_of<_Tuple>> {
+      return __apply_impl()((_Fun&&) __fn, __access::__get_impl((_Tuple&&) __self));
+    }
+
+    template <class _Fun, __is_tuple _Tuple>
+    using __apply_result_t = //
+      __call_result_t<__apply_impl, _Fun, __impl_of<_Tuple>>;
+
+    template <class _Fun, class _Tuple>
+    concept __applicable = //
+      __callable<__apply_impl, _Fun, __impl_of<_Tuple>>;
+
+    template <class _Fun, class _Tuple>
+    concept __nothrow_applicable = //
+      __nothrow_callable<__apply_impl, _Fun, __impl_of<_Tuple>>;
+
+    struct __impl_types_ {
+      template <class... _Ts>
+      auto operator()(_Ts&&...) const -> __types<_Ts...>;
+    };
+
+    template <class _Impl>
+    using __impl_types = //
+      __call_result_t<__apply_impl, __impl_types_, _Impl>;
+
+    template <class _Tuple>
+    using __types_of = __impl_types<__impl_of<_Tuple>>;
+
+    template <class _Ty>
+    constexpr _Ty&& __move(_Ty& __ty) noexcept {
+      return (_Ty&&) __ty;
+    }
+
+    template <class _Ty>
+    using __rvalue_t = decltype(__move(__declval<_Ty&>()));
+
+    template <class _Self, class _Ty>
+    using __element_t = __unwrap_t<__copy_cvref_t<_Self, __rvalue_t<_Ty>>>;
+
+    template <class _Ty>
+    void __decay_copy(_Ty) noexcept;
+
+    template <class _From, class _To>
+    concept __decay_convertible_to = //
+      requires(_From&& __from, __param_t<_To>& __w) {
+        static_cast<__param_t<_To>>(static_cast<__value_t<_To, _From>>((_From&&) __from));
+        __decay_copy(__move(__w));
+      };
+
+    template <class... _Ts>
+    constexpr auto
+      __make_impl(_Ts&&... __ts) noexcept((__nothrow_decay_copyable<__rvalue_t<_Ts>> && ...)) {
+      return [... __ts = __move(__ts)]                                                   //
+            <class _Self, class _Fun>(_Self&&, _Fun && __fn) constexpr mutable           //
+             noexcept(__nothrow_callable<__unconst_t<_Fun>, __element_t<_Self, _Ts>...>) //
+             -> __call_result_t<__unconst_t<_Fun>, __element_t<_Self, _Ts>...> {
+               return const_cast<__unconst_t<_Fun>&&>(__fn)(
+                 static_cast<__element_t<_Self, _Ts>&&>(__ts)...);
+             };
+    }
+
+    template <class _Ret, class... _Args>
+    _Ret __impl_for_(_Ret (*)(_Args...));
+
+    template <class... _Ts>
+    using __impl_for = decltype(__tup::__impl_for_(&__make_impl<__param_t<_Ts>...>));
+
+    template <class... _Ts>
+    using __tuple_for = __tuple<sizeof...(_Ts), __impl_for<_Ts...>>;
+
+    struct __make_tuple_fn {
+      template <move_constructible... _Ts>
+      constexpr __tuple_for<_Ts...> operator()(_Ts... __ts) const
+        noexcept(__nothrow_constructible_from<__tuple_for<_Ts...>, _Ts...>) {
+        return __tuple_for<_Ts...>((_Ts&&) __ts...);
+      }
+    };
+
+    template <class _Ty>
+    struct __make_default {
+      operator _Ty() const noexcept(noexcept(_Ty())) {
+        return (_Ty());
+      }
+    };
+
+    template <class _Ty>
+    using __default_init_for = __if_c<move_constructible<_Ty>, _Ty, __make_default<_Ty>>;
+
+    template <class... _Ts>
+    struct __construct_impl {
+      template <class... _Us>
+        requires(__decay_convertible_to<_Us, _Ts> && ...)
+      constexpr auto operator()(_Us&&... us) const noexcept(noexcept(
+        __tup::__make_impl<__param_t<_Ts>...>(static_cast<__value_t<_Ts, _Us>>((_Us&&) us)...)))
+        -> __impl_for<_Ts...> {
+        return __tup::__make_impl<__param_t<_Ts>...>(
+          static_cast<__value_t<_Ts, _Us>>((_Us&&) us)...);
+      };
+    };
+
+    template <class... _Ts>
+    struct __default_init_impl {
+      constexpr auto operator()() noexcept(
+        __nothrow_callable<__construct_impl<_Ts...>, __default_init_for<_Ts>...>)
+        requires(default_initializable<_Ts> && ...)
+      {
+        return __construct_impl<_Ts...>()(__default_init_for<_Ts>()...);
+      }
+    };
+
+    template <class _Ty, class U>
+    concept __nothrow_assignable_from = //
+      requires(_Ty&& t, U&& u) {
+        { ((_Ty&&) t) = ((U&&) u) } noexcept;
+      };
+
+    struct __assign_tuple {
+      template <class... _Ts>
+      constexpr auto operator()(_Ts&&... __ts) const noexcept {
+        return [&]<class... _Us>(_Us && ... us) noexcept(
+          (__nothrow_assignable_from<_Ts, _Us> && ...))
+          requires(assignable_from<_Ts, _Us> && ...)
+        {
+          ((void) (((_Ts&&) __ts) = ((_Us&&) us)), ...);
+        };
+      }
+    };
+
+    template <class _To, class _From>
+    concept __tuple_assignable_from = //
+      __applicable<__apply_result_t<__assign_tuple, _To>, _From>;
+
+    template <class _To, class _From>
+    concept __nothrow_tuple_assignable_from = //
+      __nothrow_applicable<__apply_result_t<__assign_tuple, _To>, _From>;
+
+    template <std::size_t _Nn, __is_tuple _Tuple>
+    constexpr auto get(_Tuple&& __tup) noexcept
+      -> __apply_result_t<__nth_pack_element<_Nn>, _Tuple> {
+      return __tup::apply(__nth_pack_element<_Nn>(), (_Tuple&&) __tup);
+    }
+  } // namespace __tup
+
+  template <std::size_t _Size, class _Impl>
+  struct __tuple : private __tup::__base {
+   private:
+    friend __tup::__access;
+    using __types = __tup::__impl_types<_Impl>;
+    using __construct_impl = __mapply<__q<__tup::__construct_impl>, __types>;
+    using __default_init_impl = __mapply<__q<__tup::__default_init_impl>, __types>;
+
+    template <std::size_t, class>
+    friend struct __tuple;
+
+    _Impl __fn_;
+
+   public:
+    constexpr __tuple() noexcept(__nothrow_callable<__default_init_impl>)
+      requires __callable<__default_init_impl>
+      : __fn_(__default_init_impl()()) {
+    }
+
+    __tuple(__tuple&&) = default;
+    __tuple(__tuple const &) = default;
+    __tuple& operator=(__tuple&&) = default;
+    __tuple& operator=(__tuple const &) = default;
+
+    template <class... _Us>
+      requires(sizeof...(_Us) == _Size) && __callable<__construct_impl, _Us...>
+    explicit(sizeof...(_Us) == 1) constexpr __tuple(_Us&&... __us) noexcept(
+      __nothrow_callable<__construct_impl, _Us...>)
+      : __fn_(__construct_impl()((_Us&&) __us...)) {
+    }
+
+    template <__tup::__is_tuple _Other>
+      requires (!__decays_to<_Other, __tuple>) && __tup::__applicable<__construct_impl, _Other>
+    explicit constexpr __tuple(_Other&& __other) noexcept(
+      __tup::__nothrow_applicable<__construct_impl, _Other>)
+      : __fn_(__tup::apply(__construct_impl(), (_Other&&) __other)) {
+    }
+
+    template <__tup::__is_tuple _Other>
+      requires __tup::__tuple_assignable_from<__tuple, _Other>
+    constexpr __tuple&& operator=(_Other&& __other) && noexcept(
+      __tup::__nothrow_tuple_assignable_from<__tuple, _Other>) {
+      __tup::apply(__tup::apply(__tup::__assign_tuple(), (__tuple&&) *this), (_Other&&) __other);
+      return (__tuple&&) *this;
+    }
+
+    template <__tup::__is_tuple _Other>
+      requires __tup::__tuple_assignable_from<__tuple&, _Other>
+    constexpr __tuple& operator=(_Other&& __other) & noexcept(
+      __tup::__nothrow_tuple_assignable_from<__tuple&, _Other>) {
+      __tup::apply(__tup::apply(__tup::__assign_tuple(), *this), (_Other&&) __other);
+      return *this;
+    }
+
+    template <__tup::__is_tuple _Other>
+      requires __tup::__tuple_assignable_from<const __tuple&, _Other>
+    constexpr const __tuple& operator=(_Other&& __other) const & noexcept(
+      __tup::__nothrow_tuple_assignable_from<const __tuple&, _Other>) {
+      __tup::apply(__tup::apply(__tup::__assign_tuple(), *this), (_Other&&) __other);
+      return *this;
+    }
+  };
+
+  using __tup::get;
+  using __tup::apply;
+  using __tup::__apply_result_t;
+  using __tup::__applicable;
+  using __tup::__nothrow_applicable;
+
+  // From __meta.hpp:
+  template <std::size_t _Size, class _Impl>
+  struct __mexpand<__tuple<_Size, _Impl>> {
+    template <class _MetaFn>
+    using __f = __mapply<_MetaFn, __tup::__impl_types<_Impl>>;
+  };
+
+  template <std::size_t _Size, class _Impl>
+  inline constexpr std::size_t tuple_size_v<__tuple<_Size, _Impl>> = _Size;
+
+  inline constexpr __tup::__wrap_fn ref{};
+  inline constexpr __tup::__make_tuple_fn make_tuple{};
+
+  template <class... _Ts>
+  using tuple = __tuple<sizeof...(_Ts), __tup::__impl_for<_Ts...>>;
+}
+
+STDEXEC_BEGIN_NAMESPACE_STD
+  template <class>
+  struct tuple_size;
+
+  template <size_t _Size, class _Impl>
+  struct tuple_size<stdexec::__tuple<_Size, _Impl>> : integral_constant<size_t, _Size> { };
+
+  template <size_t _Size, class _Impl>
+  struct tuple_size<const stdexec::__tuple<_Size, _Impl>> : integral_constant<size_t, _Size> { };
+
+  template <size_t _Nn>
+  struct __tuple_element_ {
+    template <class... _Ts>
+    using __f = stdexec::__m_at<_Nn, _Ts...>;
+  };
+
+  template <size_t _Nn, size_t _Size, class _Impl>
+    requires(_Nn < _Size)
+  struct tuple_element<_Nn, stdexec::__tuple<_Size, _Impl>> {
+    using type = stdexec::__mapply<__tuple_element_<_Nn>, stdexec::__tuple<_Size, _Impl>>;
+  };
+
+STDEXEC_END_NAMESPACE_STD
+
+#endif // !STDEXEC_NVHPC()

--- a/include/stdexec/__detail/__tuple.hpp
+++ b/include/stdexec/__detail/__tuple.hpp
@@ -21,8 +21,8 @@
 
 #include <bit>
 
-// nvc++ cannot yet handle lambda-based tuples
-#if STDEXEC_NVHPC()
+// nvc++ cannot yet handle lambda-based tuples, nor can gcc-11
+#if STDEXEC_NVHPC() || (STDEXEC_GCC() && (__GNUC__ < 12))
 
 #include <tuple>
 
@@ -188,7 +188,7 @@ namespace stdexec {
     struct __apply_impl {
       template <class _Fun, class _Impl>
       constexpr auto operator()(_Fun&& __fn, _Impl&& __impl) const
-        noexcept(__nothrow_callable<__unconst_t<_Impl>, _Impl, __unconst_t<_Fun>>)
+        noexcept(__nothrow_callable<__unconst_t<_Impl>, _Impl, _Fun>)
           -> __call_result_t<__unconst_t<_Impl>, _Impl, _Fun> {
         return const_cast<__unconst_t<_Impl>&&>(__impl)((_Impl&&) __impl, (_Fun&&) __fn);
       }

--- a/include/tbbexec/tbb_thread_pool.hpp
+++ b/include/tbbexec/tbb_thread_pool.hpp
@@ -156,7 +156,7 @@ namespace tbbexec {
           void apply(F f) {
             std::visit(
               [&](auto& tupl) -> void {
-                std::apply([&](auto&... args) -> void { f(args...); }, tupl);
+                stdexec::apply([&](auto&... args) -> void { f(args...); }, tupl);
               },
               data_);
           }

--- a/test/exec/test_when_any.cpp
+++ b/test/exec/test_when_any.cpp
@@ -61,7 +61,7 @@ TEST_CASE("when_any completes with only one sender", "[adaptors][when_any]") {
 TEST_CASE("when_any with move-only types", "[adaptors][when_any]") {
   ex::sender auto snd = exec::when_any( //
     completes_if{false} | ex::then([] { return movable(1); }),
-    ex::just(movable(42))               //
+    ex::just(movable(42)) //
   );
   wait_for_value(std::move(snd), movable(42));
 }

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -280,7 +280,7 @@ struct a_sender_helper_t<a_sender_kind::then> {
   template <class _Fun>
   stdexec::__binder_back<a_sender_helper_t<a_sender_kind::then>, _Fun>
     operator()(_Fun __fun) const {
-    return {{}, {}, {(_Fun&&) __fun}};
+    return {{}, {}, stdexec::make_tuple((_Fun&&) __fun)};
   };
 };
 

--- a/test/nvexec/ensure_started.cpp
+++ b/test/nvexec/ensure_started.cpp
@@ -71,7 +71,9 @@ TEST_CASE(
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("nvexec ensure_started can succeed a sender", "[cuda][stream][adaptors][ensure_started]") {
+TEST_CASE(
+  "nvexec ensure_started can succeed a sender",
+  "[cuda][stream][adaptors][ensure_started]") {
   SECTION("without values") {
     nvexec::stream_context stream_ctx{};
     flags_storage_t<2> flags_storage{};

--- a/test/nvexec/let_error.cpp
+++ b/test/nvexec/let_error.cpp
@@ -36,7 +36,9 @@ TEST_CASE("nvexec let_error executes on GPU", "[cuda][stream][adaptors][let_erro
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("nvexec let_error can preceed a sender without values", "[cuda][stream][adaptors][let_error]") {
+TEST_CASE(
+  "nvexec let_error can preceed a sender without values",
+  "[cuda][stream][adaptors][let_error]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<2> flags_storage{};

--- a/test/nvexec/let_value.cpp
+++ b/test/nvexec/let_value.cpp
@@ -54,7 +54,9 @@ TEST_CASE("nvexec let_value accepts values on GPU", "[cuda][stream][adaptors][le
   REQUIRE(flags_storage.all_set_once());
 }
 
-TEST_CASE("nvexec let_value accepts multiple values on GPU", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE(
+  "nvexec let_value accepts multiple values on GPU",
+  "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t flags_storage{};
@@ -84,7 +86,9 @@ TEST_CASE("nvexec let_value returns values on GPU", "[cuda][stream][adaptors][le
   REQUIRE(result == 1);
 }
 
-TEST_CASE("nvexec let_value can preceed a sender without values", "[cuda][stream][adaptors][let_value]") {
+TEST_CASE(
+  "nvexec let_value can preceed a sender without values",
+  "[cuda][stream][adaptors][let_value]") {
   nvexec::stream_context stream_ctx{};
 
   flags_storage_t<2> flags_storage{};

--- a/test/nvexec/transfer.cpp
+++ b/test/nvexec/transfer.cpp
@@ -9,7 +9,9 @@ namespace ex = stdexec;
 
 using nvexec::is_on_gpu;
 
-TEST_CASE("nvexec transfer to stream context returns a sender", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE(
+  "nvexec transfer to stream context returns a sender",
+  "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
   exec::inline_scheduler cpu{};
   nvexec::stream_scheduler gpu = stream_ctx.get_scheduler();
@@ -19,7 +21,9 @@ TEST_CASE("nvexec transfer to stream context returns a sender", "[cuda][stream][
   (void) snd;
 }
 
-TEST_CASE("nvexec transfer from stream context returns a sender", "[cuda][stream][adaptors][transfer]") {
+TEST_CASE(
+  "nvexec transfer from stream context returns a sender",
+  "[cuda][stream][adaptors][transfer]") {
   nvexec::stream_context stream_ctx{};
 
   exec::inline_scheduler cpu{};

--- a/test/nvexec/transfer_when_all.cpp
+++ b/test/nvexec/transfer_when_all.cpp
@@ -24,7 +24,9 @@
 
 namespace ex = stdexec;
 
-TEST_CASE("nvexec transfer_when_all returns a sender", "[cuda][stream][adaptors][transfer_when_all]") {
+TEST_CASE(
+  "nvexec transfer_when_all returns a sender",
+  "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
   auto snd = ex::transfer_when_all(gpu, ex::just(3), ex::just(0.1415));
@@ -42,7 +44,9 @@ TEST_CASE(
   (void) snd;
 }
 
-TEST_CASE("nvexec transfer_when_all with no senders", "[cuda][stream][adaptors][transfer_when_all]") {
+TEST_CASE(
+  "nvexec transfer_when_all with no senders",
+  "[cuda][stream][adaptors][transfer_when_all]") {
   nvexec::stream_context stream_ctx{};
   auto gpu = stream_ctx.get_scheduler();
   auto snd = ex::transfer_when_all(gpu);

--- a/test/stdexec/algos/adaptors/test_bulk.cpp
+++ b/test/stdexec/algos/adaptors/test_bulk.cpp
@@ -71,13 +71,13 @@ TEST_CASE("bulk keeps error_types from input sender", "[adaptors][bulk]") {
   error_scheduler sched2{};
   error_scheduler<int> sched3{43};
 
-  check_err_types<type_array<>>(                        //
+  check_err_types<type_array<>>( //
     ex::transfer_just(sched1) | ex::bulk(n, [](int) noexcept {}));
-  check_err_types<type_array<std::exception_ptr>>(      //
+  check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched2) | ex::bulk(n, [](int) noexcept {}));
-  check_err_types<type_array<int>>(                     //
+  check_err_types<type_array<int>>( //
     ex::just_error(n) | ex::bulk(n, [](int) noexcept {}));
-  check_err_types<type_array<int>>(                     //
+  check_err_types<type_array<int>>( //
     ex::transfer_just(sched3) | ex::bulk(n, [](int) noexcept {}));
   check_err_types<type_array<std::exception_ptr, int>>( //
     ex::transfer_just(sched3) | ex::bulk(n, [](int) { throw std::logic_error{"err"}; }));

--- a/test/stdexec/algos/adaptors/test_into_variant.cpp
+++ b/test/stdexec/algos/adaptors/test_into_variant.cpp
@@ -121,9 +121,9 @@ TEST_CASE("into_variant keeps error_types from input sender", "[adaptors][into_v
   inline_scheduler sched1{};
   error_scheduler sched2{};
 
-  check_err_types<type_array<std::exception_ptr>>(      //
+  check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched1) | ex::into_variant());
-  check_err_types<type_array<std::exception_ptr>>(      //
+  check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched2) | ex::into_variant());
   check_err_types<type_array<std::exception_ptr, int>>( //
     ex::just_error(-1) | ex::into_variant());
@@ -135,8 +135,8 @@ TEST_CASE("into_variant keeps sends_stopped from input sender", "[adaptors][into
 
   check_sends_stopped<false>( //
     ex::transfer_just(sched1) | ex::into_variant());
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::transfer_just(sched2) | ex::into_variant());
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::just_stopped() | ex::into_variant());
 }

--- a/test/stdexec/algos/adaptors/test_let_error.cpp
+++ b/test/stdexec/algos/adaptors/test_let_error.cpp
@@ -307,8 +307,8 @@ TEST_CASE(
   error_scheduler<int> sched3{43};
 
   // Returning ex::just_error
-  check_err_types<type_array<>>(                                //
-    ex::transfer_just(sched1)                                   //
+  check_err_types<type_array<>>( //
+    ex::transfer_just(sched1)    //
     | ex::let_error([](std::exception_ptr) { return ex::just_error(std::string{"err"}); }));
   check_err_types<type_array<std::exception_ptr, std::string>>( //
     ex::transfer_just(sched2)                                   //
@@ -320,8 +320,8 @@ TEST_CASE(
       }));
 
   // Returning ex::just
-  check_err_types<type_array<>>(                   //
-    ex::transfer_just(sched1)                      //
+  check_err_types<type_array<>>( //
+    ex::transfer_just(sched1)    //
     | ex::let_error([](std::exception_ptr) { return ex::just(); }));
   check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched2)                      //
@@ -338,9 +338,9 @@ TEST_CASE("let_error keeps sends_stopped from input sender", "[adaptors][let_err
 
   check_sends_stopped<false>( //
     ex::transfer_just(sched1) | ex::let_error([](std::exception_ptr) { return ex::just(); }));
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::transfer_just(sched2) | ex::let_error([](std::exception_ptr) { return ex::just(); }));
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::transfer_just(sched3) | ex::let_error([](std::exception_ptr) { return ex::just(); }));
 }
 

--- a/test/stdexec/algos/adaptors/test_let_stopped.cpp
+++ b/test/stdexec/algos/adaptors/test_let_stopped.cpp
@@ -145,11 +145,11 @@ TEST_CASE(
 TEST_CASE(
   "let_stopped has the error_type from the input sender if returning value",
   "[adaptors][let_stopped]") {
-  check_err_types<type_array<int>>(         //
-    ex::just_error(7)                       //
+  check_err_types<type_array<int>>( //
+    ex::just_error(7)               //
     | ex::let_stopped([] { return ex::just(0); }));
-  check_err_types<type_array<double>>(      //
-    ex::just_error(3.14)                    //
+  check_err_types<type_array<double>>( //
+    ex::just_error(3.14)               //
     | ex::let_stopped([] { return ex::just(0); }));
   check_err_types<type_array<std::string>>( //
     ex::just_error(std::string{"hello"})    //
@@ -159,11 +159,11 @@ TEST_CASE(
 TEST_CASE("let_stopped adds to error_type of the input sender", "[adaptors][let_stopped]") {
   impulse_scheduler sched;
   ex::sender auto in_snd = ex::transfer_just(sched, 11);
-  check_err_types<type_array<std::exception_ptr, int>>(         //
-    in_snd                                                      //
+  check_err_types<type_array<std::exception_ptr, int>>( //
+    in_snd                                              //
     | ex::let_stopped([] { return ex::just_error(0); }));
-  check_err_types<type_array<std::exception_ptr, double>>(      //
-    in_snd                                                      //
+  check_err_types<type_array<std::exception_ptr, double>>( //
+    in_snd                                                 //
     | ex::let_stopped([] { return ex::just_error(3.14); }));
   check_err_types<type_array<std::exception_ptr, std::string>>( //
     in_snd                                                      //

--- a/test/stdexec/algos/adaptors/test_let_value.cpp
+++ b/test/stdexec/algos/adaptors/test_let_value.cpp
@@ -277,9 +277,9 @@ TEST_CASE("let_value keeps error_types from input sender", "[adaptors][let_value
   error_scheduler sched2{};
   error_scheduler<int> sched3{43};
 
-  check_err_types<type_array<std::exception_ptr>>(      //
+  check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched1) | ex::let_value([] { return ex::just(); }));
-  check_err_types<type_array<std::exception_ptr>>(      //
+  check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched2) | ex::let_value([] { return ex::just(); }));
   check_err_types<type_array<int, std::exception_ptr>>( //
     ex::transfer_just(sched3) | ex::let_value([] { return ex::just(); }));
@@ -292,9 +292,9 @@ TEST_CASE("let_value keeps sends_stopped from input sender", "[adaptors][let_val
 
   check_sends_stopped<false>( //
     ex::transfer_just(sched1) | ex::let_value([] { return ex::just(); }));
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::transfer_just(sched2) | ex::let_value([] { return ex::just(); }));
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::transfer_just(sched3) | ex::let_value([] { return ex::just(); }));
 }
 

--- a/test/stdexec/algos/adaptors/test_stopped_as_error.cpp
+++ b/test/stdexec/algos/adaptors/test_stopped_as_error.cpp
@@ -103,7 +103,7 @@ TEST_CASE("stopped_as_error keeps error_types from input sender", "[adaptors][st
   error_scheduler sched2{};
   error_scheduler<int> sched3{-1};
 
-  check_err_types<type_array<>>(                   //
+  check_err_types<type_array<>>( //
     ex::transfer_just(sched1, 11) | ex::stopped_as_error(std::exception_ptr{}));
   check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched2, 13) | ex::stopped_as_error(std::exception_ptr{}));
@@ -117,7 +117,7 @@ TEST_CASE("stopped_as_error can add more types to error_types", "[adaptors][stop
   error_scheduler sched2{};
   error_scheduler<int> sched3{-1};
 
-  check_err_types<type_array<>>(                        //
+  check_err_types<type_array<>>( //
     ex::transfer_just(sched1, 11) | ex::stopped_as_error(-1));
   check_err_types<type_array<std::exception_ptr, int>>( //
     ex::transfer_just(sched2, 13) | ex::stopped_as_error(-1));

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -158,9 +158,9 @@ TEST_CASE("then keeps error_types from input sender", "[adaptors][then]") {
   error_scheduler sched2{};
   error_scheduler<int> sched3{43};
 
-  check_err_types<type_array<>>(                        //
+  check_err_types<type_array<>>( //
     ex::transfer_just(sched1) | ex::then([]() noexcept {}));
-  check_err_types<type_array<std::exception_ptr>>(      //
+  check_err_types<type_array<std::exception_ptr>>( //
     ex::transfer_just(sched2) | ex::then([]() noexcept {}));
   check_err_types<type_array<std::exception_ptr, int>>( //
     ex::transfer_just(sched3) | ex::then([] {}));
@@ -173,9 +173,9 @@ TEST_CASE("then keeps sends_stopped from input sender", "[adaptors][then]") {
 
   check_sends_stopped<false>( //
     ex::transfer_just(sched1) | ex::then([] {}));
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::transfer_just(sched2) | ex::then([] {}));
-  check_sends_stopped<true>(  //
+  check_sends_stopped<true>( //
     ex::transfer_just(sched3) | ex::then([] {}));
 }
 


### PR DESCRIPTION
The lambda-based tuple is 2x faster to compile than `std::tuple` for gcc, and roughly on par for clang. https://build-bench.com/b/lIckxezdT6TiXczIfPSj0zNHK4I