### PR TITLE
Fix linking the tests with GCC 12 and 13

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -1640,7 +1640,7 @@ namespace stdexec {
 
       template <class _Awaitable, class _Receiver>
 #if STDEXEC_GCC() && (__GNUC__ > 11)
-      __attribute__((used))
+      __attribute__((__used__))
 #endif
       static __operation_t<_Receiver> __co_impl(_Awaitable __await, _Receiver __rcvr) {
         using __result_t = __await_result_t<_Awaitable, __promise_t<_Receiver>>;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -1639,6 +1639,9 @@ namespace stdexec {
       }
 
       template <class _Awaitable, class _Receiver>
+#if STDEXEC_GCC() && (__GNUC__ > 11)
+      __attribute__((used))
+#endif
       static __operation_t<_Receiver> __co_impl(_Awaitable __await, _Receiver __rcvr) {
         using __result_t = __await_result_t<_Awaitable, __promise_t<_Receiver>>;
         std::exception_ptr __eptr;


### PR DESCRIPTION
I'm not entirely sure why this function ends up being discarded by the linker, but this patch cures the problem.