### PR TITLE
Add an `nvexec::get_stream` query for fetching the current `cudaStream_t` from the environment

### DIFF
--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -109,11 +109,11 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS::__algo_range_init_fun {
 
       template <class Self, class Env>
       using completion_signatures = //
-        make_completion_signatures<
+        __try_make_completion_signatures<
           __copy_cvref_t<Self, Sender>,
           Env,
           completion_signatures<set_error_t(cudaError_t)>,
-          _set_value_t >;
+          __q<_set_value_t >>;
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires receiver_of<Receiver, completion_signatures<Self, env_of_t<Receiver>>>

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -333,12 +333,12 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <std::same_as<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> make_completion_signatures<
+        -> __try_make_completion_signatures<
           Sender,
           _ensure_started::env_t,
           completion_signatures<set_error_t(cudaError_t), set_stopped_t()>,
-          _set_value_t,
-          _set_error_t> {
+          __q<_set_value_t>,
+          __q<_set_error_t>> {
         return {};
       }
 

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -78,7 +78,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     struct __tfx_signal_<_Set, _Set(_Args...)> {
       template <class _Env, class _Fun>
       using __f = //
-        make_completion_signatures<
+        __try_make_completion_signatures<
           __minvoke<__result_sender<_Fun>, _Args...>,
           _Env,
           completion_signatures<set_error_t(cudaError_t)>>;
@@ -221,7 +221,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           __transform<
             __mbind_front_q<let_xxx::__tfx_signal_t, _Env, _Fun, _Set>,
             __q<__concat_completion_signatures_t>>,
-          completion_signatures_of_t<_Sender, _Env>>;
+          __completion_signatures_of_t<_Sender, _Env>>;
 
       template <__decays_to<__t> _Self, receiver _Receiver>
         requires receiver_of<               //

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -146,7 +146,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<source_sender_t> _Self, class _Env>
       friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-        -> make_completion_signatures< __copy_cvref_t<_Self, Sender>, _Env> {
+        -> __try_make_completion_signatures< __copy_cvref_t<_Self, Sender>, _Env> {
         return {};
       }
 
@@ -207,12 +207,12 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> _Self, class _Env>
       friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&)
-        -> make_completion_signatures<
+        -> __try_make_completion_signatures<
           __copy_cvref_t<_Self, Sender>,
           _Env,
           completion_signatures<set_error_t(cudaError_t)>,
-          _sched_from::value_completions_t,
-          _sched_from::error_completions_t> {
+          __q<_sched_from::value_completions_t>,
+          __q<_sched_from::error_completions_t>> {
         return {};
       }
 

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -326,12 +326,12 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, class Env>
       friend auto tag_invoke(get_completion_signatures_t, Self&&, Env&&)
-        -> make_completion_signatures<
+        -> __try_make_completion_signatures<
           Sender,
           exec::make_env_t<exec::with_t<get_stop_token_t, in_place_stop_token>>,
           completion_signatures<set_error_t(const cudaError_t&)>,
-          _set_value_t,
-          _set_error_t> {
+          __q<_set_value_t>,
+          __q<_set_error_t>> {
         return {};
       }
 

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -127,8 +127,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
         rcvr.loop_->finish();
       }
 
-      friend empty_env tag_invoke(get_env_t, const __t& rcvr) noexcept {
-        return {};
+      friend __env tag_invoke(get_env_t, const __t& rcvr) noexcept {
+        return {rcvr.loop_->get_scheduler()};
       }
     };
   };
@@ -146,9 +146,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
     using receiver_t = stdexec::__t<receiver_t<stdexec::__id<Sender>>>;
 
     template <__single_value_variant_sender<__env> Sender>
-      requires(!__tag_invocable_with_domain< sync_wait_t, set_value_t, Sender>)
-           && (!tag_invocable<sync_wait_t, Sender>) && sender<Sender, __env>
-           && __receiver_from<receiver_t<Sender>, Sender>
+      requires sender<Sender, __env> && __receiver_from<receiver_t<Sender>, Sender>
     auto operator()(context_state_t context_state, Sender&& __sndr) const
       -> std::optional<sync_wait_result_t<Sender>> {
       using state_t = state_t<stdexec::__id<Sender>>;
@@ -180,6 +178,13 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
 
       return std::move(std::get<1>(state.data_));
     }
+
+#if STDEXEC_NVHPC()
+    // For reporting better diagnostics with nvc++
+    template <class _Sender, class _Error = stdexec::__sync_wait::__error_description_t<_Sender>>
+    auto operator()(context_state_t context_state, _Sender&&, [[maybe_unused]] _Error __diagnostic = {}) const
+      -> std::optional<std::tuple<int>> = delete;
+#endif
   };
 } // namespace _sync_wait
 } // namespace nvexec::STDEXEC_STREAM_DETAIL_NS

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -65,7 +65,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         __concat_completion_signatures_t<
 
           completion_signatures< set_error_t(cudaError_t), set_stopped_t()>,
