### PR TITLE
Clean up MSVC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,9 @@ if (STDEXEC_ENABLE_TBB)
         )
 endif ()
 
-option (STDEXEC_ENABLE_IO_URING_TESTS "Enable io_uring tests" ON)
+include(CheckIncludeFileCXX)
+CHECK_INCLUDE_FILE_CXX("linux/io_uring.h" STDEXEC_FOUND_IO_URING)
+option (STDEXEC_ENABLE_IO_URING_TESTS "Enable io_uring tests" ${STDEXEC_FOUND_IO_URING})
 
 option(STDEXEC_BUILD_EXAMPLES "Build stdexec examples" ON)
 option(STDEXEC_BUILD_TESTS "Build stdexec tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,8 @@ target_compile_options(stdexec_executable_flags INTERFACE
 # Silence warnings
 target_compile_options(stdexec_executable_flags INTERFACE
                        $<$<CXX_COMPILER_ID:GNU>:-Wno-non-template-friend>
-                       $<$<CXX_COMPILER_ID:NVHPC>:--diag_suppress177,550,111,497,554>)
+                       $<$<CXX_COMPILER_ID:NVHPC>:--diag_suppress177,550,111,497,554>
+                       $<$<CXX_COMPILER_ID:MSVC>:/wd4100 /wd4101 /wd4127 /wd4324 /wd4456 /wd4459>)
 
 # Template backtrace limit
 target_compile_options(stdexec_executable_flags INTERFACE

--- a/include/exec/__detail/__bwos_lifo_queue.hpp
+++ b/include/exec/__detail/__bwos_lifo_queue.hpp
@@ -30,9 +30,16 @@
 // Copyright (c) 2019 Maxim Egorushkin. MIT License.
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
+#if STDEXEC_MSVC()
+#include <intrin.h>
+#endif
 namespace exec::bwos {
   static inline void spin_loop_pause() noexcept {
+#if STDEXEC_MSVC()
+    _mm_pause();
+#else
     __builtin_ia32_pause();
+#endif
   }
 }
 #elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64)

--- a/include/exec/__detail/__bwos_lifo_queue.hpp
+++ b/include/exec/__detail/__bwos_lifo_queue.hpp
@@ -177,7 +177,7 @@ namespace exec::bwos {
     std::size_t block_size,
     Allocator allocator)
     : blocks_(
-      std::max(2ul, std::bit_ceil(num_blocks)),
+      std::max(static_cast<size_t>(2), std::bit_ceil(num_blocks)),
       block_type(block_size, allocator),
       allocator_of_t<block_type>(allocator))
     , mask_(blocks_.size() - 1) {

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -626,8 +626,8 @@ namespace exec {
       ++idx;
     }
     remote_queue* correct_queue = this_id == queue.id_ ? &queue : get_remote_queue();
-    std::size_t nThreads = available_parallelism();
-    for (std::size_t i = 0; i < nThreads; ++i) {
+    std::uint32_t nThreads = available_parallelism();
+    for (std::uint32_t i = 0; i < nThreads; ++i) {
       auto [i0, iEnd] = even_share(nTasks, i, available_parallelism());
       if (i0 == iEnd) {
         continue;
@@ -676,8 +676,8 @@ namespace exec {
     if (victims_.empty()) {
       return {nullptr, index_};
     }
-    std::uniform_int_distribution<std::uint32_t> dist(0, victims_.size() - 1);
-    std::uint32_t victimIndex = dist(rng_);
+    std::uniform_int_distribution<std::size_t> dist(0, victims_.size() - 1);
+    std::size_t victimIndex = dist(rng_);
     auto& v = victims_[victimIndex];
     return {v.try_steal(), v.index()};
   }

--- a/test/stdexec/algos/other/test_execute.cpp
+++ b/test/stdexec/algos/other/test_execute.cpp
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef _WIN32
-// __allocator is #defined in Windows SDK's shared/specstrings.h.
-#include <Windows.h>
-#endif
-
 #include <atomic>
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>


### PR DESCRIPTION
Suppressed the following warnings via command line options:
* C4100: Unreferenced formal parameter
* C4101: Unreferenced local variable
* C4127: Conditional expression is constant
* C4324: Structure was padded due to alignas specifier
* C4456: Declaration hides previous local declaration
* C4459: Declaration hides global declaration

Fixed two instances of "C4244: Type conversion leads to possible loss of data" in `static_thread_pool.hpp` by improving integer type safety.

Multiple instances of "C4702: Unreachable code" still remain. It's not a warning that should be suppressed, but I also did not want to go through all those cases in this PR.

This PR depends on #1137.