### PR TITLE
Fix a couple of bugs in `schedule_from`

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -28,7 +28,7 @@ namespace exec {
       template <class _VTable, class _Tp>
         requires __tag_invocable_r<const _VTable*, __create_vtable_t, __mtype<_VTable>, __mtype<_Tp>>
       constexpr const _VTable* operator()(__mtype<_VTable>, __mtype<_Tp>) const noexcept {
-        return tag_invoke(__create_vtable_t{}, __mtype<_VTable>{}, __mtype<_Tp>{});
+        return stdexec::tag_invoke(__create_vtable_t{}, __mtype<_VTable>{}, __mtype<_Tp>{});
       }
     };
 
@@ -169,7 +169,7 @@ namespace exec {
         requires tag_invocable<__delete_t, __mtype<_Tp>, _Storage&>
       void operator()(__mtype<_Tp>, _Storage& __storage) noexcept {
         static_assert(nothrow_tag_invocable<__delete_t, __mtype<_Tp>, _Storage&>);
-        tag_invoke(__delete_t{}, __mtype<_Tp>{}, __storage);
+        stdexec::tag_invoke(__delete_t{}, __mtype<_Tp>{}, __storage);
       }
     };
 
@@ -180,7 +180,7 @@ namespace exec {
         requires tag_invocable<__copy_construct_t, __mtype<_Tp>, _Storage&, const _Storage&>
       void operator()(__mtype<_Tp>, _Storage& __self, const _Storage& __from) noexcept(
         nothrow_tag_invocable<__copy_construct_t, __mtype<_Tp>, _Storage&, const _Storage&>) {
-        tag_invoke(__copy_construct_t{}, __mtype<_Tp>{}, __self, __from);
+        stdexec::tag_invoke(__copy_construct_t{}, __mtype<_Tp>{}, __self, __from);
       }
     };
 
@@ -192,7 +192,7 @@ namespace exec {
       void operator()(__mtype<_Tp>, _Storage& __self, __midentity<_Storage&&> __from) noexcept {
         static_assert(
           nothrow_tag_invocable<__move_construct_t, __mtype<_Tp>, _Storage&, _Storage&&>);
-        tag_invoke(__move_construct_t{}, __mtype<_Tp>{}, __self, (_Storage&&) __from);
+        stdexec::tag_invoke(__move_construct_t{}, __mtype<_Tp>{}, __self, (_Storage&&) __from);
       }
     };
 
