### PR TITLE
Fix query forwarding in __env_join for queries with defaulted results

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -302,9 +302,9 @@ namespace stdexec {
       STDEXEC_NO_UNIQUE_ADDRESS _Env __env_;
 
       template <__forwarding_query _Tag>
-        requires __callable<_Tag, const _Env&>
+        requires tag_invocable<_Tag, const _Env&>
       friend auto tag_invoke(_Tag, const __env_fwd& __self) //
-        noexcept(__nothrow_callable<_Tag, const _Env&>) -> __call_result_t<_Tag, const _Env&> {
+        noexcept(nothrow_tag_invocable<_Tag, const _Env&>) -> tag_invoke_result_t<_Tag, const _Env&> {
         return _Tag()(__self.__env_);
       }
     };
@@ -322,7 +322,7 @@ namespace stdexec {
       template <class _Tag>
         requires tag_invocable<_Tag, const _Env&>
       friend auto tag_invoke(_Tag, const __env_join& __self) //
-        noexcept(__nothrow_callable<_Tag, const _Env&>) -> __call_result_t<_Tag, const _Env&> {
+        noexcept(nothrow_tag_invocable<_Tag, const _Env&>) -> tag_invoke_result_t<_Tag, const _Env&> {
         return _Tag()(__self.__env_);
       }
     };

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -320,7 +320,7 @@ namespace stdexec {
       }
 
       template <class _Tag>
-        requires __callable<_Tag, const _Env&>
+        requires tag_invocable<_Tag, const _Env&>
       friend auto tag_invoke(_Tag, const __env_join& __self) //
         noexcept(__nothrow_callable<_Tag, const _Env&>) -> __call_result_t<_Tag, const _Env&> {
         return _Tag()(__self.__env_);

--- a/test/exec/test_task.cpp
+++ b/test/exec/test_task.cpp
@@ -20,6 +20,7 @@
 #if !STDEXEC_STD_NO_COROUTINES_
 #include <exec/task.hpp>
 #include <exec/single_thread_context.hpp>
+#include <exec/async_scope.hpp>
 
 #include <catch2/catch.hpp>
 
@@ -220,5 +221,16 @@ TEST_CASE("Stick on main thread if completes_inline is not used", "[types][stick
   sync_wait(std::move(t));
 }
 
+exec::task<void> check_stop_possible() {
+  auto stop_token = co_await stdexec::get_stop_token();
+  CHECK(stop_token.stop_possible());
+}
+
+TEST_CASE("task - stop token is forwarded", "[types][task]") {
+  single_thread_context context{};
+  exec::async_scope scope;
+  scope.spawn(stdexec::on(context.get_scheduler(), check_stop_possible()));
+  CHECK(stdexec::sync_wait(scope.on_empty()));
+}
 
 #endif


### PR DESCRIPTION
Addresses issue #973 