### PR TITLE
make all types passed to CUDA kernels trivially copyable

### DIFF
--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -73,7 +73,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace repeat_n {
         return;
       }
 
-      auto sch = stdexec::get_scheduler(stdexec::get_env(op_state.receiver_));
+      auto sch = stdexec::get_scheduler(stdexec::get_env(op_state.rcvr_));
       inner_op_state_t& inner_op_state = op_state.inner_op_state_.emplace(
         stdexec::__conv{[&]() noexcept {
           return ex::connect(ex::schedule(sch) | op_state.closure_, receiver_2_t<OpT>{op_state});
@@ -110,7 +110,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace repeat_n {
       OpT& op_state = __self.op_state_;
 
       if (op_state.n_) {
-        auto sch = stdexec::get_scheduler(stdexec::get_env(op_state.receiver_));
+        auto sch = stdexec::get_scheduler(stdexec::get_env(op_state.rcvr_));
         inner_op_state_t& inner_op_state = op_state.inner_op_state_.emplace(
           stdexec::__conv{[&]() noexcept {
             return ex::connect(ex::schedule(sch) | op_state.closure_, receiver_2_t<OpT>{op_state});
@@ -165,9 +165,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace repeat_n {
       }
     }
 
-    operation_state_t(PredSender&& pred_sender, Closure closure, Receiver&& receiver, std::size_t n)
+    operation_state_t(PredSender&& pred_sender, Closure closure, Receiver&& rcvr, std::size_t n)
       : operation_state_base_t<ReceiverId>(
-        (Receiver&&) receiver,
+        (Receiver&&) rcvr,
         stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(pred_sender))
           .context_state_,
         false)
@@ -194,7 +194,7 @@ class receiver_t {
   STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
     friend void
     tag_invoke(_Tag __tag, receiver_t&& __self, _Args&&... __args) noexcept {
-    __tag(std::move(__self.op_state_.receiver_), (_Args&&) __args...);
+    __tag(std::move(__self.op_state_.rcvr_), (_Args&&) __args...);
   }
 
   friend void tag_invoke(ex::set_value_t, receiver_t&& __self) noexcept {
@@ -204,12 +204,12 @@ class receiver_t {
       stdexec::sync_wait(ex::schedule(exec::inline_scheduler{}) | op_state.closure_);
     }
 
-    stdexec::set_value(std::move(op_state.receiver_));
+    stdexec::set_value(std::move(op_state.rcvr_));
   }
 
   friend auto tag_invoke(ex::get_env_t, const receiver_t& self) noexcept
     -> stdexec::env_of_t<Receiver> {
-    return stdexec::get_env(self.op_state_.receiver_);
+    return stdexec::get_env(self.op_state_.rcvr_);
   }
 
   explicit receiver_t(OpT& op_state)
@@ -227,17 +227,17 @@ struct operation_state_t {
 
   inner_op_state_t op_state_;
   Closure closure_;
-  Receiver receiver_;
+  Receiver rcvr_;
   std::size_t n_{};
 
   friend void tag_invoke(stdexec::start_t, operation_state_t& self) noexcept {
     stdexec::start(self.op_state_);
   }
 
-  operation_state_t(Sender&& sender, Closure closure, Receiver&& receiver, std::size_t n)
+  operation_state_t(Sender&& sender, Closure closure, Receiver&& rcvr, std::size_t n)
     : op_state_{stdexec::connect((Sender&&) sender, receiver_t<operation_state_t>{*this})}
     , closure_{closure}
-    , receiver_{(Receiver&&) receiver}
+    , rcvr_{(Receiver&&) rcvr}
     , n_(n) {
   }
 };

--- a/include/exec/__detail/__bit_cast.hpp
+++ b/include/exec/__detail/__bit_cast.hpp
@@ -31,7 +31,7 @@
 namespace exec {
 
   template <class _Ty>
-  concept __trivially_copyable = std::is_trivially_copyable_v<_Ty>;
+  concept __trivially_copyable = STDEXEC_IS_TRIVIALLY_COPYABLE(_Ty);
 
 #if defined(STDEXEC_HAS_BIT_CAST)
   using std::bit_cast;

--- a/include/nvexec/detail/queue.cuh
+++ b/include/nvexec/detail/queue.cuh
@@ -46,7 +46,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace queue {
 
   template <class T, class... As>
   device_ptr<T> make_device(cudaError_t& status, As&&... as) {
-    static_assert(std::is_trivially_copyable_v<T>);
+    static_assert(STDEXEC_IS_TRIVIALLY_COPYABLE(T));
 
     if (status == cudaSuccess) {
       T* ptr{};

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -79,7 +79,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS::__algo_range_init_fun {
       }
 
       friend env_of_t<Receiver> tag_invoke(get_env_t, const __t& self) noexcept {
-        return get_env(self.op_state_.receiver_);
+        return get_env(self.op_state_.rcvr_);
       }
 
       __t(InitT init, Fun fun, operation_state_base_t<ReceiverId>& op_state)

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -144,6 +144,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     template <int BlockThreads, class... As, std::integral Shape, class Fun>
     __launch_bounds__(BlockThreads) __global__
       void kernel(Shape begin, Shape end, Fun fn, As... as) {
+      static_assert(trivially_copyable<Shape, Fun, As...>);
       const Shape i = begin + static_cast<Shape>(threadIdx.x + blockIdx.x * blockDim.x);
 
       if (i < end) {
@@ -244,7 +245,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         }
 
         friend env_of_t<Receiver> tag_invoke(get_env_t, const __t& self) noexcept {
-          return get_env(self.op_state_.receiver_);
+          return get_env(self.op_state_.rcvr_);
         }
 
         explicit __t(

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -67,6 +67,16 @@ namespace nvexec {
   struct stream_context;
 
   namespace STDEXEC_STREAM_DETAIL_NS {
+
+#if STDEXEC_HAS_BUILTIN(__is_reference)
+    template <class... Ts>
+    concept trivially_copyable = ((STDEXEC_IS_TRIVIALLY_COPYABLE(Ts) || __is_reference(Ts)) && ...);
+#else
+    template <class... Ts>
+    concept trivially_copyable =
+      ((STDEXEC_IS_TRIVIALLY_COPYABLE(Ts) || std::is_reference_v<Ts>) &&...);
+#endif
+
     struct context_state_t {
       std::pmr::memory_resource* pinned_resource_{nullptr};
       std::pmr::memory_resource* managed_resource_{nullptr};
@@ -309,25 +319,27 @@ namespace nvexec {
       };
     };
 
-    template <class... As, class Receiver, class Tag>
-    __launch_bounds__(1) __global__ void continuation_kernel(Receiver receiver, Tag, As... as) {
-      Tag()(::cuda::std::move(receiver), static_cast<As&&>(as)...);
+    template <class Receiver, class... As, class Tag>
+    __launch_bounds__(1) __global__ void continuation_kernel(Receiver rcvr, Tag, As... as) {
+      // BUGBUG fix me:
+      // static_assert(trivially_copyable<Receiver, Tag, As...>);
+      Tag()(::cuda::std::move(rcvr), static_cast<As&&>(as)...);
     }
 
     template <class Receiver, class Variant>
     struct continuation_task_t : queue::task_base_t {
-      Receiver receiver_;
+      Receiver rcvr_;
       Variant* variant_;
       cudaStream_t stream_{};
       std::pmr::memory_resource* pinned_resource_{};
       cudaError_t status_{cudaSuccess};
 
       continuation_task_t(   //
-        Receiver receiver,   //
+        Receiver rcvr,       //
         Variant* variant,    //
         cudaStream_t stream, //
         std::pmr::memory_resource* pinned_resource) noexcept
-        : receiver_{receiver}
+        : rcvr_{rcvr}
         , variant_{variant}
         , stream_{stream}
         , pinned_resource_(pinned_resource) {
@@ -338,7 +350,7 @@ namespace nvexec {
             [&self](auto& tpl) noexcept {
               ::cuda::std::apply(
                 [&self]<class Tag, class... As>(Tag, As&... as) noexcept {
-                  Tag()(std::move(self.receiver_), std::move(as)...);
+                  Tag()(std::move(self.rcvr_), std::move(as)...);
                 },
                 tpl);
             },
@@ -388,14 +400,14 @@ namespace nvexec {
 
         context_state_t context_state_;
         void* temp_storage_{nullptr};
-        outer_receiver_t receiver_;
+        outer_receiver_t rcvr_;
         cudaError_t status_{cudaSuccess};
         std::optional<cudaStream_t> own_stream_{};
         bool defer_stream_destruction_{false};
 
-        __t(outer_receiver_t receiver, context_state_t context_state, bool defer_stream_destruction)
+        __t(outer_receiver_t rcvr, context_state_t context_state, bool defer_stream_destruction)
           : context_state_(context_state)
-          , receiver_(receiver)
+          , rcvr_(rcvr)
           , defer_stream_destruction_(defer_stream_destruction) {
           if constexpr (!borrows_stream) {
             std::tie(own_stream_, status_) = create_stream_with_priority(context_state_.priority_);
@@ -406,7 +418,7 @@ namespace nvexec {
           cudaStream_t stream{};
 
           if constexpr (borrows_stream) {
-            const outer_env_t& env = get_env(receiver_);
+            const outer_env_t& env = get_env(rcvr_);
             stream = ::nvexec::STDEXEC_STREAM_DETAIL_NS::get_stream(env);
           } else {
             stream = *own_stream_;
@@ -416,19 +428,27 @@ namespace nvexec {
         }
 
         env_t make_env() const noexcept {
-          return make_stream_env(get_env(receiver_), get_stream());
+          return make_stream_env(get_env(rcvr_), get_stream());
+        }
+
+        template <__decays_to<cudaError_t> Error>
+        void propagate_completion_signal(set_error_t, Error&& status) noexcept {
+          if constexpr (stream_receiver<outer_receiver_t>) {
+            set_error((outer_receiver_t&&) rcvr_, (cudaError_t&&) status);
+          } else {
+            // pass a cudaError_t by value:
+            continuation_kernel<outer_receiver_t, Error>
+              <<<1, 1, 0, get_stream()>>>((outer_receiver_t&&) rcvr_, set_error_t(), status);
+          }
         }
 
         template <class Tag, class... As>
         void propagate_completion_signal(Tag, As&&... as) noexcept {
           if constexpr (stream_receiver<outer_receiver_t>) {
-            Tag()((outer_receiver_t&&) receiver_, (As&&) as...);
-          } else if constexpr (same_as<Tag, set_error_t>) {
-            continuation_kernel<As...> // by value
-              <<<1, 1, 0, get_stream()>>>(std::move(receiver_), Tag(), (As&&) as...);
+            Tag()((outer_receiver_t&&) rcvr_, (As&&) as...);
           } else {
-            continuation_kernel<As&&...> // by reference
-              <<<1, 1, 0, get_stream()>>>(std::move(receiver_), Tag(), (As&&) as...);
+            continuation_kernel<outer_receiver_t, As&&...> // by reference
+              <<<1, 1, 0, get_stream()>>>((outer_receiver_t&&) rcvr_, Tag(), (As&&) as...);
           }
         }
 

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -25,6 +25,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace _ensure_started {
     template <class Tag, class... As, class Variant>
     __launch_bounds__(1) __global__ void copy_kernel(Variant* var, As... as) {
+      static_assert(trivially_copyable<As...>);
       using tuple_t = decayed_tuple<Tag, As...>;
       var->template emplace<tuple_t>(Tag(), static_cast<As&&>(as)...);
     }
@@ -282,8 +283,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           } else {
             // register stop callback:
             self.on_stop_.emplace(
-              get_stop_token(get_env(self.receiver_)),
-              on_stop_requested{shared_state->stop_source_});
+              get_stop_token(get_env(self.rcvr_)), on_stop_requested{shared_state->stop_source_});
             // Check if the stop_source has requested cancellation
             if (shared_state->stop_source_.stop_requested()) {
               // Stop has already been requested. Don't bother starting

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -134,6 +134,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       task_t* task_{nullptr};
       in_place_stop_source stop_source_{};
 
+      env_t env_;
       std::atomic<void*> op_state1_;
       inner_op_state_t op_state2_;
 
@@ -146,6 +147,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         : context_state_(context_state)
         , stream_(create_stream(status_, context_state_))
         , data_(malloc_managed<variant_t>(status_))
+        , env_(make_env())
         , op_state1_{nullptr}
         , op_state2_(connect((Sender&&) sndr, inner_receiver_t{*this})) {
         if (status_ == cudaSuccess) {
@@ -167,9 +169,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                   stream_,
                   context_state.pinned_resource_)
                   .release())
+        , env_(make_env())
         , op_state2_(connect(
             (Sender&&) sndr,
-            enqueue_receiver_t{make_env(), data_, task_, context_state.hub_->producer()})) {
+            enqueue_receiver_t{&env_, data_, task_, context_state.hub_->producer()})) {
         start(op_state2_);
       }
 

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -25,6 +25,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     template <class... As, class Fun, class ResultSenderT>
     __launch_bounds__(1) __global__
       void kernel_with_result(Fun fn, ResultSenderT* result, As... as) {
+      static_assert(trivially_copyable<Fun, As...>);
       new (result) ResultSenderT(::cuda::std::move(fn)(static_cast<As&&>(as)...));
     }
 

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -38,6 +38,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
     template <class Tag, class... As, class Variant>
     __launch_bounds__(1) __global__ void copy_kernel(Variant* var, As... as) {
+      static_assert(trivially_copyable<As...>);
       using tuple_t = decayed_tuple<Tag, As...>;
       var->template emplace<tuple_t>(Tag(), static_cast<As&&>(as)...);
     }
@@ -270,8 +271,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
           if (old != completion_state) {
             self.on_stop_.emplace(
-              get_stop_token(get_env(self.receiver_)),
-              on_stop_requested{shared_state->stop_source_});
+              get_stop_token(get_env(self.rcvr_)), on_stop_requested{shared_state->stop_source_});
           }
 
           do {

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -136,6 +136,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       variant_t* data_{nullptr};
       task_t* task_{nullptr};
       cudaEvent_t event_;
+      env_t env_;
       inner_op_state_t op_state2_;
       ::cuda::std::atomic_flag started_{};
 
@@ -144,6 +145,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         : context_state_(context_state)
         , stream_(create_stream(status_, context_state_))
         , data_(malloc_managed<variant_t>(status_))
+        , env_(make_env())
         , op_state2_(connect((Sender&&) sndr, inner_receiver_t{*this})) {
         if (status_ == cudaSuccess) {
           status_ = STDEXEC_DBG_ERR(cudaEventCreate(&event_));
@@ -162,9 +164,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                   stream_,
                   context_state.pinned_resource_)
                   .release())
+        , env_(make_env())
         , op_state2_(connect(
             (Sender&&) sndr,
-            enqueue_receiver_t{make_env(), data_, task_, context_state.hub_->producer()})) {
+            enqueue_receiver_t{&env_, data_, task_, context_state.hub_->producer()})) {
       }
 
       ~sh_state_t() {

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -25,11 +25,13 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace _then {
     template <class... As, class Fun>
     __launch_bounds__(1) __global__ void kernel(Fun fn, As... as) {
+      static_assert(trivially_copyable<Fun, As...>);
       ::cuda::std::move(fn)(static_cast<As&&>(as)...);
     }
 
     template <class... As, class Fun, class ResultT>
     __launch_bounds__(1) __global__ void kernel_with_result(Fun fn, ResultT* result, As... as) {
+      static_assert(trivially_copyable<Fun, As...>);
       new (result) ResultT(::cuda::std::move(fn)(static_cast<As&&>(as)...));
     }
 

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -38,7 +38,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
           template < __completion_tag Tag, class... As >
           friend void tag_invoke(Tag, receiver_t&& self, As&&... as) noexcept {
-            Tag()(std::move(self.op_state_.receiver_), (As&&) as...);
+            Tag()(std::move(self.op_state_.rcvr_), (As&&) as...);
           }
 
           friend Env tag_invoke(get_env_t, const receiver_t& self) noexcept {
@@ -66,15 +66,15 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
           if (op.status_ != cudaSuccess) {
             // Couldn't allocate memory for operation state, complete with error
-            stdexec::set_error(std::move(op.receiver_), std::move(op.status_));
+            stdexec::set_error(std::move(op.rcvr_), std::move(op.status_));
             return;
           }
 
           start(op.inner_op_);
         }
 
-        __t(Sender&& sender, Receiver&& receiver, context_state_t context_state)
-          : operation_state_base_t<ReceiverId>((Receiver&&) receiver, context_state, true)
+        __t(Sender&& sender, Receiver&& rcvr, context_state_t context_state)
+          : operation_state_base_t<ReceiverId>((Receiver&&) rcvr, context_state, true)
           , context_state_(context_state)
           , storage_(queue::make_host<variant_t>(this->status_, context_state.pinned_resource_))
           , task_(queue::make_host<task_t>(

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -59,6 +59,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         using enqueue_receiver =
           stdexec::__t<stream_enqueue_receiver<stdexec::__id<Env>, variant_t>>;
         using inner_op_state_t = connect_result_t<Sender, enqueue_receiver>;
+        Env env_;
         inner_op_state_t inner_op_;
 
         friend void tag_invoke(start_t, __t& op) noexcept {
@@ -85,10 +86,11 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                     this->get_stream(),
                     context_state.pinned_resource_)
                     .release())
+          , env_(this->make_env())
           , inner_op_{connect(
               (Sender&&) sender,
               enqueue_receiver{
-                this->make_env(),
+                &env_,
                 storage_.get(),
                 task_,
                 context_state_.hub_->producer()})} {

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -25,11 +25,13 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace _upon_error {
     template <class... As, class Fun>
     __launch_bounds__(1) __global__ void kernel(Fun fn, As... as) {
+      static_assert(trivially_copyable<Fun, As...>);
       ::cuda::std::move(fn)(static_cast<As&&>(as)...);
     }
 
     template <class... As, class Fun, class ResultT>
     __launch_bounds__(1) __global__ void kernel_with_result(Fun fn, ResultT* result, As... as) {
+      static_assert(trivially_copyable<Fun, As...>);
       new (result) ResultT(::cuda::std::move(fn)(static_cast<As&&>(as)...));
     }
 

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -25,11 +25,13 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace _upon_stopped {
     template <class Fun>
     __launch_bounds__(1) __global__ void kernel(Fun fn) {
+      static_assert(trivially_copyable<Fun>);
       ::cuda::std::move(fn)();
     }
 
     template <class Fun, class ResultT>
     __launch_bounds__(1) __global__ void kernel_with_result(Fun fn, ResultT* result) {
+      static_assert(trivially_copyable<Fun>);
       new (result) ResultT(::cuda::std::move(fn)());
     }
 

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -54,6 +54,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
     template <class... As, class TupleT>
     __launch_bounds__(1) __global__ void copy_kernel(TupleT* tpl, As... as) {
+      static_assert(trivially_copyable<As...>);
       *tpl = decayed_tuple<As...>(static_cast<As&&>(as)...);
     }
 

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -92,8 +92,8 @@ namespace nvexec {
           cudaStream_t stream_{0};
           cudaError_t status_{cudaSuccess};
 
-          __t(Receiver&& receiver, context_state_t context_state)
-            : operation_state_base_t<ReceiverId>((Receiver&&) receiver, context_state, false) {
+          __t(Receiver&& rcvr, context_state_t context_state)
+            : operation_state_base_t<ReceiverId>((Receiver&&) rcvr, context_state, false) {
           }
 
           friend void tag_invoke(start_t, __t& op) noexcept {

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -83,6 +83,12 @@
 #define STDEXEC_HAS_BUILTIN(...) 0
 #endif
 
+#if STDEXEC_HAS_BUILTIN(__is_trivially_copyable) || STDEXEC_MSVC()
+#define STDEXEC_IS_TRIVIALLY_COPYABLE(...) __is_trivially_copyable(__VA_ARGS__)
+#else
+#define STDEXEC_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable_v<__VA_ARGS__>
+#endif
+
 // Before gcc-12, gcc really didn't like tuples or variants of immovable types
 #if STDEXEC_GCC() && (__GNUC__ < 12)
 #define STDEXEC_IMMOVABLE(_XP) _XP(_XP&&)

--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -26,7 +26,7 @@ namespace stdexec {
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // __decay_t: An efficient implementation for std::decay
-#if __has_builtin(__decay)
+#if STDEXEC_HAS_BUILTIN(__decay)
 
   template <class _Ty>
   using __decay_t = __decay(_Ty);

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -123,6 +123,8 @@ namespace detail::a_sender {
     using Receiver = stdexec::__t<ReceiverId>;
     friend stdexec::receiver_adaptor<receiver_t, Receiver>;
 
+    static_assert(std::is_trivially_copyable_v<Receiver>);
+    static_assert(std::is_trivially_copyable_v<Fun>);
     Fun f_;
 
     template <class... As>


### PR DESCRIPTION
fixes #961 