### PR TITLE
don't use <ranges> for clang<=15 & libstdc++

### DIFF
--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "exec/sequence/iterate.hpp"
+#include "stdexec/execution.hpp"
 
 // Before clang-16, clang did not like libstdc++'s ranges implementation
 #if defined(__cpp_lib_ranges) && \

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -17,8 +17,11 @@
 
 #include "exec/sequence/iterate.hpp"
 
-#ifdef __cpp_lib_ranges
+// Before clang-16, clang did not like libstdc++'s ranges implementation
+#if defined(__cpp_lib_ranges) && \
+  (!STDEXEC_CLANG() || __clang_major__ >= 16 || defined(_LIBCPP_VERSION))
 
+#include <array>
 #include <catch2/catch.hpp>
 
 template <class Receiver>
@@ -94,7 +97,7 @@ struct sum_receiver {
 TEST_CASE("iterate - sum up an array ", "[sequence_senders][iterate]") {
   std::array<int, 3> array{42, 43, 44};
   int sum = 0;
-  auto iterate = exec::iterate(std::ranges::views::all(array));
+  auto iterate = exec::iterate(std::views::all(array));
   STATIC_REQUIRE(exec::sequence_sender_in<decltype(iterate), stdexec::empty_env>);
   auto op = exec::subscribe(iterate, sum_receiver{sum});
   stdexec::start(op);


### PR DESCRIPTION
The combination of clang <= 15 and libstdc++'s version of `<ranges>` runs into llvm/llvm-project#44178.