### PR TITLE
Remove printf call in async_scope unit test

### DIFF
--- a/test/exec/async_scope/test_empty.cpp
+++ b/test/exec/async_scope/test_empty.cpp
@@ -156,7 +156,6 @@ TEST_CASE(
     ex::on(sch, ex::just()) //
     | ex::upon_stopped([&] {
         work_executed = true;
-        printf(".\n");
       }));
   // note that we don't tell impulse sender to start the work
 


### PR DESCRIPTION
This looks like a piece of debug code that was accidentally committed.