### PR TITLE
Add 'stdexec::' qualifier to connect

### DIFF
--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -237,7 +237,7 @@ namespace exec {
 
         __t(_Sender&& __sndr, _Kernel __kernel, _Receiver __rcvr)
           : __state_{(_Kernel&&) __kernel, (_Receiver&&) __rcvr, (__completions_t*) nullptr}
-          , __op_(connect(
+          , __op_(stdexec::connect(
               __stl::__transform_sender(
                 __state_.__kernel_,
                 (_Sender&&) __sndr,

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -921,7 +921,7 @@ namespace exec {
               using __op_state_t = connect_result_t<_Sender, __receiver_ref_t>;
               return __immovable_operation_storage{
                 std::in_place_type<__op_state_t>, __conv{[&] {
-                  return connect((_Sender&&) __sender, (__receiver_ref_t&&) __receiver);
+                  return stdexec::connect((_Sender&&) __sender, (__receiver_ref_t&&) __receiver);
                 }}};
             }};
           return &__vtable_;

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -65,7 +65,7 @@ namespace exec {
 
       explicit __when_empty_op(const __impl* __scope, _Constrained&& __sndr, _Receiver __rcvr)
         : __task{{}, __scope, __notify_waiter}
-        , __op_(connect((_Constrained&&) __sndr, (_Receiver&&) __rcvr)) {
+        , __op_(stdexec::connect((_Constrained&&) __sndr, (_Receiver&&) __rcvr)) {
       }
 
      private:
@@ -182,7 +182,7 @@ namespace exec {
       template <__decays_to<_Constrained> _Sender, __decays_to<_Receiver> _Rcvr>
       explicit __nest_op(const __impl* __scope, _Sender&& __c, _Rcvr&& __rcvr)
         : __nest_op_base<_ReceiverId>{{}, __scope, (_Rcvr&&) __rcvr}
-        , __op_(connect((_Sender&&) __c, __nest_rcvr<_ReceiverId>{this})) {
+        , __op_(stdexec::connect((_Sender&&) __c, __nest_rcvr<_ReceiverId>{this})) {
       }
      private:
       void __start_() noexcept {
@@ -522,7 +522,7 @@ namespace exec {
 
       __future_state(_Sender __sndr, _Env __env, const __impl* __scope)
         : __future_state_base<_Completions, _Env>((_Env&&) __env, __scope)
-        , __op_(connect((_Sender&&) __sndr, __future_receiver_t<_Sender, _Env>{this, __scope})) {
+        , __op_(stdexec::connect((_Sender&&) __sndr, __future_receiver_t<_Sender, _Env>{this, __scope})) {
       }
 
       connect_result_t<_Sender, __future_receiver_t<_Sender, _Env>> __op_;
@@ -632,7 +632,7 @@ namespace exec {
           [](__spawn_op_base<_EnvId>* __op) {
             delete static_cast<__spawn_op*>(__op);
           }}
-        , __op_(connect((_Sndr&&) __sndr, __spawn_receiver_t<_Env>{this, __scope})) {
+        , __op_(stdexec::connect((_Sndr&&) __sndr, __spawn_receiver_t<_Env>{this, __scope})) {
       }
 
       void __start_() noexcept {

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -78,7 +78,7 @@ namespace exec {
             requires sender_to<_Sender, __receiver<_Receiver>>
           friend connect_result_t<_Sender, __receiver<_Receiver>>
             tag_invoke(connect_t, __t&& __self, _Receiver&& __rcvr) noexcept {
-            return connect(
+            return stdexec::connect(
               (_Sender&&) __self.__sender_, __receiver<_Receiver>{(_Receiver&&) __rcvr});
           }
 

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -157,7 +157,7 @@ namespace exec {
 
       __operation(_Sender&& __sndr, auto&& __rcvr, auto&& __env)
         : __base_t{(decltype(__rcvr)) __rcvr, (decltype(__env)) __env}
-        , __state_{connect((_Sender&&) __sndr, __receiver_t{{}, this})} {
+        , __state_{stdexec::connect((_Sender&&) __sndr, __receiver_t{{}, this})} {
       }
 
       friend void tag_invoke(start_t, __operation& __self) noexcept {

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -216,7 +216,7 @@ namespace exec {
         STDEXEC_ASSERT(__op_.index() == 0);
         _FinalSender __final_sender = (_FinalSender&&) std::get_if<0>(&__op_)->__sender_;
         __final_op_t& __final_op = __op_.template emplace<1>(__conv{[&] {
-          return connect((_FinalSender&&) __final_sender, __final_receiver_t{this});
+          return stdexec::connect((_FinalSender&&) __final_sender, __final_receiver_t{this});
         }});
         start(__final_op);
       }
@@ -226,7 +226,7 @@ namespace exec {
         , __op_(std::in_place_index<0>, __conv{[&] {
                   return __initial_op_t{
                     (_FinalSender&&) __final_sender,
-                    connect((_InitialSender&&) __initial_sender, __initial_receiver_t{this})};
+                    stdexec::connect((_InitialSender&&) __initial_sender, __initial_receiver_t{this})};
                 }}) {
       }
     };

--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -72,7 +72,7 @@ namespace exec {
         friend connect_result_t<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>
           tag_invoke(connect_t, _Self&& __self, _Receiver&& __receiver) noexcept(
             __nothrow_connectable<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>) {
-          return connect(
+          return stdexec::connect(
             ((_Self&&) __self).__sender_, __receiver_t<_Receiver>{(_Receiver&&) __receiver});
         }
 
@@ -175,7 +175,7 @@ namespace exec {
         friend connect_result_t<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>
           tag_invoke(connect_t, _Self&& __self, _Receiver&& __receiver) noexcept(
             __nothrow_connectable<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Receiver>>) {
-          return connect(
+          return stdexec::connect(
             ((_Self&&) __self).__sender_, __receiver_t<_Receiver>{(_Receiver&&) __receiver});
         }
 

--- a/include/exec/variant_sender.hpp
+++ b/include/exec/variant_sender.hpp
@@ -40,7 +40,7 @@ namespace exec {
         __t(_Sender&& __sender, _Receiver&& __receiver) noexcept(
           __nothrow_connectable<_Sender, _Receiver>)
           : __variant_{std::in_place_type<connect_result_t<_Sender, _Receiver>>, __conv{[&] {
-                         return connect((_Sender&&) __sender, (_Receiver&&) __receiver);
+                         return stdexec::connect((_Sender&&) __sender, (_Receiver&&) __receiver);
                        }}} {
         }
       };

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -207,7 +207,7 @@ namespace exec {
             && (__nothrow_connectable<stdexec::__t<_SenderIds>, __receiver_t> && ...))
           : __op_base_t{(_Receiver&&) __rcvr, static_cast<int>(sizeof...(_SenderIds))}
           , __ops_{__conv{[&__senders, this] {
-            return connect(
+            return stdexec::connect(
               std::get<_Is>((_SenderTuple&&) __senders),
               __receiver_t{static_cast<__op_base_t*>(this)});
           }}...} {


### PR DESCRIPTION
**Description**: connect is ambiguous when the "sys/socket.h" header is compiled with files in the "exec/" directory.
**Environment**: Operating system: Ubuntu 22.04 , compiler: gcc 12.1.0
**Solution**: Change "**connect**" cpo anywhere in the exec directory to "**stdexec::connect**".

The following code will not compile: 
```
#include <sys/socket.h>

#include "exec/when_any.hpp"

int main () {
  return 1;
}
```