### PR TITLE
add stdexec qualifier to avoid ambiguity error

### DIFF
--- a/include/nvexec/stream/transfer.cuh
+++ b/include/nvexec/stream/transfer.cuh
@@ -120,10 +120,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       Sender sndr_;
 
       template <class... Ts>
-      using _set_value_t = completion_signatures<set_value_t(__decay_t<Ts>&&...)>;
+      using _set_value_t = completion_signatures<set_value_t(stdexec::__decay_t<Ts>&&...)>;
 
       template <class Ty>
-      using _set_error_t = completion_signatures<set_error_t(__decay_t<Ty>&&)>;
+      using _set_error_t = completion_signatures<set_error_t(stdexec::__decay_t<Ty>&&)>;
 
       template <class Self, class Env>
       using _completion_signatures_t = //


### PR DESCRIPTION
Hi `stdexec` developers,

I was trying to use the `repeat_n` algorithm from the Maxwell eqs example and running into `line 126: error: "__decay_t" is ambiguous` compiler error. I looked into it a bit and found that adding the `stdexec` qualifier before `decay_t` resolves the error. I also verified my (repeat_n-code) to be functional with `static_thread_pool`, `stream_context` and multi_stream_context` schedulers. Please feel free to merge or delete the PR if this is not the correct solution and if I am doing something wrong. Here are some more details to help you reproduce/debug the issue. Thank you for your support!

## Setup
Here is the app that I am `repeat_n` in: `https://github.com/mhaseeb123/nvstdpar/blob/main/apps/heat-equation/heat-equation-stdexec.cpp`

Here is the local copy of the `repeat_n` algorithm that I made from `snr.cuh`: `https://github.com/mhaseeb123/nvstdpar/blob/main/include/repeat_n/repeat_n.cuh`

## Build Instructions (Perlmutter)
1. `ml cmake/3.24 ; ml unload cudatoolkit; ml use /global/cfs/cdirs/m1759/wwei/nvhpc_23_7/modulefiles ; ml nvhpc/23.7`
2. `git clone --recursive https://github.com/mhaseeb123/nvstdpar ; cd nvstdpar ; mkdir build ; cd build ; cmake .. -DCMAKE_CXX_COMPILER=$(which nvc++) ; make -j`

