### PR TITLE
Optimize some managed memory movements

### DIFF
--- a/include/nvexec/detail/memory.cuh
+++ b/include/nvexec/detail/memory.cuh
@@ -17,9 +17,15 @@
 
 #include "../../stdexec/execution.hpp"
 
+#include <cuda/std/bit>
+
 #include <memory_resource>
 #include <new>
 #include <type_traits>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <set>
 
 #include "config.cuh"
 #include "throw_on_cuda_error.cuh"
@@ -110,4 +116,243 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       return make_host<__decay_t<A>>(status, resource, (A&&) t);
     }
 
+  struct pinned_resource : public std::pmr::memory_resource {
+    pinned_resource() noexcept {
+    }
+
+    void* do_allocate(size_t bytes, size_t /* alignment */) override {
+      void* ret;
+
+      if (cudaError_t status = STDEXEC_DBG_ERR(cudaMallocHost(&ret, bytes));
+          status != cudaSuccess) {
+        throw std::bad_alloc();
+      }
+
+      return ret;
+    }
+
+    void do_deallocate(void* ptr, size_t /* bytes */, size_t /* alignment */) override {
+      STDEXEC_DBG_ERR(cudaFreeHost(ptr));
+    }
+
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+      return this == &other;
+    }
+  };
+
+  struct gpu_resource : public std::pmr::memory_resource {
+    gpu_resource() noexcept {
+    }
+
+    void* do_allocate(size_t bytes, size_t /* alignment */) override {
+      void* ret;
+
+      if (cudaError_t status = STDEXEC_DBG_ERR(cudaMalloc(&ret, bytes)); status != cudaSuccess) {
+        throw std::bad_alloc();
+      }
+
+      return ret;
+    }
+
+    void do_deallocate(void* ptr, size_t /* bytes */, size_t /* alignment */) override {
+      STDEXEC_DBG_ERR(cudaFree(ptr));
+    }
+
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+      return this == &other;
+    }
+  };
+
+  struct managed_resource : public std::pmr::memory_resource {
+    void* do_allocate(size_t bytes, size_t /* alignment */) override {
+      void* ret;
+
+      if (cudaError_t status = STDEXEC_DBG_ERR(cudaMallocManaged(&ret, bytes));
+          status != cudaSuccess) {
+        throw std::bad_alloc();
+      }
+
+      return ret;
+    }
+
+    void do_deallocate(void* ptr, size_t /* bytes */, size_t /* alignment */) override {
+      STDEXEC_DBG_ERR(cudaFree(ptr));
+    }
+
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+      return this == &other;
+    }
+  };
+
+  struct monotonic_buffer_resource : std::pmr::memory_resource {
+    static constexpr size_t block_alignment = 256;
+
+    struct block_descriptor_t {
+      void* ptr{};
+      size_t total{};
+    };
+
+    std::pmr::memory_resource* upstream;
+    std::vector<block_descriptor_t> allocated_blocks;
+
+    size_t space{};
+    void* current_ptr{};
+
+    monotonic_buffer_resource(std::size_t bytes, std::pmr::memory_resource* upstream)
+      : upstream(upstream)
+      , space(bytes) {
+      block_descriptor_t first_block{upstream->allocate(space, block_alignment), space};
+      current_ptr = first_block.ptr;
+      allocated_blocks.push_back(first_block);
+    }
+
+    ~monotonic_buffer_resource() {
+      for (block_descriptor_t& block: allocated_blocks) {
+        upstream->deallocate(block.ptr, block.total, block_alignment);
+      }
+    }
+
+    block_descriptor_t get_current_block() {
+      return allocated_blocks.back();
+    }
+
+    size_t get_next_space() {
+      return get_current_block().total * 2;
+    }
+
+    void* do_allocate(size_t bytes, size_t alignment) override {
+      void* ptr = std::align(alignment, bytes, current_ptr, space);
+
+      if (ptr == nullptr) {
+        space = std::max(bytes, get_next_space());
+        ptr = current_ptr = upstream->allocate(space, block_alignment);
+        allocated_blocks.push_back(block_descriptor_t{current_ptr, space});
+      }
+
+      current_ptr = static_cast<char*>(current_ptr) + bytes;
+      space -= bytes;
+
+      return ptr;
+    }
+
+    void do_deallocate(void* /* ptr */, size_t /* bytes */, size_t /* alignment */) override {
+    }
+
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+      return this == &other;
+    }
+  };
+
+  struct synchronized_pool_resource : std::pmr::memory_resource {
+    constexpr static size_t alignment = 256;
+
+    struct block_descriptor_t {
+      static constexpr unsigned int min_bin = 3;
+
+      void* ptr{};
+      unsigned int bin{};
+      size_t bytes{};
+
+      block_descriptor_t(size_t bytes)
+        : bin(cuda::std::bit_width(bytes))
+        , bytes(1ull << bin) {
+        if (bin < min_bin) {
+          bin = min_bin;
+          bytes = 1ull << bin;
+        }
+      }
+
+      block_descriptor_t(void* ptr)
+        : ptr(ptr) {
+      }
+    };
+
+    struct ptr_comparator_t {
+      bool operator()(const block_descriptor_t& a, const block_descriptor_t& b) const {
+        return a.ptr < b.ptr;
+      }
+    };
+
+    struct size_comparator_t {
+      bool operator()(const block_descriptor_t& a, const block_descriptor_t& b) const {
+        return a.bytes < b.bytes;
+      }
+    };
+
+    using cached_blocks_t = std::multiset<block_descriptor_t, size_comparator_t>;
+    using busy_blocks_t = std::multiset<block_descriptor_t, ptr_comparator_t>;
+
+    std::mutex mutex;
+
+    std::pmr::memory_resource* upstream;
+    cached_blocks_t cached_blocks;
+    busy_blocks_t live_blocks;
+
+    synchronized_pool_resource(std::pmr::memory_resource* upstream)
+      : upstream(upstream)
+      , cached_blocks(size_comparator_t{})
+      , live_blocks(ptr_comparator_t{}) {
+    }
+
+    void* do_allocate(size_t bytes, size_t /* alignment */) override {
+      std::lock_guard<std::mutex> lock(mutex);
+
+      block_descriptor_t search_key{bytes};
+      cached_blocks_t::iterator block_itr = cached_blocks.lower_bound(search_key);
+
+      while ((block_itr != cached_blocks.end()) && (block_itr->bin == search_key.bin)) {
+        search_key = *block_itr;
+        live_blocks.insert(search_key);
+        cached_blocks.erase(block_itr);
+        return search_key.ptr;
+      }
+
+      search_key.ptr = upstream->allocate(search_key.bytes, alignment);
+      live_blocks.insert(search_key);
+      return search_key.ptr;
+    }
+
+    void do_deallocate(void* ptr, size_t /* bytes */, size_t /* alignment */) override {
+      std::lock_guard<std::mutex> lock(mutex);
+
+      block_descriptor_t search_key{ptr};
+      busy_blocks_t::iterator block_itr = live_blocks.find(search_key);
+
+      if (block_itr != live_blocks.end()) {
+        search_key = *block_itr;
+        live_blocks.erase(block_itr);
+        cached_blocks.insert(search_key);
+      }
+    }
+
+    bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+      return this == &other;
+    }
+
+    ~synchronized_pool_resource() {
+      while (!cached_blocks.empty()) {
+        cached_blocks_t::iterator begin = cached_blocks.begin();
+        upstream->deallocate(begin->ptr, begin->bytes, alignment);
+        cached_blocks.erase(begin);
+      }
+    }
+  };
+
+  template <class UnderlyingResource>
+  class resource_storage {
+    UnderlyingResource underlying_resource_;
+    monotonic_buffer_resource monotonic_resource_;
+    synchronized_pool_resource resource_;
+
+    public:
+    resource_storage()
+      : underlying_resource_{}
+      , monotonic_resource_{512 * 1024, &underlying_resource_}
+      , resource_{&monotonic_resource_} {
+    }
+
+    std::pmr::memory_resource* get() {
+      return &resource_;
+    }
+  };
 }

