### PR TITLE
add a scratch test target for easier debugging of failed tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,9 +90,17 @@ set(stdexec_test_sources
     )
 
 add_executable(test.stdexec ${stdexec_test_sources})
-
 target_include_directories(test.stdexec PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(test.stdexec
+    PUBLIC
+    STDEXEC::stdexec
+    $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
+    stdexec_executable_flags
+    Catch2::Catch2)
+
+add_executable(test.scratch test_main.cpp test_scratch.cpp)
+target_include_directories(test.scratch PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(test.scratch
     PUBLIC
     STDEXEC::stdexec
     $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
@@ -103,6 +111,7 @@ target_link_libraries(test.stdexec
 include(${Catch2_SOURCE_DIR}/contrib/Catch.cmake)
 
 catch_discover_tests(test.stdexec)
+catch_discover_tests(test.scratch)
 
 if(STDEXEC_ENABLE_CUDA)
     add_subdirectory(nvexec)

--- a/test/test_scratch.cpp
+++ b/test/test_scratch.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Lucian Radu Teodorescu
+ * Copyright (c) 2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <stdexec/execution.hpp>
+#include <test_common/schedulers.hpp>
+#include <test_common/receivers.hpp>
+
+namespace ex = stdexec;
+
+namespace {
+  TEST_CASE(
+    "a scratch test case for minimal repro of a bug",
+    "[scratch]") {
+    CHECK(true);
+  }
+}


### PR DESCRIPTION
copy a failing test into `test_scratch.cpp`, then compile the `test_scratch` target and debug only the failing test.