## Error log
```bash
mhaseeb@login14:~/repos/nvstdpar/build/apps/heat-equation$ make heat-equation-stdexec
Consolidate compiler generated dependencies of target heat-equation-stdexec
[ 70%] Building CXX object apps/heat-equation/CMakeFiles/heat-equation-stdexec.dir/heat-equation-stdexec.cpp.o
"/global/homes/m/mhaseeb/repos/nvstdpar/externals/mdspan/include/experimental/../mdspan/../experimental/__p0009_bits/dynamic_extent.hpp", line 29: warning: using-declaration ignored -- it refers to the current namespace [useless_using_declaration]
  using std::dynamic_extent;
        ^

Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"

"/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp", line 7161: warning: statement is unreachable [code_is_unreachable]
        STDEXEC_UNREACHABLE();
        ^
          detected during instantiation of "void heat_equation(stdexec::scheduler auto, Real_t *, Real_t *, Real_t *, Real_t, Real_t, int, int, bool) [with <auto-1>=exec::static_thread_pool::scheduler]" at line 169 of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp"

"/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/nvexec/stream/transfer.cuh", line 123: error: "__decay_t" is ambiguous
        using _set_value_t = completion_signatures<set_value_t(__decay_t<Ts>&&...)>;
                                                               ^
          detected during:
            instantiation of class "nvexec::_strm::transfer_sender_t<SenderId>::__t [with SenderId=repeat_n_detail::repeat_n_sender_t<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__closure::__compose<stdexec::__closure::__compose<stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>>]" at line 230 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/nvexec/stream_context.cuh"
            instantiation of "auto nvexec::_strm::tag_invoke(stdexec::__transfer::transfer_t, const nvexec::_strm::stream_scheduler &, S &&, Sch &&) noexcept [with S=repeat_n_detail::repeat_n_sender_t<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__closure::__compose<stdexec::__closure::__compose<stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>>, Sch=stdexec::__loop::run_loop::__scheduler::__t]" at line 328 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>)) &&, stdexec::__cp, stdexec::__domain::__legacy_customization>]" at line 136 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::default_domain::transform_sender(_Sender &&) const [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>]" at line 1177 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::transform_sender_t::operator()(_Domain, _Sender &&, const _Env &...) const [with _Domain=stdexec::default_domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<>]" at line 5521 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            [ 5 instantiation contexts not shown ]
            instantiation of "decltype(auto) stdexec::transform_sender_t::operator()(_Domain, _Sender &&, const _Env &...) const [with _Domain=stdexec::default_domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<stdexec::__sync_wait::__env>]" at line 328 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<stdexec::transform_sender_t, stdexec::default_domain, stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__sync_wait::__env>]" at line 1220 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "auto stdexec::__get_completion_signatures::get_completion_signatures_t::__impl<_Sender,_Env>() [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=stdexec::__sync_wait::__env]" at line 7141 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "auto stdexec::__sync_wait::__diagnose_error<_Sender>() [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>]" at line 119 of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp"
            instantiation of "void heat_equation(stdexec::scheduler auto, Real_t *, Real_t *, Real_t *, Real_t, Real_t, int, int, bool) [with <auto-1>=nvexec::_strm::stream_scheduler]" at line 173 of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp"

"/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/nvexec/stream/transfer.cuh", line 126: error: "__decay_t" is ambiguous
        using _set_error_t = completion_signatures<set_error_t(__decay_t<Ty>&&)>;
                                                               ^
          detected during:
            instantiation of class "nvexec::_strm::transfer_sender_t<SenderId>::__t [with SenderId=repeat_n_detail::repeat_n_sender_t<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__closure::__compose<stdexec::__closure::__compose<stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>>]" at line 230 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/nvexec/stream_context.cuh"
            instantiation of "auto nvexec::_strm::tag_invoke(stdexec::__transfer::transfer_t, const nvexec::_strm::stream_scheduler &, S &&, Sch &&) noexcept [with S=repeat_n_detail::repeat_n_sender_t<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__closure::__compose<stdexec::__closure::__compose<stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>>, Sch=stdexec::__loop::run_loop::__scheduler::__t]" at line 328 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>)) &&, stdexec::__cp, stdexec::__domain::__legacy_customization>]" at line 136 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::default_domain::transform_sender(_Sender &&) const [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>]" at line 1177 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::transform_sender_t::operator()(_Domain, _Sender &&, const _Env &...) const [with _Domain=stdexec::default_domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<>]" at line 5521 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            [ 5 instantiation contexts not shown ]
            instantiation of "decltype(auto) stdexec::transform_sender_t::operator()(_Domain, _Sender &&, const _Env &...) const [with _Domain=stdexec::default_domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<stdexec::__sync_wait::__env>]" at line 328 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<stdexec::transform_sender_t, stdexec::default_domain, stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__sync_wait::__env>]" at line 1220 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "auto stdexec::__get_completion_signatures::get_completion_signatures_t::__impl<_Sender,_Env>() [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=stdexec::__sync_wait::__env]" at line 7141 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "auto stdexec::__sync_wait::__diagnose_error<_Sender>() [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>]" at line 119 of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp"
            instantiation of "void heat_equation(stdexec::scheduler auto, Real_t *, Real_t *, Real_t *, Real_t, Real_t, int, int, bool) [with <auto-1>=nvexec::_strm::stream_scheduler]" at line 173 of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp"

"/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/nvexec/stream/transfer.cuh", line 126: error: template constraint not satisfied
        using _set_error_t = completion_signatures<set_error_t(__decay_t<Ty>&&)>;
                                                                               ^
"/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp", line 797: note: type constraint failed for "stdexec::__receivers::set_error_t (<error-type> &&)"
    template <__compl_sigs::__completion_signature... _Sigs>
              ^
"/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp", line 779: note: atomic constraint failed substitution
      concept __completion_signature = __compl_sigs::__is_compl_sig<_Sig>;
                                       ^
          detected during:
            instantiation of class "nvexec::_strm::transfer_sender_t<SenderId>::__t [with SenderId=repeat_n_detail::repeat_n_sender_t<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__closure::__compose<stdexec::__closure::__compose<stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>>]" at line 230 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/nvexec/stream_context.cuh"
            instantiation of "auto nvexec::_strm::tag_invoke(stdexec::__transfer::transfer_t, const nvexec::_strm::stream_scheduler &, S &&, Sch &&) noexcept [with S=repeat_n_detail::repeat_n_sender_t<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__closure::__compose<stdexec::__closure::__compose<stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>, stdexec::__closure::__binder_back<stdexec::__bulk::bulk_t, int, lambda [](int)->void>>>, Sch=stdexec::__loop::run_loop::__scheduler::__t]" at line 328 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>)) &&, stdexec::__cp, stdexec::__domain::__legacy_customization>]" at line 136 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::default_domain::transform_sender(_Sender &&) const [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>]" at line 1177 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::transform_sender_t::operator()(_Domain, _Sender &&, const _Env &...) const [with _Domain=stdexec::default_domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<>]" at line 5521 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            [ 5 instantiation contexts not shown ]
            instantiation of "decltype(auto) stdexec::transform_sender_t::operator()(_Domain, _Sender &&, const _Env &...) const [with _Domain=stdexec::default_domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<stdexec::__sync_wait::__env>]" at line 328 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<stdexec::transform_sender_t, stdexec::default_domain, stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, stdexec::__sync_wait::__env>]" at line 1220 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "auto stdexec::__get_completion_signatures::get_completion_signatures_t::__impl<_Sender,_Env>() [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=stdexec::__sync_wait::__env]" at line 7141 of "/global/homes/m/mhaseeb/repos/nvstdpar/build/_deps/stdexec-src/include/stdexec/execution.hpp"
            instantiation of "auto stdexec::__sync_wait::__diagnose_error<_Sender>() [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>]" at line 119 of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp"
            instantiation of "void heat_equation(stdexec::scheduler auto, Real_t *, Real_t *, Real_t *, Real_t, Real_t, int, int, bool) [with <auto-1>=nvexec::_strm::stream_scheduler]" at line 173 of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp"

3 errors detected in the compilation of "/global/homes/m/mhaseeb/repos/nvstdpar/apps/heat-equation/heat-equation-stdexec.cpp".
make[2]: *** [apps/heat-equation/CMakeFiles/heat-equation-stdexec.dir/build.make:76: apps/heat-equation/CMakeFiles/heat-equation-stdexec.dir/heat-equation-stdexec.cpp.o] Error 2
make[1]: *** [CMakeFiles/Makefile2:479: apps/heat-equation/CMakeFiles/heat-equation-stdexec.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```
