### PR TITLE
Fix memory ordering in lifo_queue put

### DIFF
--- a/include/exec/__detail/__bwos_lifo_queue.hpp
+++ b/include/exec/__detail/__bwos_lifo_queue.hpp
@@ -375,7 +375,7 @@ namespace exec::bwos {
     std::uint64_t back = tail_.load(std::memory_order_relaxed);
     if (back < block_size()) [[likely]] {
       ring_buffer_[back] = static_cast<Tp &&>(value);
-      tail_.store(back + 1, std::memory_order_relaxed);
+      tail_.store(back + 1, std::memory_order_release);
       return lifo_queue_error_code::success;
     }
     return lifo_queue_error_code::full;


### PR DESCRIPTION
The error is in a function that is not being used in the `static_thread_pool` implementation. The memory ordering in the member function `bulk_put`, which is being used, is correct.

The `put` function needs a similar release on the `tail_` member variable as it is done in `bulk_put`. There is an analogous acquire operation in the `steal()` member function.