### PR TITLE
Implement transform_each

### DIFF
--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../sequence_senders.hpp"
+
+#include "../__detail/__basic_sequence.hpp"
+
+namespace exec {
+  namespace __transform {
+    using namespace stdexec;
+
+    template <class _Receiver, class _Adaptor>
+    struct __operation_base {
+      _Receiver __receiver_;
+      _Adaptor __adaptor_;
+    };
+
+    template <class _ReceiverId, class _Adaptor>
+    struct __receiver {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      struct __t {
+        using is_receiver = void;
+        using __id = __receiver;
+        __operation_base<_Receiver, _Adaptor>* __op_;
+
+        template <same_as<set_next_t> _SetNext, same_as<__t> _Self, class _Item>
+          requires __callable<_Adaptor&, _Item>
+                && __callable<exec::set_next_t, _Receiver&, __call_result_t<_Adaptor&, _Item>>
+        friend auto tag_invoke(_SetNext, _Self& __self, _Item&& __item) noexcept(
+          __nothrow_callable<_SetNext, _Receiver&, __call_result_t<_Adaptor&, _Item>> //
+          && __nothrow_callable<_Adaptor&, _Item>)
+          -> next_sender_of_t<_Receiver, __call_result_t<_Adaptor&, _Item>> {
+          return exec::set_next(
+            __self.__op_->__receiver_, __self.__op_->__adaptor_(static_cast<_Item&&>(__item)));
+        }
+
+        template <same_as<set_value_t> _SetValue, same_as<__t> _Self>
+        friend void tag_invoke(_SetValue, _Self&& __self) noexcept {
+          stdexec::set_value(static_cast<_Receiver&&>(__self.__op_->__receiver_));
+        }
+
+        template <same_as<set_stopped_t> _SetStopped, same_as<__t> _Self>
+          requires __callable<_SetStopped, _Receiver&&>
+        friend void tag_invoke(_SetStopped, _Self&& __self) noexcept {
+          stdexec::set_stopped(static_cast<_Receiver&&>(__self.__op_->__receiver_));
+        }
+
+        template <same_as<set_error_t> _SetError, same_as<__t> _Self, class _Error>
+          requires __callable<_SetError, _Receiver&&, _Error>
+        friend void tag_invoke(_SetError, _Self&& __self, _Error&& __error) noexcept {
+          stdexec::set_error(
+            static_cast<_Receiver&&>(__self.__op_->__receiver_), static_cast<_Error&&>(__error));
+        }
+
+        template <same_as<get_env_t> _GetEnv, __decays_to<__t> _Self>
+        friend env_of_t<_Receiver> tag_invoke(_GetEnv, _Self&& __self) noexcept {
+          return stdexec::get_env(__self.__op_->__receiver_);
+        }
+      };
+    };
+
+    template <class _Sender, class _ReceiverId, class _Adaptor>
+    struct __operation {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      struct __t : __operation_base<_Receiver, _Adaptor> {
+        using __id = __operation;
+        subscribe_result_t<_Sender, stdexec::__t<__receiver<_ReceiverId, _Adaptor>>> __op_;
+
+        __t(_Sender&& __sndr, _Receiver __rcvr, _Adaptor __adaptor)
+          : __operation_base<
+            _Receiver,
+            _Adaptor>{static_cast<_Receiver&&>(__rcvr), static_cast<_Adaptor&&>(__adaptor)}
+          , __op_{exec::subscribe(
+              static_cast<_Sender&&>(__sndr),
+              stdexec::__t<__receiver<_ReceiverId, _Adaptor>>{this})} {
+        }
+
+        friend void tag_invoke(start_t, __t& __self) noexcept {
+          stdexec::start(__self.__op_);
+        }
+      };
+    };
+
+    template <class _Receiver>
+    struct __subscribe_fn {
+      _Receiver& __rcvr_;
+
+      template <class _Adaptor, class _Sequence>
+      auto operator()(__ignore, _Adaptor __adaptor, _Sequence&& __sequence) noexcept(
+        __nothrow_decay_copyable<_Adaptor> && __nothrow_decay_copyable<_Sequence>
+        && __nothrow_decay_copyable<_Receiver>)
+        -> __t< __operation<_Sequence, __id<_Receiver>, _Adaptor>> {
+        return {
+          static_cast<_Sequence&&>(__sequence),
+          static_cast<_Receiver&&>(__rcvr_),
+          static_cast<_Adaptor&&>(__adaptor)};
+      }
+    };
+
+    template <class _Adaptor>
+    struct _NOT_CALLABLE_ADAPTOR_ { };
+
+    template <class _Item>
+    struct _WITH_ITEM_SENDER_ { };
+
+    template <class _Adaptor, class _Item>
+    auto __try_call(_Item*)
+      -> stdexec::__mexception<_NOT_CALLABLE_ADAPTOR_<_Adaptor&>, _WITH_ITEM_SENDER_<_Item>>;
+
+    template <class _Adaptor, class _Item>
+      requires stdexec::__callable<_Adaptor&, _Item>
+    stdexec::__msuccess __try_call(_Item*);
+
+    template <class _Adaptor, class... _Items>
+    auto __try_calls(item_types<_Items...>*)
+      -> decltype((stdexec::__msuccess() && ... && __try_call<_Adaptor>((_Items*) nullptr)));
+
+    template <class _Adaptor, class _Items>
+    concept __callabale_adaptor_for = requires(_Items* __items) {
+      { __try_calls<stdexec::__decay_t<_Adaptor>>(__items) } -> stdexec::__ok;
+    };
+
+    struct transform_each_t {
+      template <sender _Sequence, __sender_adaptor_closure _Adaptor>
+      auto operator()(_Sequence&& __sndr, _Adaptor&& __adaptor) const noexcept(
+        __nothrow_decay_copyable<_Sequence> //
+        && __nothrow_decay_copyable<_Adaptor>) {
+        return make_sequence_expr<transform_each_t>(
+          static_cast<_Adaptor&&>(__adaptor), static_cast<_Sequence&&>(__sndr));
+      }
+
+      template <class _Adaptor>
+      constexpr auto operator()(_Adaptor __adaptor) const noexcept
+        -> __binder_back<transform_each_t, _Adaptor> {
+        return {{}, {}, {static_cast<_Adaptor&&>(__adaptor)}};
+      }
+
+      template <class _Self, class _Env>
+      using __completion_sigs_t = __sequence_completion_signatures_of_t<__child_of<_Self>, _Env>;
+
+      template <sender_expr_for<transform_each_t> _Self, class _Env>
+      static __completion_sigs_t<_Self, _Env> get_completion_signatures(_Self&&, _Env&&) noexcept {
+        return {};
+      }
+
+      template <class _Self, class _Env>
+      using __item_types_t = stdexec::__mapply<
+        stdexec::__transform<
+          stdexec::__mbind_front_q<__call_result_t, __data_of<_Self>&>,
+          stdexec::__munique<stdexec::__q<item_types>>>,
+        item_types_of_t<__child_of<_Self>, _Env>>;
+
+      template <sender_expr_for<transform_each_t> _Self, class _Env>
+      static __item_types_t<_Self, _Env> get_item_types(_Self&&, _Env&&) noexcept {
+        return {};
+      }
+
+      template <class _Self, class _Receiver>
+      using __receiver_t = __t<__receiver<__id<_Receiver>, __data_of<_Self>>>;
+
+      template <class _Self, class _Receiver>
+      using __operation_t = __t< __operation<__child_of<_Self>, __id<_Receiver>, __data_of<_Self>>>;
+
+      template <sender_expr_for<transform_each_t> _Self, receiver _Receiver>
+        requires __callabale_adaptor_for<
+                   __data_of<_Self>,
+                   __item_types_t<_Self, env_of_t<_Receiver>>>
+              && sequence_receiver_of<_Receiver, __item_types_t<_Self, env_of_t<_Receiver>>>
+              && sequence_sender_to<__child_of<_Self>, __receiver_t<_Self, _Receiver>>
+      static auto subscribe(_Self&& __self, _Receiver __rcvr) noexcept(
+        __nothrow_callable<apply_sender_t, _Self, __subscribe_fn<_Receiver>>)
+        -> __call_result_t<apply_sender_t, _Self, __subscribe_fn<_Receiver>> {
+        return apply_sender(static_cast<_Self&&>(__self), __subscribe_fn<_Receiver>{__rcvr});
+      }
+
+      template <sender_expr_for<transform_each_t> _Sexpr>
+      static env_of_t<__child_of<_Sexpr>> get_env(const _Sexpr& __sexpr) noexcept {
+        return apply_sender(__sexpr, []<class _Child>(__ignore, __ignore, const _Child& __child) {
+          return stdexec::get_env(__child);
+        });
+      }
+    };
+  }
+
+  using __transform::transform_each_t;
+  inline constexpr transform_each_t transform_each{};
+}

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -122,7 +122,7 @@ namespace exec {
 
     template <class _Adaptor, class _Item>
     auto __try_call(_Item*)
-      -> stdexec::__mexception<_NOT_CALLABLE_ADAPTOR_<_Adaptor&>, _WITH_ITEM_SENDER_<_Item>>;
+      -> stdexec::__mexception<_NOT_CALLABLE_ADAPTOR_<_Adaptor&>, _WITH_ITEM_SENDER_<stdexec::__name_of<_Item>>>;
 
     template <class _Adaptor, class _Item>
       requires stdexec::__callable<_Adaptor&, _Item>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,6 +85,7 @@ set(stdexec_test_sources
     exec/sequence/test_empty_sequence.cpp
     exec/sequence/test_ignore_all_values.cpp
     exec/sequence/test_iterate.cpp
+    exec/sequence/test_transform_each.cpp
     $<$<BOOL:${STDEXEC_ENABLE_TBB}>:tbbexec/test_tbb_thread_pool.cpp>
     )
 

--- a/test/exec/sequence/test_transform_each.cpp
+++ b/test/exec/sequence/test_transform_each.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/sequence/transform_each.hpp"
+
+#include "exec/sequence/any_sequence_of.hpp"
+#include "exec/sequence/empty_sequence.hpp"
+#include "exec/sequence/iterate.hpp"
+#include "exec/sequence/ignore_all_values.hpp"
+#include <catch2/catch.hpp>
+
+#include <exec/on.hpp>
+#include <test_common/schedulers.hpp>
+#include <test_common/receivers.hpp>
+#include <test_common/senders.hpp>
+#include <test_common/type_helpers.hpp>
+
+struct next_rcvr {
+  using __id = next_rcvr;
+  using __t = next_rcvr;
+  using is_receiver = void;
+
+  friend auto tag_invoke(exec::set_next_t, next_rcvr, auto item) {
+    return item;
+  }
+
+  friend void tag_invoke(stdexec::set_value_t, next_rcvr) noexcept {
+  }
+
+  friend stdexec::empty_env tag_invoke(stdexec::get_env_t, next_rcvr) noexcept {
+    return {};
+  }
+};
+
+TEST_CASE(
+  "transform_each - transform sender applies adaptor to no elements",
+  "[sequence_senders][transform_each][empty_sequence]") {
+  int counter = 0;
+  auto transformed = exec::transform_each(
+    exec::empty_sequence(), stdexec::then([&counter]() noexcept { ++counter; }));
+  auto op = exec::subscribe(transformed, next_rcvr{});
+  stdexec::start(op);
+  CHECK(counter == 0);
+}
+
+TEST_CASE(
+  "transform_each - transform sender applies adaptor to a sender",
+  "[sequence_senders][transform_each]") {
+  int value = 0;
+  auto transformed = exec::transform_each(
+    stdexec::just(42), stdexec::then([&value](int x) noexcept { value = x; }));
+  auto op = exec::subscribe(transformed, next_rcvr{});
+  stdexec::start(op);
+  CHECK(value == 42);
+}
+
+TEST_CASE(
+  "transform_each - transform sender applies adaptor to a sender and ignores all values",
+  "[sequence_senders][transform_each][ignore_all_values]") {
+  int value = 0;
+  auto transformed =
+    exec::transform_each(stdexec::just(42), stdexec::then([&value](int x) { value = x; }))
+    | exec::ignore_all_values();
+  stdexec::sync_wait(transformed);
+  CHECK(value == 42);
+}
+
+#if STDEXEC_HAS_STD_RANGES()
+TEST_CASE(
+  "transform_each - transform sender applies adaptor to each item",
+  "[sequence_senders][transform_each][iterate]") {
+  auto range = [](auto from, auto to) {
+    return exec::iterate(std::views::iota(from, to));
+  };
+  auto then_each = [](auto f) {
+    return exec::transform_each(stdexec::then(f));
+  };
+  int total = 0;
+  auto sum = range(0, 10) //
+           | then_each([&total](int x) noexcept { total += x; });
+  stdexec::sync_wait(exec::ignore_all_values(sum));
+  CHECK(total == 45);
+}
+#endif
+
+struct my_domain {
+  template <ex::sender_expr_for<ex::then_t> Sender, class Env>
+  static auto transform_sender(Sender&&, const Env&) {
+    return ex::just(int{42});
+  }
+};
+
+TEST_CASE("transform_each - can be customized late", "[transform_each][ignore_all_values]") {
+  // The customization will return a different value
+  basic_inline_scheduler<my_domain> sched;
+  int result = 0;
+  auto start = ex::just(std::string{"hello"});
+  auto with_scheduler = exec::write(exec::with(ex::get_scheduler, inline_scheduler()));
+  auto adaptor = exec::on(sched, ex::then([](std::string x) { return x + ", world"; }))
+               | with_scheduler;
+  auto snd = start                                                      //
+           | exec::transform_each(adaptor)                              //
+           | exec::transform_each(ex::then([&](int x) { result = x; })) //
+           | exec::ignore_all_values();
+  stdexec::sync_wait(snd);
+  CHECK(result == 42);
+}

--- a/test/exec/sequence/test_transform_each.cpp
+++ b/test/exec/sequence/test_transform_each.cpp
@@ -23,6 +23,7 @@
 #include "exec/sequence/ignore_all_values.hpp"
 #include <catch2/catch.hpp>
 
+#include <exec/env.hpp>
 #include <exec/on.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>


### PR DESCRIPTION
This algorithm is a sequence sender adaptor. It takes as input parameters a sequence sender and a sender adaptor. 
The algorithm applies the sender adaptor to each emited item of the input sequence sender and returns the resulting sequence sender.

