### PR TITLE
More MSVC cl and clang-cl fixes

### DIFF
--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -165,7 +165,8 @@
 // MSVCBUG https://developercommunity.visualstudio.com/t/Incorrect-codegen-when-using-msvc::no_/10452874
 #define STDEXEC_ATTR_WHICH_3(_ATTR) // [[msvc::no_unique_address]]
 #elif STDEXEC_CLANG_CL()
-#define STDEXEC_ATTR_WHICH_3(_ATTR) [[msvc::no_unique_address]]
+// clang-cl does not support: https://reviews.llvm.org/D110485
+#define STDEXEC_ATTR_WHICH_3(_ATTR) // [[msvc::no_unique_address]]
 #else
 #define STDEXEC_ATTR_WHICH_3(_ATTR) [[no_unique_address]]
 #endif

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -270,7 +270,7 @@ namespace stdexec {
 
     // TODO: implement allocator concept
     template <class _T0>
-    concept __allocator = true;
+    concept __allocator_c = true;
 
     struct get_scheduler_t : __query<get_scheduler_t> {
       friend constexpr bool tag_invoke(forwarding_query_t, const get_scheduler_t&) noexcept {
@@ -309,7 +309,7 @@ namespace stdexec {
       auto operator()(const _Env& __env) const noexcept
         -> tag_invoke_result_t<get_allocator_t, const _Env&> {
         static_assert(nothrow_tag_invocable<get_allocator_t, const _Env&>);
-        static_assert(__allocator<tag_invoke_result_t<get_allocator_t, const _Env&>>);
+        static_assert(__allocator_c<tag_invoke_result_t<get_allocator_t, const _Env&>>);
         return tag_invoke(get_allocator_t{}, __env);
       }
 

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <catch2/catch.hpp>
+#include <numeric>
 
 template <class Receiver>
 struct sum_item_rcvr {

--- a/test/stdexec/algos/other/test_execute.cpp
+++ b/test/stdexec/algos/other/test_execute.cpp
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+#ifdef _WIN32
+// __allocator is #defined in Windows SDK's shared/specstrings.h.
+#include <Windows.h>
+#endif
+
 #include <atomic>
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>


### PR DESCRIPTION
As requested from #1107.

Hi

There are few cl/clang-cl issues I've tripped over after #1061 (with VS17.8pre3):

* clang-cl doesn't yet implement `[[msvc::no_unique_address]]` (https://reviews.llvm.org/D110485), so things are currently very noisy (`warning : unknown attribute 'no_unique_address' ignored [-Wunknown-attributes]`) especially with the levels of expansion of `STDEXEC_ATTRIBUTE`...
* `test_iterate` doesn't build; missing a `<numeric>` include for `std::accumulate`
* `__allocator` is a #define in Windows SDK's shared/specstrings.h, so triggers `stdexec/execution.hpp(273,25): error : expected unqualified-id`. Maybe it's worth `#include <windows.h>` in a test(s) to highlight that? I've just hackily renamed the [concept](https://github.com/NVIDIA/stdexec/blob/a5c350f8e3751c4cc110494ee5ab3f555d991a04/include/stdexec/execution.hpp#L266-L268) to `__allocator_c`.
