### PR TITLE
Disable io_uring tests on Linux kernel < 5.4

### DIFF
--- a/test/exec/test_io_uring_context.cpp
+++ b/test/exec/test_io_uring_context.cpp
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-#if __has_include(<linux/io_uring.h>)
+#include <linux/version.h>
+
+// Some kernel versions have <linux/io_uring.h> but don't support or don't
+// allow user access to some of the necessary system calls.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0) && __has_include(<linux/io_uring.h>)
+
 #include "exec/linux/io_uring_context.hpp"
 #include "exec/scope.hpp"
 #include "exec/single_thread_context.hpp"


### PR DESCRIPTION
Some Linux distributions have `<linux/io_uring.h>`, but fail with "Operation not permitted" on `syscall(__NR_io_uring_setup, __entries, &__params)`

To work around this, skip the entire test when running on a system with a Linux kernel older than 5.4.  (I am not certain that this is the correct check.  But it is the best I could come up with in testing on our systems.)