@@ -1086,7 +1086,7 @@ namespace exec {
       requires stdexec::tag_invocable< _Tag, stdexec::__copy_cvref_t<Self, __receiver_base>, _As...>
     friend auto tag_invoke(_Tag, Self&& __self, _As&&... __as) noexcept(
       std::is_nothrow_invocable_v< _Tag, stdexec::__copy_cvref_t<Self, __receiver_base>, _As...>) {
-      return tag_invoke(_Tag{}, ((Self&&) __self).__receiver_, (_As&&) __as...);
+      return stdexec::tag_invoke(_Tag{}, ((Self&&) __self).__receiver_, (_As&&) __as...);
     }
 
    public:
@@ -1112,7 +1112,7 @@ namespace exec {
         requires stdexec::tag_invocable< _Tag, stdexec::__copy_cvref_t<Self, __sender_base>, _As...>
       friend auto tag_invoke(_Tag, Self&& __self, _As&&... __as) noexcept(
         std::is_nothrow_invocable_v< _Tag, stdexec::__copy_cvref_t<Self, __sender_base>, _As...>) {
-        return tag_invoke(_Tag{}, ((Self&&) __self).__sender_, (_As&&) __as...);
+        return stdexec::tag_invoke(_Tag{}, ((Self&&) __self).__sender_, (_As&&) __as...);
       }
      public:
       using is_sender = void;
@@ -1176,7 +1176,7 @@ namespace exec {
               _Tag,
               stdexec::__copy_cvref_t<Self, __scheduler_base>,
               _As...>) {
-          return tag_invoke(_Tag{}, ((Self&&) __self).__scheduler_, (_As&&) __as...);
+          return stdexec::tag_invoke(_Tag{}, ((Self&&) __self).__scheduler_, (_As&&) __as...);
         }
 
         friend bool

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4938,7 +4938,7 @@ namespace stdexec {
         set_error_t,
         set_stopped_t>>;
 
-    template <class _SchedulerId, class _Variant, class _ReceiverId>
+    template <class _SchedulerId, class _VariantId, class _ReceiverId>
     struct __operation1_base;
 
     // This receiver is to be completed on the execution context
@@ -4948,14 +4948,14 @@ namespace stdexec {
     // read the completion out of the operation state and forward it
     // to the output receiver after transitioning to the scheduler's
     // context.
-    template <class _SchedulerId, class _Variant, class _ReceiverId>
+    template <class _SchedulerId, class _VariantId, class _ReceiverId>
     struct __receiver2 {
       using _Receiver = stdexec::__t<_ReceiverId>;
 
       struct __t {
         using is_receiver = void;
         using __id = __receiver2;
-        __operation1_base<_SchedulerId, _Variant, _ReceiverId>* __op_state_;
+        __operation1_base<_SchedulerId, _VariantId, _ReceiverId>* __op_state_;
 
         // If the work is successfully scheduled on the new execution
         // context and is ready to run, forward the completion signal in
@@ -4984,15 +4984,15 @@ namespace stdexec {
     // context of the scheduler. That second receiver will read the
     // completion information out of the operation state and propagate
     // it to the output receiver from within the desired context.
-    template <class _SchedulerId, class _Variant, class _ReceiverId>
+    template <class _SchedulerId, class _VariantId, class _ReceiverId>
     struct __receiver1 {
       using _Scheduler = stdexec::__t<_SchedulerId>;
       using _Receiver = stdexec::__t<_ReceiverId>;
-      using __receiver2_t = stdexec::__t<__receiver2<_SchedulerId, _Variant, _ReceiverId>>;
+      using __receiver2_t = stdexec::__t<__receiver2<_SchedulerId, _VariantId, _ReceiverId>>;
 
       struct __t {
         using is_receiver = void;
-        __operation1_base<_SchedulerId, _Variant, _ReceiverId>* __op_state_;
+        __operation1_base<_SchedulerId, _VariantId, _ReceiverId>* __op_state_;
 
         template <class... _Args>
         static constexpr bool __nothrow_complete_ = (__nothrow_decay_copyable<_Args> && ...);
@@ -5027,11 +5027,12 @@ namespace stdexec {
       };
     };
 
-    template <class _SchedulerId, class _Variant, class _ReceiverId>
+    template <class _SchedulerId, class _VariantId, class _ReceiverId>
     struct __operation1_base : __immovable {
       using _Scheduler = stdexec::__t<_SchedulerId>;
       using _Receiver = stdexec::__t<_ReceiverId>;
-      using __receiver2_t = stdexec::__t<__receiver2<_SchedulerId, _Variant, _ReceiverId>>;
+      using _Variant = stdexec::__t<_VariantId>;
+      using __receiver2_t = stdexec::__t<__receiver2<_SchedulerId, _VariantId, _ReceiverId>>;
 
       _Scheduler __sched_;
       _Receiver __rcvr_;
@@ -5068,8 +5069,8 @@ namespace stdexec {
       using _CvrefSender = stdexec::__cvref_t<_CvrefSenderId>;
       using _Receiver = stdexec::__t<_ReceiverId>;
       using __variant_t = __variant_for_t<_CvrefSender, env_of_t<_Receiver>>;
-      using __receiver1_t = stdexec::__t<__receiver1<_SchedulerId, __variant_t, _ReceiverId>>;
-      using __base_t = __operation1_base<_SchedulerId, __variant_t, _ReceiverId>;
+      using __receiver1_t = stdexec::__t<__receiver1<_SchedulerId, stdexec::__id<__variant_t>, _ReceiverId>>;
+      using __base_t = __operation1_base<_SchedulerId, stdexec::__id<__variant_t>, _ReceiverId>;
 
       struct __t : __base_t {
         using __id = __operation1;
@@ -5123,8 +5124,10 @@ namespace stdexec {
 
         template <class _Self, class _Receiver>
         using __receiver_t = //
-          stdexec::__t<
-            __receiver1<_SchedulerId, __variant_for_t<_Self, env_of_t<_Receiver>>, stdexec::__id<_Receiver>>>;
+          stdexec::__t< __receiver1<
+            _SchedulerId,
+            stdexec::__id<__variant_for_t<_Self, env_of_t<_Receiver>>>,
+            stdexec::__id<_Receiver>>>;
 
         template <__decays_to<__t> _Self, receiver _Receiver>
           requires sender_to<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Self, _Receiver>>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -5124,7 +5124,7 @@ namespace stdexec {
         template <class _Self, class _Receiver>
         using __receiver_t = //
           stdexec::__t<
-            __receiver1<_SchedulerId, stdexec::__cvref_id<_Self, _Sender>, stdexec::__id<_Receiver>>>;
+            __receiver1<_SchedulerId, __variant_for_t<_Self, env_of_t<_Receiver>>, stdexec::__id<_Receiver>>>;
 
         template <__decays_to<__t> _Self, receiver _Receiver>
           requires sender_to<__copy_cvref_t<_Self, _Sender>, __receiver_t<_Self, _Receiver>>

--- a/test/stdexec/algos/adaptors/test_schedule_from.cpp
+++ b/test/stdexec/algos/adaptors/test_schedule_from.cpp
@@ -19,6 +19,7 @@
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
 #include <test_common/type_helpers.hpp>
+#include <exec/any_sender_of.hpp>
 #include <exec/static_thread_pool.hpp>
 
 #include <chrono>
@@ -232,4 +233,15 @@ TEST_CASE("schedule_from can be customized", "[adaptors][schedule_from]") {
   auto snd = ex::schedule_from(inline_scheduler{}, ex::just(std::string{"transfer"}));
   auto op = ex::connect(std::move(snd), expect_value_receiver(std::string{"hijacked"}));
   ex::start(op);
+}
+
+
+template <class... Ts>
+using any_sender_of =
+  typename exec::any_receiver_ref<stdexec::completion_signatures<Ts...>>::template any_sender<>;
+
+TEST_CASE("schedule_from can handle any_sender", "[adaptors][schedule_from]") {
+    auto snd = stdexec::schedule_from(inline_scheduler{}, any_sender_of<ex::set_value_t(int)>(ex::just(3)));
+    auto op = ex::connect(std::move(snd), expect_value_receiver(3));
+    ex::start(op);
 }


### PR DESCRIPTION
- Adds a test that triggers the bug in `schedule_from` using `any_sender`. It's unfortunately not clear to me why `any_sender` triggers this but not others (though I didn't try _all_ the other adaptors), but presumably it instantiates some parts (more) eagerly which hits the buggy part? https://github.com/NVIDIA/stdexec/commit/1b238558991ef64557e286f33dd15d001f218480
- Fixes the buggy part in `schedule_from` which was to to still pass the sender type rather than the variant type as the second template parameter to `receiver1` (introduced in #1018). https://github.com/NVIDIA/stdexec/commit/db0ed0cdc401a2d73f213eeb9cf28b136c6525f8
- Adds ADL isolation for the variant template parameter in the various `schedule_from` types, since it may contain user-defined types. https://github.com/NVIDIA/stdexec/commit/1fe63a93e649bb34e3b607c32f0ac9cb89bd238b