### PR TITLE
Implement Numa affinity for worker threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,13 @@ if (STDEXEC_ENABLE_TBB)
 endif ()
 
 option (STDEXEC_ENABLE_IO_URING_TESTS "Enable io_uring tests" ON)
+option (STDEXEC_ENABLE_NUMA "Enable NUMA affinity for static_thread_pool" OFF)
+if (STDEXEC_ENABLE_NUMA)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
+  find_package(numa REQUIRED)
+  target_link_libraries(stdexec INTERFACE numa::numa)
+  target_compile_definitions(stdexec INTERFACE STDEXEC_ENABLE_NUMA)
+endif()
 
 option(STDEXEC_BUILD_EXAMPLES "Build stdexec examples" ON)
 option(STDEXEC_BUILD_TESTS "Build stdexec tests" ON)

--- a/cmake/Modules/Findnuma.cmake
+++ b/cmake/Modules/Findnuma.cmake
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2023 Maikel Nadolski
+# Copyright (c) 2023 NVIDIA Corporation
+#
+# Licensed under the Apache License Version 2.0 with LLVM Exceptions
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#[=======================================================================[.rst:
+Findnuma
+-------
+
+Finds the numa library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``numa::numa``
+  The numa library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``numa_FOUND``
+  True if the system has the Foo library.
+``numa_VERSION``
+  The version of the Foo library which was found.
+``numa_INCLUDE_DIRS``
+  Include directories needed to use Foo.
+``numa_LIBRARIES``
+  Libraries needed to link to Foo.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``numa_INCLUDE_DIR``
+  The directory containing ``numa.h``.
+``numa_LIBRARY``
+  The path to the Foo library.
+
+#]=======================================================================]
+
+find_path(numa_INCLUDE_DIR
+  NAMES numa.h
+  PATHS ${PC_Foo_INCLUDE_DIRS}
+  PATH_SUFFIXES numa
+)
+find_library(numa_LIBRARY
+  NAMES numa
+  PATHS ${PC_Foo_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(numa
+  FOUND_VAR numa_FOUND
+  REQUIRED_VARS
+    numa_LIBRARY
+    numa_INCLUDE_DIR
+  VERSION_VAR numa_VERSION
+)
+
+if(numa_FOUND)
+  set(numa_LIBRARIES ${numa_LIBRARY})
+  set(numa_INCLUDE_DIRS ${numa_INCLUDE_DIR})
+  set(numa_DEFINITIONS ${PC_numa_CFLAGS_OTHER})
+endif()
+
+if(numa_FOUND AND NOT TARGET numa::numa)
+  add_library(numa::numa UNKNOWN IMPORTED)
+  set_target_properties(numa::numa PROPERTIES
+    IMPORTED_LOCATION "${numa_LIBRARY}"
+    INTERFACE_COMPILE_OPTIONS "${PC_numa_CFLAGS_OTHER}"
+    INTERFACE_INCLUDE_DIRECTORIES "${numa_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(
+  numa_INCLUDE_DIR
+  numa_LIBRARY
+)

--- a/examples/benchmark/common.hpp
+++ b/examples/benchmark/common.hpp
@@ -97,7 +97,7 @@ void my_main(int argc, char** argv) {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
   std::vector<std::unique_ptr<char[]>> buffers(nthreads);
 #endif
-  Pool pool(nthreads + 1);
+  Pool pool(nthreads);
   std::barrier<> barrier(nthreads + 1);
   std::vector<std::thread> threads;
   std::atomic<bool> stop{false};

--- a/examples/benchmark/common.hpp
+++ b/examples/benchmark/common.hpp
@@ -117,7 +117,7 @@ void my_main(int argc, char** argv, exec::numa_policy* policy = exec::get_numa_p
   std::vector<std::thread> threads;
   std::atomic<bool> stop{false};
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
-  std::size_t buffer_size = 1000 << 20;
+  std::size_t buffer_size = 2000 << 20;
   for (std::size_t i = 0; i < static_cast<std::size_t>(nthreads); ++i) {
     exec::numa_allocator<char> alloc(policy->thread_index_to_node(i));
     buffers.push_back(std::unique_ptr<char, numa_deleter>{alloc.allocate(buffer_size), numa_deleter{buffer_size, alloc}});

--- a/examples/benchmark/static_thread_pool.cpp
+++ b/examples/benchmark/static_thread_pool.cpp
@@ -29,7 +29,9 @@ struct RunThread {
     exec::numa_policy* numa) {
     std::size_t numa_node = numa->thread_index_to_node(tid);
     numa->bind_to_node(numa_node);
-    auto scheduler = pool.get_scheduler();
+    exec::nodemask mask{};
+    mask.set(numa_node);
+    auto scheduler = pool.get_constrained_scheduler(mask);
     std::mutex mut;
     std::condition_variable cv;
     while (true) {

--- a/examples/benchmark/static_thread_pool.cpp
+++ b/examples/benchmark/static_thread_pool.cpp
@@ -85,7 +85,7 @@ struct RunThread {
 
 struct my_numa_distribution : public exec::default_numa_policy {
   std::size_t thread_index_to_node(std::size_t index) override {
-    return default_numa_policy::thread_index_to_node(2 * index);
+    return exec::default_numa_policy::thread_index_to_node(2 * index);
   }
 };
 

--- a/examples/benchmark/static_thread_pool.cpp
+++ b/examples/benchmark/static_thread_pool.cpp
@@ -25,7 +25,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     auto scheduler = pool.get_scheduler();
     std::mutex mut;
     std::condition_variable cv;
@@ -80,7 +83,13 @@ struct RunThread {
   }
 };
 
+struct my_numa_distribution : public exec::default_numa_policy {
+  std::size_t thread_index_to_node(std::size_t index) override {
+    return default_numa_policy::thread_index_to_node(2 * index);
+  }
+};
 
 int main(int argc, char** argv) {
-  my_main<exec::static_thread_pool, RunThread>(argc, argv);
+  my_numa_distribution numa{};
+  my_main<exec::static_thread_pool, RunThread>(argc, argv, &numa);
 }

--- a/examples/benchmark/static_thread_pool_bulk_enqueue.cpp
+++ b/examples/benchmark/static_thread_pool_bulk_enqueue.cpp
@@ -58,8 +58,15 @@ struct RunThread {
   }
 };
 
+struct my_numa_distribution : public exec::default_numa_policy {
+  std::size_t thread_index_to_node(std::size_t index) override {
+    return exec::default_numa_policy::thread_index_to_node(2 * index);
+  }
+};
+
 int main(int argc, char** argv) {
-  my_main<exec::static_thread_pool, RunThread>(argc, argv);
+  my_numa_distribution numa{};
+  my_main<exec::static_thread_pool, RunThread>(argc, argv, &numa);
 }
 #else
 int main() {}

--- a/examples/benchmark/static_thread_pool_bulk_enqueue.cpp
+++ b/examples/benchmark/static_thread_pool_bulk_enqueue.cpp
@@ -30,7 +30,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     while (true) {
       barrier.arrive_and_wait();
       if (stop.load()) {

--- a/examples/benchmark/static_thread_pool_bulk_enqueue_nested.cpp
+++ b/examples/benchmark/static_thread_pool_bulk_enqueue_nested.cpp
@@ -30,7 +30,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     auto scheduler = pool.get_scheduler();
     while (true) {
       barrier.arrive_and_wait();

--- a/examples/benchmark/static_thread_pool_bulk_enqueue_nested.cpp
+++ b/examples/benchmark/static_thread_pool_bulk_enqueue_nested.cpp
@@ -34,7 +34,7 @@ struct RunThread {
     exec::numa_policy* numa) {
     std::size_t numa_node = numa->thread_index_to_node(tid);
     numa->bind_to_node(numa_node);
-    auto scheduler = pool.get_scheduler();
+    auto scheduler = pool.get_scheduler_on_thread(tid);
     while (true) {
       barrier.arrive_and_wait();
       if (stop.load()) {

--- a/examples/benchmark/static_thread_pool_nested.cpp
+++ b/examples/benchmark/static_thread_pool_nested.cpp
@@ -26,7 +26,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     auto scheduler = pool.get_scheduler();
     std::mutex mut;
     std::condition_variable cv;

--- a/examples/benchmark/static_thread_pool_nested_old.cpp
+++ b/examples/benchmark/static_thread_pool_nested_old.cpp
@@ -26,7 +26,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     auto scheduler = pool.get_scheduler();
     std::mutex mut;
     std::condition_variable cv;

--- a/examples/benchmark/static_thread_pool_old.cpp
+++ b/examples/benchmark/static_thread_pool_old.cpp
@@ -26,7 +26,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     auto scheduler = pool.get_scheduler();
     std::mutex mut;
     std::condition_variable cv;

--- a/examples/benchmark/tbb_thread_pool.cpp
+++ b/examples/benchmark/tbb_thread_pool.cpp
@@ -39,7 +39,7 @@ struct RunThread {
       pmr::monotonic_buffer_resource resource{
         buffer.data(), buffer.size(), pmr::null_memory_resource()};
       pmr::polymorphic_allocator<char> alloc(&resource);
-      auto [start, end] = exec::even_share(total_scheds, tid, pool.available_parallelism() - 1);
+      auto [start, end] = exec::even_share(total_scheds, tid, pool.available_parallelism());
       std::size_t scheds = end - start;
       std::atomic<std::size_t> counter{scheds};
       auto env = exec::make_env(exec::with(stdexec::get_allocator, alloc));
@@ -57,7 +57,7 @@ struct RunThread {
         --scheds;
       }
 #else
-      auto [start, end] = exec::even_share(total_scheds, tid, pool.available_parallelism() - 1);
+      auto [start, end] = exec::even_share(total_scheds, tid, pool.available_parallelism());
       std::size_t scheds = end - start;
       std::atomic<std::size_t> counter{scheds};
       while (scheds) {

--- a/examples/benchmark/tbb_thread_pool.cpp
+++ b/examples/benchmark/tbb_thread_pool.cpp
@@ -26,7 +26,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     auto scheduler = pool.get_scheduler();
     std::mutex mut;
     std::condition_variable cv;

--- a/examples/benchmark/tbb_thread_pool_nested.cpp
+++ b/examples/benchmark/tbb_thread_pool_nested.cpp
@@ -28,7 +28,10 @@ struct RunThread {
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
     [[maybe_unused]] std::span<char> buffer,
 #endif
-    std::atomic<bool>& stop) {
+    std::atomic<bool>& stop,
+    exec::numa_policy* numa) {
+    std::size_t numa_node = numa->thread_index_to_node(tid);
+    numa->bind_to_node(numa_node);
     auto scheduler = pool.get_scheduler();
     std::mutex mut;
     std::condition_variable cv;

--- a/include/exec/__detail/__bwos_lifo_queue.hpp
+++ b/include/exec/__detail/__bwos_lifo_queue.hpp
@@ -147,7 +147,7 @@ namespace exec::bwos {
       alignas(hardware_destructive_interference_size) std::atomic<std::uint64_t> tail_{};
       alignas(hardware_destructive_interference_size) std::atomic<std::uint64_t> steal_head_{};
       alignas(hardware_destructive_interference_size) std::atomic<std::uint64_t> steal_tail_{};
-      std::vector<Tp, Allocator> ring_buffer_{};
+      std::vector<Tp, Allocator> ring_buffer_;
     };
 
     bool advance_get_index() noexcept;
@@ -331,12 +331,12 @@ namespace exec::bwos {
   }
 
   template <class Tp, class Allocator>
-  lifo_queue<Tp, Allocator>::block_type::block_type(const block_type &other) {
+  lifo_queue<Tp, Allocator>::block_type::block_type(const block_type &other)
+  : ring_buffer_(other.ring_buffer_) {
     head_.store(other.head_.load(std::memory_order_relaxed), std::memory_order_relaxed);
     tail_.store(other.tail_.load(std::memory_order_relaxed), std::memory_order_relaxed);
     steal_tail_.store(other.steal_tail_.load(std::memory_order_relaxed), std::memory_order_relaxed);
     steal_head_.store(other.steal_head_.load(std::memory_order_relaxed), std::memory_order_relaxed);
-    ring_buffer_ = other.ring_buffer_;
   }
 
   template <class Tp, class Allocator>

--- a/include/exec/__detail/__numa.hpp
+++ b/include/exec/__detail/__numa.hpp
@@ -134,8 +134,10 @@ namespace exec {
 }
 #else
 namespace exec {
+  using default_numa_policy = no_numa_policy;
+
   inline numa_policy* get_numa_policy() noexcept {
-    thread_local no_numa_policy g_default_numa_policy{};
+    thread_local default_numa_policy g_default_numa_policy{};
     return &g_default_numa_policy;
   }
 

--- a/include/exec/__detail/__numa.hpp
+++ b/include/exec/__detail/__numa.hpp
@@ -1,0 +1,105 @@
+#include "../../stdexec/__detail/__config.hpp"
+#include "../scope.hpp"
+
+#include <cstddef>
+#include <thread>
+
+namespace exec {
+  struct numa_policy {
+    virtual std::size_t num_nodes() = 0;
+    virtual std::size_t num_cpus(int node) = 0;
+    virtual int bind_to_node(int node) = 0;
+  };
+
+  class no_numa_policy : public numa_policy {
+   public:
+    no_numa_policy() noexcept;
+    std::size_t num_nodes() override { return 1; }
+    std::size_t num_cpus(int node) override { return std::thread::hardware_concurrency(); }
+    int bind_to_node(int node) override { return 0; }
+  };
+}
+
+#if __has_include(<numa.h>)
+#include <numa.h>
+namespace exec {
+  struct numa_policy_impl : numa_policy {
+    numa_policy_impl() noexcept = default;
+
+    std::size_t num_nodes() override { return ::numa_num_task_nodes(); }
+    
+    std::size_t num_cpus(int node) override { 
+      struct ::bitmask* cpus = ::numa_allocate_cpumask();
+      if (!cpus) {
+        return 0;
+      }
+      scope_guard sg{[&]() noexcept { ::numa_free_cpumask(cpus); }};
+      int rc = ::numa_node_to_cpus(node, cpus);
+      if (rc < 0) {
+        return 0;
+      }
+      std::size_t num_cpus = ::numa_bitmask_weight(cpus);
+      return num_cpus;
+    }
+
+    int bind_to_node(int node) override { 
+      struct ::bitmask* nodes = ::numa_allocate_nodemask();
+      if (!nodes) {
+        return -1;
+      }
+      scope_guard sg{[&]() noexcept { ::numa_free_nodemask(nodes); }};
+      ::numa_bitmask_setbit(nodes, node);
+      ::numa_bind(nodes);
+      return 0;
+    }
+  };
+
+  inline numa_policy* get_numa_policy() noexcept {
+    thread_local numa_policy_impl g_default_numa_policy{};
+    thread_local no_numa_policy g_no_numa_policy{};
+    if (::numa_available() < 0) {
+      return &g_no_numa_policy;
+    }
+    return &g_default_numa_policy;
+  }
+
+  template <class T>
+  struct numa_allocator {
+    using pointer = T*;
+    using const_pointer = const T*;
+    using value_type = T;
+
+    explicit numa_allocator(int node) noexcept : node_(node) {}
+
+    template <class U>
+    explicit numa_allocator(const numa_allocator<U>& other) noexcept : node_(other.node_) {}
+
+    int node_;
+
+    void* do_allocate(std::size_t n) {
+      return ::numa_alloc_onnode(n, node_);
+    }
+
+    void do_deallocate(void* p, std::size_t n) {
+      ::numa_free(p, n);
+    }
+
+    T* allocate(std::size_t n) {
+      return static_cast<T*>(do_allocate(n * sizeof(T)));
+    }
+
+    void deallocate(T* p, std::size_t n) {
+      do_deallocate(p, n * sizeof(T));
+    }
+
+    friend bool operator==(const numa_allocator&, const numa_allocator&) noexcept = default;
+  };
+}
+#else
+namespace exec {
+  inline numa_policy* get_numa_policy() noexcept {
+    thread_local no_numa_policy g_default_numa_policy{};
+    return &g_default_numa_policy;
+  }
+}
+#endif

--- a/include/exec/__detail/__numa.hpp
+++ b/include/exec/__detail/__numa.hpp
@@ -239,12 +239,16 @@ namespace exec {
       return mask_ && nodemask == 0;
     }
 
+    void set(std::size_t nodemask) noexcept {
+      mask_ |= nodemask == 0;
+    }
+
     friend bool operator==(const nodemask& lhs, const nodemask& rhs) noexcept {
       return lhs.mask_ == rhs.mask_;
     }
 
   private:
-    bool mask_;
+    bool mask_{false};
   };
 }
 #endif

--- a/include/exec/__detail/__numa.hpp
+++ b/include/exec/__detail/__numa.hpp
@@ -200,5 +200,32 @@ namespace exec {
 
     friend bool operator==(const numa_allocator&, const numa_allocator&) noexcept = default;
   };
+
+  class nodemask {
+    static nodemask make_any() noexcept {
+      nodemask mask;
+      mask.mask_ = true;
+      return mask;
+    }
+
+  public:
+    nodemask() noexcept = default;
+
+    static const nodemask& any() noexcept {
+      static nodemask mask = make_any();
+      return mask;
+    }
+
+    bool operator[](std::size_t nodemask) const noexcept {
+      return mask_ && nodemask == 0;
+    }
+
+    friend bool operator==(const nodemask& lhs, const nodemask& rhs) noexcept {
+      return lhs.mask_ == rhs.mask_;
+    }
+
+  private:
+    bool mask_;
+  };
 }
 #endif

--- a/include/exec/__detail/__numa.hpp
+++ b/include/exec/__detail/__numa.hpp
@@ -138,9 +138,14 @@ namespace exec {
       ::copy_bitmask_to_nodemask(::numa_all_nodes_ptr, &mask.mask_);
       return mask;
     }
+    
 
   public:
-    nodemask() noexcept = default;
+    nodemask() noexcept 
+    : mask_{}
+    {
+      ::copy_bitmask_to_nodemask(::numa_no_nodes_ptr, &mask_);
+    }
 
     static const nodemask& any() noexcept {
       static nodemask mask = make_any();
@@ -148,6 +153,20 @@ namespace exec {
     }
 
     bool operator[](std::size_t nodemask) const noexcept {
+      ::bitmask mask;
+      mask.maskp = const_cast<unsigned long*>(mask_.n);
+      mask.size = sizeof(nodemask_t);
+      return ::numa_bitmask_isbitset(&mask, nodemask);
+    }
+
+    void set(std::size_t nodemask) noexcept {
+      ::bitmask mask;
+      mask.maskp = const_cast<unsigned long*>(mask_.n);
+      mask.size = sizeof(nodemask_t);
+      ::numa_bitmask_setbit(&mask, nodemask);
+    }
+
+    bool get(std::size_t nodemask) const noexcept {
       ::bitmask mask;
       mask.maskp = const_cast<unsigned long*>(mask_.n);
       mask.size = sizeof(nodemask_t);

--- a/include/exec/__detail/__xorshift.hpp
+++ b/include/exec/__detail/__xorshift.hpp
@@ -46,6 +46,10 @@ namespace exec {
       seed(rd);
     }
 
+    explicit xorshift(std::uint64_t seed)
+      : m_seed(seed) {
+    }
+
     void seed(std::random_device &rd) {
       m_seed = std::uint64_t(rd()) << 31 | std::uint64_t(rd());
     }

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -34,6 +34,7 @@
 #include <condition_variable>
 #include <exception>
 #include <mutex>
+#include <span>
 #include <thread>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
This PR introduces numa awareness for the `static_thread_pool`.

### Summary of Changes

- [x] There is a new CMake option `STDEXEC_ENABLE_NUMA` to explicitly opt-in numa awareness. Notice that we need to link `stdexec` with `libnuma`, if enabled. We might also introduce a new CMake target especially for `exec` or for `exec::static_thread_pool`.
- [x] The constructor of `static_thread_pool` takes an additional pointer to `exec::numa_policy`, which defaults to `exec::get_default_numa_policy()`. This Numa policy defines a distribution mapping, which maps a thread number to a Numa node. It also provides a member function to bind the current thread to a specified Numa node. If `STDEXEC_ENABLE_NUMA` is false, then the numa policy is doing nothing.
- [x] We use a stateful `exec::numa_allocator<T>` that allocates memory on a specified numa node.
- [x] Introduce member functions `static_thread_pool::get_scheduler_on(numa_node_mask)` and `static_thread_pool::get_scheduler_on(cpu_mask)` to return a scheduler that schedules with specified constraints.
- [x] Worker threads try to steal from other worker threads on their own Numa node.  When this fails a certain amount of times every other worker thread becomes a stealing target.

### API Design

This PR introduces the interface `numa_policy` which is defined as

```cpp
  struct numa_policy {
    virtual std::size_t num_nodes() = 0;
    virtual std::size_t num_cpus(int node) = 0;
    virtual int bind_to_node(int node) = 0;
    virtual std::size_t thread_index_to_node(std::size_t index) = 0;
  };
```

The thread pool takes a pointer to `numa_policy` as an optional argument to customize the distribution of worker threads to Numa nodes.

The `static_thread_pool` has the following ways to get a scheduler with certain properties

```cpp
    // Returns a scheduler without any constraints
    scheduler get_scheduler() noexcept;

    // Returns a scheduler that schedules on a specific worker thread (enumerated from 0...N-1)
    scheduler get_scheduler_on_thread(std::size_t threadIndex) noexcept;
    
    // Returns a scheduler that schedules only on worker threads that run on one of the specified nodes
    scheduler get_constrained_scheduler(const nodemask& constraints) noexcept;
```

### Benchmarks

We perform a benchmark on a machine with 2 numa nodes. Each node has 14 cores (28 threads).

```
  Model name:            Intel(R) Xeon(R) CPU E5-2690 v4 @ 2.60GHz
    CPU family:          6
    Model:               79
    Thread(s) per core:  2
    Core(s) per socket:  14
    Socket(s):           2
```

We perform the nested schedule benchmark from the last PR and we see that the scaling is better with numa affinity enabled.

The OS scheduler does an amazing job when having less than 28 threads.

![numa_vs_non_numa](https://github.com/NVIDIA/stdexec/assets/138201/a73ac4f7-aa57-4a73-950a-3dc0a48782fb)

Max throughput

| No Numa | With Numa |
| -------------  | ----------------  |
|  5.27+e08 |  6.4e+08      |

Which is an improvement of roughly 20%