### PR TITLE
`STDEXEC_ATTRIBUTE` portability macro

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,9 +24,9 @@ AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros: [
+  'STDEXEC_ATTRIBUTE',
   'STDEXEC_NO_UNIQUE_ADDRESS',
   'STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS',
-  'STDEXEC_DETAIL_CUDACC_HOST_DEVICE',
 ]
 BinPackArguments: false
 BinPackParameters: false

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -197,9 +197,8 @@ namespace repeat_n_detail {
     using is_receiver = void;
 
     template <stdexec::__one_of<ex::set_error_t, ex::set_stopped_t> _Tag, class... _Args>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      friend void
-      tag_invoke(_Tag __tag, receiver_t&& __self, _Args&&... __args) noexcept {
+    STDEXEC_ATTRIBUTE((host, device))
+    friend void tag_invoke(_Tag __tag, receiver_t&& __self, _Args&&... __args) noexcept {
       __tag(std::move(__self.op_state_.rcvr_), (_Args&&) __args...);
     }
 
@@ -330,8 +329,7 @@ inline constexpr repeat_n_t repeat_n{};
 
 template <class SchedulerT>
 [[nodiscard]] bool is_gpu_scheduler(SchedulerT&& scheduler) {
-  auto snd = ex::just()
-           | exec::on(scheduler, ex::then([] { return nvexec::is_on_gpu(); }));
+  auto snd = ex::just() | exec::on(scheduler, ex::then([] { return nvexec::is_on_gpu(); }));
   auto [on_gpu] = stdexec::sync_wait(std::move(snd)).value();
   return on_gpu;
 }
@@ -363,9 +361,7 @@ void run_snr(
   time_storage_t time{is_gpu_scheduler(computer)};
   fields_accessor accessor = grid.accessor();
 
-  auto init =
-    ex::just()
-    | exec::on(computer, ex::bulk(grid.cells, grid_initializer(dt, accessor)));
+  auto init = ex::just() | exec::on(computer, ex::bulk(grid.cells, grid_initializer(dt, accessor)));
   stdexec::sync_wait(init);
 
   auto snd = maxwell_eqs_snr(dt, time.get(), write_vtk, n_iterations, accessor, computer);

--- a/include/exec/__detail/__basic_sequence.hpp
+++ b/include/exec/__detail/__basic_sequence.hpp
@@ -42,8 +42,8 @@ namespace exec {
 
     mutable _ImplFn __impl_;
 
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      explicit __seqexpr(_ImplFn __impl)
+    STDEXEC_ATTRIBUTE((host, device))
+    explicit __seqexpr(_ImplFn __impl)
       : __impl_((_ImplFn&&) __impl) {
     }
 
@@ -106,8 +106,8 @@ namespace exec {
   };
 
   template <class _ImplFn>
-  STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-    __seqexpr(_ImplFn) -> __seqexpr<_ImplFn>;
+  STDEXEC_ATTRIBUTE((host, device))
+  __seqexpr(_ImplFn) -> __seqexpr<_ImplFn>;
 
 #if STDEXEC_NVHPC() || (STDEXEC_GCC() && __GNUC__ < 13)
   namespace __detail {

--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -185,8 +185,8 @@ namespace exec {
         }
 
         _Receiver __rcvr_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Kernel __kernel_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Data __data_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Kernel __kernel_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Data __data_;
       };
 
       struct __t {

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -350,7 +350,7 @@ namespace exec {
         const __vtable_t* __vtable_{__default_storage_vtable((__vtable_t*) nullptr)};
         void* __object_pointer_{nullptr};
         alignas(__alignment) std::byte __buffer_[__buffer_size]{};
-        STDEXEC_NO_UNIQUE_ADDRESS _Allocator __allocator_{};
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Allocator __allocator_{};
       };
     };
 
@@ -541,7 +541,7 @@ namespace exec {
       const __vtable_t* __vtable_{__default_storage_vtable((__vtable_t*) nullptr)};
       void* __object_pointer_{nullptr};
       alignas(__alignment) std::byte __buffer_[__buffer_size]{};
-      STDEXEC_NO_UNIQUE_ADDRESS _Allocator __allocator_{};
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Allocator __allocator_{};
     };
 
     struct __empty_vtable {
@@ -771,7 +771,7 @@ namespace exec {
 
     template <class _Receiver>
     struct __operation_base {
-      STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
       stdexec::in_place_stop_source __stop_source_{};
       using __stop_callback = typename stdexec::stop_token_of_t<
         stdexec::env_of_t<_Receiver>>::template callback_type<__on_stop_t>;
@@ -873,7 +873,7 @@ namespace exec {
         }
 
        private:
-        STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rec_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rec_;
         __immovable_operation_storage __storage_{};
 
         friend void tag_invoke(start_t, __t& __self) noexcept {

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -55,7 +55,7 @@ namespace exec {
     template <class _ReceiverId>
     struct __when_empty_op_base : __task {
       using _Receiver = __t<_ReceiverId>;
-      STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
     };
 
     template <class _ConstrainedId, class _ReceiverId>
@@ -120,7 +120,7 @@ namespace exec {
       }
 
       const __impl* __scope_;
-      STDEXEC_NO_UNIQUE_ADDRESS _Constrained __c_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Constrained __c_;
     };
 
     template <class _Constrained>
@@ -132,7 +132,7 @@ namespace exec {
     struct __nest_op_base : __immovable {
       using _Receiver = __t<_ReceiverId>;
       const __impl* __scope_;
-      STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
     };
 
     template <class _ReceiverId>
@@ -208,7 +208,7 @@ namespace exec {
       using is_sender = void;
 
       const __impl* __scope_;
-      STDEXEC_NO_UNIQUE_ADDRESS _Constrained __c_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Constrained __c_;
 
       template <class _Receiver>
       using __nest_operation_t = __nest_op<_ConstrainedId, __x<_Receiver>>;
@@ -333,9 +333,9 @@ namespace exec {
         }
       }
 
-      STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
       std::unique_ptr<__future_state<_Sender, _Env>> __state_;
-      STDEXEC_NO_UNIQUE_ADDRESS __forward_consumer __forward_consumer_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) __forward_consumer __forward_consumer_;
 
      public:
       ~__future_op() noexcept {

--- a/include/exec/create.hpp
+++ b/include/exec/create.hpp
@@ -32,8 +32,8 @@ namespace exec {
 
     template <class _Receiver, class _Args>
     struct __context {
-      STDEXEC_NO_UNIQUE_ADDRESS _Receiver receiver;
-      STDEXEC_NO_UNIQUE_ADDRESS _Args args;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver receiver;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Args args;
     };
 
     template <class _ReceiverId, class _Fun, class _ArgsId>
@@ -42,9 +42,9 @@ namespace exec {
       using _Result = __call_result_t<_Fun, _Context&>;
       using _State = __if_c<same_as<_Result, void>, __void, std::optional<_Result>>;
 
-      STDEXEC_NO_UNIQUE_ADDRESS _Context __ctx_;
-      STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
-      STDEXEC_NO_UNIQUE_ADDRESS _State __state_{};
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Context __ctx_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _State __state_{};
 
       friend void tag_invoke(start_t, __operation& __self) noexcept {
         __self.__state_.emplace(__conv{[&]() noexcept {

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -57,7 +57,7 @@ namespace exec {
       using _Default = __t<_DefaultId>;
       using _Receiver = __t<_ReceiverId>;
 
-      STDEXEC_NO_UNIQUE_ADDRESS _Default __default_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Default __default_;
       _Receiver __rcvr_;
 
       friend void tag_invoke(start_t, __operation& __self) noexcept {
@@ -78,7 +78,7 @@ namespace exec {
     struct __sender {
       using _Default = __t<_DefaultId>;
       using is_sender = void;
-      STDEXEC_NO_UNIQUE_ADDRESS _Default __default_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Default __default_;
 
       template <class _Env>
       using __value_t =

--- a/include/exec/linux/io_uring_context.hpp
+++ b/include/exec/linux/io_uring_context.hpp
@@ -698,7 +698,7 @@ namespace exec {
 
       struct __impl {
         __context& __context_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Receiver __receiver_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __receiver_;
 
         __impl(__context& __context, _Receiver&& __receiver)
           : __context_{__context}

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -47,8 +47,8 @@ namespace exec {
           __call_result_t<stdexec::on_t, trampoline_scheduler, _Source &>;
         using __source_op_t = stdexec::connect_result_t<__source_on_scheduler_sender, __receiver_t>;
 
-        STDEXEC_NO_UNIQUE_ADDRESS _Source __source_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Source __source_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
         __manual_lifetime<__source_op_t> __source_op_;
         trampoline_scheduler __sched_;
 
@@ -150,7 +150,7 @@ namespace exec {
       struct __t {
         using is_sender = void;
         using __id = __sender;
-        STDEXEC_NO_UNIQUE_ADDRESS _Source __source_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Source __source_;
 
         template <class... Ts>
         using __value_t = stdexec::completion_signatures<>;

--- a/include/exec/sequence/empty_sequence.hpp
+++ b/include/exec/sequence/empty_sequence.hpp
@@ -29,7 +29,7 @@ namespace exec {
 
       struct __t {
         using __id = __operation;
-        STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
 
         friend void tag_invoke(start_t, __t& __self) noexcept {
           stdexec::set_value(static_cast<_Receiver&&>(__self.__rcvr_));

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -70,7 +70,7 @@ namespace exec {
 
     template <class _ItemReceiver, class _ResultVariant>
     struct __item_operation_base {
-      STDEXEC_NO_UNIQUE_ADDRESS _ItemReceiver __receiver_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _ItemReceiver __receiver_;
       __result_type<_ResultVariant>* __result_;
     };
 
@@ -123,10 +123,9 @@ namespace exec {
         __t(
           __result_type<_ResultVariant>* __parent,
           _Sender&& __sndr,
-          _ItemReceiver __rcvr) //
-          noexcept(
-            __nothrow_decay_copyable<_ItemReceiver> //
-            && __nothrow_connectable<_Sender, __item_receiver_t>)
+          _ItemReceiver __rcvr)                            //
+          noexcept(__nothrow_decay_copyable<_ItemReceiver> //
+                     && __nothrow_connectable<_Sender, __item_receiver_t>)
           : __base_type{static_cast<_ItemReceiver&&>(__rcvr), __parent}
           , __op_{stdexec::connect(static_cast<_Sender&&>(__sndr), __item_receiver_t{this})} {
         }
@@ -168,7 +167,7 @@ namespace exec {
 
     template <class _Receiver, class _ResultVariant>
     struct __operation_base : __result_type<_ResultVariant> {
-      STDEXEC_NO_UNIQUE_ADDRESS _Receiver __receiver_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __receiver_;
     };
 
     template <class _ReceiverId, class _ResultVariant>

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -34,8 +34,8 @@ namespace exec {
 
     template <class _Iterator, class _Sentinel>
     struct __operation_base {
-      STDEXEC_NO_UNIQUE_ADDRESS _Iterator __iterator_;
-      STDEXEC_NO_UNIQUE_ADDRESS _Sentinel __sentinel_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Iterator __iterator_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Sentinel __sentinel_;
     };
 
     template <class _Range>
@@ -46,7 +46,7 @@ namespace exec {
     struct __item_operation {
       struct __t {
         using __id = __item_operation;
-        STDEXEC_NO_UNIQUE_ADDRESS _ItemRcvr __rcvr_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _ItemRcvr __rcvr_;
         __operation_base<_Iterator, _Sentinel>* __parent_;
 
         friend void tag_invoke(start_t, __t& __self) noexcept {

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -44,7 +44,7 @@ namespace exec {
                 && __callable<exec::set_next_t, _Receiver&, __call_result_t<_Adaptor&, _Item>>
         friend auto tag_invoke(_SetNext, _Self& __self, _Item&& __item) noexcept(
           __nothrow_callable<_SetNext, _Receiver&, __call_result_t<_Adaptor&, _Item>> //
-          && __nothrow_callable<_Adaptor&, _Item>)
+            && __nothrow_callable<_Adaptor&, _Item>)
           -> next_sender_of_t<_Receiver, __call_result_t<_Adaptor&, _Item>> {
           return exec::set_next(
             __self.__op_->__receiver_, __self.__op_->__adaptor_(static_cast<_Item&&>(__item)));
@@ -104,8 +104,8 @@ namespace exec {
 
       template <class _Adaptor, class _Sequence>
       auto operator()(__ignore, _Adaptor __adaptor, _Sequence&& __sequence) noexcept(
-        __nothrow_decay_copyable<_Adaptor> && __nothrow_decay_copyable<_Sequence>
-        && __nothrow_decay_copyable<_Receiver>)
+        __nothrow_decay_copyable<_Adaptor>&& __nothrow_decay_copyable<_Sequence>&&
+          __nothrow_decay_copyable<_Receiver>)
         -> __t< __operation<_Sequence, __id<_Receiver>, _Adaptor>> {
         return {
           static_cast<_Sequence&&>(__sequence),
@@ -121,8 +121,9 @@ namespace exec {
     struct _WITH_ITEM_SENDER_ { };
 
     template <class _Adaptor, class _Item>
-    auto __try_call(_Item*)
-      -> stdexec::__mexception<_NOT_CALLABLE_ADAPTOR_<_Adaptor&>, _WITH_ITEM_SENDER_<stdexec::__name_of<_Item>>>;
+    auto __try_call(_Item*) -> stdexec::__mexception<
+      _NOT_CALLABLE_ADAPTOR_<_Adaptor&>,
+      _WITH_ITEM_SENDER_<stdexec::__name_of<_Item>>>;
 
     template <class _Adaptor, class _Item>
       requires stdexec::__callable<_Adaptor&, _Item>
@@ -139,9 +140,9 @@ namespace exec {
 
     struct transform_each_t {
       template <sender _Sequence, __sender_adaptor_closure _Adaptor>
-      auto operator()(_Sequence&& __sndr, _Adaptor&& __adaptor) const noexcept(
-        __nothrow_decay_copyable<_Sequence> //
-        && __nothrow_decay_copyable<_Adaptor>) {
+      auto operator()(_Sequence&& __sndr, _Adaptor&& __adaptor) const
+        noexcept(__nothrow_decay_copyable<_Sequence> //
+                   && __nothrow_decay_copyable<_Adaptor>) {
         return make_sequence_expr<transform_each_t>(
           static_cast<_Adaptor&&>(__adaptor), static_cast<_Sequence&&>(__sndr));
       }

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -81,7 +81,7 @@ namespace exec {
         using __id = __stopped_means_break;
         using _Receiver = stdexec::__t<_ReceiverId>;
         using _Token = stop_token_of_t<env_of_t<_Receiver>>;
-        STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
 
         template <same_as<get_env_t> _GetEnv, same_as<__t> _Self>
         friend env_of_t<_Receiver> tag_invoke(_GetEnv, const _Self& __self) noexcept {

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -96,7 +96,8 @@ namespace exec {
 
       static constexpr bool __with_scheduler = _SchedulerAffinity == __scheduler_affinity::__sticky;
 
-      STDEXEC_NO_UNIQUE_ADDRESS __if_c<__with_scheduler, __any_scheduler, __ignore> //
+      STDEXEC_ATTRIBUTE((no_unique_address))
+      __if_c<__with_scheduler, __any_scheduler, __ignore> //
         __scheduler_{exec::inline_scheduler{}};
       in_place_stop_token __stop_token_;
 

--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -96,7 +96,7 @@ namespace exec {
 
         struct __t : __operation_base {
           using __id = __operation;
-          STDEXEC_NO_UNIQUE_ADDRESS _Receiver __receiver_;
+          STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __receiver_;
 
           explicit __t(_Receiver __rcvr, std::size_t __max_depth) noexcept(
             __nothrow_decay_copyable<_Receiver>)

--- a/include/nvexec/detail/queue.cuh
+++ b/include/nvexec/detail/queue.cuh
@@ -41,9 +41,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace queue {
   struct producer_t {
     task_base_t** tail_;
 
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      void
-      operator()(task_base_t* task) {
+    STDEXEC_ATTRIBUTE((host, device)) void operator()(task_base_t* task) {
       atom_task_ref tail_ref(*tail_);
       task_base_t* old_tail = tail_ref.load(::cuda::memory_order_acquire);
 

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -106,7 +106,8 @@ namespace nvexec {
     };
 
     template <class VisitorT, class V>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE void visit_impl(
+    STDEXEC_ATTRIBUTE((host, device))
+    void visit_impl(
       std::integral_constant<std::size_t, 0>,
       VisitorT&& visitor,
       V&& v,
@@ -117,7 +118,8 @@ namespace nvexec {
     }
 
     template <std::size_t I, class VisitorT, class V>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE void visit_impl(
+    STDEXEC_ATTRIBUTE((host, device))
+    void visit_impl(
       std::integral_constant<std::size_t, I>,
       VisitorT&& visitor,
       V&& v,
@@ -133,7 +135,8 @@ namespace nvexec {
   }
 
   template <class VisitorT, class V>
-  STDEXEC_DETAIL_CUDACC_HOST_DEVICE void visit(VisitorT&& visitor, V&& v) {
+  STDEXEC_ATTRIBUTE((host, device))
+  void visit(VisitorT&& visitor, V&& v) {
     detail::visit_impl(
       std::integral_constant<std::size_t, stdexec::__decay_t<V>::size - 1>{},
       (VisitorT&&) visitor,
@@ -142,7 +145,8 @@ namespace nvexec {
   }
 
   template <class VisitorT, class V>
-  STDEXEC_DETAIL_CUDACC_HOST_DEVICE void visit(VisitorT&& visitor, V&& v, std::size_t index) {
+  STDEXEC_ATTRIBUTE((host, device))
+  void visit(VisitorT&& visitor, V&& v, std::size_t index) {
     detail::visit_impl(
       std::integral_constant<std::size_t, stdexec::__decay_t<V>::size - 1>{},
       (VisitorT&&) visitor,
@@ -165,43 +169,48 @@ namespace nvexec {
     using index_of = std::integral_constant< index_t, detail::find_index<index_t, T, Ts...>()>;
 
     template <detail::one_of<Ts...> T>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE T& get() noexcept {
+    STDEXEC_ATTRIBUTE((host, device))
+    T& get() noexcept {
       void* data = storage_.data_;
       return *static_cast<T*>(data);
     }
 
     template <std::size_t I>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE detail::nth_type<I, Ts...>& get() noexcept {
+    STDEXEC_ATTRIBUTE((host, device))
+    detail::nth_type<I, Ts...>& get() noexcept {
       return get<detail::nth_type<I, Ts...>>();
     }
 
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE variant_t()
+    STDEXEC_ATTRIBUTE((host, device))
+    variant_t()
       requires std::default_initializable<front_t>
     {
       emplace<front_t>();
     }
 
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE ~variant_t() {
+    STDEXEC_ATTRIBUTE((host, device)) ~variant_t() {
       destroy();
     }
 
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE bool holds_alternative() const {
+    STDEXEC_ATTRIBUTE((host, device)) bool holds_alternative() const {
       return index_ != detail::npos<index_t>();
     }
 
     template <detail::one_of<Ts...> T, class... As>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE void emplace(As&&... as) {
+    STDEXEC_ATTRIBUTE((host, device))
+    void emplace(As&&... as) {
       destroy();
       construct<T>((As&&) as...);
     }
 
     template <detail::one_of<Ts...> T, class... As>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE void construct(As&&... as) {
+    STDEXEC_ATTRIBUTE((host, device))
+    void construct(As&&... as) {
       ::new (storage_.data_) T((As&&) as...);
       index_ = index_of<T>();
     }
 
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE void destroy() {
+    STDEXEC_ATTRIBUTE((host, device)) void destroy() {
       if (holds_alternative()) {
         visit(
           [](auto& val) noexcept {

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -61,8 +61,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS::__algo_range_init_fun {
       };
 
       operation_state_base_t<ReceiverId>& op_state_;
-      STDEXEC_NO_UNIQUE_ADDRESS InitT init_;
-      STDEXEC_NO_UNIQUE_ADDRESS Fun fun_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) InitT init_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) Fun fun_;
 
      public:
       using __id = receiver_t;
@@ -104,8 +104,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS::__algo_range_init_fun {
       using _set_value_t = typename DerivedSender::template _set_value_t<Range>;
 
       Sender sndr_;
-      STDEXEC_NO_UNIQUE_ADDRESS InitT init_;
-      STDEXEC_NO_UNIQUE_ADDRESS Fun fun_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) InitT init_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) Fun fun_;
 
       template <class Self, class Env>
       using completion_signatures = //

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -59,7 +59,7 @@ namespace nvexec {
   }
 #endif
 
-  inline STDEXEC_DETAIL_CUDACC_HOST_DEVICE bool is_on_gpu() noexcept {
+  inline STDEXEC_ATTRIBUTE((host, device)) bool is_on_gpu() noexcept {
     return get_device_type() == device_type::device;
   }
 }
@@ -293,9 +293,8 @@ namespace nvexec {
 
     struct set_noop {
       template <class... Ts>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        void
-        operator()(Ts&&...) const noexcept {
+      STDEXEC_ATTRIBUTE((host, device))
+      void operator()(Ts&&...) const noexcept {
         // TODO TRAP
         std::printf("ERROR: use of empty variant.");
       }
@@ -320,7 +319,7 @@ namespace nvexec {
         return get_stream_provider(env)->own_stream_.value();
       }
 
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE auto operator()() const noexcept {
+      STDEXEC_ATTRIBUTE((host, device)) auto operator()() const noexcept {
         return stdexec::read(*this);
       }
     };
@@ -389,17 +388,15 @@ namespace nvexec {
         using __id = stream_enqueue_receiver;
 
         template <__one_of<set_value_t, set_stopped_t> Tag, class... As>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend void
-          tag_invoke(Tag, __t&& self, As&&... as) noexcept {
+        STDEXEC_ATTRIBUTE((host, device))
+        friend void tag_invoke(Tag, __t&& self, As&&... as) noexcept {
           self.variant_->template emplace<decayed_tuple<Tag, As...>>(Tag(), std::move(as)...);
           self.producer_(self.task_);
         }
 
         template <same_as<set_error_t> _Tag, class Error>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend void
-          tag_invoke(_Tag, __t&& self, Error&& e) noexcept {
+        STDEXEC_ATTRIBUTE((host, device))
+        friend void tag_invoke(_Tag, __t&& self, Error&& e) noexcept {
           if constexpr (__decays_to<Error, std::exception_ptr>) {
             // What is `exception_ptr` but death pending
             self.variant_->template emplace<decayed_tuple<set_error_t, cudaError_t>>(

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -345,7 +345,6 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
 namespace stdexec::__detail {
   template <class SenderId>
-  extern __mconst<
-    nvexec::STDEXEC_STREAM_DETAIL_NS::split_sender_t<__name_of<__t<SenderId>>>>
+  extern __mconst< nvexec::STDEXEC_STREAM_DETAIL_NS::split_sender_t<__name_of<__t<SenderId>>>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::split_sender_t<SenderId>>;
 }

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -419,6 +419,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 namespace stdexec::__detail {
   template <bool WithCompletionScheduler, class Scheduler, class... SenderIds>
   inline constexpr __mconst<
-    nvexec::STDEXEC_STREAM_DETAIL_NS::when_all_sender_t<WithCompletionScheduler, Scheduler, __name_of<__t<SenderIds>>...>>
-    __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::when_all_sender_t<WithCompletionScheduler, Scheduler, SenderIds...>>{};
+    nvexec::STDEXEC_STREAM_DETAIL_NS::
+      when_all_sender_t<WithCompletionScheduler, Scheduler, __name_of<__t<SenderIds>>...>>
+    __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::
+                  when_all_sender_t<WithCompletionScheduler, Scheduler, SenderIds...>>{};
 }

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -139,8 +139,8 @@ namespace nvexec {
             return self.env_;
           };
 
-          STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-            inline __t(context_state_t context_state) noexcept
+          STDEXEC_ATTRIBUTE((host, device))
+          inline __t(context_state_t context_state) noexcept
             : env_{context_state} {
           }
 
@@ -236,15 +236,13 @@ namespace nvexec {
         return split_sender_th<S>(sch.context_state_, (S&&) sndr);
       }
 
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        friend inline sender_t
-        tag_invoke(schedule_t, const stream_scheduler& self) noexcept {
+      STDEXEC_ATTRIBUTE((host, device))
+      friend inline sender_t tag_invoke(schedule_t, const stream_scheduler& self) noexcept {
         return {self.context_state_};
       }
 
-      friend std::true_type tag_invoke(   //
-        __has_algorithm_customizations_t, //
-        const stream_scheduler& self) noexcept {
+      friend std::true_type
+        tag_invoke(__has_algorithm_customizations_t, const stream_scheduler& self) noexcept {
         return {};
       }
 

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -74,8 +74,8 @@ namespace stdexec {
 
     mutable _ImplFn __impl_;
 
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      explicit __sexpr(_ImplFn __impl)
+    STDEXEC_ATTRIBUTE((host, device))
+    explicit __sexpr(_ImplFn __impl)
       : __impl_((_ImplFn&&) __impl) {
     }
 
@@ -119,8 +119,8 @@ namespace stdexec {
   };
 
   template <class _ImplFn>
-  STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-    __sexpr(_ImplFn) -> __sexpr<_ImplFn>;
+  STDEXEC_ATTRIBUTE((host, device))
+  __sexpr(_ImplFn) -> __sexpr<_ImplFn>;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // make_sender_expr

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -28,6 +28,8 @@
 #include <cassert>
 #include <version>
 
+#define STDEXEC_STRINGIZE(_ARG) #_ARG
+
 #define STDEXEC_CAT_(_XP, ...) _XP##__VA_ARGS__
 #define STDEXEC_CAT(_XP, ...) STDEXEC_CAT_(_XP, __VA_ARGS__)
 
@@ -47,15 +49,42 @@
   STDEXEC_EXPAND(STDEXEC_COUNT_(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
 #define STDEXEC_COUNT_(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _NP, ...) _NP
 
-#define STDEXEC_CHECK(...) STDEXEC_EXPAND(STDEXEC_CHECK_N(__VA_ARGS__, 0, ))
-#define STDEXEC_CHECK_N(_XP, _NP, ...) _NP
-#define STDEXEC_PROBE(_XP) _XP, 1,
+#define STDEXEC_CHECK(...) STDEXEC_EXPAND(STDEXEC_CHECK_(__VA_ARGS__, 0, ))
+#define STDEXEC_CHECK_(_XP, _NP, ...) _NP
+#define STDEXEC_PROBE(...) STDEXEC_PROBE_(__VA_ARGS__, 1)
+#define STDEXEC_PROBE_(_XP, _NP, ...) _XP, _NP,
+
+////////////////////////////////////////////////////////////////////////////////
+// STDEXEC_FOR_EACH
+//   Inspired by "Recursive macros with C++20 __VA_OPT__", by David Mazières
+//   https://www.scs.stanford.edu/~dm/blog/va-opt.html
+#define STDEXEC_EXPAND_R(...) \
+  STDEXEC_EXPAND_R1(STDEXEC_EXPAND_R1(STDEXEC_EXPAND_R1(STDEXEC_EXPAND_R1(__VA_ARGS__)))) \
+  /**/
+#define STDEXEC_EXPAND_R1(...) \
+  STDEXEC_EXPAND_R2(STDEXEC_EXPAND_R2(STDEXEC_EXPAND_R2(STDEXEC_EXPAND_R2(__VA_ARGS__)))) \
+  /**/
+#define STDEXEC_EXPAND_R2(...) \
+  STDEXEC_EXPAND_R3(STDEXEC_EXPAND_R3(STDEXEC_EXPAND_R3(STDEXEC_EXPAND_R3(__VA_ARGS__)))) \
+  /**/
+#define STDEXEC_EXPAND_R3(...) \
+  STDEXEC_EXPAND(STDEXEC_EXPAND(STDEXEC_EXPAND(STDEXEC_EXPAND(__VA_ARGS__)))) \
+  /**/
+
+#define STDEXEC_PARENS ()
+#define STDEXEC_FOR_EACH(_MACRO, ...) \
+  __VA_OPT__(STDEXEC_EXPAND_R(STDEXEC_FOR_EACH_HELPER(_MACRO, __VA_ARGS__))) \
+  /**/
+#define STDEXEC_FOR_EACH_HELPER(_MACRO, _A1, ...) \
+  _MACRO(_A1) __VA_OPT__(STDEXEC_FOR_EACH_AGAIN STDEXEC_PARENS(_MACRO, __VA_ARGS__)) /**/
+#define STDEXEC_FOR_EACH_AGAIN() STDEXEC_FOR_EACH_HELPER
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // If tail is non-empty, expand to the tail. Otherwise, expand to the head
-#define STDEXEC_HEAD_OR_TAIL(_XP, ...) STDEXEC_EXPAND __VA_OPT__((__VA_ARGS__)STDEXEC_EAT)(_XP)
+#define STDEXEC_HEAD_OR_TAIL(_XP, ...) STDEXEC_EXPAND __VA_OPT__((__VA_ARGS__) STDEXEC_EAT)(_XP)
 
 // If tail is non-empty, expand to nothing. Otherwise, expand to the head
-#define STDEXEC_HEAD_OR_NULL(_XP, ...) STDEXEC_EXPAND __VA_OPT__(()STDEXEC_EAT)(_XP)
+#define STDEXEC_HEAD_OR_NULL(_XP, ...) STDEXEC_EXPAND __VA_OPT__(() STDEXEC_EAT)(_XP)
 
 // When used with no arguments, these macros expand to 1 if the current
 // compiler corresponds to the macro name; 0, otherwise. When used with arguments,
@@ -100,7 +129,50 @@
 #define STDEXEC_MSVC(...) STDEXEC_HEAD_OR_NULL(0, __VA_ARGS__)
 #endif
 
-#define STDEXEC_STRINGIZE(_ARG) #_ARG
+////////////////////////////////////////////////////////////////////////////////////////////////////
+#ifdef __CUDACC__
+#define STDEXEC_CUDA(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
+#else
+#define STDEXEC_CUDA(...) STDEXEC_HEAD_OR_NULL(0, __VA_ARGS__)
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// For portably declaring attributes on functions and types
+//   Usage:
+//
+//   STDEXEC_ATTRIBUTE((attr1, attr2, ...))
+//   void foo() { ... }
+#define STDEXEC_ATTRIBUTE(_XP) STDEXEC_FOR_EACH(STDEXEC_ATTR, STDEXEC_EXPAND _XP)
+
+// unknown attributes are treated like C++-style attributes
+#define STDEXEC_ATTR_WHICH_0(_ATTR) [[_ATTR]]
+
+// custom handling for specific attribute types
+#define STDEXEC_ATTR_WHICH_1(_ATTR) STDEXEC_CUDA(__host__)
+#define STDEXEC_ATTR_host STDEXEC_PROBE(~, 1)
+#define STDEXEC_ATTR___host__ STDEXEC_PROBE(~, 1)
+
+#define STDEXEC_ATTR_WHICH_2(_ATTR) STDEXEC_CUDA(__device__)
+#define STDEXEC_ATTR_device STDEXEC_PROBE(~, 2)
+#define STDEXEC_ATTR___device__ STDEXEC_PROBE(~, 2)
+
+// NVBUG #4067067: NVHPC does not fully support [[no_unique_address]]
+#if STDEXEC_NVHPC()
+#define STDEXEC_ATTR_WHICH_3(_ATTR) /*nothing*/
+#define STDEXEC_ATTR_no_unique_address STDEXEC_PROBE(~, 3)
+#endif
+
+#if STDEXEC_MSVC()
+#define STDEXEC_ATTR_WHICH_4(_ATTR) __forceinline
+#elif defined(__GNUC__)
+#define STDEXEC_ATTR_WHICH_4(_ATTR) __attribute__((always_inline))
+#else
+#define STDEXEC_ATTR_WHICH_4(_ATTR) /*nothing*/
+#endif
+#define STDEXEC_ATTR_always_inline STDEXEC_PROBE(~, 4)
+
+#define STDEXEC_ATTR(_ATTR) \
+  STDEXEC_CAT(STDEXEC_ATTR_WHICH_, STDEXEC_CHECK(STDEXEC_CAT(STDEXEC_ATTR_, _ATTR)))(_ATTR)
 
 #if STDEXEC_NVCC()
 #define STDEXEC_PRAGMA_PUSH() _Pragma("nv_diagnostic push")
@@ -114,17 +186,18 @@
 #elif STDEXEC_CLANG() || STDEXEC_GCC()
 #define STDEXEC_PRAGMA_PUSH() _Pragma("GCC diagnostic push")
 #define STDEXEC_PRAGMA_POP() _Pragma("GCC diagnostic pop")
-#define STDEXEC_PRAGMA_IGNORE_GNU(_ARG) _Pragma(STDEXEC_STRINGIZE(GCC diagnostic ignored _ARG))
+#define STDEXEC_PRAGMA_IGNORE_GNU(...) \
+  _Pragma(STDEXEC_STRINGIZE(GCC diagnostic ignored __VA_ARGS__))
 #else
 #define STDEXEC_PRAGMA_PUSH()
 #define STDEXEC_PRAGMA_POP()
 #endif
 
 #ifndef STDEXEC_PRAGMA_IGNORE_GNU
-#define STDEXEC_PRAGMA_IGNORE_GNU(_ARG)
+#define STDEXEC_PRAGMA_IGNORE_GNU(...)
 #endif
 #ifndef STDEXEC_PRAGMA_IGNORE_EDG
-#define STDEXEC_PRAGMA_IGNORE_EDG(_ARG)
+#define STDEXEC_PRAGMA_IGNORE_EDG(...)
 #endif
 
 #if !STDEXEC_MSVC() && defined(__has_builtin)
@@ -170,32 +243,19 @@
 #define STDEXEC_IMMOVABLE(_XP) _XP(_XP&&) = delete
 #endif
 
-// NVBUG #4067067
-#if STDEXEC_NVHPC()
-#define STDEXEC_NO_UNIQUE_ADDRESS
-#else
-#define STDEXEC_NO_UNIQUE_ADDRESS [[no_unique_address]]
-#endif
-
 // BUG (gcc PR93711): copy elision fails when initializing a
 // [[no_unique_address]] field from a function returning an object
 // of class type by value
 #if STDEXEC_GCC()
 #define STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS
 #else
-#define STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS [[no_unique_address]]
-#endif
-
-#if STDEXEC_CLANG() && defined(__CUDACC__)
-#define STDEXEC_DETAIL_CUDACC_HOST_DEVICE __host__ __device__
-#else
-#define STDEXEC_DETAIL_CUDACC_HOST_DEVICE
+#define STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS STDEXEC_ATTRIBUTE((no_unique_address))
 #endif
 
 #if STDEXEC_NVHPC()
 #include <nv/target>
 #define STDEXEC_TERMINATE() NV_IF_TARGET(NV_IS_HOST, (std::terminate();), (__trap();)) void()
-#elif STDEXEC_CLANG() && defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#elif STDEXEC_CLANG() && STDEXEC_CUDA() && defined(__CUDA_ARCH__)
 #define STDEXEC_TERMINATE() \
   __trap(); \
   __builtin_unreachable()
@@ -239,12 +299,12 @@
 #endif
 
 #if defined(__cpp_explicit_this_parameter) && (__cpp_explicit_this_parameter >= 202110)
-#define STDEXEC_HAS_EXPLICIT_THIS() 1
+#define STDEXEC_EXPLICIT_THIS(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
 #else
-#define STDEXEC_HAS_EXPLICIT_THIS() 0
+#define STDEXEC_EXPLICIT_THIS(...) STDEXEC_HEAD_OR_NULL(0, __VA_ARGS__)
 #endif
 
-#if STDEXEC_HAS_EXPLICIT_THIS()
+#if STDEXEC_EXPLICIT_THIS()
 #define STDEXEC_DEFINE_EXPLICIT_THIS_MEMFN(...) __VA_ARGS__
 #define STDEXEC_CALL_EXPLICIT_THIS_MEMFN(_OBJ, _NAME) (_OBJ)._NAME( STDEXEC_CALL_EXPLICIT_THIS_MEMFN_DETAIL
 #define STDEXEC_CALL_EXPLICIT_THIS_MEMFN_DETAIL(...) __VA_ARGS__ )
@@ -266,7 +326,7 @@
 #define STDEXEC_PROBE_TYPE_CHECKING_1 STDEXEC_TYPE_CHECKING_ONE
 #define STDEXEC_PROBE_TYPE_CHECKING_STDEXEC_ENABLE_EXTRA_TYPE_CHECKING STDEXEC_TYPE_CHECKING_TWO
 
-#define STDEXEC_TYPE_CHECKING_WHICH3(...) STDEXEC_PROBE_TYPE_CHECKING_ ## __VA_ARGS__
+#define STDEXEC_TYPE_CHECKING_WHICH3(...) STDEXEC_PROBE_TYPE_CHECKING_##__VA_ARGS__
 #define STDEXEC_TYPE_CHECKING_WHICH2(...) STDEXEC_TYPE_CHECKING_WHICH3(__VA_ARGS__)
 #define STDEXEC_TYPE_CHECKING_WHICH STDEXEC_TYPE_CHECKING_WHICH2(STDEXEC_ENABLE_EXTRA_TYPE_CHECKING)
 

--- a/include/stdexec/__detail/__scope.hpp
+++ b/include/stdexec/__detail/__scope.hpp
@@ -24,8 +24,8 @@ namespace stdexec {
 
   template <class _Fn>
   struct __scope_guard<_Fn> {
-    STDEXEC_NO_UNIQUE_ADDRESS _Fn __fn_;
-    STDEXEC_NO_UNIQUE_ADDRESS __immovable __hidden_{};
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Fn __fn_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) __immovable __hidden_{};
     bool __dismissed_{false};
 
     ~__scope_guard() {
@@ -40,9 +40,9 @@ namespace stdexec {
 
   template <class _Fn, class _T0>
   struct __scope_guard<_Fn, _T0> {
-    STDEXEC_NO_UNIQUE_ADDRESS _Fn __fn_;
-    STDEXEC_NO_UNIQUE_ADDRESS _T0 __t0_;
-    STDEXEC_NO_UNIQUE_ADDRESS __immovable __hidden_{};
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Fn __fn_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _T0 __t0_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) __immovable __hidden_{};
 
     bool __dismissed_{false};
 
@@ -58,10 +58,10 @@ namespace stdexec {
 
   template <class _Fn, class _T0, class _T1>
   struct __scope_guard<_Fn, _T0, _T1> {
-    STDEXEC_NO_UNIQUE_ADDRESS _Fn __fn_;
-    STDEXEC_NO_UNIQUE_ADDRESS _T0 __t0_;
-    STDEXEC_NO_UNIQUE_ADDRESS _T1 __t1_;
-    STDEXEC_NO_UNIQUE_ADDRESS __immovable __hidden_{};
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Fn __fn_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _T0 __t0_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _T1 __t1_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) __immovable __hidden_{};
 
     bool __dismissed_{false};
 
@@ -77,11 +77,11 @@ namespace stdexec {
 
   template <class _Fn, class _T0, class _T1, class _T2>
   struct __scope_guard<_Fn, _T0, _T1, _T2> {
-    STDEXEC_NO_UNIQUE_ADDRESS _Fn __fn_;
-    STDEXEC_NO_UNIQUE_ADDRESS _T0 __t0_;
-    STDEXEC_NO_UNIQUE_ADDRESS _T1 __t1_;
-    STDEXEC_NO_UNIQUE_ADDRESS _T2 __t2_;
-    STDEXEC_NO_UNIQUE_ADDRESS __immovable __hidden_{};
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Fn __fn_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _T0 __t0_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _T1 __t1_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _T2 __t2_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) __immovable __hidden_{};
 
     bool __dismissed_{false};
 

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -185,7 +185,7 @@ namespace stdexec {
         return __base_;
       }
 
-      STDEXEC_NO_UNIQUE_ADDRESS _Base __base_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Base __base_;
     };
   }
 
@@ -472,7 +472,7 @@ namespace stdexec {
     struct __env_fn {
       using __t = __env_fn;
       using __id = __env_fn;
-      STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
 
       template <class _Tag>
         requires __callable<const _Fun&, _Tag>
@@ -490,7 +490,7 @@ namespace stdexec {
       static_assert(__nothrow_move_constructible<_Env>);
       using __t = __env_fwd;
       using __id = __env_fwd;
-      STDEXEC_NO_UNIQUE_ADDRESS _Env __env_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Env __env_;
 
       template <__forwarding_query _Tag>
         requires tag_invocable<_Tag, const _Env&>
@@ -509,7 +509,7 @@ namespace stdexec {
       static_assert(__nothrow_move_constructible<_Env>);
       using __t = __joined_env;
       using __id = __joined_env;
-      STDEXEC_NO_UNIQUE_ADDRESS _Env __env_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Env __env_;
 
       const _Base& base() const noexcept {
         return this->__env_fwd<_Base>::__env_;
@@ -528,7 +528,7 @@ namespace stdexec {
     struct __joined_env<__prop<_Tag>, _Base> : __env_fwd<_Base> {
       using __t = __joined_env;
       using __id = __joined_env;
-      STDEXEC_NO_UNIQUE_ADDRESS __prop<_Tag> __env_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) __prop<_Tag> __env_;
 
       friend void tag_invoke(_Tag, const __joined_env&) noexcept = delete;
     };
@@ -722,8 +722,7 @@ namespace stdexec {
 
       template <class _Receiver, class... _As>
         requires tag_invocable<set_value_t, _Receiver, _As...>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        void
+      STDEXEC_ATTRIBUTE((host, device)) void
         operator()(_Receiver&& __rcvr, _As&&... __as) const noexcept {
         static_assert(nothrow_tag_invocable<set_value_t, _Receiver, _As...>);
         (void) tag_invoke(set_value_t{}, (_Receiver&&) __rcvr, (_As&&) __as...);
@@ -737,8 +736,7 @@ namespace stdexec {
 
       template <class _Receiver, class _Error>
         requires tag_invocable<set_error_t, _Receiver, _Error>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        void
+      STDEXEC_ATTRIBUTE((host, device)) void
         operator()(_Receiver&& __rcvr, _Error&& __err) const noexcept {
         static_assert(nothrow_tag_invocable<set_error_t, _Receiver, _Error>);
         (void) tag_invoke(set_error_t{}, (_Receiver&&) __rcvr, (_Error&&) __err);
@@ -752,9 +750,7 @@ namespace stdexec {
 
       template <class _Receiver>
         requires tag_invocable<set_stopped_t, _Receiver>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        void
-        operator()(_Receiver&& __rcvr) const noexcept {
+      STDEXEC_ATTRIBUTE((host, device)) void operator()(_Receiver&& __rcvr) const noexcept {
         static_assert(nothrow_tag_invocable<set_stopped_t, _Receiver>);
         (void) tag_invoke(set_stopped_t{}, (_Receiver&&) __rcvr);
       }
@@ -1055,9 +1051,7 @@ namespace stdexec {
     struct __valid_completions {
       template <derived_from<__valid_completions> _Self, class _Tag, class... _Args>
         requires __one_of<_Tag (*)(_Args&&...), _Sigs...>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        friend void
-        tag_invoke(_Tag, _Self&&, _Args&&...) noexcept {
+      STDEXEC_ATTRIBUTE((host, device)) friend void tag_invoke(_Tag, _Self&&, _Args&&...) noexcept {
         STDEXEC_TERMINATE();
       }
     };
@@ -1077,9 +1071,8 @@ namespace stdexec {
       using is_receiver = void;
 
       template <same_as<get_env_t> _Tag>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        friend __debug_env_t<_Env>
-        tag_invoke(_Tag, __debug_receiver) noexcept {
+      STDEXEC_ATTRIBUTE((host, device))
+      friend __debug_env_t<_Env> tag_invoke(_Tag, __debug_receiver) noexcept {
         STDEXEC_TERMINATE();
       }
     };
@@ -1099,9 +1092,7 @@ namespace stdexec {
     [[deprecated(
       "The sender claims to send a particular set of completions,"
       " but in actual fact it completes with a result that is not"
-      " one of the declared completion signatures.")]] STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      void
-      _ATTENTION_() noexcept {
+      " one of the declared completion signatures.")]] STDEXEC_ATTRIBUTE((host, device)) void _ATTENTION_() noexcept {
     }
 
     template <class _Sig>
@@ -1125,9 +1116,8 @@ namespace stdexec {
     };
 
     template <__completion_tag _Tag, class... _Args>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      void
-      tag_invoke(_Tag, __t<__invalid_completion<_Tag(_Args...)>>, _Args&&...) noexcept {
+    STDEXEC_ATTRIBUTE((host, device))
+    void tag_invoke(_Tag, __t<__invalid_completion<_Tag(_Args...)>>, _Args&&...) noexcept {
     }
 
     struct __debug_operation {
@@ -1708,9 +1698,7 @@ namespace stdexec {
     struct schedule_t {
       template <class _Scheduler>
         requires tag_invocable<schedule_t, _Scheduler>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        auto
-        operator()(_Scheduler&& __sched) const
+      STDEXEC_ATTRIBUTE((host, device)) auto operator()(_Scheduler&& __sched) const
         noexcept(nothrow_tag_invocable<schedule_t, _Scheduler>) {
         static_assert(sender<tag_invoke_result_t<schedule_t, _Scheduler>>);
         return tag_invoke(schedule_t{}, (_Scheduler&&) __sched);
@@ -2532,9 +2520,7 @@ namespace stdexec {
       using __t = __scheduler;
       using __id = __scheduler;
 
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        friend auto
-        tag_invoke(schedule_t, __scheduler) {
+      STDEXEC_ATTRIBUTE((host, device)) friend auto tag_invoke(schedule_t, __scheduler) {
         return make_sender_expr<__schedule_t>();
       }
 
@@ -2562,7 +2548,7 @@ namespace stdexec {
       struct __t {
         using is_receiver = void;
         using __id = __detached_receiver;
-        STDEXEC_NO_UNIQUE_ADDRESS _Env __env_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Env __env_;
 
         template <same_as<set_value_t> _Tag, class... _As>
         friend void tag_invoke(_Tag, __t&&, _As&&...) noexcept {
@@ -2706,26 +2692,22 @@ namespace stdexec {
 
     struct just_t : __just_impl<just_t, set_value_t> {
       template <__movable_value... _Ts>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        auto
-        operator()(_Ts&&... __ts) const noexcept((__nothrow_decay_copyable<_Ts> && ...)) {
+      STDEXEC_ATTRIBUTE((host, device))
+      auto operator()(_Ts&&... __ts) const noexcept((__nothrow_decay_copyable<_Ts> && ...)) {
         return make_sender_expr<just_t>(__decayed_tuple<_Ts...>{(_Ts&&) __ts...});
       }
     };
 
     struct just_error_t : __just_impl<just_error_t, set_error_t> {
       template <__movable_value _Error>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        auto
-        operator()(_Error&& __err) const noexcept(__nothrow_decay_copyable<_Error>) {
+      STDEXEC_ATTRIBUTE((host, device))
+      auto operator()(_Error&& __err) const noexcept(__nothrow_decay_copyable<_Error>) {
         return make_sender_expr<just_error_t>(__decayed_tuple<_Error>{(_Error&&) __err});
       }
     };
 
     struct just_stopped_t : __just_impl<just_stopped_t, set_stopped_t> {
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        auto
-        operator()() const noexcept {
+      STDEXEC_ATTRIBUTE((host, device)) auto operator()() const noexcept {
         return make_sender_expr<just_stopped_t>(__decayed_tuple<>());
       }
     };
@@ -2735,9 +2717,9 @@ namespace stdexec {
   using __just::just_error_t;
   using __just::just_stopped_t;
 
-  inline constexpr just_t just {};
-  inline constexpr just_error_t just_error {};
-  inline constexpr just_stopped_t just_stopped {};
+  inline constexpr just_t just{};
+  inline constexpr just_error_t just_error{};
+  inline constexpr just_stopped_t just_stopped{};
 
   /////////////////////////////////////////////////////////////////////////////
   // [execution.execute]
@@ -2813,8 +2795,8 @@ namespace stdexec {
   namespace __closure {
     template <class _T0, class _T1>
     struct __compose : sender_adaptor_closure<__compose<_T0, _T1>> {
-      STDEXEC_NO_UNIQUE_ADDRESS _T0 __t0_;
-      STDEXEC_NO_UNIQUE_ADDRESS _T1 __t1_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _T0 __t0_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _T1 __t1_;
 
       template <sender _Sender>
         requires __callable<_T0, _Sender> && __callable<_T1, __call_result_t<_T0, _Sender>>
@@ -2845,13 +2827,12 @@ namespace stdexec {
 
     template <class _Fun, class... _As>
     struct __binder_back : sender_adaptor_closure<__binder_back<_Fun, _As...>> {
-      STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
       std::tuple<_As...> __as_;
 
       template <sender _Sender>
         requires __callable<_Fun, _Sender, _As...>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        __call_result_t<_Fun, _Sender, _As...>
+      STDEXEC_ATTRIBUTE((host, device)) __call_result_t<_Fun, _Sender, _As...>
         operator()(_Sender&& __sndr) && noexcept(__nothrow_callable<_Fun, _Sender, _As...>) {
         return std::apply(
           [&__sndr, this](_As&... __as) -> __call_result_t<_Fun, _Sender, _As...> {
@@ -2862,8 +2843,7 @@ namespace stdexec {
 
       template <sender _Sender>
         requires __callable<const _Fun&, _Sender, const _As&...>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        __call_result_t<const _Fun&, _Sender, const _As&...>
+      STDEXEC_ATTRIBUTE((host, device)) __call_result_t<const _Fun&, _Sender, const _As&...>
         operator()(_Sender&& __sndr) const & //
         noexcept(__nothrow_callable<const _Fun&, _Sender, const _As&...>) {
         return std::apply(
@@ -2882,9 +2862,8 @@ namespace stdexec {
     // A derived-to-base cast that works even when the base is not
     // accessible from derived.
     template <class _Tp, class _Up>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-      __copy_cvref_t<_Up&&, _Tp>
-      __c_cast(_Up&& u) noexcept
+    STDEXEC_ATTRIBUTE((host, device))
+    __copy_cvref_t<_Up&&, _Tp> __c_cast(_Up&& u) noexcept
       requires __decays_to<_Tp, _Tp>
     {
       static_assert(std::is_reference_v<__copy_cvref_t<_Up&&, _Tp>>);
@@ -2916,24 +2895,18 @@ namespace stdexec {
         }
 
        private:
-        STDEXEC_NO_UNIQUE_ADDRESS _Base __base_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Base __base_;
 
        protected:
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          _Base&
-          base() & noexcept {
+        STDEXEC_ATTRIBUTE((host, device)) _Base& base() & noexcept {
           return __base_;
         }
 
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          const _Base&
-          base() const & noexcept {
+        STDEXEC_ATTRIBUTE((host, device)) const _Base& base() const & noexcept {
           return __base_;
         }
 
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          _Base&&
-          base() && noexcept {
+        STDEXEC_ATTRIBUTE((host, device)) _Base&& base() && noexcept {
           return (_Base&&) __base_;
         }
       };
@@ -2952,8 +2925,8 @@ namespace stdexec {
 // but 'int(type::existing_member_function)' is an error (as desired).
 #define _DISPATCH_MEMBER(_TAG) \
   template <class _Self, class... _Ts> \
-  STDEXEC_DETAIL_CUDACC_HOST_DEVICE static auto __call_##_TAG( \
-    _Self&& __self, _Ts&&... __ts) noexcept \
+  STDEXEC_ATTRIBUTE((host, device)) \
+  static auto __call_##_TAG(_Self&& __self, _Ts&&... __ts) noexcept \
     -> decltype(((_Self&&) __self)._TAG((_Ts&&) __ts...)) { \
     static_assert(noexcept(((_Self&&) __self)._TAG((_Ts&&) __ts...))); \
     return ((_Self&&) __self)._TAG((_Ts&&) __ts...); \
@@ -2998,9 +2971,8 @@ namespace stdexec {
         using __base_t = __minvoke<__get_base_t, _Dp&&>;
 
         template <class _Dp>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          static __base_t<_Dp>
-          __get_base(_Dp&& __self) noexcept {
+        STDEXEC_ATTRIBUTE((host, device))
+        static __base_t<_Dp> __get_base(_Dp&& __self) noexcept {
           if constexpr (__has_base) {
             return __c_cast<__t>((_Dp&&) __self).base();
           } else {
@@ -3009,10 +2981,9 @@ namespace stdexec {
         }
 
         template <same_as<set_value_t> _SetValue, class... _As>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend auto
-          tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept //
-          -> __msecond<                                                    //
+        STDEXEC_ATTRIBUTE((host, device))
+        friend auto tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept //
+          -> __msecond<                                                              //
             __if_c<same_as<set_value_t, _SetValue>>,
             decltype(_CALL_MEMBER(set_value, (_Derived&&) __self, (_As&&) __as...))> {
           static_assert(noexcept(_CALL_MEMBER(set_value, (_Derived&&) __self, (_As&&) __as...)));
@@ -3022,16 +2993,16 @@ namespace stdexec {
         template <same_as<set_value_t> _SetValue, class _Dp = _Derived, class... _As>
           requires _MISSING_MEMBER(_Dp, set_value)
                 && tag_invocable<_SetValue, __base_t<_Dp>, _As...>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend void tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept {
+        STDEXEC_ATTRIBUTE(
+          (host,
+           device)) friend void tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept {
           stdexec::set_value(__get_base((_Dp&&) __self), (_As&&) __as...);
         }
 
         template <same_as<set_error_t> _SetError, class _Error>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend auto
-          tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept //
-          -> __msecond<                                                     //
+        STDEXEC_ATTRIBUTE((host, device))
+        friend auto tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept //
+          -> __msecond<                                                               //
             __if_c<same_as<set_error_t, _SetError>>,
             decltype(_CALL_MEMBER(set_error, (_Derived&&) __self, (_Error&&) __err))> {
           static_assert(noexcept(_CALL_MEMBER(set_error, (_Derived&&) __self, (_Error&&) __err)));
@@ -3041,16 +3012,16 @@ namespace stdexec {
         template <same_as<set_error_t> _SetError, class _Error, class _Dp = _Derived>
           requires _MISSING_MEMBER(_Dp, set_error)
                 && tag_invocable<_SetError, __base_t<_Dp>, _Error>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend void tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept {
+        STDEXEC_ATTRIBUTE(
+          (host,
+           device)) friend void tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept {
           stdexec::set_error(__get_base((_Derived&&) __self), (_Error&&) __err);
         }
 
         template <same_as<set_stopped_t> _SetStopped, class _Dp = _Derived>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend auto
-          tag_invoke(_SetStopped, _Derived&& __self) noexcept //
-          -> __msecond<                                       //
+        STDEXEC_ATTRIBUTE((host, device))
+        friend auto tag_invoke(_SetStopped, _Derived&& __self) noexcept //
+          -> __msecond<                                                 //
             __if_c<same_as<set_stopped_t, _SetStopped>>,
             decltype(_CALL_MEMBER(set_stopped, (_Dp&&) __self))> {
           static_assert(noexcept(_CALL_MEMBER(set_stopped, (_Derived&&) __self)));
@@ -3059,16 +3030,15 @@ namespace stdexec {
 
         template <same_as<set_stopped_t> _SetStopped, class _Dp = _Derived>
           requires _MISSING_MEMBER(_Dp, set_stopped) && tag_invocable<_SetStopped, __base_t<_Dp>>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend void tag_invoke(_SetStopped, _Derived&& __self) noexcept {
+        STDEXEC_ATTRIBUTE(
+          (host, device)) friend void tag_invoke(_SetStopped, _Derived&& __self) noexcept {
           stdexec::set_stopped(__get_base((_Derived&&) __self));
         }
 
         // Pass through the get_env receiver query
         template <same_as<get_env_t> _GetEnv, class _Dp = _Derived>
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend auto
-          tag_invoke(_GetEnv, const _Derived& __self) noexcept
+        STDEXEC_ATTRIBUTE((host, device))
+        friend auto tag_invoke(_GetEnv, const _Derived& __self) noexcept
           -> decltype(_CALL_MEMBER(get_env, (const _Dp&) __self)) {
           static_assert(noexcept(_CALL_MEMBER(get_env, __self)));
           return _CALL_MEMBER(get_env, __self);
@@ -3076,8 +3046,8 @@ namespace stdexec {
 
         template <same_as<get_env_t> _GetEnv, class _Dp = _Derived>
           requires _MISSING_MEMBER(_Dp, get_env)
-        STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-          friend auto tag_invoke(_GetEnv, const _Derived& __self) noexcept
+        STDEXEC_ATTRIBUTE(
+          (host, device)) friend auto tag_invoke(_GetEnv, const _Derived& __self) noexcept
           -> env_of_t<__base_t<const _Dp&>> {
           return stdexec::get_env(__get_base(__self));
         }
@@ -3194,7 +3164,7 @@ namespace stdexec {
 
       struct __data {
         _Receiver __rcvr_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
       };
 
       struct __t {
@@ -3333,7 +3303,7 @@ namespace stdexec {
 
       struct __data {
         _Receiver __rcvr_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
       };
 
       struct __t {
@@ -3474,7 +3444,7 @@ namespace stdexec {
 
       struct __data {
         _Receiver __rcvr_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
       };
 
       struct __t {
@@ -3618,7 +3588,7 @@ namespace stdexec {
     template <class _Shape, class _Fun>
     struct __data {
       _Shape __shape_;
-      STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
       static constexpr auto __mbrs_ = __mliterals<&__data::__shape_, &__data::__fun_>();
     };
     template <class _Shape, class _Fun>
@@ -3629,7 +3599,7 @@ namespace stdexec {
       using _Receiver = stdexec::__t<_ReceiverId>;
 
       struct __op_state : __data<_Shape, _Fun> {
-        STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
       };
 
       struct __t {
@@ -3755,9 +3725,8 @@ namespace stdexec {
 
     struct bulk_t : __default_get_env<bulk_t> {
       template <sender _Sender, integral _Shape, __movable_value _Fun>
-      STDEXEC_DETAIL_CUDACC_HOST_DEVICE //
-        auto
-        operator()(_Sender&& __sndr, _Shape __shape, _Fun __fun) const {
+      STDEXEC_ATTRIBUTE((host, device))
+      auto operator()(_Sender&& __sndr, _Shape __shape, _Fun __fun) const {
         auto __domain = __get_sender_domain((_Sender&&) __sndr);
         return transform_sender(
           __domain, make_sender_expr<bulk_t>(__data{__shape, (_Fun&&) __fun}, (_Sender&&) __sndr));
@@ -4538,8 +4507,9 @@ namespace stdexec {
       using _Receiver = stdexec::__t<_ReceiverId>;
       using _Scheduler = stdexec::__t<_SchedulerId>;
 
-      _Receiver __rcvr_;                             // the input (outer) receiver
-      STDEXEC_NO_UNIQUE_ADDRESS _Scheduler __sched_; // the input sender's completion scheduler
+      _Receiver __rcvr_; // the input (outer) receiver
+      STDEXEC_ATTRIBUTE((no_unique_address))
+      _Scheduler __sched_; // the input sender's completion scheduler
     };
 
     inline constexpr auto __get_scheduler_prop = [](auto* __op) noexcept {
@@ -5025,7 +4995,7 @@ namespace stdexec {
         using __id = __operation;
 
         run_loop* __loop_;
-        STDEXEC_NO_UNIQUE_ADDRESS _Receiver __rcvr_;
+        STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
 
         static void __execute_impl(__task* __p) noexcept {
           auto& __rcvr = ((__t*) __p)->__rcvr_;
@@ -6172,7 +6142,7 @@ namespace stdexec {
       // Could be non-atomic here and atomic_ref everywhere except __completion_fn
       std::atomic<__state_t> __state_{__started};
       _ErrorsVariant __errors_{};
-      STDEXEC_NO_UNIQUE_ADDRESS _ValuesTuple __values_{};
+      STDEXEC_ATTRIBUTE((no_unique_address)) _ValuesTuple __values_{};
       std::optional<
         typename stop_token_of_t<env_of_t<_Receiver>&>::template callback_type<__on_stop_requested>>
         __on_stop_{};

--- a/include/stdexec/functional.hpp
+++ b/include/stdexec/functional.hpp
@@ -79,8 +79,8 @@ namespace stdexec {
 
   template <class _Fun0, class _Fun1>
   struct __composed {
-    STDEXEC_NO_UNIQUE_ADDRESS _Fun0 __t0_;
-    STDEXEC_NO_UNIQUE_ADDRESS _Fun1 __t1_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Fun0 __t0_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Fun1 __t1_;
 
     template <class... _Ts>
       requires __callable<_Fun1, _Ts...> && __callable<_Fun0, __call_result_t<_Fun1, _Ts...>>

--- a/include/stdexec/stop_token.hpp
+++ b/include/stdexec/stop_token.hpp
@@ -234,7 +234,7 @@ namespace stdexec {
       std::move(static_cast<in_place_stop_callback*>(cb)->__fun_)();
     }
 
-    STDEXEC_NO_UNIQUE_ADDRESS _Fun __fun_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Fun __fun_;
   };
 
   namespace __stok {

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -128,7 +128,8 @@ namespace detail::a_sender {
     Fun f_;
 
     template <class... As>
-    STDEXEC_DETAIL_CUDACC_HOST_DEVICE void set_value(As&&... as) && noexcept
+    STDEXEC_ATTRIBUTE((host, device))
+    void set_value(As&&... as) && noexcept
       requires stdexec::__callable<Fun, As&&...>
     {
       using result_t = std::invoke_result_t<Fun, As&&...>;


### PR DESCRIPTION
One attribute macro to rule them all. This macro is also friendlier to clang-format, which treat it more sanely.