### PR TITLE
Fix result type computation in `exec::when_any`

### DIFF
--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -75,7 +75,7 @@ namespace exec {
     // transform Tag(Args...) to a tuple __decayed_tuple<Tag, Args...>
     template <class _Env, class... _SenderIds>
     using __result_type_t = __mapply<
-      __transform<__q<__signature_to_tuple_t>, __q<std::variant>>,
+      __transform<__q<__signature_to_tuple_t>, __munique<__q<std::variant>>>,
       __completion_signatures_t<_Env, _SenderIds...>>;
 
     template <class _Variant, class... _Ts>

--- a/test/exec/test_when_any.cpp
+++ b/test/exec/test_when_any.cpp
@@ -210,3 +210,25 @@ TEST_CASE("when_any completion signatures", "[adaptors][when_any]") {
         set_error_t(std::exception_ptr)>>>);
   // wait_for_value(std::move(snd), movable(42));
 }
+
+template <class Receiver>
+struct dup_op {
+  Receiver rec;
+  friend void tag_invoke(start_t, dup_op& self) noexcept {
+    stdexec::set_error(static_cast<Receiver&&>(self.rec), std::make_exception_ptr(std::runtime_error("dup")));
+  }
+};
+
+struct dup_sender {
+  using is_sender = void;
+  using completion_signatures = stdexec::completion_signatures<set_value_t(), set_error_t(std::exception_ptr), set_error_t(std::exception_ptr&&)>;
+
+  template <class Receiver>
+  friend dup_op<Receiver> tag_invoke(connect_t, dup_sender, Receiver rec) noexcept {
+    return {static_cast<Receiver&&>(rec)};
+  }
+};
+
+TEST_CASE("when_any - with duplicate completions", "[adaptors][when_any]") {
+  REQUIRE_THROWS(stdexec::sync_wait(exec::when_any(dup_sender{})));
+}


### PR DESCRIPTION
There is a missing `__munique` within the variant computation. I also added a test that catches this for me.