### PR TITLE
in `let_[value|error|stopped]` the result sender sees the input sender's completion scheduler as the current scheduler

### DIFF
--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -23,8 +23,8 @@
 #endif
 
 namespace exec {
-  template <class... _TagValue>
-  using with_t = stdexec::__with<_TagValue...>;
+  template <class _Tag, class _Value = stdexec::__none_such>
+  using with_t = stdexec::__with<_Tag, _Value>;
 
   namespace __detail {
     struct __with_t {

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -31,8 +31,8 @@
 #include "scope.hpp"
 
 STDEXEC_PRAGMA_PUSH()
-STDEXEC_PRAGMA_IGNORE("-Wpragmas")
-STDEXEC_PRAGMA_IGNORE("-Wundefined-inline")
+STDEXEC_PRAGMA_IGNORE_GNU("-Wpragmas")
+STDEXEC_PRAGMA_IGNORE_GNU("-Wundefined-inline")
 
 namespace exec {
   namespace __task {

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -54,6 +54,8 @@
 #define STDEXEC_NVCC() 1
 #elif defined(__NVCOMPILER)
 #define STDEXEC_NVHPC() 1
+#elif defined(__EDG__)
+#define LEGATE_EDG() 1
 #elif defined(__clang__)
 #define STDEXEC_CLANG() 1
 #elif defined(__GNUC__)
@@ -68,6 +70,9 @@
 #ifndef STDEXEC_NVHPC
 #define STDEXEC_NVHPC() 0
 #endif
+#ifndef STDEXEC_EDG
+#define STDEXEC_EDG() 0
+#endif
 #ifndef STDEXEC_CLANG
 #define STDEXEC_CLANG() 0
 #endif
@@ -78,15 +83,31 @@
 #define STDEXEC_MSVC() 0
 #endif
 
-#if STDEXEC_CLANG() || STDEXEC_GCC()
 #define STDEXEC_STRINGIZE(_ARG) #_ARG
+
+#if STDEXEC_NVCC()
+#define STDEXEC_PRAGMA_PUSH() _Pragma("nv_diagnostic push")
+#define STDEXEC_PRAGMA_POP() _Pragma("nv_diagnostic pop")
+#define STDEXEC_PRAGMA_IGNORE_EDG(...) _Pragma(STDEXEC_STRINGIZE(nv_diag_suppress __VA_ARGS__))
+#elif STDEXEC_NVHPC() || STDEXEC_EDG()
+#define STDEXEC_PRAGMA_PUSH() \
+  _Pragma("diagnostic push") STDEXEC_PRAGMA_IGNORE_EDG(invalid_error_number)
+#define STDEXEC_PRAGMA_POP() _Pragma("diagnostic pop")
+#define STDEXEC_PRAGMA_IGNORE_EDG(...) _Pragma(STDEXEC_STRINGIZE(diag_suppress __VA_ARGS__))
+#elif STDEXEC_CLANG() || STDEXEC_GCC()
 #define STDEXEC_PRAGMA_PUSH() _Pragma("GCC diagnostic push")
 #define STDEXEC_PRAGMA_POP() _Pragma("GCC diagnostic pop")
-#define STDEXEC_PRAGMA_IGNORE(_ARG) _Pragma(STDEXEC_STRINGIZE(GCC diagnostic ignored _ARG))
+#define STDEXEC_PRAGMA_IGNORE_GNU(_ARG) _Pragma(STDEXEC_STRINGIZE(GCC diagnostic ignored _ARG))
 #else
 #define STDEXEC_PRAGMA_PUSH()
 #define STDEXEC_PRAGMA_POP()
-#define STDEXEC_PRAGMA_IGNORE(_ARG)
+#endif
+
+#ifndef STDEXEC_PRAGMA_IGNORE_GNU
+#define STDEXEC_PRAGMA_IGNORE_GNU(_ARG)
+#endif
+#ifndef STDEXEC_PRAGMA_IGNORE_EDG
+#define STDEXEC_PRAGMA_IGNORE_EDG(_ARG)
 #endif
 
 #if !STDEXEC_MSVC() && defined(__has_builtin)

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -123,9 +123,6 @@ namespace stdexec {
   using __get_completion_signatures::get_completion_signatures_t;
   extern const get_completion_signatures_t get_completion_signatures;
 
-  template <class _Sender, class _Env>
-  using __completion_signatures_of_t = __call_result_t< get_completion_signatures_t, _Sender, _Env>;
-
   //////////////////////////////////////////////////////////////////////////////////////////////////
   namespace __connect {
     struct connect_t;

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -351,6 +351,12 @@ namespace stdexec {
     requires(sizeof...(_False) <= 1)
   using __if_c = __minvoke<__if_::__<_Pred>, _True, _False...>;
 
+  template <class _Pred, class _True, class... _False>
+  using __minvoke_if = __minvoke<__if<_Pred, _True, _False...>>;
+
+  template <bool _Pred, class _True, class... _False>
+  using __minvoke_if_c = __minvoke<__if_c<_Pred, _True, _False...>>;
+
   template <class _Tp>
   struct __mconst {
     template <class...>
@@ -371,6 +377,9 @@ namespace stdexec {
 
   template <class _Fn, class _Default>
   using __with_default = __mtry_catch<_Fn, __mconst<_Default>>;
+
+  template <template <class...> class _Fn, class _Default>
+  using __with_default_q = __mtry_catch_q<_Fn, __mconst<_Default>>;
 
   inline constexpr __mstring __mbad_substitution =
     "The specified meta-function could not be evaluated with the types provided."__csz;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -84,9 +84,9 @@
 #define STDEXEC_LEGACY_R5_CONCEPTS() 1
 
 STDEXEC_PRAGMA_PUSH()
-STDEXEC_PRAGMA_IGNORE("-Wpragmas")
-STDEXEC_PRAGMA_IGNORE("-Wundefined-inline")
-STDEXEC_PRAGMA_IGNORE("-Wundefined-internal")
+STDEXEC_PRAGMA_IGNORE_GNU("-Wpragmas")
+STDEXEC_PRAGMA_IGNORE_GNU("-Wundefined-inline")
+STDEXEC_PRAGMA_IGNORE_GNU("-Wundefined-internal")
 
 namespace stdexec {
   // [exec.queries.queryable]
@@ -6645,7 +6645,7 @@ namespace stdexec {
       template <class _Sender, class _Env>
       auto operator()(_Sender&&, const _Env&) const {
         STDEXEC_PRAGMA_PUSH()
-        STDEXEC_PRAGMA_IGNORE("-Wunused-local-typedefs")
+        STDEXEC_PRAGMA_IGNORE_GNU("-Wunused-local-typedefs")
 
         struct __no_scheduler_in_environment {
           using is_sender = void;

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -19,7 +19,7 @@
 #include <test_common/schedulers.hpp>
 
 STDEXEC_PRAGMA_PUSH()
-STDEXEC_PRAGMA_IGNORE("-Wunused-function")
+STDEXEC_PRAGMA_IGNORE_GNU("-Wunused-function")
 
 namespace ex = stdexec;
 


### PR DESCRIPTION
Fixes #1077 