### PR TITLE
use `always_inline` attribute on one-liners; custom `apply` and `invoke` implementations

### DIFF
--- a/examples/io_uring.cpp
+++ b/examples/io_uring.cpp
@@ -56,14 +56,12 @@ int main() {
     exec::schedule_after(scheduler, 1s) | stdexec::then([] { std::cout << "Hello, 1!\n"; }),
     exec::schedule_after(scheduler2, 2s) | stdexec::then([] { std::cout << "Hello, 2!\n"; }),
     exec::schedule_after(scheduler, 3s) | stdexec::then([] { std::cout << "Stop it!\n"; }),
-    exec::finally(exec::schedule_after(scheduler2, 4s), 
-      stdexec::just() | stdexec::then([&] {
-      context.request_stop(); })),
+    exec::finally(
+      exec::schedule_after(scheduler2, 4s),
+      stdexec::just() | stdexec::then([&] { context.request_stop(); })),
     exec::finally(
       exec::schedule_after(scheduler, 4s),
-      stdexec::just() | stdexec::then([&] {
-        context2.request_stop();
-      })),
+      stdexec::just() | stdexec::then([&] { context2.request_stop(); })),
     exec::schedule_after(scheduler, 10s)    //
       | stdexec::then([] {                  //
           std::cout << "Hello, world!\n";   //

--- a/include/exec/linux/io_uring_context.hpp
+++ b/include/exec/linux/io_uring_context.hpp
@@ -264,7 +264,8 @@ namespace exec {
       // This function first completes all tasks that are ready in the completion queue of the io_uring.
       // Then it completes all tasks that are ready in the given queue of ready tasks.
       // The function returns the number of previously submitted completed tasks.
-      int complete(stdexec::__intrusive_queue<&__task::__next_> __ready = __task_queue{}) noexcept {
+      int
+        complete(stdexec::__intrusive_queue<& __task::__next_> __ready = __task_queue{}) noexcept {
         __u32 __head = __head_.load(std::memory_order_relaxed);
         __u32 __tail = __tail_.load(std::memory_order_acquire);
         int __count = 0;

--- a/include/exec/variant_sender.hpp
+++ b/include/exec/variant_sender.hpp
@@ -80,8 +80,9 @@ namespace exec {
 
         template <__decays_to<__t> _Self, receiver _Receiver>
           requires(sender_to<__copy_cvref_t<_Self, stdexec::__t<_SenderIds>>, _Receiver> && ...)
-        friend stdexec::__t<
-          __operation_state<stdexec::__id<_Receiver>, __cvref_id<_Self, stdexec::__t<_SenderIds>>...>>
+        friend stdexec::__t< __operation_state<
+          stdexec::__id<_Receiver>,
+          __cvref_id<_Self, stdexec::__t<_SenderIds>>...>>
           tag_invoke(connect_t, _Self&& __self, _Receiver __r) noexcept(
             (__nothrow_connectable<__copy_cvref_t<_Self, stdexec::__t<_SenderIds>>, _Receiver>
              && ...)) {

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -68,18 +68,20 @@ namespace stdexec {
     using __id = __sexpr;
     using __tag_t = __call_result_t<_ImplFn, __cp, __detail::__get_tag>;
 
+    STDEXEC_ATTRIBUTE((always_inline)) //
     static __tag_t __tag() noexcept {
       return {};
     }
 
     mutable _ImplFn __impl_;
 
-    STDEXEC_ATTRIBUTE((host, device))
+    STDEXEC_ATTRIBUTE((host, device, always_inline))
     explicit __sexpr(_ImplFn __impl)
       : __impl_((_ImplFn&&) __impl) {
     }
 
     template <same_as<get_env_t> _Tag, same_as<__sexpr> _Self>
+    STDEXEC_ATTRIBUTE((always_inline))                         //
     friend auto tag_invoke(_Tag, const _Self& __self) noexcept //
       -> __msecond<
         __if_c<same_as<_Tag, get_env_t>>, //
@@ -89,6 +91,7 @@ namespace stdexec {
     }
 
     template < same_as<get_completion_signatures_t> _Tag, __decays_to<__sexpr> _Self, class _Env>
+    STDEXEC_ATTRIBUTE((always_inline))                         //
     friend auto tag_invoke(_Tag, _Self&& __self, _Env&& __env) //
       -> __msecond<
         __if_c<same_as<_Tag, get_completion_signatures_t>>,
@@ -101,6 +104,7 @@ namespace stdexec {
       same_as<connect_t> _Tag,
       __decays_to<__sexpr> _Self,
       /*receiver*/ class _Receiver>
+    STDEXEC_ATTRIBUTE((always_inline))                                                   //
     friend auto tag_invoke(_Tag, _Self&& __self, _Receiver&& __rcvr)                     //
       noexcept(noexcept(__self.__tag().connect((_Self&&) __self, (_Receiver&&) __rcvr))) //
       -> __msecond<
@@ -110,6 +114,7 @@ namespace stdexec {
     }
 
     template <class _Sender, class _ApplyFn>
+    STDEXEC_ATTRIBUTE((always_inline))                                                      //
     STDEXEC_DEFINE_EXPLICIT_THIS_MEMFN(auto apply)(this _Sender&& __sndr, _ApplyFn&& __fun) //
       noexcept(
         __nothrow_callable<__detail::__impl_of<_Sender>, __copy_cvref_fn<_Sender>, _ApplyFn>) //
@@ -146,12 +151,14 @@ namespace stdexec {
 
       _Ty __value;
 
+      STDEXEC_ATTRIBUTE((always_inline))
       explicit __mbc(_Ty& __v) noexcept(std::is_nothrow_move_constructible_v<_Ty>)
         : __value((_Ty&&) __v) {
       }
 
       // This is a template so as to not be considered a copy/move constructor. Therefore,
       // it doesn't suppress the generation of the default copy/move constructors.
+      STDEXEC_ATTRIBUTE((always_inline))
       __mbc(same_as<__mbc> auto& __that) noexcept(std::is_nothrow_move_constructible_v<_Ty>)
         : __value(static_cast<_Ty&&>(__that.__value)) {
       }
@@ -223,6 +230,7 @@ namespace stdexec {
   namespace __detail {
     struct apply_sender_t {
       template <class _Sender, class _ApplyFn>
+      STDEXEC_ATTRIBUTE((always_inline))                        //
       auto operator()(_Sender&& __sndr, _ApplyFn&& __fun) const //
         noexcept(noexcept(
           STDEXEC_CALL_EXPLICIT_THIS_MEMFN(((_Sender&&) __sndr), apply)((_ApplyFn&&) __fun))) //

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -174,8 +174,11 @@
 
 #if STDEXEC_MSVC()
 #define STDEXEC_ATTR_WHICH_4(_ATTR) __forceinline
+#elif STDEXEC_CLANG()
+#define STDEXEC_ATTR_WHICH_4(_ATTR) \
+  __attribute__((__always_inline__, __artificial__, __nodebug__)) inline
 #elif defined(__GNUC__)
-#define STDEXEC_ATTR_WHICH_4(_ATTR) __attribute__((always_inline))
+#define STDEXEC_ATTR_WHICH_4(_ATTR) __attribute__((__always_inline__, __artificial__)) inline
 #else
 #define STDEXEC_ATTR_WHICH_4(_ATTR) /*nothing*/
 #endif
@@ -233,6 +236,12 @@
 #define STDEXEC_IS_CONVERTIBLE_TO(...) __is_convertible(__VA_ARGS__)
 #else
 #define STDEXEC_IS_CONVERTIBLE_TO(...) std::is_convertible_v<__VA_ARGS__>
+#endif
+
+#if STDEXEC_HAS_BUILTIN(__is_const)
+#define STDEXEC_IS_CONST(...) __is_const(__VA_ARGS__)
+#else
+#define STDEXEC_IS_CONST(...) stdexec::__is_const<__VA_ARGS__>
 #endif
 
 #if defined(__cpp_lib_unreachable) && __cpp_lib_unreachable >= 202202L

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -33,6 +33,7 @@ namespace stdexec {
   struct __ignore {
     __ignore() = default;
 
+    STDEXEC_ATTRIBUTE((always_inline)) //
     constexpr __ignore(auto&&...) noexcept {
     }
   };

--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -167,4 +167,11 @@ namespace stdexec {
   template <class _From, class _To>
   using __copy_cvref_t = typename __copy_cvref_fn<_From>::template __f<_To>;
 
+#if !STDEXEC_HAS_BUILTIN(__is_const)
+  template <class>
+  inline constexpr bool __is_const = false;
+  template <class _Up>
+  inline constexpr bool __is_const<_Up const> = true;
+#endif
+
 } // namespace stdexec

--- a/include/stdexec/functional.hpp
+++ b/include/stdexec/functional.hpp
@@ -37,28 +37,16 @@ namespace std {
 }
 
 namespace stdexec {
-  template <class _Fun, class... _As>
-  concept __nothrow_invocable = //
-    invocable<_Fun, _As...> &&  //
-    requires(_Fun&& __f, _As&&... __as) {
-      { std::invoke((_Fun&&) __f, (_As&&) __as...) } noexcept;
-    };
-
-  struct __first {
-    template <class _First, class _Second>
-    constexpr _First&& operator()(_First&& __first, _Second&&) const noexcept {
-      return (_First&&) __first;
-    }
-  };
-
   template <auto _Fun>
   struct __function_constant {
     using _FunT = decltype(_Fun);
 
     template <class... _Args>
       requires __callable<_FunT, _Args...>
-    auto operator()(_Args&&... __args) const noexcept(noexcept(_Fun((_Args&&) __args...)))
-      -> decltype(_Fun((_Args&&) __args...)) {
+    STDEXEC_ATTRIBUTE((always_inline)) //
+      auto
+      operator()(_Args&&... __args) const
+      noexcept(noexcept(_Fun((_Args&&) __args...))) -> decltype(_Fun((_Args&&) __args...)) {
       return _Fun((_Args&&) __args...);
     }
   };
@@ -69,8 +57,9 @@ namespace stdexec {
 
     template <class _Arg>
       requires requires(_Arg&& __arg) { ((_Arg&&) __arg).*_MemPtr; }
-    constexpr auto operator()(_Arg&& __arg) const noexcept
-      -> decltype((((_Arg&&) __arg).*_MemPtr)) {
+    STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto
+      operator()(_Arg&& __arg) const noexcept -> decltype((((_Arg&&) __arg).*_MemPtr)) {
       return ((_Arg&&) __arg).*_MemPtr;
     }
   };
@@ -85,56 +74,205 @@ namespace stdexec {
 
     template <class... _Ts>
       requires __callable<_Fun1, _Ts...> && __callable<_Fun0, __call_result_t<_Fun1, _Ts...>>
-    __call_result_t<_Fun0, __call_result_t<_Fun1, _Ts...>> operator()(_Ts&&... __ts) && {
+    STDEXEC_ATTRIBUTE((always_inline)) //
+      __call_result_t<_Fun0, __call_result_t<_Fun1, _Ts...>>
+      operator()(_Ts&&... __ts) && {
       return ((_Fun0&&) __t0_)(((_Fun1&&) __t1_)((_Ts&&) __ts...));
     }
 
     template <class... _Ts>
       requires __callable<const _Fun1&, _Ts...>
             && __callable<const _Fun0&, __call_result_t<const _Fun1&, _Ts...>>
-    __call_result_t<_Fun0, __call_result_t<_Fun1, _Ts...>> operator()(_Ts&&... __ts) const & {
+    STDEXEC_ATTRIBUTE((always_inline)) //
+      __call_result_t<_Fun0, __call_result_t<_Fun1, _Ts...>>
+      operator()(_Ts&&... __ts) const & {
       return __t0_(__t1_((_Ts&&) __ts...));
     }
   };
 
   inline constexpr struct __compose_t {
     template <class _Fun0, class _Fun1>
+    STDEXEC_ATTRIBUTE((always_inline)) //
     __composed<_Fun0, _Fun1> operator()(_Fun0 __fun0, _Fun1 __fun1) const {
       return {(_Fun0&&) __fun0, (_Fun1&&) __fun1};
     }
   } __compose{};
 
-  namespace __detail {
-    template <class _Fn, class _Tup>
-    using __apply_result_t = decltype(std::apply(__declval<_Fn>(), __declval<_Tup>()));
+  namespace __invoke_ {
+    template <class>
+    inline constexpr bool __is_refwrap = false;
+    template <class _Up>
+    inline constexpr bool __is_refwrap<std::reference_wrapper<_Up>> = true;
 
-    template <class _Fn>
-    struct __applicable_helper {
-      template <class... Ts>
-      auto operator()(Ts&&...) const noexcept {
-        return std::is_invocable<_Fn, Ts...>();
+    struct __funobj {
+      template <class _Fun, class... _Args>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Fun&& __fun, _Args&&... __args) const
+        noexcept(noexcept(((_Fun&&) __fun)((_Args&&) __args...)))
+          -> decltype(((_Fun&&) __fun)((_Args&&) __args...)) {
+        return ((_Fun&&) __fun)((_Args&&) __args...);
       }
     };
-  } // namespace __detail
+
+    struct __memfn {
+      template <class _Memptr, class _Ty, class... _Args>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Memptr __mem_ptr, _Ty&& __ty, _Args&&... __args) const
+        noexcept(noexcept((((_Ty&&) __ty).*__mem_ptr)((_Args&&) __args...)))
+          -> decltype((((_Ty&&) __ty).*__mem_ptr)((_Args&&) __args...)) {
+        return (((_Ty&&) __ty).*__mem_ptr)((_Args&&) __args...);
+      }
+    };
+
+    struct __memfn_refwrap {
+      template <class _Memptr, class _Ty, class... _Args>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Memptr __mem_ptr, _Ty __ty, _Args&&... __args) const
+        noexcept(noexcept((__ty.get().*__mem_ptr)((_Args&&) __args...)))
+          -> decltype((__ty.get().*__mem_ptr)((_Args&&) __args...)) {
+        return (__ty.get().*__mem_ptr)((_Args&&) __args...);
+      }
+    };
+
+    struct __memfn_smartptr {
+      template <class _Memptr, class _Ty, class... _Args>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Memptr __mem_ptr, _Ty&& __ty, _Args&&... __args) const
+        noexcept(noexcept(((*(_Ty&&) __ty).*__mem_ptr)((_Args&&) __args...)))
+          -> decltype(((*(_Ty&&) __ty).*__mem_ptr)((_Args&&) __args...)) {
+        return ((*(_Ty&&) __ty).*__mem_ptr)((_Args&&) __args...);
+      }
+    };
+
+    struct __memobj {
+      template <class _Mbr, class _Class, class _Ty>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Mbr _Class::*__mem_ptr, _Ty&& __ty) const noexcept
+        -> decltype((((_Ty&&) __ty).*__mem_ptr)) {
+        return (((_Ty&&) __ty).*__mem_ptr);
+      }
+    };
+
+    struct __memobj_refwrap {
+      template <class _Mbr, class _Class, class _Ty>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Mbr _Class::*__mem_ptr, _Ty __ty) const noexcept
+        -> decltype((__ty.get().*__mem_ptr)) {
+        return (__ty.get().*__mem_ptr);
+      }
+    };
+
+    struct __memobj_smartptr {
+      template <class _Mbr, class _Class, class _Ty>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Mbr _Class::*__mem_ptr, _Ty&& __ty) const noexcept
+        -> decltype(((*(_Ty&&) __ty).*__mem_ptr)) {
+        return ((*(_Ty&&) __ty).*__mem_ptr);
+      }
+    };
+
+    __funobj __invoke_selector(__ignore, __ignore) noexcept;
+
+    template <class _Mbr, class _Class, class _Ty>
+    auto __invoke_selector(_Mbr _Class::*, const _Ty&) noexcept {
+      if constexpr (STDEXEC_IS_CONST(_Mbr) || STDEXEC_IS_CONST(_Mbr const)) {
+        // member function ptr case
+        if constexpr (STDEXEC_IS_BASE_OF(_Class, _Ty)) {
+          return __memobj{};
+        } else if constexpr (__is_refwrap<_Ty>) {
+          return __memobj_refwrap{};
+        } else {
+          return __memobj_smartptr{};
+        }
+      } else {
+        // member object ptr case
+        if constexpr (STDEXEC_IS_BASE_OF(_Class, _Ty)) {
+          return __memfn{};
+        } else if constexpr (__is_refwrap<_Ty>) {
+          return __memfn_refwrap{};
+        } else {
+          return __memfn_smartptr{};
+        }
+      }
+    }
+
+    struct __invoke_t {
+      template <class _Fun>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Fun&& __fun) const noexcept(noexcept(((_Fun&&) __fun)()))
+        -> decltype(((_Fun&&) __fun)()) {
+        return ((_Fun&&) __fun)();
+      }
+
+      template <class _Fun, class _Ty, class... _Args>
+      STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto operator()(_Fun&& __fun, _Ty&& __ty, _Args&&... __args) const noexcept(
+        noexcept(__invoke_selector(__fun, __ty)((_Fun&&) __fun, (_Ty&&) __ty, (_Args&&) __args...)))
+        -> decltype(__invoke_selector(
+          __fun,
+          __ty)((_Fun&&) __fun, (_Ty&&) __ty, (_Args&&) __args...)) {
+        return decltype(__invoke_selector(__fun, __ty))()(
+          (_Fun&&) __fun, (_Ty&&) __ty, (_Args&&) __args...);
+      }
+    };
+  }
+
+  inline constexpr __invoke_::__invoke_t __invoke{};
+
+  template <class _Fun, class... _As>
+  concept __invocable = //
+    requires(_Fun&& __f, _As&&... __as) { __invoke((_Fun&&) __f, (_As&&) __as...); };
+
+  template <class _Fun, class... _As>
+  concept __nothrow_invocable =  //
+    __invocable<_Fun, _As...> && //
+    requires(_Fun&& __f, _As&&... __as) {
+      { __invoke((_Fun&&) __f, (_As&&) __as...) } noexcept;
+    };
+
+  template <class _Fun, class... _As>
+  using __invoke_result_t = //
+    decltype(__invoke(__declval<_Fun>(), __declval<_As>()...));
+
+  namespace __apply_ {
+    using std::get;
+
+    template <std::size_t... _Is, class _Fn, class _Tup>
+    STDEXEC_ATTRIBUTE((always_inline)) //
+    constexpr auto __impl(__indices<_Is...>, _Fn&& __fn, _Tup&& __tup) noexcept(
+      noexcept(__invoke((_Fn&&) __fn, get<_Is>((_Tup&&) __tup)...)))
+      -> decltype(__invoke((_Fn&&) __fn, get<_Is>((_Tup&&) __tup)...)) {
+      return __invoke((_Fn&&) __fn, get<_Is>((_Tup&&) __tup)...);
+    }
+
+    template <class _Tup>
+    using __tuple_indices = __make_indices<std::tuple_size<std::remove_cvref_t<_Tup>>::value>;
+
+    template <class _Fn, class _Tup>
+    using __result_t =
+      decltype(__apply_::__impl(__tuple_indices<_Tup>(), __declval<_Fn>(), __declval<_Tup>()));
+  } // namespace __apply_
 
   template <class _Fn, class _Tup>
-  concept __applicable =
-    __detail::__apply_result_t<__detail::__applicable_helper<_Fn>, _Tup>::value;
+  concept __applicable = __mvalid<__apply_::__result_t, _Fn, _Tup>;
 
   template <class _Fn, class _Tup>
-  concept __nothrow_applicable =
-    __applicable<_Fn, _Tup>&& noexcept(std::apply(__declval<_Fn>(), __declval<_Tup>()));
+  concept __nothrow_applicable = __applicable<_Fn, _Tup> //
+    && noexcept(
+      __apply_::__impl(__apply_::__tuple_indices<_Tup>(), __declval<_Fn>(), __declval<_Tup>()));
 
   template <class _Fn, class _Tup>
     requires __applicable<_Fn, _Tup>
-  using __apply_result_t = __detail::__apply_result_t<_Fn, _Tup>;
+  using __apply_result_t = __apply_::__result_t<_Fn, _Tup>;
 
   struct __apply_t {
     template <class _Fn, class _Tup>
       requires __applicable<_Fn, _Tup>
-    constexpr auto operator()(_Fn&& __fn, _Tup&& __tup) const
+    STDEXEC_ATTRIBUTE((always_inline)) //
+      constexpr auto
+      operator()(_Fn&& __fn, _Tup&& __tup) const
       noexcept(__nothrow_applicable<_Fn, _Tup>) -> __apply_result_t<_Fn, _Tup> {
-      return std::apply((_Fn&&) __fn, (_Tup&&) __tup);
+      return __apply_::__impl(__apply_::__tuple_indices<_Tup>(), (_Fn&&) __fn, (_Tup&&) __tup);
     }
   };
 
@@ -142,6 +280,7 @@ namespace stdexec {
 
   template <class _Tag, class _Ty>
   struct __field {
+    STDEXEC_ATTRIBUTE((always_inline)) //
     _Ty operator()(_Tag) const noexcept(__nothrow_decay_copyable<const _Ty&>) {
       return __t_;
     }
@@ -152,6 +291,7 @@ namespace stdexec {
   template <class _Tag>
   struct __mkfield_ {
     template <class _Ty>
+    STDEXEC_ATTRIBUTE((always_inline)) //
     __field<_Tag, __decay_t<_Ty>> operator()(_Ty&& __ty) const
       noexcept(__nothrow_decay_copyable<_Ty>) {
       return {(_Ty&&) __ty};
@@ -201,7 +341,8 @@ namespace stdexec {
     struct tag_invoke_t {
       template <class _Tag, class... _Args>
         requires tag_invocable<_Tag, _Args...>
-      constexpr auto operator()(_Tag __tag, _Args&&... __args) const
+      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto
+        operator()(_Tag __tag, _Args&&... __args) const
         noexcept(nothrow_tag_invocable<_Tag, _Args...>) -> tag_invoke_result_t<_Tag, _Args...> {
         return tag_invoke((_Tag&&) __tag, (_Args&&) __args...);
       }


### PR DESCRIPTION
This makes debugging clang builds much nicer by avoiding the need to step into `tag_invoke` boilerplate or `std::apply`/`std::invoke` machinery.