### PR TITLE
NVTX helper

### DIFF
--- a/examples/nvexec/CMakeLists.txt
+++ b/examples/nvexec/CMakeLists.txt
@@ -102,6 +102,7 @@ set(nvexec_gpu_examples
     "         example.nvexec.bulk : bulk.cpp"
     "       example.nvexec.reduce : reduce.cpp"
     "        example.nvexec.split : split.cpp"
+    "         example.nvexec.nvtx : nvtx.cpp"
     "example.nvexec.maxwell_gpu_s : maxwell_gpu_s.cpp"
     "example.nvexec.maxwell_gpu_m : maxwell_gpu_m.cpp"
 )

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -268,7 +268,7 @@ struct repeat_n_sender_t {
   template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
     requires(stdexec::tag_invocable<stdexec::connect_t, Sender, Receiver>)
          && (!nvexec::STDEXEC_STREAM_DETAIL_NS::receiver_with_stream_env<Receiver>)
-  friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& r)
+  friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver r)
     -> repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__id<Receiver>> {
     return repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__id<Receiver>>(
       (Sender&&) self.sender_, self.closure_, (Receiver&&) r, self.n_);
@@ -277,7 +277,7 @@ struct repeat_n_sender_t {
   template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
     requires(stdexec::tag_invocable<stdexec::connect_t, Sender, Receiver>)
          && (nvexec::STDEXEC_STREAM_DETAIL_NS::receiver_with_stream_env<Receiver>)
-  friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& r)
+  friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver r)
     -> nvexec::STDEXEC_STREAM_DETAIL_NS::repeat_n::
       operation_state_t<SenderId, ClosureId, stdexec::__id<Receiver>> {
     return nvexec::STDEXEC_STREAM_DETAIL_NS::repeat_n::
@@ -287,7 +287,7 @@ struct repeat_n_sender_t {
 #else
     template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
       requires stdexec::tag_invocable<stdexec::connect_t, Sender, Receiver>
-    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver&& r)
+    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver r)
       -> repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__id<Receiver>> {
       return repeat_n_detail::operation_state_t<SenderId, ClosureId, stdexec::__id<Receiver>>(
         (Sender&&) self.sender_, self.closure_, (Receiver&&) r, self.n_);

--- a/examples/nvexec/nvtx.cpp
+++ b/examples/nvexec/nvtx.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <nvexec/stream_context.cuh>
+#include <nvexec/nvtx.cuh>
+#include <cstdio>
+
+namespace ex = stdexec;
+
+int main() {
+  nvexec::stream_context stream_ctx{};
+  auto snd = ex::schedule(stream_ctx.get_scheduler()) //
+           | nvexec::nvtx::push("manual push")
+           | nvexec::nvtx::scoped("scope", ex::then([] { printf("hello!\n"); }) 
+                                         | ex::then([] { printf("bye!\n"); }))
+           | nvexec::nvtx::pop();
+  stdexec::sync_wait(std::move(snd));
+}

--- a/include/nvexec/nvtx.cuh
+++ b/include/nvexec/nvtx.cuh
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <nvtx3/nvToolsExt.h>
+
+#include "../stdexec/execution.hpp"
+#include <type_traits>
+
+#include "stream/common.cuh"
+
+namespace nvexec {
+
+  namespace STDEXEC_STREAM_DETAIL_NS { namespace nvtx {
+
+    enum class kind {
+      push,
+      pop
+    };
+
+    template <kind Kind, class ReceiverId>
+    struct receiver_t {
+      class __t : public stream_receiver_base {
+        using Receiver = stdexec::__t<ReceiverId>;
+        using Env = typename operation_state_base_t<ReceiverId>::env_t;
+
+        operation_state_base_t<ReceiverId>& op_state_;
+        std::string name_;
+
+       public:
+        using __id = receiver_t;
+
+        template <__one_of<set_value_t, set_error_t, set_stopped_t> Tag, class... As>
+        friend void tag_invoke(Tag tag, __t&& self, As&&... as) noexcept {
+          if constexpr (Kind == kind::push) {
+            nvtxRangePushA(self.name_.c_str());
+          } else {
+            nvtxRangePop();
+          }
+
+          self.op_state_.propagate_completion_signal(tag, (As&&) as...);
+        }
+
+        friend Env tag_invoke(get_env_t, const __t& self) noexcept {
+          return self.op_state_.make_env();
+        }
+
+        explicit __t(operation_state_base_t<ReceiverId>& op_state, std::string name)
+          : op_state_(op_state)
+          , name_(name) {
+        }
+      };
+    };
+
+    template <kind Kind, class SenderId>
+    struct nvtx_sender_t {
+      using Sender = stdexec::__t<SenderId>;
+
+      struct __t : stream_sender_base {
+        using __id = nvtx_sender_t;
+        Sender sndr_;
+        std::string name_;
+
+        using _set_error_t = completion_signatures<set_error_t(cudaError_t)>;
+
+        template <class Receiver>
+        using receiver_t = stdexec::__t<receiver_t<Kind, stdexec::__id<Receiver>>>;
+
+        template <class... Tys>
+        using _set_value_t = completion_signatures<set_value_t(Tys...)>;
+
+        template <class Self, class Env>
+        using _completion_signatures_t = //
+          __try_make_completion_signatures<
+            __copy_cvref_t<Self, Sender>,
+            Env,
+            _set_error_t,
+            __q<_set_value_t>>;
+
+        template <__decays_to<__t> Self, receiver Receiver>
+          requires receiver_of<Receiver, _completion_signatures_t<Self, env_of_t<Receiver>>>
+        friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+          -> stream_op_state_t<__copy_cvref_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
+          return stream_op_state< __copy_cvref_t<Self, Sender>>(
+            ((Self&&) self).sndr_,
+            (Receiver&&) rcvr,
+            [&](operation_state_base_t<stdexec::__id<Receiver>>& stream_provider)
+              -> receiver_t<Receiver> {
+              return receiver_t<Receiver>(stream_provider, std::move(self.name_));
+            });
+        }
+
+        template <__decays_to<__t> Self, class Env>
+        friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
+          -> dependent_completion_signatures<Env>;
+
+        template <__decays_to<__t> Self, class Env>
+        friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
+          -> _completion_signatures_t<Self, Env>
+          requires true;
+
+        friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
+          return get_env(self.sndr_);
+        }
+      };
+    };
+
+    template <kind Kind, stdexec::sender Sender>
+    using nvtx_sender_th =
+      stdexec::__t<nvtx_sender_t<Kind, stdexec::__id<stdexec::__decay_t<Sender>>>>;
+
+    struct push_t {
+      template <stdexec::sender Sender>
+      nvtx_sender_th<kind::push, Sender> operator()(Sender&& sndr, std::string &&name) const {
+        return nvtx_sender_th<kind::push, Sender>{{}, (Sender&&) sndr, std::move(name)};
+      }
+
+      stdexec::__binder_back<push_t, std::string> operator()(std::string name) const {
+        return {{}, {}, std::move(name)};
+      }
+    };
+
+    struct pop_t {
+      template <stdexec::sender Sender>
+      nvtx_sender_th<kind::pop, Sender> operator()(Sender&& sndr) const {
+        return nvtx_sender_th<kind::pop, Sender>{{}, (Sender&&) sndr, {}};
+      }
+
+      stdexec::__binder_back<pop_t> operator()() const {
+        return {{}, {}};
+      }
+    };
+
+    constexpr inline push_t push{};
+    constexpr inline pop_t pop{};
+
+    struct scoped_t {
+      template <stdexec::sender Sender, stdexec::__sender_adaptor_closure Closure>
+      auto operator()(Sender&& __sndr, std::string &&name, Closure closure) const noexcept {
+        return (Sender&&) __sndr | push(std::move(name)) | closure | pop();
+      }
+
+      template <stdexec::__sender_adaptor_closure Closure>
+      auto operator()(std::string name, Closure closure) const
+        -> stdexec::__binder_back<scoped_t, std::string, Closure> {
+        return {
+          {},
+          {},
+          {std::move(name), (Closure&&) closure}
+        };
+      }
+    };
+
+    constexpr inline scoped_t scoped{};
+
+  }} // STDEXEC_STREAM_DETAIL_NS
+
+  namespace nvtx {
+    using STDEXEC_STREAM_DETAIL_NS::nvtx::push;
+    using STDEXEC_STREAM_DETAIL_NS::nvtx::pop;
+    using STDEXEC_STREAM_DETAIL_NS::nvtx::scoped;
+  }
+
+} // namespace nvexec

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -115,7 +115,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires receiver_of< Receiver, _completion_signatures_t<Self, env_of_t<Receiver>>>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr)
         -> stream_op_state_t<__copy_cvref_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<__copy_cvref_t<Self, Sender>>(
           ((Self&&) self).sndr_,

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -314,7 +314,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <std::same_as<__t> Self, receiver Receiver>
         requires receiver_of<Receiver, completion_signatures_of_t<Self, empty_env>>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr) //
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr) //
         noexcept(__nothrow_constructible_from<__decay_t<Receiver>, Receiver>)
           -> operation_t<Receiver> {
         return operation_t<Receiver>{(Receiver&&) rcvr, std::move(self).shared_state_};

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -229,7 +229,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           __completions<                    //
             __copy_cvref_t<_Self, _Sender>, //
             env_of_t<_Receiver>>>           //
-      friend auto tag_invoke(connect_t, _Self&& __self, _Receiver&& __rcvr)
+      friend auto tag_invoke(connect_t, _Self&& __self, _Receiver __rcvr)
         -> __operation_t<_Self, _Receiver> {
         return __operation_t<_Self, _Receiver>{
           ((_Self&&) __self).__sndr_, (_Receiver&&) __rcvr, ((_Self&&) __self).__fun_};

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -130,7 +130,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     template <class Sender>
     struct source_sender_t : stream_sender_base {
       template <__decays_to<source_sender_t> Self, receiver Receiver>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr)
         -> connect_result_t<__copy_cvref_t<Self, Sender>, Receiver> {
         return connect(((Self&&) self).sender_, (Receiver&&) rcvr);
       }
@@ -182,7 +182,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires sender_to<__copy_cvref_t<Self, source_sender_th>, Receiver>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr) -> stream_op_state_t<
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr) -> stream_op_state_t<
         __copy_cvref_t<Self, source_sender_th>,
         receiver_t<Self, Receiver>,
         Receiver> {

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -308,7 +308,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires receiver_of<Receiver, completion_signatures_of_t<Self, empty_env>>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& recvr) //
+      friend auto tag_invoke(connect_t, Self&& self, Receiver recvr) //
         noexcept(__nothrow_constructible_from<__decay_t<Receiver>, Receiver>)
           -> operation_t<Receiver> {
         return operation_t<Receiver>{(Receiver&&) recvr, self.shared_state_};

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -174,7 +174,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires receiver_of< Receiver, _completion_signatures_t<Self, env_of_t<Receiver>>>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr)
         -> stream_op_state_t<__copy_cvref_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<__copy_cvref_t<Self, Sender>>(
           ((Self&&) self).sndr_,

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -138,7 +138,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires receiver_of<Receiver, _completion_signatures_t<Self, env_of_t<Receiver>>>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr)
         -> op_state_th<Self, Receiver> {
         return op_state_th<Self, Receiver>{
           (Sender&&) self.sndr_, (Receiver&&) rcvr, self.context_state_};

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -157,7 +157,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires receiver_of< Receiver, completion_signatures<Self, env_of_t<Receiver>>>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr)
         -> stream_op_state_t<__copy_cvref_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<__copy_cvref_t<Self, Sender>>(
           ((Self&&) self).sndr_,

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -132,7 +132,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires receiver_of< Receiver, completion_signatures<Self, env_of_t<Receiver>>>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr)
         -> stream_op_state_t<__copy_cvref_t<Self, Sender>, receiver_t<Receiver>, Receiver> {
         return stream_op_state<__copy_cvref_t<Self, Sender>>(
           ((Self&&) self).sndr_,

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -392,7 +392,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       };
 
       template <__decays_to<__t> Self, receiver Receiver>
-      friend auto tag_invoke(connect_t, Self&& self, Receiver&& rcvr)
+      friend auto tag_invoke(connect_t, Self&& self, Receiver rcvr)
         -> operation_t<__copy_cvref_t<Self, stdexec::__id<__decay_t<Receiver>>>> {
         return {(Self&&) self, (Receiver&&) rcvr};
       }


### PR DESCRIPTION
This PR provides a few NVTX helpers and addresses https://github.com/NVIDIA/stdexec/issues/909:

```cpp
nvexec::stream_context stream_ctx{};
auto snd = ex::schedule(stream_ctx.get_scheduler()) 
         | nvexec::nvtx::push("manual push")
         | nvexec::nvtx::scoped("scope", ex::then([] { printf("hello!\n"); }) 
                                       | ex::then([] { printf("bye!\n"); }))
         | nvexec::nvtx::pop();
stdexec::sync_wait(std::move(snd));
```

![image](https://github.com/NVIDIA/stdexec/assets/9890394/8ba44944-20bb-43d7-b013-de3129f0e3ac)
