### PR TITLE
Enable verbose compiler output in cmake build step for GPU jobs

### DIFF
--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -51,7 +51,7 @@ jobs:
             -DCMAKE_CUDA_COMPILER="$cxx" \
             -DCMAKE_CUDA_ARCHITECTURES=${{ matrix.sm }};
           # Compile
-          cmake --build build;
+          cmake --build build -v;
           # Tests
           ctest --test-dir build --verbose --output-on-failure --timeout 60;
           # Examples

--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -52,12 +52,17 @@ jobs:
             -DCMAKE_CUDA_ARCHITECTURES=${{ matrix.sm }};
           # Compile
           cmake --build build -v;
+          
+          # Print sccache stats
+          sccache -s
+          
           # Tests
           ctest --test-dir build --verbose --output-on-failure --timeout 60;
           # Examples
           ./build/examples/nvexec/maxwell_cpu_st --iterations=1000 --N=512 --run-cpp --run-inline-scheduler
           ./build/examples/nvexec/maxwell_cpu_mt --iterations=1000 --N=512 --run-std --run-stdpar --run-thread-pool-scheduler
           ./build/examples/nvexec/maxwell_gpu_s --iterations=1000 --N=512 --run-cuda --run-stdpar --run-stream-scheduler
+
 
   ci-gpu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes it easier to verify what flags are being passed to the compiler. 