### PR TITLE
drop support for P2300R5-style senders and receivers

### DIFF
--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -91,13 +91,6 @@ namespace exec {
       __declval<__data_placeholder&>(),
       __declval<__receiver_placeholder<_Env>&>()));
 
-    struct __dependent_sender {
-      using is_sender = void;
-      using __t = __dependent_sender;
-      friend auto tag_invoke(get_completion_signatures_t, __dependent_sender, no_env)
-        -> dependent_completion_signatures<no_env>;
-    };
-
     struct __sender_transform_failed {
       using __t = __sender_transform_failed;
     };
@@ -109,8 +102,6 @@ namespace exec {
       } else {
         if constexpr (__mvalid<__tfx_sender_, _Kernel, _Sender, _Env>) {
           return __mtype<__tfx_sender_<_Kernel, _Sender, _Env>>{};
-        } else if constexpr (same_as<_Env, no_env>) {
-          return __dependent_sender{};
         } else {
           return __sender_transform_failed{};
         }
@@ -120,7 +111,6 @@ namespace exec {
 
     template <class _Kernel, class _Sender, class _Data, class _Receiver>
     auto __transform_sender(_Kernel& __kernel, _Sender&& __sndr, _Data& __data, _Receiver& __rcvr) {
-      static_assert(!same_as<env_of_t<_Receiver>, no_env>);
       if constexpr (__lacks_transform_sender<_Kernel>) {
         return (_Sender&&) __sndr;
       } else {
@@ -141,11 +131,7 @@ namespace exec {
       __declval<_As>()...));
 
     template <class _Kernel, class _Env>
-    using __get_env_ = decltype(__declval<_Kernel&>().get_env(__declval<_Env>()));
-
-    template <class _Kernel, class _Env>
-    using __env_t =
-      __minvoke< __if_c<same_as<_Env, no_env>, __mconst<no_env>, __q<__get_env_>>, _Kernel, _Env>;
+    using __env_t = decltype(__declval<_Kernel&>().get_env(__declval<_Env>()));
 
     template <class _Kernel, class _Env, class _Tag, class... _As>
     auto __completions_from_sig(_Tag (*)(_As...))
@@ -312,19 +298,13 @@ namespace exec {
                 __completions_t<_NewEnv, __pre_completions_t<_NewSender, _NewEnv>>;
               if constexpr (__valid_completion_signatures<_Completions, _Env>) {
                 return (_Completions(*)()) nullptr;
-              } else if constexpr (same_as<no_env, _Env>) {
-                return (dependent_completion_signatures<no_env>(*)()) nullptr;
               } else {
                 // assume this is an error message and return it directly
                 return (_Completions(*)()) nullptr;
               }
-            } else if constexpr (same_as<no_env, _Env>) {
-              return (dependent_completion_signatures<no_env>(*)()) nullptr;
             } else {
               return (__diagnostic_t<_Env>(*)()) nullptr;
             }
-          } else if constexpr (same_as<no_env, _Env>) {
-            return (dependent_completion_signatures<no_env>(*)()) nullptr;
           } else if constexpr (same_as<_NewSender, __sender_transform_failed>) {
             return (__diagnostic_t<_Env>(*)()) nullptr;
           } else {

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -794,6 +794,7 @@ namespace exec {
       using _Receiver = stdexec::__t<_ReceiverId>;
 
       struct __t {
+        using is_receiver = void;
         __operation_base<_Receiver>* __op_;
 
         template <same_as<set_next_t> _SetNext, same_as<__t> _Self, class _Item>

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -95,7 +95,7 @@ namespace exec {
         return {{}, ((_Self&&) __self).__default_, (_Receiver&&) __rcvr};
       }
 
-      template <__none_of<no_env> _Env>
+      template <class _Env>
       friend auto tag_invoke(get_completion_signatures_t, __sender, _Env&&)
         -> __completions_t<_Env> {
         return {};

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -263,7 +263,7 @@ namespace exec {
             (_Rec&&) __receiver};
         }
 
-        template <__decays_to<__t> _Self, __none_of<no_env> _Env>
+        template <__decays_to<__t> _Self, class _Env>
         friend auto tag_invoke(get_completion_signatures_t, _Self&&, _Env&&) noexcept
           -> __completion_signatures_t<
             __copy_cvref_t<_Self, _InitialSender>,

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -21,7 +21,7 @@
 namespace exec {
   namespace __any {
     namespace __next {
-      template <__is_completion_signatures _Sigs>
+      template <__valid_completion_signatures _Sigs>
       struct __rcvr_next_vfun {
         using __return_sigs = completion_signatures<set_value_t(), set_stopped_t()>;
         using __void_sender = typename any_receiver_ref<__return_sigs>::template any_sender<>;
@@ -37,7 +37,7 @@ namespace exec {
         template <class _Sigs>
         using __item_sender = typename any_receiver_ref<_Sigs>::template any_sender<>;
 
-        template <__is_completion_signatures _Sigs>
+        template <__valid_completion_signatures _Sigs>
         constexpr __void_sender (*operator()(_Sigs*) const)(void*, __item_sender<_Sigs>&&) {
           return +[](void* __r, __item_sender<_Sigs>&& __sndr) noexcept -> __void_sender {
             return __void_sender{
@@ -295,7 +295,7 @@ namespace exec {
     template <
       std::same_as<exec::set_next_t> _SetNext,
       std::same_as<__t> _Self,
-      stdexec::__sender _Sender>
+      stdexec::sender _Sender>
       requires stdexec::__callable<set_next_t, _Self&, _Sender>
     friend auto tag_invoke(_SetNext, _Self& __self, _Sender&& __sender) {
       return exec::set_next(__self.__receiver_, static_cast<_Sender&&>(__sender));

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -160,7 +160,7 @@ namespace exec {
           using _Result = __member_alias_t<_TfxSender, _Env>;
           return (_Result(*)()) nullptr;
         } else if constexpr (
-          sender<_TfxSender, _Env> && !enable_sequence_sender<stdexec::__decay_t<_TfxSender>>) {
+          sender_in<_TfxSender, _Env> && !enable_sequence_sender<stdexec::__decay_t<_TfxSender>>) {
           using _Result = item_types<stdexec::__decay_t<_TfxSender>>;
           return (_Result(*)()) nullptr;
         } else if constexpr (__is_debug_env<_Env>) {
@@ -194,8 +194,8 @@ namespace exec {
     decltype(get_item_types(stdexec::__declval<_Sender>(), stdexec::__declval<_Env>()));
 
   template <class _Sender, class _Env>
-  concept sequence_sender =           //
-    stdexec::sender<_Sender, _Env> && //
+  concept sequence_sender =              //
+    stdexec::sender_in<_Sender, _Env> && //
     enable_sequence_sender<stdexec::__decay_t<_Sender>>;
 
   template <class _Sender, class _Env>

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -333,15 +333,6 @@ namespace exec {
           __nothrow_callable<get_env_t, _Receiver&>
           && __nothrow_callable<transform_sender_t, _Domain, _Sender, env_of_t<_Receiver&>>;
         using _TfxSender = __tfx_sndr<_Sender, _Receiver>;
-        if constexpr (!enable_sender<__decay_t<_Sender>>)
-          __connect::_PLEASE_UPDATE_YOUR_SENDER_TYPE<__decay_t<_Sender>>();
-
-        if constexpr (!enable_sender<__decay_t<_TfxSender>>)
-          __connect::_PLEASE_UPDATE_YOUR_SENDER_TYPE<__decay_t<_TfxSender>>();
-
-        if constexpr (!enable_receiver<__decay_t<_Receiver>>)
-          __connect::_PLEASE_UPDATE_YOUR_RECEIVER_TYPE<__decay_t<_Receiver>>();
-
         if constexpr (__next_connectable_with_tag_invoke<_TfxSender, _Receiver>) {
           using _Result = tag_invoke_result_t<
             connect_t,

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -122,7 +122,7 @@ namespace exec {
             try {
               __result_.emplace(std::tuple{_CPO{}, (_Args&&) __args...});
             } catch (...) {
-              __result_.emplace(set_error_t{}, std::current_exception());
+              __result_.emplace(std::tuple{set_error_t{}, std::current_exception()});
             }
           }
           // stop pending operations

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -146,7 +146,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
     using receiver_t = stdexec::__t<receiver_t<stdexec::__id<Sender>>>;
 
     template <__single_value_variant_sender<__env> Sender>
-      requires sender<Sender, __env> && __receiver_from<receiver_t<Sender>, Sender>
+      requires sender_in<Sender, __env> && __receiver_from<receiver_t<Sender>, Sender>
     auto operator()(context_state_t context_state, Sender&& __sndr) const
       -> std::optional<sync_wait_result_t<Sender>> {
       using state_t = state_t<stdexec::__id<Sender>>;

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -47,11 +47,11 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     template <class...>
     using swallow_values = completion_signatures<>;
 
+    template <class Sender, class Env>
+    using too_many_completions = __mbool<(1 < __v<__count_of<set_value_t, Sender, Env>>)>;
+
     template <class Env, class... Senders>
     struct completions {
-      template <class Sender, class Env>
-      using too_many_completions = __mbool<(__v<__count_of<set_value_t, Sender, Env>> > 1)>;
-
       using InvalidArg = //
         __minvoke<
           __mfind_if<__mbind_back_q<too_many_completions, Env>, __q<__mfront>>,
@@ -67,7 +67,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     }
 
     template <class Env, class... Senders>
-      requires((__v<__count_of<set_value_t, Senders, Env>> <= 1) && ...)
+      requires (!__v<too_many_completions<Senders, Env>> &&...)
     struct completions<Env, Senders...> {
       using non_values = //
         __concat_completion_signatures_t<

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -49,7 +49,15 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
     template <class Env, class... Senders>
     struct completions {
-      using __t = dependent_completion_signatures<Env>;
+      template <class Sender, class Env>
+      using too_many_completions = __mbool<(__v<__count_of<set_value_t, Sender, Env>> > 1)>;
+
+      using InvalidArg = //
+        __minvoke<
+          __mfind_if<__mbind_back_q<too_many_completions, Env>, __q<__mfront>>,
+          Senders...>;
+
+      using __t = stdexec::__when_all::__too_many_value_completions_error<InvalidArg, Env>;
     };
 
     template <class... As, class TupleT>
@@ -63,7 +71,6 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     struct completions<Env, Senders...> {
       using non_values = //
         __concat_completion_signatures_t<
-
           completion_signatures< set_error_t(cudaError_t), set_stopped_t()>,
           __try_make_completion_signatures<
             Senders,

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -389,7 +389,7 @@ namespace stdexec {
   struct _BAD_SUBSTITUTION_ { };
 
   template <class... _Args>
-  struct _WITH_TYPES_ { };
+  struct _WITH_TYPES_;
 
   template <template <class...> class _Fun>
   struct _WITH_META_FUNCTION_T_ {

--- a/include/stdexec/__detail/__p2300.hpp
+++ b/include/stdexec/__detail/__p2300.hpp
@@ -89,7 +89,8 @@ namespace std {
     using stop_token_of_t STDEXEC_STD_DEPRECATED = stdexec::stop_token_of_t<_StopTokenProvider>;
 
     // [exec.env], execution environments
-    using no_env STDEXEC_STD_DEPRECATED = stdexec::no_env;
+    struct __no_env {};
+    using no_env STDEXEC_STD_DEPRECATED = __no_env;
     using get_env_t STDEXEC_STD_DEPRECATED = stdexec::get_env_t;
     //using forwarding_env_query_t STDEXEC_STD_DEPRECATED = stdexec::forwarding_env_query_t; // BUGBUG
     STDEXEC_STD_DEPRECATED
@@ -138,13 +139,13 @@ namespace std {
     inline constexpr stdexec::start_t start{};
 
     // [exec.snd], senders
-    template <class _Sender, class _Env = stdexec::no_env>
+    template <class _Sender, class _Env = __no_env>
     concept sender /*STDEXEC_STD_DEPRECATED*/ = stdexec::sender_in<_Sender, _Env>;
 
     template <class _Sender, class _Receiver>
     concept sender_to /*STDEXEC_STD_DEPRECATED*/ = stdexec::sender_to<_Sender, _Receiver>;
 
-    template <class _Sender, class _SetSig, class _Env = stdexec::no_env>
+    template <class _Sender, class _SetSig, class _Env = __no_env>
     concept sender_of /*STDEXEC_STD_DEPRECATED*/ = stdexec::sender_of<_Sender, _SetSig, _Env>;
 
     // [exec.sndtraits], completion signatures
@@ -152,17 +153,20 @@ namespace std {
     STDEXEC_STD_DEPRECATED
     inline constexpr stdexec::get_completion_signatures_t get_completion_signatures{};
 
-    template <class _Sender, class _Env = stdexec::no_env>
+    template <class _Sender, class _Env = __no_env>
     using completion_signatures_of_t STDEXEC_STD_DEPRECATED =
       stdexec::completion_signatures_of_t<_Sender, _Env>;
 
     template <class _Env>
+    struct __dependent_completion_signatures { };
+
+    template <class _Env>
     using dependent_completion_signatures STDEXEC_STD_DEPRECATED =
-      stdexec::dependent_completion_signatures<_Env>;
+      __dependent_completion_signatures<_Env>;
 
     template <                                                     //
       class _Sender,                                               //
-      class _Env = stdexec::no_env,                                //
+      class _Env = __no_env,                                //
       template <class...> class _Tuple = stdexec::__decayed_tuple, //
       template <class...> class _Variant = stdexec::__variant>
     using value_types_of_t STDEXEC_STD_DEPRECATED =
@@ -170,12 +174,12 @@ namespace std {
 
     template <                      //
       class _Sender,                //
-      class _Env = stdexec::no_env, //
+      class _Env = __no_env, //
       template <class...> class _Variant = stdexec::__variant>
     using error_types_of_t STDEXEC_STD_DEPRECATED =
       stdexec::error_types_of_t<_Sender, _Env, _Variant>;
 
-    template <class _Sender, class _Env = stdexec::no_env>
+    template <class _Sender, class _Env = __no_env>
     STDEXEC_STD_DEPRECATED inline constexpr bool sends_stopped =
       stdexec::sends_stopped<_Sender, _Env>;
 
@@ -295,7 +299,7 @@ namespace std {
     // [exec.utils.mkcmplsigs]
     template <       //
       class _Sender, //
-      class _Env = stdexec::no_env,
+      class _Env = __no_env,
       class _Sigs = stdexec::completion_signatures<>,                                   //
       template <class...> class _SetValue = stdexec::__compl_sigs::__default_set_value, //
       template <class> class _SetError = stdexec::__compl_sigs::__default_set_error,    //

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -59,6 +59,8 @@ namespace {
   };
 
   struct sink_receiver {
+    using is_receiver = void;
+
     std::variant<std::monostate, int, std::exception_ptr, set_stopped_t> value_{};
 
     friend void tag_invoke(set_value_t, sink_receiver&& r, int value) noexcept {

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -77,7 +77,11 @@ namespace {
     }
   };
 
-  using dependent = ex::dependent_completion_signatures<ex::no_env>;
+  struct invalid_awaiter {
+    bool await_ready();
+    bool await_suspend(__coro::coroutine_handle<>);
+    //void await_resume();
+  };
 
   STDEXEC_PRAGMA_PUSH()
   STDEXEC_PRAGMA_IGNORE_GNU("-Wpragmas")
@@ -94,7 +98,7 @@ namespace {
     using promise_type = promise<__coro::suspend_always>;
 
    private:
-    friend dependent operator co_await(awaitable_sender_2) {
+    friend invalid_awaiter operator co_await(awaitable_sender_2) {
       return {};
     }
   };
@@ -103,7 +107,7 @@ namespace {
     using promise_type = promise<awaiter>;
 
    private:
-    friend dependent operator co_await(awaitable_sender_3) {
+    friend invalid_awaiter operator co_await(awaitable_sender_3) {
       return {};
     }
   };
@@ -116,10 +120,6 @@ namespace {
    private:
     template <class Promise>
     friend awaiter tag_invoke(ex::as_awaitable_t, awaitable_sender_4, Promise&) {
-      return {};
-    }
-
-    friend dependent tag_invoke(ex::as_awaitable_t, awaitable_sender_4, ex::no_env_promise&) {
       return {};
     }
   };
@@ -145,36 +145,28 @@ namespace {
   }
 
   void test_awaitable_sender2() {
-    static_assert(ex::sender<awaitable_sender_2>);
-    static_assert(sender_with_env<awaitable_sender_2>);
+    static_assert(!ex::sender<awaitable_sender_2>);
+    static_assert(!sender_with_env<awaitable_sender_2>);
     static_assert(!ex::sender_in<awaitable_sender_2, ex::empty_env>);
 
-    static_assert(ex::__awaitable<awaitable_sender_2>);
+    static_assert(!ex::__awaitable<awaitable_sender_2>);
     static_assert(ex::__awaitable<awaitable_sender_2, promise<__coro::suspend_always>>);
 
     static_assert(
       !ex::__get_completion_signatures::__with_member_alias<awaitable_sender_2, ex::empty_env>);
-
-#if STDEXEC_LEGACY_R5_CONCEPTS()
-    static_assert(std::is_same_v<ex::completion_signatures_of_t<awaitable_sender_2>, dependent>);
-#endif
   }
 
   void test_awaitable_sender3() {
-    static_assert(ex::sender<awaitable_sender_3>);
-    static_assert(sender_with_env<awaitable_sender_3>);
+    static_assert(!ex::sender<awaitable_sender_3>);
+    static_assert(!sender_with_env<awaitable_sender_3>);
     static_assert(!ex::sender_in<awaitable_sender_3, ex::empty_env>);
 
     static_assert(ex::__awaiter<awaiter>);
-    static_assert(ex::__awaitable<awaitable_sender_3>);
+    static_assert(!ex::__awaitable<awaitable_sender_3>);
     static_assert(ex::__awaitable<awaitable_sender_3, promise<awaiter>>);
 
     static_assert(
       !ex::__get_completion_signatures::__with_member_alias<awaitable_sender_3, ex::empty_env>);
-
-#if STDEXEC_LEGACY_R5_CONCEPTS()
-    static_assert(std::is_same_v<ex::completion_signatures_of_t<awaitable_sender_3>, dependent>);
-#endif
   }
 
   template <class Signatures>
@@ -186,15 +178,11 @@ namespace {
     static_assert(ex::__awaiter<awaiter>);
     static_assert(!ex::__awaitable<awaitable_sender_4>);
     static_assert(ex::__awaitable<awaitable_sender_4, promise<awaiter>>);
-    static_assert(ex::__awaitable<awaitable_sender_4, ex::no_env_promise>);
     static_assert(ex::__awaitable<awaitable_sender_4, ex::__env_promise<ex::empty_env>>);
 
     static_assert(
       !ex::__get_completion_signatures::__with_member_alias<awaitable_sender_4, ex::empty_env>);
 
-#if STDEXEC_LEGACY_R5_CONCEPTS()
-    static_assert(std::is_same_v<ex::completion_signatures_of_t<awaitable_sender_4>, dependent>);
-#endif
     static_assert(
       !ex::__get_completion_signatures::__with_member_alias<awaitable_sender_4, ex::empty_env>);
 
@@ -214,7 +202,6 @@ namespace {
     static_assert(ex::__awaiter<awaiter>);
     static_assert(!ex::__awaitable<awaitable_sender_5>);
     static_assert(ex::__awaitable<awaitable_sender_5, promise<awaiter>>);
-    static_assert(ex::__awaitable<awaitable_sender_5, ex::no_env_promise>);
     static_assert(ex::__awaitable<awaitable_sender_5, ex::__env_promise<ex::empty_env>>);
 
     static_assert(

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -166,44 +166,6 @@ namespace {
     "[concepts][scheduler]") {
     REQUIRE(!ex::scheduler<sched_no_completion>);
   }
-
-#if STDEXEC_LEGACY_R5_CONCEPTS()
-  struct sched_no_env {
-    // P2300R5 senders defined sender queries on the sender itself.
-    struct my_sender {
-      // Intentionally left out:
-      //using is_sender = void;
-      using completion_signatures = ex::completion_signatures< //
-        ex::set_value_t(),                                     //
-        ex::set_error_t(std::exception_ptr),                   //
-        ex::set_stopped_t()>;
-
-      template <typename CPO>
-      friend sched_no_env tag_invoke(ex::get_completion_scheduler_t<CPO>, my_sender) {
-        return {};
-      }
-    };
-
-    friend my_sender tag_invoke(ex::schedule_t, sched_no_env) {
-      return {};
-    }
-
-    friend bool operator==(sched_no_env, sched_no_env) noexcept {
-      return true;
-    }
-
-    friend bool operator!=(sched_no_env, sched_no_env) noexcept {
-      return false;
-    }
-  };
-
-  TEST_CASE(
-    "type without sender get_env is still a scheduler",
-    "[concepts][scheduler][r5_backwards_compatibility]") {
-    static_assert(ex::scheduler<sched_no_env>);
-    REQUIRE(ex::scheduler<sched_no_env>);
-  }
-#endif
 }
 
 STDEXEC_PRAGMA_POP()

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -254,7 +254,7 @@ namespace {
   // nvc++ doesn't yet implement subsumption correctly
   struct not_a_sender_tag { };
 
-  struct sender_no_env_tag { };
+  struct sender_tag { };
 
   struct sender_env_tag { };
 
@@ -266,7 +266,7 @@ namespace {
   }
 
   template <ex::sender T>
-  sender_no_env_tag test_subsumption(T&&) {
+  sender_tag test_subsumption(T&&) {
     return {};
   }
 
@@ -289,7 +289,7 @@ namespace {
     "check for subsumption relationships between the sender concepts",
     "[concepts][sender]") {
     ::has_type<not_a_sender_tag>(::test_subsumption(42));
-    ::has_type<sender_no_env_tag>(::test_subsumption(ex::get_scheduler()));
+    ::has_type<sender_tag>(::test_subsumption(ex::get_scheduler()));
     ::has_type<sender_env_tag>(::test_subsumption(ex::just(42)));
     ::has_type<sender_of_tag>(::test_subsumption(ex::just()));
   }

--- a/test/stdexec/cpos/test_cpo_connect.cpp
+++ b/test/stdexec/cpos/test_cpo_connect.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#define STDEXEC_DISABLE_R5_DEPRECATION_WARNINGS
-
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>
 #include "test_common/receivers.hpp"
@@ -84,6 +82,7 @@ namespace {
   }
 
   struct strange_receiver {
+    using is_receiver = void;
     bool* called_;
 
     friend inline op_state<strange_receiver>


### PR DESCRIPTION
the sender concept now requires `enable_sender<Sndr> == true`. the easiest way to achieve that is to give your sender types a nested type alias `is_sender`.

```c++
struct my_sender {
  using is_sender = _unspecified_;
  ...
};
```

likewise for receivers; they should have a nested `is_receiver` type alias.