-          make_completion_signatures< Senders, Env, completion_signatures<>, swallow_values>...>;
+          __try_make_completion_signatures< Senders, Env, completion_signatures<>, __q<swallow_values>>...>;
       using values = //
         __minvoke<
           __mconcat<__qf<set_value_t>>,

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -194,18 +194,6 @@ namespace stdexec {
   template <class... _Ts>
   using __disp = decltype((__msuccess(), ..., __ok_t<_Ts>()));
 
-  template <bool _AllOK>
-  struct __i {
-    template <template <class...> class _Fn, class... _Args>
-    using __g = _Fn<_Args...>;
-  };
-
-  template <>
-  struct __i<false> {
-    template <template <class...> class, class... _Args>
-    using __g = __disp<_Args...>;
-  };
-
   template <class _Arg>
   concept __ok = __same_as<__ok_t<_Arg>, __msuccess>;
 
@@ -214,6 +202,9 @@ namespace stdexec {
 
   template <class... _Args>
   concept _Ok = (__ok<_Args> && ...);
+
+  template <bool _AllOK>
+  struct __i;
 
 #if STDEXEC_NVHPC()
   // Most compilers memoize alias template specializations, but
@@ -234,15 +225,48 @@ namespace stdexec {
   template <template <class...> class _Fn, class... _Args>
   using __meval = __t<__meval_<_Fn, _Args...>>;
 
+  template <class _Fn, class... _Args>
+  using __minvoke__ = typename __i<_Ok<_Fn>>::template __h<_Fn, _Args...>;
+
+  template <class _Fn, class... _Args>
+  struct __minvoke_ { };
+
+  template <class _Fn, class... _Args>
+    requires __typename<__minvoke__<_Fn, _Args...>>
+  struct __minvoke_<_Fn, _Args...> {
+    using __t = __minvoke__<_Fn, _Args...>;
+  };
+
+  template <class _Fn, class... _Args>
+  using __minvoke = __t<__minvoke_<_Fn, _Args...>>;
+
 #else
 
   template <template <class...> class _Fn, class... _Args>
   using __meval = typename __i<_Ok<_Args...>>::template __g<_Fn, _Args...>;
 
+  template <class _Fn, class... _Args>
+  using __minvoke = typename __i<_Ok<_Fn>>::template __h<_Fn, _Args...>;
+
 #endif
 
-  template <class _Fn, class... _Args>
-  using __minvoke = __meval<_Fn::template __f, _Args...>;
+  template <bool _AllOK>
+  struct __i {
+    template <template <class...> class _Fn, class... _Args>
+    using __g = _Fn<_Args...>;
+
+    template <class _Fn, class... _Args>
+    using __h = __meval<_Fn::template __f, _Args...>;
+  };
+
+  template <>
+  struct __i<false> {
+    template <template <class...> class, class... _Args>
+    using __g = __disp<_Args...>;
+
+    template <class _Fn, class...>
+    using __h = _Fn;
+  };
 
   template <template <class...> class _Fn>
   struct __q {

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -433,6 +433,9 @@ namespace stdexec {
       }
     };
 
+    template <class _Env>
+    __env_fwd(_Env&&) -> __env_fwd<_Env>;
+
     template <class _Env, class _Base = empty_env>
     struct __joined_env : __env_fwd<_Base> {
       static_assert(__nothrow_move_constructible<_Env>);
@@ -6189,7 +6192,39 @@ namespace stdexec {
 
   namespace __read {
     template <class _Tag, class _ReceiverId>
+    using __result_t = __call_result_t<_Tag, env_of_t<stdexec::__t<_ReceiverId>>>;
+
+    template <class _Tag, class _ReceiverId>
+    concept __nothrow_t = __nothrow_callable<_Tag, env_of_t<stdexec::__t<_ReceiverId>>>;
+
+    // NOT TO SPEC: if the query returns a value, store the value in the operation
+    // state and pass an rvalue reference to it.
+    template <class _Tag, class _ReceiverId>
     struct __operation {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      struct __t : __immovable {
+        using __id = __operation;
+        _Receiver __rcvr_;
+        std::optional<__result_t<_Tag, _ReceiverId>> __result_;
+
+        friend void tag_invoke(start_t, __t& __self) noexcept {
+          constexpr bool _Nothrow = __nothrow_callable<_Tag, env_of_t<_Receiver>>;
+          auto __query = [&]() noexcept(_Nothrow) -> __result_t<_Tag, _ReceiverId>&& {
+            __self.__result_.emplace(__conv{[&]() noexcept(_Nothrow) {
+              return _Tag()(get_env(__self.__rcvr_));
+            }});
+            return std::move(*__self.__result_);
+          };
+          stdexec::__set_value_invoke(std::move(__self.__rcvr_), __query);
+        }
+      };
+    };
+
+    // if the query returns a reference type, pass it straight through to the receiver.
+    template <class _Tag, class _ReceiverId>
+      requires std::same_as<__result_t<_Tag, _ReceiverId>&&, __result_t<_Tag, _ReceiverId>>
+    struct __operation<_Tag, _ReceiverId> {
       using _Receiver = stdexec::__t<_ReceiverId>;
 
       struct __t : __immovable {
@@ -6197,12 +6232,7 @@ namespace stdexec {
         _Receiver __rcvr_;
 
         friend void tag_invoke(start_t, __t& __self) noexcept {
-          try {
-            auto __env = get_env(__self.__rcvr_);
-            set_value(std::move(__self.__rcvr_), _Tag{}(__env));
-          } catch (...) {
-            set_error(std::move(__self.__rcvr_), std::current_exception());
-          }
+          stdexec::__set_value_invoke(std::move(__self.__rcvr_), _Tag(), get_env(__self.__rcvr_));
         }
       };
     };
@@ -6223,9 +6253,12 @@ namespace stdexec {
     template <class _Tag, class _Env>
       requires __callable<_Tag, _Env>
     using __completions_t = //
-      completion_signatures<
-        set_value_t(__call_result_t<_Tag, _Env>),
-        set_error_t(std::exception_ptr)>;
+      __if_c<
+        __nothrow_callable<_Tag, _Env>,
+        completion_signatures<set_value_t(__call_result_t<_Tag, _Env>)>,
+        completion_signatures<
+          set_value_t(__call_result_t<_Tag, _Env>),
+          set_error_t(std::exception_ptr)>>;
 
     template <class _Tag>
     struct __sender {


### PR DESCRIPTION
Also:

* improve meta-exception propagation in `__minvoke`.
* make sure the stream algo customizations propagate compile-time diagnostics
* fix the environment seen by `nvexec::let_value`'s children to include the cuda stream
* temporarily change `stdexec::read` to persist query results in the operation state as a workaround for #1059 