### PR TITLE
added exec::reduce including a customization for static_thread_pool

### DIFF
--- a/include/exec/reduce.hpp
+++ b/include/exec/reduce.hpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/execution.hpp"
+
+#include <numeric>
+#include <ranges>
+
+namespace exec {
+
+  namespace __reduce {
+
+    template <class _ReceiverId, class _InitT, class _RedOp>
+    struct __receiver {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      struct __data {
+        _Receiver __rcvr_;
+        STDEXEC_NO_UNIQUE_ADDRESS _InitT __init_;
+        STDEXEC_NO_UNIQUE_ADDRESS _RedOp __redop_;
+      };
+
+      struct __t {
+        using __id = __receiver;
+        __data* __op_;
+
+        template <
+          stdexec::__same_as<stdexec::set_value_t> _Tag,
+          class _Range,
+          class _Value = stdexec::range_value_t<_Range>>
+          requires stdexec::invocable<_RedOp, _InitT, _Value>
+                && stdexec::__receiver_of_invoke_result<_Receiver, _RedOp, _InitT, _Value>
+        friend void tag_invoke(_Tag, __t&& __self, _Range&& __range) noexcept {
+          auto result = std::reduce(
+            std::ranges::begin(__range), std::ranges::end(__range), __self.__op_->__init_, __self.__op_->__redop_);
+
+          stdexec::set_value((_Receiver&&) __self.__op_->__rcvr_, std::move(result));
+        }
+
+        template <stdexec::__one_of<stdexec::set_error_t, stdexec::set_stopped_t> _Tag, class... _As>
+          requires stdexec::__callable<_Tag, _Receiver, _As...>
+        friend void tag_invoke(_Tag __tag, __t&& __self, _As&&... __as) noexcept {
+          __tag((_Receiver&&) __self.__op_->__rcvr_, (_As&&) __as...);
+        }
+
+        friend auto tag_invoke(stdexec::get_env_t, const __t& __self) noexcept
+          -> stdexec::env_of_t<const _Receiver&> {
+          return stdexec::get_env(__self.__op_->__rcvr_);
+        }
+      };
+    };
+
+    template <class _Sender, class _ReceiverId, class _InitT, class _RedOp>
+    struct __operation {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+      using __receiver_id = __receiver<_ReceiverId, _InitT, _RedOp>;
+      using __receiver_t = stdexec::__t<__receiver_id>;
+
+      struct __t : stdexec::__immovable {
+        using __id = __operation;
+        typename __receiver_id::__data __data_;
+        stdexec::connect_result_t<_Sender, __receiver_t> __op_;
+
+        __t(_Sender&& __sndr, _Receiver __rcvr, _InitT __init, _RedOp __redop) noexcept(
+          stdexec::__nothrow_decay_copyable<_Receiver> && stdexec::__nothrow_decay_copyable<_RedOp>
+          && stdexec::__nothrow_connectable<_Sender, __receiver_t>)
+          : __data_{(_Receiver&&) __rcvr, (_InitT&&) __init, (_RedOp&&) __redop}
+          , __op_(stdexec::connect((_Sender&&) __sndr, __receiver_t{&__data_})) {
+        }
+
+        friend void tag_invoke(stdexec::start_t, __t& __self) noexcept {
+          stdexec::start(__self.__op_);
+        }
+      };
+    };
+
+    template <class _SenderId, class _InitT, class _RedOp>
+    struct __sender {
+      using _Sender = stdexec::__t<_SenderId>;
+      template <class _Receiver>
+      using __receiver = stdexec::__t<__receiver<stdexec::__id<_Receiver>, _InitT, _RedOp>>;
+      template <class _Self, class _Receiver>
+      using __operation = stdexec::__t<
+        __operation<stdexec::__copy_cvref_t<_Self, _Sender>, stdexec::__id<_Receiver>, _InitT, _RedOp>>;
+
+      struct __t {
+        using __id = __sender;
+        using is_sender = void;
+        STDEXEC_NO_UNIQUE_ADDRESS _Sender __sndr_;
+        STDEXEC_NO_UNIQUE_ADDRESS _InitT __init_;
+        STDEXEC_NO_UNIQUE_ADDRESS _RedOp __redop_;
+
+        template <stdexec::__decays_to<__t> _Self, stdexec::receiver _Receiver>
+          requires stdexec::sender_to<stdexec::__copy_cvref_t<_Self, _Sender>, __receiver<_Receiver>>
+        friend auto tag_invoke(stdexec::connect_t, _Self&& __self, _Receiver __rcvr) noexcept(
+          stdexec::__nothrow_constructible_from<
+            __operation<_Self, _Receiver>,
+            stdexec::__copy_cvref_t<_Self, _Sender>,
+            _Receiver&&,
+            stdexec::__copy_cvref_t<_Self, _InitT>,
+            stdexec::__copy_cvref_t<_Self, _RedOp>>) -> __operation<_Self, _Receiver> {
+          return {
+            ((_Self&&) __self).__sndr_,
+            (_Receiver&&) __rcvr,
+            ((_Self&&) __self).__init_,
+            ((_Self&&) __self).__redop_};
+        }
+
+        template <stdexec::__decays_to<__t> _Self, class _Env>
+        friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env&&)
+          -> stdexec::dependent_completion_signatures<_Env>;
+
+        template <stdexec::__decays_to<__t> _Self, class _Env>
+        friend auto tag_invoke(stdexec::get_completion_signatures_t, _Self&&, _Env&&)
+          -> stdexec::completion_signatures<stdexec::set_value_t(_InitT)>
+          requires true;
+
+        friend auto tag_invoke(stdexec::get_env_t, const __t& __self) noexcept
+          -> stdexec::env_of_t<const _Sender&> {
+          return get_env(__self.__sndr_);
+        }
+      };
+    };
+
+    struct reduce_t {
+      template <stdexec::sender _Sender, class _InitT, class _RedOp>
+      using __sender =
+        stdexec::__t<__sender<stdexec::__id<stdexec::__decay_t<_Sender>>, _InitT, _RedOp>>;
+
+      template <stdexec::sender _Sender, class _InitT, stdexec::__movable_value _RedOp>
+        requires stdexec::__tag_invocable_with_completion_scheduler<
+          reduce_t,
+          stdexec::set_value_t,
+          _Sender,
+          _InitT,
+          _RedOp>
+      stdexec::sender auto operator()(_Sender&& __sndr, _InitT __init, _RedOp __redop) const noexcept(
+        stdexec::nothrow_tag_invocable<
+          reduce_t,
+          stdexec::__completion_scheduler_for<_Sender, stdexec::set_value_t>,
+          _Sender,
+          _InitT,
+          _RedOp>) {
+        auto __sched = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(__sndr));
+        return tag_invoke(
+          reduce_t{}, std::move(__sched), (_Sender&&) __sndr, (_InitT&&) __init, (_RedOp&&) __redop);
+      }
+
+      template <stdexec::sender _Sender, class _InitT, stdexec::__movable_value _RedOp>
+        requires(!stdexec::__tag_invocable_with_completion_scheduler<
+                  reduce_t,
+                  stdexec::set_value_t,
+                  _Sender,
+                  _InitT,
+                  _RedOp>)
+             && stdexec::tag_invocable<reduce_t, _Sender, _InitT, _RedOp>
+      stdexec::sender auto operator()(_Sender&& __sndr, _InitT __init, _RedOp __redop) const
+        noexcept(stdexec::nothrow_tag_invocable<reduce_t, _Sender, _InitT, _RedOp>) {
+        return tag_invoke(reduce_t{}, (_Sender&&) __sndr, (_InitT&&) __init, (_RedOp&&) __redop);
+      }
+
+      template <stdexec::sender _Sender, class _InitT, stdexec::__movable_value _RedOp>
+        requires(!stdexec::__tag_invocable_with_completion_scheduler<
+                  reduce_t,
+                  stdexec::set_value_t,
+                  _Sender,
+                  _InitT,
+                  _RedOp>)
+             && (!stdexec::tag_invocable<reduce_t, _Sender, _InitT, _RedOp>)
+      STDEXEC_DETAIL_CUDACC_HOST_DEVICE __sender<_Sender, _InitT, _RedOp>
+        operator()(_Sender&& __sndr, _InitT __init, _RedOp __redop) const {
+        return __sender<_Sender, _InitT, _RedOp>{(_Sender&&) __sndr, __init, (_RedOp&&) __redop};
+      }
+
+      template <class _InitT, class _RedOp = std::plus<>>
+      stdexec::__binder_back<reduce_t, _InitT, _RedOp> operator()(_InitT __init, _RedOp __redop = {}) const {
+        return {
+          {},
+          {},
+          {(_InitT&&) __init, (_RedOp&&) __redop}
+        };
+      }
+    };
+
+  }
+
+  using __reduce::reduce_t;
+  inline constexpr reduce_t reduce{};
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ set(stdexec_test_sources
     exec/test_on.cpp
     exec/test_on2.cpp
     exec/test_on3.cpp
+    exec/test_reduce.cpp
     exec/test_repeat_effect_until.cpp
     exec/async_scope/test_dtor.cpp
     exec/async_scope/test_spawn.cpp

--- a/test/exec/test_reduce.cpp
+++ b/test/exec/test_reduce.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <exec/reduce.hpp>
+#include <exec/inline_scheduler.hpp>
+#include <exec/single_thread_context.hpp>
+#include <exec/static_thread_pool.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <span>
+#include <numeric>
+#include <vector>
+
+TEST_CASE("exec reduce returns a sender with single input", "[adaptors][reduce]") {
+  constexpr int N = 2048;
+  int input[N] = {};
+  std::fill_n(input, N, 1);
+
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input}) | exec::reduce(0);
+
+  STATIC_REQUIRE(stdexec::sender_of<decltype(task), stdexec::set_value_t(int)>);
+
+  (void) task;
+}
+
+TEST_CASE("exec reduce returns a sender with two inputs", "[adaptors][reduce]") {
+  constexpr int N = 2048;
+  int input[N] = {};
+  std::fill_n(input, N, 1);
+
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input})
+            | exec::reduce(0, std::minus<>{});
+
+  STATIC_REQUIRE(stdexec::sender_of<decltype(task), stdexec::set_value_t(int)>);
+
+  (void) task;
+}
+
+TEST_CASE("exec reduce returns init value when value range is empty", "[adaptors][reduce]") {
+  constexpr int input[1]{};
+  constexpr int init = 47;
+  std::span<const int> range{input, 0};
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), range) | exec::reduce(47);
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == init);
+}
+
+TEST_CASE("exec reduce yields correct result for single value in range", "[adaptors][reduce]") {
+  constexpr int single = 37;
+  constexpr int init = 47;
+
+  std::vector<int> input{single};
+
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input}) | exec::reduce(init);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == init + single);
+}
+
+TEST_CASE("exec reduce uses sum as default operation", "[adaptors][reduce]") {
+  constexpr int N = 2048;
+  constexpr int init = 47;
+
+  std::vector<int> input(N);
+  std::iota(input.begin(), input.end(), 1);
+
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input}) | exec::reduce(init);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == (N * (N + 1) / 2) + init);
+}
+
+TEST_CASE("exec reduce uses the passed reduction operation", "[adaptors][reduce]") {
+  constexpr int N = 2048;
+  constexpr int init = 47;
+
+  std::vector<int> input(N);
+  std::iota(input.begin(), input.end(), 2);
+
+  auto minFun = [](auto acc, auto value) {
+    return std::min(acc, value);
+  };
+
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input})
+            | exec::reduce(init, minFun);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == 2);
+}
+
+TEST_CASE("exec reduce yields correct result with product as operation", "[adaptors][reduce]") {
+  constexpr int N = 15;
+  constexpr int init = 3;
+
+  std::vector<int> input(N, 2);
+
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input})
+            | exec::reduce(init, std::multiplies<>{});
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == 3 * std::pow(2, 15));
+}
+
+TEST_CASE("exec reduce works with custom value type", "[adaptors][reduce]") {
+  constexpr int N = 2048;
+  constexpr int init = 47;
+
+  struct value_t {
+    int x;
+  };
+
+  auto sum = [](value_t acc, value_t val) {
+    return value_t{acc.x + val.x};
+  };
+
+  std::vector<value_t> input(N, value_t{1});
+
+  exec::static_thread_pool pool{};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input})
+            | exec::reduce(value_t{init}, sum);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  STATIC_REQUIRE(stdexec::sender_of<decltype(task), stdexec::set_value_t(value_t)>);
+
+  REQUIRE(result.x == N + init);
+}
+
+TEST_CASE("exec reduce yields correct result if thread pool has 1 thread", "[adaptors][reduce]") {
+  constexpr int N = 128;
+  constexpr int init = 47;
+
+  std::vector<int> input(N);
+  std::iota(input.begin(), input.end(), 1);
+
+  exec::static_thread_pool pool{1};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input}) | exec::reduce(init);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == (N * (N + 1) / 2) + init);
+}
+
+TEST_CASE(
+  "exec reduce correct if thread pool has more threads than values in range",
+  "[adaptors][reduce]") {
+  constexpr int N = 4;
+  constexpr int init = 47;
+
+  std::vector<int> input(N);
+  std::iota(input.begin(), input.end(), 1);
+
+  exec::static_thread_pool pool{N + 2};
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input}) | exec::reduce(init);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == (N * (N + 1) / 2) + init);
+}
+
+TEST_CASE(
+  "exec reduce correct if reduction threads are not balanced [adaptors][reduce]") {
+  constexpr int N = 128;
+  constexpr int init = 47;
+
+  std::vector<int> input(N);
+  std::iota(input.begin(), input.end(), 1);
+
+  exec::static_thread_pool pool{3};  // N mod 3 = 2
+  auto task = stdexec::transfer_just(pool.get_scheduler(), std::span{input}) | exec::reduce(init);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == (N * (N + 1) / 2) + init);
+}
+
+TEST_CASE("exec reduce runs on single_thread_context scheduler", "[adaptors][reduce]") {
+  constexpr int N = 128;
+  constexpr int init = 47;
+
+  std::vector<int> input(N);
+  std::iota(input.begin(), input.end(), 1);
+
+  exec::single_thread_context single{};
+  auto task = stdexec::transfer_just(single.get_scheduler(), std::span{input}) | exec::reduce(init);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == (N * (N + 1) / 2) + init);
+}
+
+TEST_CASE("exec reduce runs on inline_scheduler", "[adaptors][reduce]") {
+  constexpr int N = 128;
+  constexpr int init = 47;
+
+  std::vector<int> input(N);
+  std::iota(input.begin(), input.end(), 1);
+
+  exec::inline_scheduler sched;
+  auto task = stdexec::transfer_just(sched, std::span{input}) | exec::reduce(init);
+
+  auto [result] = stdexec::sync_wait(std::move(task)).value();
+
+  REQUIRE(result == (N * (N + 1) / 2) + init);
+}


### PR DESCRIPTION
This adds 
- `exec::reduce`
- a parallelized specialization of `exec::reduce` for running on `exec::static_thread_pool`'s scheduler
- tests covering basic usage with different reduction operations, input value-range edge cases, ranges of non-fundamental types, different schedulers, etc.

This does not (yet) introduce a common customization point with `nvexec::reduce` mainly because this would require a common default reduction operation (`nvexec::reduce` uses `cub::Sum` by default while `exec::reduce` uses `std::plus<>`).
If this is desired then one should probably also provide an entire set of common reduction operations like min, max, sum, product, etc.

