### PR TITLE
Add Windows CI builds

### DIFF
--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -51,3 +51,33 @@ jobs:
       - build-cpu
     steps:
       - run: echo "CI (CPU) success"
+
+  build-cpu-windows:
+    runs-on: windows-latest
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { compiler: "cl",       build: "Debug",   name: "CPU (Windows) (msvc, Debug)" }
+          - { compiler: "cl",       build: "Release", name: "CPU (Windows) (msvc, Release)" }
+          - { compiler: "clang++",  build: "Debug",   name: "CPU (Windows) (clang, Debug)" }
+          - { compiler: "clang++",  build: "Release", name: "CPU (Windows) (clang, Release)" }
+          - { compiler: "clang-cl", build: "Debug",   name: "CPU (Windows) (clang-cl, Debug)" }
+          - { compiler: "clang-cl", build: "Release", name: "CPU (Windows) (clang-cl, Release)" }
+    steps:
+      - name: Checkout stdexec (Windows)
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Build and test CPU schedulers (Windows)
+        shell: pwsh
+        run: .github/workflows/test-windows.ps1 -Compiler '${{ matrix.compiler }}' -Config '${{ matrix.build }}'
+
+  ci-cpu-windows:
+    runs-on: windows-latest
+    name: CI (CPU) (Windows)
+    needs:
+      - build-cpu-windows
+    steps:
+      - run: echo "CI (CPU) (Windows) success"

--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -61,10 +61,10 @@ jobs:
         include:
           - { compiler: "cl",       build: "Debug",   name: "CPU (Windows) (msvc, Debug)" }
           - { compiler: "cl",       build: "Release", name: "CPU (Windows) (msvc, Release)" }
-          - { compiler: "clang++",  build: "Debug",   name: "CPU (Windows) (clang, Debug)" }
-          - { compiler: "clang++",  build: "Release", name: "CPU (Windows) (clang, Release)" }
-          - { compiler: "clang-cl", build: "Debug",   name: "CPU (Windows) (clang-cl, Debug)" }
-          - { compiler: "clang-cl", build: "Release", name: "CPU (Windows) (clang-cl, Release)" }
+          #- { compiler: "clang++",  build: "Debug",   name: "CPU (Windows) (clang, Debug)" }
+          #- { compiler: "clang++",  build: "Release", name: "CPU (Windows) (clang, Release)" }
+          #- { compiler: "clang-cl", build: "Debug",   name: "CPU (Windows) (clang-cl, Debug)" }
+          #- { compiler: "clang-cl", build: "Release", name: "CPU (Windows) (clang-cl, Release)" }
     steps:
       - name: Checkout stdexec (Windows)
         uses: actions/checkout@v3

--- a/.github/workflows/test-windows.ps1
+++ b/.github/workflows/test-windows.ps1
@@ -1,0 +1,39 @@
+param(
+	[string]$BuildDirectory="build",
+	[string]$Compiler="cl",
+	[string]$Config="Debug"
+)
+
+function Invoke-NativeCommand($Command) {
+	& $Command $Args
+
+	if (!$?) {
+		throw "${Command}: $LastExitCode"
+	}
+}
+
+$VSVersion = 2022
+$VSEdition = 'Enterprise'
+$Architecture = 'x64'
+
+Push-Location "C:/Program Files/Microsoft Visual Studio/$VSVersion/$VSEdition/VC/Auxiliary/Build"
+$VCVersion = Get-Content 'Microsoft.VCToolsVersion.default.txt'
+cmd /c "vcvarsall.bat $Architecture -vcvars_ver=$VCVersion > nul & set" | ForEach-Object {
+	if ($_ -match '^(.+?)=(.*)') {
+		Set-Item -Force -Path "ENV:$($matches[1])" -Value $matches[2]
+	}
+}
+Pop-Location
+
+if ($Compiler -ne "cl") {
+	$ENV:CXX=$Compiler
+}
+
+if (Test-Path -PathType Container $BuildDirectory) {
+	Remove-Item -Recurse $BuildDirectory | Out-Null
+}
+New-Item -ItemType Directory $BuildDirectory | Out-Null
+
+Invoke-NativeCommand cmake -B $BuildDirectory -G Ninja "-DCMAKE_BUILD_TYPE=$Config" .
+Invoke-NativeCommand cmake --build $BuildDirectory
+Invoke-NativeCommand ctest --test-dir $BuildDirectory


### PR DESCRIPTION
* Added CI builds on Windows using MSVC, Clang and Clang-CL.
* Disabled the Clang builds due to a baffling compiler bug causing test failures.