### PR TITLE
Implement the iterate sequence sender

### DIFF
--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -44,6 +44,7 @@ namespace exec {
     template <class _Iterator, class _Sentinel, class _ItemRcvr>
     struct __item_operation {
       struct __t {
+        using __id = __item_operation;
         STDEXEC_NO_UNIQUE_ADDRESS _ItemRcvr __rcvr_;
         __operation_base<_Iterator, _Sentinel>* __parent_;
 
@@ -176,7 +177,8 @@ namespace exec {
     };
 
     struct iterate_t {
-      template <std::ranges::range _Range>
+      template <std::ranges::forward_range _Range>
+        requires stdexec::__decay_copyable<_Range>
       stdexec::__t<__sequence<__decay_t<_Range>>> operator()(_Range&& __range) const noexcept {
         return {static_cast<_Range&&>(__range)};
       }

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#if __has_include(<version>)
+#include <version>
+#ifdef __cpp_lib_ranges
+
+#include "../sequence_senders.hpp"
+
+#include "../env.hpp"
+#include "../trampoline_scheduler.hpp"
+
+#include <ranges>
+
+namespace exec {
+  namespace __iterate {
+    using namespace stdexec;
+
+    template <class _Iterator, class _Sentinel>
+    struct __operation_base {
+      STDEXEC_NO_UNIQUE_ADDRESS _Iterator __iterator_;
+      STDEXEC_NO_UNIQUE_ADDRESS _Sentinel __sentinel_;
+    };
+
+    template <class _Range>
+    using __operation_base_t =
+      __operation_base<std::ranges::iterator_t<_Range>, std::ranges::sentinel_t<_Range>>;
+
+    template <class _Iterator, class _Sentinel, class _ItemRcvr>
+    struct __item_operation {
+      struct __t {
+        STDEXEC_NO_UNIQUE_ADDRESS _ItemRcvr __rcvr_;
+        __operation_base<_Iterator, _Sentinel>* __parent_;
+
+        friend void tag_invoke(start_t, __t& __self) noexcept {
+          stdexec::set_value(
+            static_cast<_ItemRcvr&&>(__self.__rcvr_), *__self.__parent_->__iterator_++);
+        }
+      };
+    };
+
+    template <class _Iterator, class _Sentinel>
+    struct __sender {
+      struct __t {
+        using __id = __sender;
+        using is_sender = void;
+        using completion_signatures =
+          stdexec::completion_signatures<set_value_t(std::iter_reference_t<_Iterator>)>;
+        __operation_base<_Iterator, _Sentinel>* __parent_;
+
+        template <__decays_to<__t> _Self, receiver_of<completion_signatures> _ItemRcvr>
+        friend auto tag_invoke(connect_t, _Self&& __self, _ItemRcvr __rcvr) //
+          noexcept(__nothrow_decay_copyable<_ItemRcvr>)
+            -> stdexec::__t<__item_operation<_Iterator, _Sentinel, _ItemRcvr>> {
+          return {static_cast<_ItemRcvr&&>(__rcvr), __self.__parent_};
+        }
+      };
+    };
+
+    template <class _Range>
+    using __sender_t =
+      stdexec::__t<__sender<std::ranges::iterator_t<_Range>, std::ranges::sentinel_t<_Range>>>;
+
+    template <class _Range, class _Receiver>
+    struct __operation {
+      struct __t;
+    };
+
+    template <class _Range, class _ReceiverId>
+    struct __next_receiver {
+      struct __t {
+        using _Receiver = stdexec::__t<_ReceiverId>;
+        using __id = __next_receiver;
+        using is_receiver = void;
+        stdexec::__t<__operation<_Range, _ReceiverId>>* __op_;
+
+        template <same_as<set_value_t> _SetValue, same_as<__t> _Self>
+        friend void tag_invoke(_SetValue, _Self&& __self) noexcept {
+          __self.__op_->__start_next();
+        }
+
+        template <same_as<set_stopped_t> _SetStopped, same_as<__t> _Self>
+        friend void tag_invoke(_SetStopped, _Self&& __self) noexcept {
+          __set_value_unless_stopped(static_cast<_Receiver&&>(__self.__op_->__rcvr_));
+        }
+
+        template <same_as<get_env_t> _GetEnv, __decays_to<__t> _Self>
+        friend env_of_t<_Receiver> tag_invoke(_GetEnv, _Self&& __self) noexcept {
+          return stdexec::get_env(__self.__op_->__rcvr_);
+        }
+      };
+    };
+
+    template <class _Range, class _ReceiverId>
+    struct __operation<_Range, _ReceiverId>::__t : __operation_base_t<_Range> {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+      _Receiver __rcvr_;
+
+      using _ItemSender = decltype(stdexec::on(
+        std::declval<trampoline_scheduler&>(),
+        std::declval<__sender_t<_Range>>()));
+
+      using __next_receiver_t = stdexec::__t<__next_receiver<_Range, _ReceiverId>>;
+
+      std::optional<connect_result_t<__next_sender_of_t<_Receiver, _ItemSender>, __next_receiver_t>>
+        __op_{};
+      trampoline_scheduler __scheduler_{};
+
+      void __start_next() noexcept {
+        if (this->__iterator_ == this->__sentinel_) {
+          stdexec::set_value(static_cast<_Receiver&&>(__rcvr_));
+        } else {
+          try {
+            stdexec::start(__op_.emplace(__conv{[&] {
+              return stdexec::connect(
+                exec::set_next(__rcvr_, stdexec::on(__scheduler_, __sender_t<_Range>{this})),
+                __next_receiver_t{this});
+            }}));
+          } catch (...) {
+            stdexec::set_error(static_cast<_Receiver&&>(__rcvr_), std::current_exception());
+          }
+        }
+      }
+
+      template <same_as<__t> _Self>
+      friend void tag_invoke(start_t, _Self& __self) noexcept {
+        __self.__start_next();
+      }
+    };
+
+    template <class _Range>
+    struct __sequence {
+      struct __t {
+        using __id = __sequence;
+        using is_sender = sequence_tag;
+
+        using completion_signatures = stdexec::completion_signatures<
+          set_value_t(std::ranges::range_reference_t<_Range>),
+          set_error_t(std::exception_ptr),
+          set_stopped_t()>;
+
+        STDEXEC_NO_UNIQUE_ADDRESS _Range __range_;
+
+        template <class _Receiver>
+        using __next_receiver_t = stdexec::__t<__next_receiver<_Range, stdexec::__id<_Receiver>>>;
+
+        template < __decays_to<__t> _Self, sequence_receiver_of<completion_signatures> _Receiver>
+          requires sender_to<
+            __next_sender_of_t<_Receiver, __sender_t<_Range>>,
+            __next_receiver_t<_Receiver>
+            >
+        friend auto tag_invoke(subscribe_t, _Self&& __self, _Receiver __rcvr) //
+          noexcept(__nothrow_decay_copyable<_Receiver>)
+            -> stdexec::__t<__operation<_Range, stdexec::__id<_Receiver>>> {
+          return {
+            {std::ranges::begin(__self.__range_), std::ranges::end(__self.__range_)},
+            static_cast<_Receiver&&>(__rcvr)
+          };
+        }
+      };
+    };
+
+    struct iterate_t {
+      template <std::ranges::range _Range>
+      stdexec::__t<__sequence<__decay_t<_Range>>> operator()(_Range&& __range) const noexcept {
+        return {static_cast<_Range&&>(__range)};
+      }
+    };
+  }
+
+  using __iterate::iterate_t;
+  inline constexpr iterate_t iterate;
+}
+
+#endif
+#endif

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -302,4 +302,26 @@ namespace exec {
     requires(_Sender&& __sndr, _Receiver&& __rcvr) {
       { subscribe((_Sender&&) __sndr, (_Receiver&&) __rcvr) };
     };
+
+  template <class _Receiver>
+  concept __stoppable_receiver =                            //
+    stdexec::__callable<stdexec::set_value_t, _Receiver> && //
+    (stdexec::unstoppable_token< stdexec::stop_token_of_t<stdexec::env_of_t<_Receiver>>>
+     || stdexec::__callable<stdexec::set_stopped_t, _Receiver>);
+
+  template <class _Receiver>
+    requires __stoppable_receiver<_Receiver>
+  void __set_value_unless_stopped(_Receiver&& __rcvr) {
+    using token_type = stdexec::stop_token_of_t<stdexec::env_of_t<_Receiver>>;
+    if constexpr (stdexec::unstoppable_token<token_type>) {
+      stdexec::set_value(static_cast<_Receiver&&>(__rcvr));
+    } else {
+      auto token = stdexec::get_stop_token(stdexec::get_env(__rcvr));
+      if (!token.stop_requested()) {
+        stdexec::set_value(static_cast<_Receiver&&>(__rcvr));
+      } else {
+        stdexec::set_stopped(static_cast<_Receiver&&>(__rcvr));
+      }
+    }
+  }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ set(stdexec_test_sources
     exec/test_trampoline_scheduler.cpp
     exec/test_sequence_senders.cpp
     exec/sequence/test_empty_sequence.cpp
+    exec/sequence/test_iterate.cpp
     $<$<BOOL:${STDEXEC_ENABLE_TBB}>:tbbexec/test_tbb_thread_pool.cpp>
     )
 

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -1,4 +1,23 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "exec/sequence/iterate.hpp"
+
+#ifdef __cpp_lib_ranges
 
 #include <catch2/catch.hpp>
 
@@ -82,3 +101,5 @@ TEST_CASE("iterate - sum up an array ", "[sequence_senders][iterate]") {
   stdexec::start(op);
   CHECK(sum == (42 + 43 + 44));
 }
+
+#endif  // __cpp_lib_ranges

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -21,7 +21,6 @@
 
 #include <catch2/catch.hpp>
 
-
 template <class Receiver>
 struct sum_item_rcvr {
   using is_receiver = void;

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -1,0 +1,84 @@
+#include "exec/sequence/iterate.hpp"
+
+#include <catch2/catch.hpp>
+
+
+template <class Receiver>
+struct sum_item_rcvr {
+  using is_receiver = void;
+  Receiver rcvr;
+  int* sum_;
+
+  friend stdexec::env_of_t<Receiver>
+    tag_invoke(stdexec::get_env_t, const sum_item_rcvr& self) noexcept {
+    return stdexec::get_env(self.rcvr);
+  }
+
+  template <class... As>
+  friend void tag_invoke(stdexec::set_value_t, sum_item_rcvr&& self, int x) noexcept {
+    *self.sum_ += x;
+    stdexec::set_value(static_cast<Receiver&&>(self.rcvr));
+  }
+
+  friend void tag_invoke(stdexec::set_stopped_t, sum_item_rcvr&& self) noexcept {
+    stdexec::set_value(static_cast<Receiver&&>(self.rcvr));
+  }
+
+  template <class E>
+  friend void tag_invoke(stdexec::set_error_t, sum_item_rcvr&& self, E&&) noexcept {
+    stdexec::set_value(static_cast<Receiver&&>(self.rcvr));
+  }
+};
+
+template <class Item>
+struct sum_sender {
+  using is_sender = void;
+  using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t()>;
+
+  Item item_;
+  int* sum_;
+
+  template <
+    stdexec::__decays_to<sum_sender> Self,
+    stdexec::receiver_of<completion_signatures> Receiver>
+  friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver rcvr) noexcept {
+    return stdexec::connect(
+      static_cast<Self&&>(self).item_,
+      sum_item_rcvr<Receiver>{static_cast<Receiver&&>(rcvr), self.sum_});
+  }
+};
+
+struct sum_receiver {
+  using is_receiver = void;
+
+  int& sum_;
+
+  template <class Item>
+  friend sum_sender<stdexec::__decay_t<Item>>
+    tag_invoke(exec::set_next_t, sum_receiver& self, Item&& item) noexcept {
+    return {static_cast<Item&&>(item), &self.sum_};
+  }
+
+  friend void tag_invoke(stdexec::set_value_t, sum_receiver&&) noexcept {
+  }
+
+  friend void tag_invoke(stdexec::set_stopped_t, sum_receiver&&) noexcept {
+  }
+
+  friend void tag_invoke(stdexec::set_error_t, sum_receiver&&, std::exception_ptr) noexcept {
+  }
+
+  friend stdexec::empty_env tag_invoke(stdexec::get_env_t, const sum_receiver&) noexcept {
+    return {};
+  }
+};
+
+TEST_CASE("iterate - sum up an array ", "[sequence_senders][iterate]") {
+  std::array<int, 3> array{42, 43, 44};
+  int sum = 0;
+  auto iterate = exec::iterate(std::ranges::views::all(array));
+  STATIC_REQUIRE(exec::sequence_sender_in<decltype(iterate), stdexec::empty_env>);
+  auto op = exec::subscribe(iterate, sum_receiver{sum});
+  stdexec::start(op);
+  CHECK(sum == (42 + 43 + 44));
+}


### PR DESCRIPTION
This algorithm is a sequence sender factory. It takes an input range as function parameter and returns a lock step sequence sender that iterates through the range. The sequence operation completes if the end of the range is reached or if a next sender completes with via the stop signal. 