--- a/include/nvexec/detail/memory.cuh
+++ b/include/nvexec/detail/memory.cuh
@@ -281,7 +281,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     };
 
     using cached_blocks_t = std::multiset<block_descriptor_t, size_comparator_t>;
-    using busy_blocks_t = std::multiset<block_descriptor_t, ptr_comparator_t>;
+    using busy_blocks_t = std::set<block_descriptor_t, ptr_comparator_t>;
 
     std::mutex mutex;
 
@@ -303,7 +303,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       block_descriptor_t search_key{bytes};
       cached_blocks_t::iterator block_itr = cached_blocks.lower_bound(search_key);
 
-      while ((block_itr != cached_blocks.end()) && (block_itr->bin == search_key.bin)) {
+      if ((block_itr != cached_blocks.end()) && (block_itr->bin == search_key.bin)) {
         search_key = *block_itr;
         live_blocks.insert(search_key);
         cached_blocks.erase(block_itr);

--- a/include/nvexec/detail/memory.cuh
+++ b/include/nvexec/detail/memory.cuh
@@ -121,7 +121,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     pinned_resource() noexcept {
     }
 
-    void* do_allocate(size_t bytes, size_t /* alignment */) override {
+    void* do_allocate(const std::size_t bytes, const std::size_t /* alignment */) override {
       void* ret;
 
       if (cudaError_t status = STDEXEC_DBG_ERR(cudaMallocHost(&ret, bytes));
@@ -145,7 +145,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     gpu_resource() noexcept {
     }
 
-    void* do_allocate(size_t bytes, size_t /* alignment */) override {
+    void* do_allocate(const std::size_t bytes, const std::size_t /* alignment */) override {
       void* ret;
 
       if (cudaError_t status = STDEXEC_DBG_ERR(cudaMalloc(&ret, bytes)); status != cudaSuccess) {
@@ -165,7 +165,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   };
 
   struct managed_resource : public std::pmr::memory_resource {
-    void* do_allocate(size_t bytes, size_t /* alignment */) override {
+    void* do_allocate(const std::size_t bytes, const std::size_t /* alignment */) override {
       void* ret;
 
       if (cudaError_t status = STDEXEC_DBG_ERR(cudaMallocManaged(&ret, bytes));
@@ -222,7 +222,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       return last_block_size + last_block_size / 2;
     }
 
-    void* do_allocate(size_t bytes, size_t alignment) override {
+    void* do_allocate(const std::size_t bytes, const std::size_t alignment) override {
       assert(alignment <= block_alignment);
       void* ptr = std::align(alignment, bytes, current_ptr, space);
 
@@ -297,7 +297,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       , live_blocks(ptr_comparator_t{}) {
     }
 
-    void* do_allocate(size_t bytes, size_t alignment) override {
+    void* do_allocate(const std::size_t bytes, const std::size_t alignment) override {
       assert(alignment <= block_alignment);
 
       std::lock_guard<std::mutex> lock(mutex);

--- a/include/nvexec/detail/memory.cuh
+++ b/include/nvexec/detail/memory.cuh
@@ -230,7 +230,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         allocated_blocks.push_back(block_descriptor_t{current_ptr, space});
       }
 
-      current_ptr = static_cast<char*>(current_ptr) + bytes;
+      current_ptr = static_cast<char*>(ptr) + bytes;
       space -= bytes;
 
       return ptr;

--- a/include/nvexec/detail/memory.cuh
+++ b/include/nvexec/detail/memory.cuh
@@ -263,7 +263,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         }
       }
 
-      block_descriptor_t(void* ptr)
+      explicit block_descriptor_t(void* ptr)
         : ptr(ptr) {
       }
     };

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -46,7 +46,15 @@ namespace nvexec {
 
         template <class Range>
         static void set_value_impl(base::__t&& self, Range&& range) noexcept {
+          cudaError_t status{cudaSuccess};
           cudaStream_t stream = self.op_state_.get_stream();
+
+          // `range` is produced asynchronously, so we need to wait for it to be ready
+          if (status = STDEXEC_DBG_ERR(cudaStreamSynchronize(stream));
+              status != cudaSuccess) {
+            self.op_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
+            return;
+          }
 
           using value_t = result_t<Range>;
           value_t* d_out = static_cast<value_t*>(self.op_state_.temp_storage_);
@@ -58,8 +66,6 @@ namespace nvexec {
           auto last = end(range);
 
           std::size_t num_items = std::distance(first, last);
-
-          cudaError_t status;
 
           if (status = STDEXEC_DBG_ERR(cub::DeviceReduce::Reduce(
                 d_temp_storage,

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -92,7 +92,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
             if constexpr (construct_on_device) {
               cudaStream_t stream = self.operation_state_.get_stream();
-              kernel<Tag, storage_t, __decay_t<As>...><<<1, 1>>>(storage, as...);
+              kernel<Tag, storage_t, __decay_t<As>...><<<1, 1, 0, stream>>>(storage, as...);
 
               if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError());
                   status != cudaSuccess) {

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -24,6 +24,13 @@
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace _sched_from {
+
+    template <class Tag, class Storage, class... As>
+    __launch_bounds__(1) __global__ void kernel(Storage* storage, As... as) {
+      ::new (storage) Storage();
+      storage->template emplace<decayed_tuple<Tag, As...>>(Tag(), (As&&) as...);
+    }
+
     template <class CvrefSenderId, class ReceiverId>
     struct receiver_t {
       using Sender = __cvref_t<CvrefSenderId>;
@@ -40,15 +47,61 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
         template < __completion_tag Tag, class... As>
         friend void tag_invoke(Tag, __t&& self, As&&... as) noexcept {
+          using tuple_t = decayed_tuple<Tag, As...>;
+
           // As an optimization, if there are no values to persist to temporary
           // storage, skip it and simply propagate the completion signal.
           if constexpr (sizeof...(As) == 0) {
             self.operation_state_.propagate_completion_signal(Tag());
           } else {
             storage_t* storage = static_cast<storage_t*>(self.operation_state_.temp_storage_);
-            // BUGBUG TODO: construct/emplace from the device, not the host!
-            ::new (storage) storage_t();
-            storage->template emplace<decayed_tuple<Tag, As...>>(Tag(), (As&&) as...);
+            constexpr bool construct_on_device = trivially_copyable<__decay_t<As>...>;
+
+            if constexpr (!construct_on_device) {
+              ::new (storage) storage_t();
+              storage->template emplace<tuple_t>(Tag(), (As&&) as...);
+            }
+
+            int dev_id{};
+            if (cudaError_t status = STDEXEC_DBG_ERR(cudaGetDevice(&dev_id)); 
+                status != cudaSuccess) {
+              self.operation_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
+              return;
+            }
+
+            int concurrent_managed_access;
+            if (cudaError_t status = STDEXEC_DBG_ERR(cudaDeviceGetAttribute(&concurrent_managed_access, 
+                                                                            cudaDevAttrConcurrentManagedAccess, 
+                                                                            dev_id)); 
+                status != cudaSuccess) {
+              self.operation_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
+              return;
+            }
+
+            if (concurrent_managed_access) {
+              cudaStream_t stream = self.operation_state_.get_stream();
+              if (cudaError_t status = STDEXEC_DBG_ERR(cudaMemPrefetchAsync(storage, 
+                                                                            sizeof(storage_t), 
+                                                                            dev_id, 
+                                                                            stream)); 
+                  status != cudaSuccess) {
+                self.operation_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
+                return;
+              }
+            }
+
+            if constexpr (construct_on_device) {
+              cudaStream_t stream = self.operation_state_.get_stream();
+              kernel<Tag, storage_t, __decay_t<As>...><<<1, 1>>>(storage, as...);
+
+              if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError());
+                  status != cudaSuccess) {
+                self.operation_state_.propagate_completion_signal(stdexec::set_error, std::move(status));
+                return;
+              }
+            } 
+
+            unsigned int index = storage_t::template index_of<tuple_t>::value;
 
             visit(
               [&](auto& tpl) noexcept {
@@ -57,8 +110,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
                     self.operation_state_.propagate_completion_signal(Tag2(), std::move(tas)...);
                   },
                   tpl);
-              },
-              *storage);
+              }, *storage, index);
           }
         }
 

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -57,7 +57,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           cudaStream_t stream = self.op_state_.get_stream();
 
           if constexpr (does_not_return_a_value) {
-            kernel<Error><<<1, 1, 0, stream>>>(std::move(self.f_), (Error&&) error);
+            kernel<Error&&><<<1, 1, 0, stream>>>(std::move(self.f_), (Error&&) error);
             if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError());
                 status == cudaSuccess) {
               self.op_state_.propagate_completion_signal(stdexec::set_value);
@@ -68,7 +68,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             using decayed_result_t = __decay_t<result_t>;
             decayed_result_t* d_result = static_cast<decayed_result_t*>(
               self.op_state_.temp_storage_);
-            kernel_with_result<Error>
+            kernel_with_result<Error&&>
               <<<1, 1, 0, stream>>>(std::move(self.f_), d_result, (Error&&) error);
             if (cudaError_t status = STDEXEC_DBG_ERR(cudaPeekAtLastError());
                 status == cudaSuccess) {

--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -18,6 +18,8 @@ set(nvexec_test_sources
     ensure_started.cpp
     start_detached.cpp
     variant.cpp
+    monotonic_buffer.cpp
+    synchronized_pool.cpp
     split.cpp
     upon_stopped.cpp
     transfer.cpp

--- a/test/nvexec/monotonic_buffer.cpp
+++ b/test/nvexec/monotonic_buffer.cpp
@@ -1,0 +1,87 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include "nvexec/detail/memory.cuh"
+#include "tracer_resource.h"
+
+TEST_CASE("monotonic buffer releases storage", "[cuda][stream][memory][monotonic buffer]") {
+  tracer_resource resource{};
+
+  {
+    nvdetail::monotonic_buffer_resource buffer{1024, &resource};
+
+    void* ptr_1 = buffer.allocate(128, 8);
+    void* ptr_2 = buffer.allocate(256, 16);
+    REQUIRE(ptr_1 != nullptr);
+    REQUIRE(ptr_2 != nullptr);
+    REQUIRE(ptr_1 != ptr_2);
+    REQUIRE(1 == resource.allocations.size());
+
+    buffer.deallocate(ptr_1, 128, 8);
+    buffer.deallocate(ptr_2, 256, 16);
+    REQUIRE(1 == resource.allocations.size());
+  }
+
+  REQUIRE(0 == resource.allocations.size());
+}
+
+TEST_CASE(
+  "monotonic buffer keeps track of new allocations",
+  "[cuda][stream][memory][monotonic buffer]") {
+  tracer_resource resource{};
+
+  {
+    nvdetail::monotonic_buffer_resource buffer{1024, &resource};
+
+    void* ptr_1 = buffer.allocate(128, 8);
+    void* ptr_2 = buffer.allocate(256, 16);
+    void* ptr_3 = buffer.allocate(1024, 1);
+    void* ptr_4 = buffer.allocate(512, 2);
+    REQUIRE(ptr_1 != nullptr);
+    REQUIRE(ptr_2 != nullptr);
+    REQUIRE(ptr_3 != nullptr);
+    REQUIRE(ptr_4 != nullptr);
+    REQUIRE(ptr_1 != ptr_2);
+    REQUIRE(ptr_2 != ptr_3);
+    REQUIRE(ptr_3 != ptr_4);
+    REQUIRE(2 == resource.allocations.size());
+
+    buffer.deallocate(ptr_1, 128, 8);
+    buffer.deallocate(ptr_2, 256, 16);
+    buffer.deallocate(ptr_3, 1024, 1);
+    buffer.deallocate(ptr_4, 512, 2);
+    REQUIRE(2 == resource.allocations.size());
+  }
+
+  REQUIRE(0 == resource.allocations.size());
+}
+
+TEST_CASE(
+  "monotonic buffer provides required allocations",
+  "[cuda][stream][memory][monotonic buffer]") {
+  tracer_resource resource{};
+  nvdetail::monotonic_buffer_resource buffer{1024, &resource};
+
+  char* ptr_1 = reinterpret_cast<char*>(buffer.allocate(32, 8));
+  char* ptr_2 = reinterpret_cast<char*>(buffer.allocate(32, 8));
+
+  size_t distance = std::distance(ptr_1, ptr_2);
+  REQUIRE(distance == 32);
+
+  buffer.deallocate(ptr_1, 32, 8);
+  buffer.deallocate(ptr_2, 32, 16);
+}
+
+TEST_CASE(
+  "monotonic buffer provides required alignment",
+  "[cuda][stream][memory][monotonic buffer]") {
+  tracer_resource resource{};
+  nvdetail::monotonic_buffer_resource buffer{2048, &resource};
+
+  for (int alignment = 1; alignment < 512; alignment *= 2) 
+  {
+    void* ptr = buffer.allocate(32, alignment);
+    REQUIRE(reinterpret_cast<uintptr_t>(ptr) % alignment == 0);
+    buffer.deallocate(ptr, 32, alignment);
+  }
+}

--- a/test/nvexec/synchronized_pool.cpp
+++ b/test/nvexec/synchronized_pool.cpp
@@ -1,0 +1,90 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include "nvexec/detail/memory.cuh"
+#include "tracer_resource.h"
+
+TEST_CASE("synchronized pool releases storage", "[cuda][stream][memory][synchronized pool]") {
+  tracer_resource resource{};
+
+  {
+    nvdetail::synchronized_pool_resource pool{&resource};
+
+    void* ptr_1 = pool.allocate(128, 8);
+    void* ptr_2 = pool.allocate(256, 16);
+    REQUIRE(ptr_1 != nullptr);
+    REQUIRE(ptr_2 != nullptr);
+    REQUIRE(ptr_1 != ptr_2);
+    REQUIRE(2 == resource.allocations.size());
+
+    pool.deallocate(ptr_2, 256, 16);
+    pool.deallocate(ptr_1, 128, 8);
+    REQUIRE(2 == resource.allocations.size());
+  }
+
+  REQUIRE(0 == resource.allocations.size());
+}
+
+TEST_CASE("synchronized pool caches allocations", "[cuda][stream][memory][synchronized pool]") {
+  tracer_resource resource{};
+
+  {
+    nvdetail::synchronized_pool_resource pool{&resource};
+
+    for (int i = 0; i < 10; i++)
+    {
+      void* ptr_1 = pool.allocate(128, 8);
+      void* ptr_2 = pool.allocate(256, 16);
+      REQUIRE(ptr_1 != nullptr);
+      REQUIRE(ptr_2 != nullptr);
+      REQUIRE(ptr_1 != ptr_2);
+      REQUIRE(2 == resource.allocations.size());
+
+      pool.deallocate(ptr_2, 256, 16);
+      pool.deallocate(ptr_1, 128, 8);
+      REQUIRE(2 == resource.allocations.size());
+    }
+
+    REQUIRE(2 == resource.allocations.size());
+  }
+
+  REQUIRE(0 == resource.allocations.size());
+}
+
+TEST_CASE(
+  "synchronized pool doesn't touch allocated memory",
+  "[cuda][stream][memory][synchronized pool]") {
+  tracer_resource resource{};
+  nvdetail::synchronized_pool_resource pool{&resource};
+
+  for (int n = 32; n < 512; n *= 2)
+  {
+    int bytes = n * sizeof(int);
+    int alignment = alignof(int);
+
+    int* ptr = reinterpret_cast<int*>(pool.allocate(bytes, alignment));
+    std::iota(ptr, ptr + n, n);
+    pool.deallocate(ptr, 128, 8);
+
+    ptr = reinterpret_cast<int*>(pool.allocate(bytes, alignment));
+    for (int i = 0; i < n; i++) {
+      REQUIRE(ptr[i] == i + n);
+    }
+    pool.deallocate(ptr, 128, 8);
+  }
+}
+
+TEST_CASE(
+  "synchronized pool provides required alignment",
+  "[cuda][stream][memory][synchronized pool]") {
+  tracer_resource resource{};
+  nvdetail::synchronized_pool_resource pool{&resource};
+
+  for (int alignment = 1; alignment < 512; alignment *= 2) 
+  {
+    void* ptr = pool.allocate(32, alignment);
+    INFO("Alignment: " << alignment);
+    REQUIRE(reinterpret_cast<uintptr_t>(ptr) % alignment == 0);
+    pool.deallocate(ptr, 32, alignment);
+  }
+}

--- a/test/nvexec/tracer_resource.h
+++ b/test/nvexec/tracer_resource.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <new>
+#include <vector>
+#include <memory_resource>
+
+#include <catch2/catch.hpp>
+
+namespace nvdetail = nvexec::STDEXEC_STREAM_DETAIL_NS;
+
+struct tracer_resource : public std::pmr::memory_resource {
+  struct allocation_info_t {
+    void* ptr;
+    size_t bytes;
+    size_t alignment;
+
+    bool operator==(const allocation_info_t& other) const noexcept {
+      return ptr == other.ptr && bytes == other.bytes && alignment == other.alignment;
+    }
+  };
+
+  std::vector<allocation_info_t> allocations;
+
+  void* do_allocate(size_t bytes, size_t alignment) override {
+    INFO("Allocate: " << bytes << " bytes, " << alignment << " alignment");
+    void* ptr = ::operator new[](bytes, std::align_val_t(alignment));
+    allocations.push_back(allocation_info_t{ptr, bytes, alignment});
+    return ptr;
+  }
+
+  void do_deallocate(void* ptr, size_t bytes, size_t alignment) override {
+    INFO("Deallocate: " << bytes << " bytes, " << alignment << " alignment");
+
+    auto it = std::find(
+      allocations.begin(), allocations.end(), allocation_info_t{ptr, bytes, alignment});
+
+    REQUIRE(it != allocations.end());
+
+    if (it != allocations.end()) {
+      allocations.erase(it);
+      ::operator delete[](ptr, std::align_val_t(alignment));
+    }
+  }
+
+  bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override {
+    return this == &other;
+  }
+};


### PR DESCRIPTION
Standard memory resources access allocated memory leading to managed memory traffic. This PR replaces `monotonic_buffer_resource` and `synchronized_pool_resource` with some simplified implementations. It also fixes `upon_error`, which used to dereference error. Main changes are related to `schedule_from`. It's copying input values into kernel arguments if those are trivially copyable and constructs the temporary storage on device in stream order. Otherwise, it constructs the temporary storage on the host and starts asynchronous prefetch on device if possible. 