### PR TITLE
`get_completion_signatures` customization cleanup

### DIFF
--- a/examples/algorithms/retry.hpp
+++ b/examples/algorithms/retry.hpp
@@ -127,7 +127,9 @@ struct _retry_sender {
       Env,
       stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>,
       _value,
-      _error>;
+      _error> {
+    return {};
+  }
 
   template <stdexec::receiver R>
   friend _op<S, R> tag_invoke(stdexec::connect_t, _retry_sender&& self, R r) {

--- a/examples/algorithms/then.hpp
+++ b/examples/algorithms/then.hpp
@@ -72,7 +72,9 @@ struct _then_sender {
 
   template <class Env>
   friend auto tag_invoke(stdexec::get_completion_signatures_t, _then_sender&&, Env)
-    -> _completions_t<Env>;
+    -> _completions_t<Env> {
+    return {};
+  }
 
   // Connect:
   template <class R>

--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -340,7 +340,9 @@ namespace exec {
 
         template <__is_derived_sender<_DerivedId> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-          -> __new_completions_t<_Self, _Env>;
+          -> __new_completions_t<_Self, _Env> {
+          return {};
+        }
 
         friend auto tag_invoke(stdexec::get_env_t, const __t& __self) noexcept
           -> env_of_t<const _Sender&> {

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -85,13 +85,7 @@ namespace exec {
 
           template <__decays_to<__t> _Self, class _Env>
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-            -> dependent_completion_signatures<_Env>;
-
-          template <__decays_to<__t> _Self, class _Env>
-          friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-            -> __completion_signatures<_Env>
-            requires true
-          {
+            -> __completion_signatures<_Env> {
             return {};
           }
 

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -86,10 +86,14 @@ namespace exec {
           template <__decays_to<__t> _Self, class _Env>
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
             -> dependent_completion_signatures<_Env>;
+
           template <__decays_to<__t> _Self, class _Env>
           friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
             -> __completion_signatures<_Env>
-            requires true;
+            requires true
+          {
+            return {};
+          }
 
           friend env_of_t<_Sender> tag_invoke(get_env_t, const __t& __self) noexcept {
             return get_env(__self.__sender_);

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -99,9 +99,12 @@ namespace exec {
 
       friend auto tag_invoke(get_completion_signatures_t, __sender, no_env)
         -> dependent_completion_signatures<no_env>;
+
       template <__none_of<no_env> _Env>
       friend auto tag_invoke(get_completion_signatures_t, __sender, _Env&&)
-        -> __completions_t<_Env>;
+        -> __completions_t<_Env> {
+        return {};
+      }
     };
 
     struct __read_with_default_t {
@@ -198,7 +201,9 @@ namespace exec {
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _BaseEnv&&)
           -> stdexec::__completion_signatures_of_t<
             __copy_cvref_t<_Self, _Sender>,
-            __env::__env_join_t<_Env, _BaseEnv>>;
+            __env::__env_join_t<_Env, _BaseEnv>> {
+          return {};
+        }
       };
     };
 

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -97,9 +97,6 @@ namespace exec {
         return {{}, ((_Self&&) __self).__default_, (_Receiver&&) __rcvr};
       }
 
-      friend auto tag_invoke(get_completion_signatures_t, __sender, no_env)
-        -> dependent_completion_signatures<no_env>;
-
       template <__none_of<no_env> _Env>
       friend auto tag_invoke(get_completion_signatures_t, __sender, _Env&&)
         -> __completions_t<_Env> {

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -65,7 +65,7 @@ namespace exec {
     };
 
     template <class... _Args>
-    using __as_rvalues = completion_signatures<set_value_t(__decay_t<_Args> && ...)>;
+    using __as_rvalues = completion_signatures<set_value_t(__decay_t<_Args>&&...)>;
 
     template <class _InitialSender, class _FinalSender, class _Env>
     using __completion_signatures_t = make_completion_signatures<
@@ -272,7 +272,9 @@ namespace exec {
           -> __completion_signatures_t<
             __copy_cvref_t<_Self, _InitialSender>,
             __copy_cvref_t<_Self, _FinalSender>,
-            _Env>;
+            _Env> {
+          return {};
+        }
 
        public:
         using is_sender = void;

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -263,10 +263,6 @@ namespace exec {
             (_Rec&&) __receiver};
         }
 
-        template <__decays_to<__t> _Self, class _Env>
-        friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&) noexcept
-          -> dependent_completion_signatures<_Env>;
-
         template <__decays_to<__t> _Self, __none_of<no_env> _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&) noexcept
           -> __completion_signatures_t<

--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -95,7 +95,9 @@ namespace exec {
 
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&& __self, _Env __env)
-          -> __completion_signatures_for_t<_Env>;
+          -> __completion_signatures_for_t<_Env> {
+          return {};
+        }
       };
     };
 
@@ -193,7 +195,9 @@ namespace exec {
 
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&& __self, _Env __env)
-          -> __completion_signatures_for_t<_Env>;
+          -> __completion_signatures_for_t<_Env> {
+          return {};
+        }
       };
     };
 

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -278,7 +278,9 @@ namespace exec {
 
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-          -> __completion_sigs<_Self, _Env>;
+          -> __completion_sigs<_Self, _Env> {
+          return {};
+        }
       };
     };
 

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -468,7 +468,10 @@ namespace exec {
     template <stdexec::__decays_to<bulk_sender> Self, class Env>
     friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env&&)
       -> completion_signatures<Self, Env>
-      requires true;
+      requires true
+    {
+      return {};
+    }
 
     friend auto tag_invoke(stdexec::get_env_t, const bulk_sender& self) noexcept
       -> stdexec::env_of_t<const Sender&> {

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -463,13 +463,7 @@ namespace exec {
 
     template <stdexec::__decays_to<bulk_sender> Self, class Env>
     friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env&&)
-      -> stdexec::dependent_completion_signatures<Env>;
-
-    template <stdexec::__decays_to<bulk_sender> Self, class Env>
-    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env&&)
-      -> completion_signatures<Self, Env>
-      requires true
-    {
+      -> completion_signatures<Self, Env> {
       return {};
     }
 

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -482,7 +482,9 @@ namespace exec {
         completion_signatures< __set_value_sig_t, set_error_t(std::exception_ptr), set_stopped_t()>;
 
       friend auto tag_invoke(get_completion_signatures_t, const basic_task&, auto)
-        -> __task_traits_t;
+        -> __task_traits_t {
+        return {};
+      }
 
       explicit basic_task(__coro::coroutine_handle<promise_type> __coro) noexcept
         : __coro_(__coro) {

--- a/include/exec/variant_sender.hpp
+++ b/include/exec/variant_sender.hpp
@@ -91,7 +91,9 @@ namespace exec {
 
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-          -> __completion_signatures_t<_Self, _Env>;
+          -> __completion_signatures_t<_Self, _Env> {
+          return {};
+        }
 
        public:
         using is_sender = void;

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -267,7 +267,10 @@ namespace exec {
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&& __self, _Env __env) noexcept
           -> __completion_signatures_t<_Env, _SenderIds...>
-          requires true;
+          requires true
+        {
+          return {};
+        }
 
         std::tuple<stdexec::__t<_SenderIds>...> __senders_;
       };

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -262,13 +262,7 @@ namespace exec {
 
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&& __self, _Env __env) noexcept
-          -> dependent_completion_signatures<_Env>;
-
-        template <__decays_to<__t> _Self, class _Env>
-        friend auto tag_invoke(get_completion_signatures_t, _Self&& __self, _Env __env) noexcept
-          -> __completion_signatures_t<_Env, _SenderIds...>
-          requires true
-        {
+          -> __completion_signatures_t<_Env, _SenderIds...> {
           return {};
         }
 

--- a/include/nvexec/nvtx.cuh
+++ b/include/nvexec/nvtx.cuh
@@ -96,13 +96,7 @@ namespace nvexec {
 
         template <__decays_to<__t> Self, class Env>
         friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-          -> dependent_completion_signatures<Env>;
-
-        template <__decays_to<__t> Self, class Env>
-        friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-          -> _completion_signatures_t<Self, Env>
-          requires true
-        {
+          -> _completion_signatures_t<Self, Env> {
           return {};
         }
 

--- a/include/nvexec/nvtx.cuh
+++ b/include/nvexec/nvtx.cuh
@@ -101,7 +101,10 @@ namespace nvexec {
         template <__decays_to<__t> Self, class Env>
         friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
           -> _completion_signatures_t<Self, Env>
-          requires true;
+          requires true
+        {
+          return {};
+        }
 
         friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
           return get_env(self.sndr_);

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -134,7 +134,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS::__algo_range_init_fun {
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
         -> completion_signatures<Self, Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
         return get_env(self.sndr_);

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -129,13 +129,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS::__algo_range_init_fun {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> dependent_completion_signatures<Env>;
-
-      template <__decays_to<__t> Self, class Env>
-      friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> completion_signatures<Self, Env>
-        requires true
-      {
+        -> completion_signatures<Self, Env> {
         return {};
       }
 

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -133,7 +133,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
         -> _completion_signatures_t<Self, Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
         return get_env(self.sndr_);
@@ -369,7 +372,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
         -> _completion_signatures_t<Self, Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
         return get_env(self.sndr_);

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -128,13 +128,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> dependent_completion_signatures<Env>;
-
-      template <__decays_to<__t> Self, class Env>
-      friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> _completion_signatures_t<Self, Env>
-        requires true
-      {
+        -> _completion_signatures_t<Self, Env> {
         return {};
       }
 
@@ -367,13 +361,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> dependent_completion_signatures<Env>;
-
-      template <__decays_to<__t> Self, class Env>
-      friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> _completion_signatures_t<Self, Env>
-        requires true
-      {
+        -> _completion_signatures_t<Self, Env> {
         return {};
       }
 

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -338,7 +338,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           _ensure_started::env_t,
           completion_signatures<set_error_t(cudaError_t), set_stopped_t()>,
           _set_value_t,
-          _set_error_t>;
+          _set_error_t> {
+        return {};
+      }
 
       explicit __t(context_state_t context_state, Sender sndr)
         : sndr_((Sender&&) sndr)

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -242,10 +242,14 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <__decays_to<__t> _Self, class _Env>
       friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
         -> dependent_completion_signatures<_Env>;
+
       template <__decays_to<__t> _Self, class _Env>
       friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
         -> __completions<__copy_cvref_t<_Self, _Sender>, _Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       _Sender __sndr_;
       _Fun __fun_;

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -241,13 +241,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> _Self, class _Env>
       friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-        -> dependent_completion_signatures<_Env>;
-
-      template <__decays_to<__t> _Self, class _Env>
-      friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-        -> __completions<__copy_cvref_t<_Self, _Sender>, _Env>
-        requires true
-      {
+        -> __completions<__copy_cvref_t<_Self, _Sender>, _Env> {
         return {};
       }
 

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -146,7 +146,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<source_sender_t> _Self, class _Env>
       friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-        -> make_completion_signatures< __copy_cvref_t<_Self, Sender>, _Env>;
+        -> make_completion_signatures< __copy_cvref_t<_Self, Sender>, _Env> {
+        return {};
+      }
 
       Sender sndr_;
     };
@@ -210,7 +212,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           _Env,
           completion_signatures<set_error_t(cudaError_t)>,
           _sched_from::value_completions_t,
-          _sched_from::error_completions_t>;
+          _sched_from::error_completions_t> {
+        return {};
+      }
 
       __t(context_state_t context_state, Sender sndr)
         : env_{context_state}

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -331,7 +331,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           exec::make_env_t<exec::with_t<get_stop_token_t, in_place_stop_token>>,
           completion_signatures<set_error_t(const cudaError_t&)>,
           _set_value_t,
-          _set_error_t>;
+          _set_error_t> {
+        return {};
+      }
 
       explicit __t(context_state_t context_state, Sender sndr)
         : sndr_((Sender&&) sndr)

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -185,13 +185,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> dependent_completion_signatures<Env>;
-
-      template <__decays_to<__t> Self, class Env>
-      friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> _completion_signatures_t<Self, Env>
-        requires true
-      {
+        -> _completion_signatures_t<Self, Env> {
         return {};
       }
 

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -190,7 +190,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
         -> _completion_signatures_t<Self, Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
         return get_env(self.sndr_);

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -145,13 +145,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> dependent_completion_signatures<Env>;
-
-      template <__decays_to<__t> Self, class Env>
-      friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> _completion_signatures_t<Self, Env>
-        requires true
-      {
+        -> _completion_signatures_t<Self, Env> {
         return {};
       }
 

--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -150,7 +150,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
         -> _completion_signatures_t<Self, Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
         return get_env(self.sndr_);

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -168,13 +168,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> dependent_completion_signatures<Env>;
-
-      template <__decays_to<__t> Self, class Env>
-      friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> completion_signatures<Self, Env>
-        requires true
-      {
+        -> completion_signatures<Self, Env> {
         return {};
       }
 

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -173,7 +173,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
         -> completion_signatures<Self, Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
         return get_env(self.sndr_);

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -143,13 +143,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> dependent_completion_signatures<Env>;
-
-      template <__decays_to<__t> Self, class Env>
-      friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> completion_signatures<Self, Env>
-        requires true
-      {
+        -> completion_signatures<Self, Env> {
         return {};
       }
 

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -148,7 +148,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
         -> completion_signatures<Self, Env>
-        requires true;
+        requires true
+      {
+        return {};
+      }
 
       friend auto tag_invoke(get_env_t, const __t& self) noexcept -> env_of_t<const Sender&> {
         return get_env(self.sndr_);

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -399,7 +399,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> completion_sigs<Env, Self>;
+        -> completion_sigs<Env, Self> {
+        return {};
+      }
 
       friend const env& tag_invoke(get_env_t, const __t& __self) noexcept {
         return __self.env_;

--- a/include/stdexec/concepts.hpp
+++ b/include/stdexec/concepts.hpp
@@ -102,7 +102,7 @@ namespace stdexec {
   template <class _Ty, class... _As>
   concept constructible_from = //
     destructible<_Ty> &&       //
-      std::is_constructible_v<_Ty, _As...>;
+    std::is_constructible_v<_Ty, _As...>;
 #endif
 
   template <class _Ty>

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -4298,7 +4298,8 @@ namespace stdexec {
                     __default_domain{query_or(get_completion_scheduler<set_value_t>, get_env(__sndr), __none_such())}))));
           // clang-format on
 
-          using __ensure_started_sender_t = __result_of<__make_basic_sender, ensure_started_t, __, _Sender>;
+          using __ensure_started_sender_t =
+            __result_of<__make_basic_sender, ensure_started_t, __, _Sender>;
           using __tfx_sender_t = //
             decltype(__domain.transform_sender(
               __declval<__copy_cvref_t<_Sender, __ensure_started_sender_t>>(), __env));
@@ -4308,7 +4309,9 @@ namespace stdexec {
           if constexpr (!same_as<__decay_t<__ensure_started_sender_t>, __decay_t<__tfx_sender_t>>) {
             auto __ensure_started_sender = __make_basic_sender(*this, __(), (_Sender&&) __sndr);
             return __domain.transform_sender(
-              const_cast<__copy_cvref_t<_Sender, __ensure_started_sender_t>&&>(__ensure_started_sender), __env);
+              const_cast<__copy_cvref_t<_Sender, __ensure_started_sender_t>&&>(
+                __ensure_started_sender),
+              __env);
           } else {
             using __sh_state_t = __t<__sh_state<__cvref_id<_Sender>, __id<__decay_t<_Env>>>>;
             auto __sh_state = __make_intrusive<__sh_state_t>((_Sender&&) __sndr, (_Env&&) __env);
@@ -4533,7 +4536,9 @@ namespace stdexec {
 
         template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-          -> __completions<__copy_cvref_t<_Self, _Sender>, _Env>;
+          -> __completions<__copy_cvref_t<_Self, _Sender>, _Env> {
+          return {};
+        }
 
         _Sender __sndr_;
         _Fun __fun_;
@@ -4706,7 +4711,9 @@ namespace stdexec {
             completion_signatures<set_error_t(std::exception_ptr)>,
             __set_value_t,
             __set_error_t,
-            completion_signatures<>>;
+            completion_signatures<>> {
+          return {};
+        }
 
         _Sender __sndr_;
       };
@@ -5446,7 +5453,9 @@ namespace stdexec {
               __copy_cvref_t<_Self, _Sender>,
               __make_env_t<_Env, __with<get_scheduler_t, _Scheduler>>,
               completion_signatures<set_error_t(std::exception_ptr)>>,
-            __q<__value_t>>;
+            __q<__value_t>> {
+          return {};
+        }
       };
     };
 
@@ -5602,7 +5611,9 @@ namespace stdexec {
 
         template <class _Env>
         friend auto tag_invoke(get_completion_signatures_t, __t&&, _Env&&) //
-          -> __compl_sigs<_Env>;
+          -> __compl_sigs<_Env> {
+          return {};
+        }
       };
     };
 
@@ -6236,7 +6247,9 @@ namespace stdexec {
 
       template <__none_of<no_env> _Env>
       friend auto tag_invoke(get_completion_signatures_t, __sender, _Env&&)
-        -> __completions_t<_Env>;
+        -> __completions_t<_Env> {
+        return {};
+      }
 
       friend empty_env tag_invoke(get_env_t, const __t&) noexcept {
         return {};

--- a/include/tbbexec/tbb_thread_pool.hpp
+++ b/include/tbbexec/tbb_thread_pool.hpp
@@ -368,13 +368,7 @@ namespace tbbexec {
 
           template <stdexec::__decays_to<bulk_sender> Self, class Env>
           friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env&&)
-            -> stdexec::dependent_completion_signatures<Env>;
-
-          template <stdexec::__decays_to<bulk_sender> Self, class Env>
-          friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env&&)
-            -> completion_signatures<Self, Env>
-            requires true
-          {
+            -> completion_signatures<Self, Env> {
             return {};
           }
 

--- a/include/tbbexec/tbb_thread_pool.hpp
+++ b/include/tbbexec/tbb_thread_pool.hpp
@@ -373,7 +373,10 @@ namespace tbbexec {
           template <stdexec::__decays_to<bulk_sender> Self, class Env>
           friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env&&)
             -> completion_signatures<Self, Env>
-            requires true;
+            requires true
+          {
+            return {};
+          }
 
           template <stdexec::tag_category<stdexec::forwarding_query> Tag, class... As>
             requires stdexec::__callable<Tag, const Sender&, As...>

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -183,13 +183,7 @@ namespace detail::a_sender {
 
     template <stdexec::__decays_to<sender_t> Self, class Env>
     friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
-      -> stdexec::dependent_completion_signatures<Env>;
-
-    template <stdexec::__decays_to<sender_t> Self, class Env>
-    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
-      -> completion_signatures<Self, Env>
-      requires true
-    {
+      -> completion_signatures<Self, Env> {
       return {};
     }
 
@@ -247,13 +241,7 @@ namespace detail::a_receiverless_sender {
 
     template <stdexec::__decays_to<sender_t> Self, class Env>
     friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
-      -> stdexec::dependent_completion_signatures<Env>;
-
-    template <stdexec::__decays_to<sender_t> Self, class Env>
-    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
-      -> completion_signatures<Self, Env>
-      requires true
-    {
+      -> completion_signatures<Self, Env> {
       return {};
     }
 

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -188,7 +188,10 @@ namespace detail::a_sender {
     template <stdexec::__decays_to<sender_t> Self, class Env>
     friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
       -> completion_signatures<Self, Env>
-      requires true;
+      requires true
+    {
+      return {};
+    }
 
     friend auto tag_invoke(stdexec::get_env_t, const sender_t& self) //
       noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
@@ -249,7 +252,10 @@ namespace detail::a_receiverless_sender {
     template <stdexec::__decays_to<sender_t> Self, class Env>
     friend auto tag_invoke(stdexec::get_completion_signatures_t, Self&&, Env)
       -> completion_signatures<Self, Env>
-      requires true;
+      requires true
+    {
+      return {};
+    }
 
     friend auto tag_invoke(stdexec::get_env_t, const sender_t& self) //
       noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -90,9 +90,12 @@ struct custom_sender {
   friend auto tag_invoke(ex::connect_t, custom_sender, Receiver&& rcvr) {
     return ex::connect(ex::schedule(inline_scheduler{}), (Receiver&&) rcvr);
   }
+
   template <class Env>
   friend auto tag_invoke(ex::get_completion_signatures_t, custom_sender, Env) noexcept
-    -> ex::completion_signatures<ex::set_value_t()>;
+    -> ex::completion_signatures<ex::set_value_t()> {
+    return {};
+  }
 
   friend void tag_invoke(ex::start_detached_t, custom_sender sndr) {
     *sndr.called = true;

--- a/test/test_common/retry.hpp
+++ b/test/test_common/retry.hpp
@@ -127,7 +127,9 @@ struct _retry_sender {
       Env,
       stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>,
       _value,
-      _error>;
+      _error> {
+    return {};
+  }
 
   template <stdexec::receiver R>
   friend _op<S, R> tag_invoke(stdexec::connect_t, _retry_sender&& self, R r) {


### PR DESCRIPTION
* avoid linkage errors by giving the customizations function bodies
* remove vestigal customizations that return `dependent_completion_signatures`