### PR TITLE
Handle references as return types in `binder_back`

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -2655,7 +2655,8 @@ namespace stdexec {
         __call_result_t<_Fun, _Sender, _As...>
         operator()(_Sender&& __sndr) && noexcept(__nothrow_callable<_Fun, _Sender, _As...>) {
         return std::apply(
-          [&__sndr, this](_As&... __as) {
+          [&__sndr, this](_As&... __as) -> __call_result_t<_Fun, _Sender, _As...>
+          {
             return ((_Fun&&) __fun_)((_Sender&&) __sndr, (_As&&) __as...);
           },
           __as_);
@@ -2668,7 +2669,9 @@ namespace stdexec {
         operator()(_Sender&& __sndr) const & //
         noexcept(__nothrow_callable<const _Fun&, _Sender, const _As&...>) {
         return std::apply(
-          [&__sndr, this](const _As&... __as) { return __fun_((_Sender&&) __sndr, __as...); },
+          [&__sndr, this](const _As&... __as) -> __call_result_t<const _Fun&, _Sender, const _As&...> {
+            return __fun_((_Sender&&) __sndr, __as...);
+          },
           __as_);
       }
     };

--- a/test/stdexec/algos/adaptors/test_ensure_started.cpp
+++ b/test/stdexec/algos/adaptors/test_ensure_started.cpp
@@ -298,3 +298,11 @@ TEST_CASE("ensure_started with move only input sender", "[adaptors][ensure_start
   auto op = ex::connect(std::move(snd), expect_void_receiver{});
   ex::start(op);
 }
+
+TEST_CASE(
+  "Repeated ensure_started with operator| does not return reference to temporary",
+  "[adaptors][ensure_started]") {
+  auto snd = ex::ensure_started(ex::just()) | ex::ensure_started();
+  auto op = ex::connect(std::move(snd), expect_void_receiver{});
+  ex::start(op);
+}


### PR DESCRIPTION
The `__binder_back` `operator()` computes the return type with `__call_result` which may be a reference type. The lambda passed to `std::apply` did not have its return type specified so it would return a non-reference. The only case where I know this would be triggered is the added test case, since `ensure_started` on an `ensure_started` sender returns the sender unchanged. I've explicitly specified the return type on the lambda to fix the issue. I suppose the return type on `operator()` could be changed to `decltype(auto)` now to avoid repeating it?

GCC actually warns about this as well (but only on the added test):
```
/home/mjs/src/stdexec/include/stdexec/execution.hpp:2661:16: warning: returning reference to temporary [-Wreturn-local-addr]
 2661 |           __as_);
      |                ^
```