### PR TITLE
rename `is_sender`/`is_receiver` to `sender_concept`/`receiver_concept`

### DIFF
--- a/examples/algorithms/retry.hpp
+++ b/examples/algorithms/retry.hpp
@@ -108,7 +108,7 @@ struct _op {
 
 template <class S>
 struct _retry_sender {
-  using is_sender = void;
+  using sender_concept = stdexec::sender_t;
   S s_;
 
   explicit _retry_sender(S s)

--- a/examples/algorithms/then.hpp
+++ b/examples/algorithms/then.hpp
@@ -52,7 +52,7 @@ class _then_receiver : stdexec::receiver_adaptor<_then_receiver<R, F>, R> {
 
 template <stdexec::sender S, class F>
 struct _then_sender {
-  using is_sender = void;
+  using sender_concept = stdexec::sender_t;
 
   S s_;
   F f_;

--- a/examples/benchmark/static_thread_pool_old.hpp
+++ b/examples/benchmark/static_thread_pool_old.hpp
@@ -160,7 +160,7 @@ namespace exec_old {
        public:
         using __t = sender;
         using __id = sender;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures =
           stdexec::completion_signatures< stdexec::set_value_t(), stdexec::set_stopped_t()>;
        private:
@@ -441,7 +441,7 @@ namespace exec_old {
   struct static_thread_pool::bulk_sender {
     using Sender = stdexec::__t<SenderId>;
     using Fun = stdexec::__t<FunId>;
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
 
     static_thread_pool& pool_;
     Sender sndr_;
@@ -609,7 +609,7 @@ namespace exec_old {
 
   template <class SenderId, class ReceiverId, class Shape, class Fn, bool MayThrow>
   struct static_thread_pool::bulk_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     using Sender = stdexec::__t<SenderId>;
     using Receiver = stdexec::__t<ReceiverId>;
 

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -26,9 +26,13 @@
 #include <nvexec/multi_gpu_context.cuh>
 #else
 namespace nvexec {
-  struct stream_receiver_base { };
+  struct stream_receiver_base {
+    using receiver_concept = stdexec::receiver_t;
+  };
 
-  struct stream_sender_base { };
+  struct stream_sender_base {
+    using sender_concept = stdexec::sender_t;
+  };
 
   namespace detail {
     struct stream_op_state_base { };
@@ -187,13 +191,15 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { //
 namespace repeat_n_detail {
 
   template <class OpT>
-  class receiver_2_t : public stdexec::__receiver_base {
+  class receiver_2_t {
     using Sender = typename OpT::PredSender;
     using Receiver = typename OpT::Receiver;
 
     OpT& op_state_;
 
    public:
+    using receiver_concept = stdexec::receiver_t;
+
     template <stdexec::__one_of<ex::set_error_t, ex::set_stopped_t> _Tag, class... _Args>
     friend void tag_invoke(_Tag __tag, receiver_2_t&& __self, _Args&&... __args) noexcept {
       OpT& op_state = __self.op_state_;
@@ -231,12 +237,14 @@ namespace repeat_n_detail {
   };
 
   template <class OpT>
-  class receiver_1_t : public stdexec::__receiver_base {
+  class receiver_1_t {
     using Receiver = typename OpT::Receiver;
 
     OpT& op_state_;
 
    public:
+    using receiver_concept = stdexec::receiver_t;
+
     template <stdexec::__one_of<ex::set_error_t, ex::set_stopped_t> _Tag, class... _Args>
     friend void tag_invoke(_Tag __tag, receiver_1_t&& __self, _Args&&... __args) noexcept {
       OpT& op_state = __self.op_state_;

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -316,7 +316,7 @@ namespace repeat_n_detail {
     using __t = repeat_n_sender_t;
     using __id = repeat_n_sender_t;
     using Sender = stdexec::__t<SenderId>;
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
 
     using completion_signatures = //
       stdexec::completion_signatures<

--- a/examples/retry.cpp
+++ b/examples/retry.cpp
@@ -23,7 +23,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Example code:
 struct fail_some {
-  using is_sender = void;
+  using sender_concept = stdexec::sender_t;
   using completion_signatures = stdexec::
     completion_signatures< stdexec::set_value_t(int), stdexec::set_error_t(std::exception_ptr)>;
 

--- a/include/exec/__detail/__basic_sequence.hpp
+++ b/include/exec/__detail/__basic_sequence.hpp
@@ -31,7 +31,7 @@ namespace exec {
 
   template <class _ImplFn>
   struct __seqexpr<_ImplFn> {
-    using is_sender = sequence_tag;
+    using sender_concept = sequence_sender_t;
     using __t = __seqexpr;
     using __id = __seqexpr;
     using __tag_t = stdexec::__call_result_t<_ImplFn, stdexec::__cp, stdexec::__detail::__get_tag>;

--- a/include/exec/__detail/__sender_facade.hpp
+++ b/include/exec/__detail/__sender_facade.hpp
@@ -27,7 +27,7 @@ namespace exec {
     struct _WHAT_ {
       struct __t {
         using __id = _WHAT_;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures = _WHAT_;
       };
     };
@@ -174,7 +174,7 @@ namespace exec {
       };
 
       struct __t {
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         using __id = __receiver;
         __state* __state_;
 
@@ -252,7 +252,7 @@ namespace exec {
 
       struct __t {
         using __id = _DerivedId;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         _Sender __sndr_;
         _Kernel __kernel_;
 

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -656,7 +656,7 @@ namespace exec {
           }
         } __env_;
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         using __id = __ref;
         using __t = __ref;
 
@@ -721,7 +721,7 @@ namespace exec {
           }
         } __env_;
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         using __id = __ref;
         using __t = __ref;
 
@@ -794,7 +794,7 @@ namespace exec {
       using _Receiver = stdexec::__t<_ReceiverId>;
 
       struct __t {
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         __operation_base<_Receiver>* __op_;
 
         template <same_as<set_next_t> _SetNext, same_as<__t> _Self, class _Item>
@@ -967,7 +967,7 @@ namespace exec {
        public:
         using __id = __sender;
         using completion_signatures = _Sigs;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
 
         __t(const __t&) = delete;
         __t& operator=(const __t&) = delete;
@@ -1099,7 +1099,7 @@ namespace exec {
     }
 
    public:
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     using __t = any_receiver_ref;
     using __id = any_receiver_ref;
 
@@ -1124,7 +1124,7 @@ namespace exec {
         return stdexec::tag_invoke(_Tag{}, ((Self&&) __self).__sender_, (_As&&) __as...);
       }
      public:
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = typename __sender_base::completion_signatures;
 
       template <stdexec::__not_decays_to<any_sender> _Sender>

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -95,7 +95,7 @@ namespace exec {
     template <class _ConstrainedId>
     struct __when_empty_sender {
       using _Constrained = __t<_ConstrainedId>;
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
 
       template <class _Self, class _Receiver>
       using __when_empty_op_t =
@@ -137,7 +137,7 @@ namespace exec {
 
     template <class _ReceiverId>
     struct __nest_rcvr {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
       using _Receiver = __t<_ReceiverId>;
       __nest_op_base<_ReceiverId>* __op_;
 
@@ -205,7 +205,7 @@ namespace exec {
     template <class _ConstrainedId>
     struct __nest_sender {
       using _Constrained = __t<_ConstrainedId>;
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
 
       const __impl* __scope_;
       STDEXEC_ATTRIBUTE((no_unique_address)) _Constrained __c_;
@@ -473,7 +473,7 @@ namespace exec {
 
     template <class _CompletionsId, class _EnvId>
     struct __future_rcvr {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
       using _Completions = __t<_CompletionsId>;
       using _Env = __t<_EnvId>;
       __future_state_base<_Completions, _Env>* __state_;
@@ -543,7 +543,7 @@ namespace exec {
       using _Env = __t<_EnvId>;
       friend struct async_scope;
      public:
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
 
       __future(__future&&) = default;
       __future& operator=(__future&&) = default;
@@ -614,7 +614,7 @@ namespace exec {
 
     template <class _EnvId>
     struct __spawn_rcvr {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
       using _Env = __t<_EnvId>;
       __spawn_op_base<_EnvId>* __op_;
       const __impl* __scope_;

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -38,7 +38,7 @@ namespace exec {
       template <class _Receiver>
       struct __receiver_id {
         struct __t {
-          using is_receiver = void;
+          using receiver_concept = stdexec::receiver_t;
           using __id = __receiver_id;
           _Receiver __receiver_;
 
@@ -71,7 +71,7 @@ namespace exec {
 
         struct __t {
           using __id = __sender_id;
-          using is_sender = void;
+          using sender_concept = stdexec::sender_t;
 
           _Sender __sender_;
 

--- a/include/exec/create.hpp
+++ b/include/exec/create.hpp
@@ -56,7 +56,7 @@ namespace exec {
     template <class _Fun, class _ArgsId, class... _Sigs>
     struct __sender {
       using _Args = __t<_ArgsId>;
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = stdexec::completion_signatures<_Sigs...>;
 
       _Fun __fun_;

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -75,7 +75,7 @@ namespace exec {
     template <class _Tag, class _DefaultId>
     struct __sender {
       using _Default = __t<_DefaultId>;
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       STDEXEC_ATTRIBUTE((no_unique_address)) _Default __default_;
 
       template <class _Env>

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -100,7 +100,7 @@ namespace exec {
 
       class __t {
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
 
         explicit __t(__final_operation_base<_ResultType, _ReceiverId>* __op) noexcept
           : __op_{__op} {
@@ -167,7 +167,7 @@ namespace exec {
 
       class __t {
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
 
         explicit __t(__base_op_t* __op) noexcept
           : __op_(__op) {
@@ -273,7 +273,7 @@ namespace exec {
         }
 
        public:
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
 
         template <__decays_to<_InitialSender> _Is, __decays_to<_FinalSender> _Fs>
         __t(_Is&& __initial_sender, _Fs&& __final_sender) noexcept(

--- a/include/exec/linux/io_uring_context.hpp
+++ b/include/exec/linux/io_uring_context.hpp
@@ -560,7 +560,7 @@ namespace exec {
 
       class __run_sender {
        public:
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures = stdexec::completion_signatures<
           stdexec::set_value_t(),
           stdexec::set_error_t(std::exception_ptr),
@@ -1057,7 +1057,7 @@ namespace exec {
       class __schedule_sender {
         __schedule_env __env_;
        public:
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using __id = __schedule_sender;
         using __t = __schedule_sender;
 
@@ -1094,7 +1094,7 @@ namespace exec {
 
       class __schedule_after_sender {
        public:
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using __id = __schedule_after_sender;
         using __t = __schedule_after_sender;
 

--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -28,7 +28,7 @@ namespace exec {
 
       class __t {
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
 
         __t(_Receiver&& __upstream)
           : __upstream_{(_Receiver&&) __upstream} {
@@ -59,7 +59,7 @@ namespace exec {
 
       class __t {
        public:
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
 
         template <__decays_to<_Sender> _Sndr>
         __t(_Sndr&& __sender)
@@ -125,7 +125,7 @@ namespace exec {
 
       class __t {
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
 
         __t(_Receiver&& __upstream)
           : __upstream_{(_Receiver&&) __upstream} {
@@ -166,7 +166,7 @@ namespace exec {
 
       class __t {
        public:
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
 
         template <__decays_to<_Sender> _Sndr>
         __t(_Sndr&& __sndr) noexcept(__nothrow_decay_copyable<_Sndr>)

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -72,7 +72,7 @@ namespace exec {
 
     template <class _SourceId, class _ReceiverId>
     struct __receiver<_SourceId, _ReceiverId>::__t {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
       using __id = __receiver;
       using _Source = stdexec::__t<_SourceId>;
       using _Receiver = stdexec::__t<_ReceiverId>;
@@ -148,7 +148,7 @@ namespace exec {
       using __receiver_t = stdexec::__t< __receiver<_SourceId, stdexec::__id<_Receiver>>>;
 
       struct __t {
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using __id = __sender;
         STDEXEC_ATTRIBUTE((no_unique_address)) _Source __source_;
 

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -116,7 +116,7 @@ namespace exec {
           using __env_t = stdexec::__t<__env<__next_sigs, _Queries...>>;
           __env_t __env_;
 
-          using is_receiver = void;
+          using receiver_concept = stdexec::receiver_t;
 
           template <__none_of<__t, const __t, __env_t, const __env_t> _Rcvr>
             requires sequence_receiver_of<_Rcvr, __item_types>
@@ -284,7 +284,7 @@ namespace exec {
    public:
     using __id = any_sequence_receiver_ref;
     using __t = any_sequence_receiver_ref;
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     template <std::same_as<stdexec::get_env_t> _GetEnv, std::same_as<__t> _Self>
       requires stdexec::__callable<stdexec::get_env_t, const __receiver_base&>

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -238,7 +238,7 @@ namespace exec {
         using __id = __sequence_sender;
         using completion_signatures = __compl_sigs;
         using item_types = exec::item_types<__item_sender>;
-        using is_sender = sequence_tag;
+        using sender_concept = sequence_sender_t;
 
         __t(const __t&) = delete;
         __t& operator=(const __t&) = delete;
@@ -337,7 +337,7 @@ namespace exec {
      public:
       using __id = any_sender;
       using __t = any_sender;
-      using is_sender = sequence_tag;
+      using sender_concept = sequence_sender_t;
       using completion_signatures = typename __sender_base::completion_signatures;
       using item_types = typename __sender_base::item_types;
 

--- a/include/exec/sequence/empty_sequence.hpp
+++ b/include/exec/sequence/empty_sequence.hpp
@@ -40,7 +40,7 @@ namespace exec {
     struct __sender {
       struct __t {
         using __id = __sender;
-        using is_sender = sequence_tag;
+        using sender_concept = sequence_sender_t;
         using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t()>;
         using item_types = exec::item_types<>;
 

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -78,7 +78,7 @@ namespace exec {
     struct __item_receiver {
       struct __t {
         using __id = __item_receiver;
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         __item_operation_base<_ItemReceiver, _ResultVariant>* __op_;
 
         template <same_as<set_value_t> _Tag, same_as<__t> _Self, class... _Args>
@@ -139,7 +139,7 @@ namespace exec {
     template <class _Sender, class _ResultVariant>
     struct __item_sender {
       struct __t {
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures =
           stdexec::completion_signatures<set_value_t(), set_stopped_t()>;
 
@@ -176,7 +176,7 @@ namespace exec {
 
       struct __t {
         using __id = __receiver;
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         __operation_base<_Receiver, _ResultVariant>* __op_;
 
         template <same_as<set_next_t> _SetNext, same_as<__t> _Self, sender _Item>

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -60,7 +60,7 @@ namespace exec {
     struct __sender {
       struct __t {
         using __id = __sender;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures =
           stdexec::completion_signatures<set_value_t(std::iter_reference_t<_Iterator>)>;
         __operation_base<_Iterator, _Sentinel>* __parent_;
@@ -88,7 +88,7 @@ namespace exec {
       struct __t {
         using _Receiver = stdexec::__t<_ReceiverId>;
         using __id = __next_receiver;
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         stdexec::__t<__operation<_Range, _ReceiverId>>* __op_;
 
         template <same_as<set_value_t> _SetValue, same_as<__t> _Self>

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -35,7 +35,7 @@ namespace exec {
       using _Receiver = stdexec::__t<_ReceiverId>;
 
       struct __t {
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         using __id = __receiver;
         __operation_base<_Receiver, _Adaptor>* __op_;
 

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -19,7 +19,8 @@
 #include "../stdexec/execution.hpp"
 
 namespace exec {
-  struct sequence_tag { };
+  struct sequence_sender_t : stdexec::sender_t { };
+  using sequence_tag [[deprecated("Renamed to exec::sequence_sender_t")]] = exec::sequence_sender_t;
 
   namespace __sequence_sndr {
     using namespace stdexec;
@@ -117,9 +118,9 @@ namespace exec {
   } // namespace __sequence_sndr
 
   template <class _Sender>
-  concept __enable_sequence_sender =             //
-    requires { typename _Sender::is_sender; } && //
-    stdexec::same_as<typename _Sender::is_sender, sequence_tag>;
+  concept __enable_sequence_sender =                  //
+    requires { typename _Sender::sender_concept; } && //
+    stdexec::same_as<typename _Sender::sender_concept, sequence_tag>;
 
   template <class _Sender>
   inline constexpr bool enable_sequence_sender = __enable_sequence_sender<_Sender>;

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -77,7 +77,7 @@ namespace exec {
     template <class _ReceiverId>
     struct __stopped_means_break {
       struct __t {
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         using __id = __stopped_means_break;
         using _Receiver = stdexec::__t<_ReceiverId>;
         using _Token = stop_token_of_t<env_of_t<_Receiver>>;

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -74,7 +74,7 @@ namespace exec {
 
   template <class>
   struct not_a_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
   };
 
   struct task_base {
@@ -295,7 +295,7 @@ namespace exec {
        public:
         using __t = sender;
         using __id = sender;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures =
           stdexec::completion_signatures< stdexec::set_value_t(), stdexec::set_stopped_t()>;
        private:
@@ -810,7 +810,7 @@ namespace exec {
   struct static_thread_pool::bulk_sender {
     using Sender = stdexec::__t<SenderId>;
     using Fun = stdexec::__t<FunId>;
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
 
     static_thread_pool& pool_;
     Sender sndr_;
@@ -978,7 +978,7 @@ namespace exec {
 
   template <class SenderId, class ReceiverId, class Shape, class Fn, bool MayThrow>
   struct static_thread_pool::bulk_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     using Sender = stdexec::__t<SenderId>;
     using Receiver = stdexec::__t<ReceiverId>;
 
@@ -1128,7 +1128,7 @@ namespace exec {
     struct item_sender {
       struct __t {
         using __id = item_sender;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t(
           std::ranges::range_reference_t<Range>)>;
 
@@ -1172,7 +1172,7 @@ namespace exec {
     template <class Range, class Receiver>
     struct next_receiver {
       struct __t {
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         operation_base_with_receiver<Range, Receiver>* op_;
 
         template <stdexec::same_as<stdexec::set_value_t> SetValue, stdexec::same_as<__t> Self>

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1279,7 +1279,7 @@ namespace exec {
      public:
       using __id = sequence;
 
-      using is_sender = sequence_tag;
+      using sender_concept = sequence_sender_t;
 
       using completion_signatures = stdexec::completion_signatures<
         stdexec::set_value_t(),

--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -126,7 +126,7 @@ namespace exec {
       using __operation_t = stdexec::__t<__operation<__id<__decay_t<_Receiver>>>>;
 
       struct __schedule_sender {
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using completion_signatures =
           stdexec::completion_signatures<set_value_t(), set_stopped_t()>;
 

--- a/include/exec/variant_sender.hpp
+++ b/include/exec/variant_sender.hpp
@@ -97,7 +97,7 @@ namespace exec {
         }
 
        public:
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
         using __id = __sender;
 
         __t() = default;

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -155,7 +155,7 @@ namespace exec {
     struct __receiver {
       class __t {
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         using __id = __receiver;
 
         explicit __t(__op_base<_Receiver, _ResultVariant>* __op) noexcept
@@ -241,7 +241,7 @@ namespace exec {
       class __t {
        public:
         using __id = __sender;
-        using is_sender = void;
+        using sender_concept = stdexec::sender_t;
 
         template <class... _Senders>
         explicit(sizeof...(_Senders) == 1)

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -320,7 +320,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   template <class SenderId, std::integral Shape, class Fun>
   struct multi_gpu_bulk_sender_t {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using Sender = stdexec::__t<SenderId>;
 
     struct __t : stream_sender_base {

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -197,10 +197,11 @@ namespace nvexec {
     struct stream_scheduler;
 
     struct stream_sender_base {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
     };
 
-    struct stream_receiver_base : __receiver_base {
+    struct stream_receiver_base {
+      using receiver_concept = stdexec::receiver_t;
       constexpr static std::size_t memory_allocation_size = 0;
     };
 
@@ -384,7 +385,7 @@ namespace nvexec {
         queue::producer_t producer_;
 
        public:
-        using is_receiver = void;
+        using receiver_concept = stdexec::receiver_t;
         using __id = stream_enqueue_receiver;
 
         template <__one_of<set_value_t, set_stopped_t> Tag, class... As>

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -46,7 +46,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
     template <class SenderId, class SharedState>
     struct receiver_t {
-      class __t : stream_receiver_base {
+      class __t : public stream_receiver_base {
         using Sender = stdexec::__t<SenderId>;
 
         __intrusive_ptr<SharedState> shared_state_;

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -300,7 +300,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   template <class SenderId>
   struct ensure_started_sender_t {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using Sender = stdexec::__t<SenderId>;
 
     struct __t : stream_sender_base {

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -293,7 +293,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   template <class SenderId>
   struct split_sender_t {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using Sender = stdexec::__t<SenderId>;
     using sh_state_ = _split::sh_state_t<Sender>;
 

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -39,7 +39,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
     struct receiver_t {
       using Receiver = stdexec::__t<ReceiverId>;
 
-      class __t : stream_receiver_base {
+      class __t : public stream_receiver_base {
         Fun f_;
         operation_state_base_t<ReceiverId>& op_state_;
 

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -218,7 +218,7 @@ namespace stdexec {
     template <class _ReceiverId, class _Sexpr, class _Idx>
     struct __receiver {
       struct __t {
-        using is_receiver = void;
+        using receiver_concept = receiver_t;
         using _Receiver = stdexec::__t<_ReceiverId>;
         using __sexpr = _Sexpr;
         using __index = _Idx;
@@ -410,7 +410,7 @@ namespace stdexec {
 
   template <class _ImplFn>
   struct __sexpr<_ImplFn> {
-    using is_sender = void;
+    using sender_concept = sender_t;
     using __t = __sexpr;
     using __id = __sexpr;
     using __meta_t = __call_result_t<_ImplFn, __cp, __detail::__get_meta>;

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -198,7 +198,7 @@ namespace stdexec {
           _Receiver&& __rcvr,
           _SetTag,
           _Args&&... __args) noexcept {
-        _SetTag()((_Receiver&&) __rcvr, (_Args&&) __args...);
+        _SetTag()(std::move(__rcvr), (_Args&&) __args...);
       }
 
       // By default, return a generic operation state
@@ -298,6 +298,9 @@ namespace stdexec {
       }
     };
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(offset_in_non_POD_nonstandard)
+
     template <class _Sexpr, class _Receiver>
     struct __enable_receiver_from_this {
       using __op_base_t = __op_base<_Sexpr, _Receiver>;
@@ -318,6 +321,8 @@ namespace stdexec {
         return __base->__rcvr();
       }
     };
+
+STDEXEC_PRAGMA_POP()
 
     template <class _Sexpr, class _Receiver>
     struct __connect_fn {

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -42,6 +42,8 @@ namespace stdexec {
   template <class _Tag>
   concept __completion_tag = __one_of<_Tag, set_value_t, set_error_t, set_stopped_t>;
 
+  struct receiver_t;
+
   template <class _Sender>
   extern const bool enable_receiver;
 
@@ -131,6 +133,8 @@ namespace stdexec {
 
   template <class _Sender, class _Receiver>
   concept __nothrow_connectable = __nothrow_callable<connect_t, _Sender, _Receiver>;
+
+  struct sender_t;
 
   template <class _Sender>
   extern const bool enable_sender;

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -1025,8 +1025,9 @@ namespace stdexec {
 
   namespace __detail {
     template <class _Receiver>
-    concept __enable_receiver = //
-      derived_from<typename _Receiver::receiver_concept, receiver_t>
+    concept __enable_receiver =                                            //
+      (STDEXEC_NVHPC(requires { typename _Receiver::receiver_concept; }&&) //
+       derived_from<typename _Receiver::receiver_concept, receiver_t>)
       || requires { typename _Receiver::is_receiver; } // back-compat, NOT TO SPEC
       || STDEXEC_IS_BASE_OF(receiver_t, _Receiver);    // NOT TO SPEC, for receiver_adaptor
   }                                                    // namespace __detail
@@ -2997,7 +2998,7 @@ namespace stdexec {
     };
 
     template <derived_from<__no::__nope> _Base>
-    struct __adaptor_base<_Base> : __no::__nope { };
+    struct __adaptor_base<_Base> { };
 
 // BUGBUG Not to spec: on gcc and nvc++, member functions in derived classes
 // don't shadow type aliases of the same name in base classes. :-O

--- a/include/tbbexec/tbb_thread_pool.hpp
+++ b/include/tbbexec/tbb_thread_pool.hpp
@@ -54,7 +54,7 @@ namespace tbbexec {
 
         class sender {
          public:
-          using is_sender = void;
+          using sender_concept = stdexec::sender_t;
           using __t = sender;
           using __id = sender;
           using completion_signatures =
@@ -220,7 +220,7 @@ namespace tbbexec {
 
         template <class SenderId, class ReceiverId, class Shape, class Fn, bool MayThrow>
         struct bulk_receiver {
-          using is_receiver = void;
+          using receiver_concept = stdexec::receiver_t;
           using Sender = stdexec::__t<SenderId>;
           using Receiver = stdexec::__t<ReceiverId>;
 
@@ -311,7 +311,7 @@ namespace tbbexec {
 
         template <class SenderId, std::integral Shape, class FunId>
         struct bulk_sender {
-          using is_sender = void;
+          using sender_concept = stdexec::sender_t;
           using Sender = stdexec::__t<SenderId>;
           using Fun = stdexec::__t<FunId>;
 

--- a/test/exec/async_scope/test_spawn.cpp
+++ b/test/exec/async_scope/test_spawn.cpp
@@ -12,7 +12,7 @@ namespace {
 
   //! Sender that throws exception when connected
   struct throwing_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
 
     template <class Receiver>

--- a/test/exec/async_scope/test_spawn_future.cpp
+++ b/test/exec/async_scope/test_spawn_future.cpp
@@ -23,7 +23,7 @@ namespace {
 
   //! Sender that throws exception when connected
   struct throwing_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
 
     template <class Receiver>

--- a/test/exec/sequence/test_any_sequence_of.cpp
+++ b/test/exec/sequence/test_any_sequence_of.cpp
@@ -29,7 +29,7 @@ namespace {
 
   template <class Receiver>
   struct ignore_all_item_rcvr {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     Receiver rcvr;
 
     friend stdexec::env_of_t<Receiver>
@@ -54,7 +54,7 @@ namespace {
 
   template <class Item>
   struct ignore_all_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t()>;
 
     Item item_;
@@ -70,7 +70,7 @@ namespace {
   };
 
   struct ignore_all_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     template <class Item>
     friend ignore_all_sender<stdexec::__decay_t<Item>>

--- a/test/exec/sequence/test_empty_sequence.cpp
+++ b/test/exec/sequence/test_empty_sequence.cpp
@@ -38,7 +38,7 @@ namespace {
   }
 
   struct count_set_next_receiver_t {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     int& count_invocations_;
 
     friend auto

--- a/test/exec/sequence/test_ignore_all_values.cpp
+++ b/test/exec/sequence/test_ignore_all_values.cpp
@@ -83,7 +83,7 @@ namespace {
 
   template <class Item>
   struct sequence {
-    using is_sender = exec::sequence_tag;
+    using sender_concept = exec::sequence_sender_t;
 
     using completion_signatures =
       stdexec::completion_signatures<stdexec::set_value_t(), stdexec::set_error_t(int)>;

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -28,7 +28,7 @@ namespace {
 
   template <class Receiver>
   struct sum_item_rcvr {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     Receiver rcvr;
     int* sum_;
 
@@ -55,7 +55,7 @@ namespace {
 
   template <class Item>
   struct sum_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = stdexec::completion_signatures<stdexec::set_value_t()>;
 
     Item item_;
@@ -73,7 +73,7 @@ namespace {
 
   template <class Env = stdexec::empty_env>
   struct sum_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     int& sum_;
     Env env_{};

--- a/test/exec/sequence/test_transform_each.cpp
+++ b/test/exec/sequence/test_transform_each.cpp
@@ -35,7 +35,7 @@ namespace {
   struct next_rcvr {
     using __id = next_rcvr;
     using __t = next_rcvr;
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     friend auto tag_invoke(exec::set_next_t, next_rcvr, auto item) {
       return item;

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -59,7 +59,7 @@ namespace {
   };
 
   struct sink_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     std::variant<std::monostate, int, std::exception_ptr, set_stopped_t> value_{};
 
@@ -367,7 +367,7 @@ namespace {
 
   template <class Token>
   struct stopped_receiver_base {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     Token stop_token_{};
   };
 
@@ -682,7 +682,7 @@ namespace {
       using __id = sender;
       using __t = sender;
 
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
 
       template <ex::receiver R>

--- a/test/exec/test_repeat_effect_until.cpp
+++ b/test/exec/test_repeat_effect_until.cpp
@@ -37,7 +37,7 @@ using namespace stdexec;
 namespace {
 
   struct boolean_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using __t = boolean_sender;
     using __id = boolean_sender;
     using completion_signatures = stdexec::completion_signatures<set_value_t(bool)>;

--- a/test/exec/test_sequence_senders.cpp
+++ b/test/exec/test_sequence_senders.cpp
@@ -120,7 +120,7 @@ namespace {
 
   template <__completion_signature... _Sigs>
   struct some_sequence_sender_of {
-    using is_sender = sequence_tag;
+    using sender_concept = sequence_sender_t;
     using completion_signatures = stdexec::completion_signatures<set_value_t()>;
     using item_types = exec::item_types<some_sender_of<_Sigs...>>;
 

--- a/test/exec/test_sequence_senders.cpp
+++ b/test/exec/test_sequence_senders.cpp
@@ -35,7 +35,7 @@ namespace {
 
   template <__completion_signature... _Sigs>
   struct some_sender_of {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = stdexec::completion_signatures<_Sigs...>;
 
     template <class R>
@@ -57,7 +57,7 @@ namespace {
 
   template <__completion_signature... _Sigs>
   struct test_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     template <class _Tag, class... _Args>
       requires __one_of<_Tag(_Args...), _Sigs...>
@@ -86,7 +86,7 @@ namespace {
 
   template <__completion_signature... _Sigs>
   struct next_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     template <sender_to<test_receiver<_Sigs...>> _Item>
     friend _Item tag_invoke(set_next_t, next_receiver&, _Item&& __item) noexcept {

--- a/test/exec/test_trampoline_scheduler.cpp
+++ b/test/exec/test_trampoline_scheduler.cpp
@@ -32,7 +32,7 @@ namespace {
   struct try_again { };
 
   struct fails_alot {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using __t = fails_alot;
     using __id = fails_alot;
     using completion_signatures =

--- a/test/exec/test_when_any.cpp
+++ b/test/exec/test_when_any.cpp
@@ -224,7 +224,7 @@ namespace {
   };
 
   struct dup_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = stdexec::completion_signatures<
       set_value_t(),
       set_error_t(std::exception_ptr),

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -153,7 +153,7 @@ namespace {
 
     template <class SenderId, class FunId>
     struct sender_t {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using Sender = stdexec::__t<SenderId>;
       using Fun = stdexec::__t<FunId>;
 
@@ -218,7 +218,7 @@ namespace {
 
     template <class SenderId>
     struct sender_t {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using Sender = stdexec::__t<SenderId>;
 
       Sender sndr_;

--- a/test/stdexec/algos/adaptors/test_on.cpp
+++ b/test/stdexec/algos/adaptors/test_on.cpp
@@ -244,7 +244,7 @@ namespace {
     };
 
     struct my_sender {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
 
       template <typename R>

--- a/test/stdexec/algos/adaptors/test_upon_error.cpp
+++ b/test/stdexec/algos/adaptors/test_upon_error.cpp
@@ -78,7 +78,7 @@ namespace {
 
   template <class... AdditionalCompletions>
   struct many_error_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures<
       AdditionalCompletions...,
       ex::set_error_t(Error1),

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -314,7 +314,7 @@ namespace {
   struct my_string_sender_t {
     std::string str_;
 
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures =
       ex::completion_signatures_of_t<decltype(ex::just(std::string{})), empty_env>;
 

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -94,7 +94,7 @@ namespace {
   }
 
   struct custom_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     bool* called;
 
     template <class Receiver>

--- a/test/stdexec/algos/consumers/test_sync_wait.cpp
+++ b/test/stdexec/algos/consumers/test_sync_wait.cpp
@@ -214,7 +214,7 @@ namespace {
   }
 
   struct my_other_string_sender_t {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     std::string str_;
 
     using completion_signatures = ex::completion_signatures_of_t<decltype(ex::just(std::string{}))>;
@@ -259,7 +259,7 @@ namespace {
     decltype(fallible_just{std::string{}} | ex::let_error(always(ex::just(0))));
 
   struct my_multi_value_sender_t {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     std::string str_;
     using completion_signatures = ex::completion_signatures_of_t<multi_value_impl_t>;
 

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -36,7 +36,7 @@ namespace {
 
   struct my_scheduler {
     struct my_sender {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                     //
         ex::set_error_t(std::exception_ptr),                   //
@@ -76,7 +76,7 @@ namespace {
 
   struct my_scheduler_except {
     struct my_sender {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                     //
         ex::set_error_t(std::exception_ptr),                   //
@@ -107,7 +107,7 @@ namespace {
 
   struct noeq_sched {
     struct my_sender {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                     //
         ex::set_error_t(std::exception_ptr),                   //
@@ -129,7 +129,7 @@ namespace {
 
   struct sched_no_completion {
     struct my_sender {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                     //
         ex::set_error_t(std::exception_ptr),                   //

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -36,7 +36,7 @@ namespace {
   }
 
   struct P2300r7_sender_1 {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
   };
 
   struct P2300r7_sender_2 { };
@@ -88,7 +88,7 @@ namespace {
   };
 
   struct my_sender0 {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures< //
       ex::set_value_t(),                                     //
       ex::set_error_t(std::exception_ptr),                   //
@@ -122,7 +122,7 @@ namespace {
   }
 
   struct my_sender_int {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures< //
       ex::set_value_t(int),                                  //
       ex::set_error_t(std::exception_ptr),                   //
@@ -180,7 +180,7 @@ namespace {
   }
 
   struct multival_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures< //
       ex::set_value_t(int, double),                          //
       ex::set_value_t(short, long),                          //
@@ -206,7 +206,7 @@ namespace {
   }
 
   struct ec_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures< //
       ex::set_value_t(),                                     //
       ex::set_error_t(std::exception_ptr),                   //
@@ -231,7 +231,7 @@ namespace {
   }
 
   struct my_r5_sender0 {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures< //
       ex::set_value_t(),                                     //
       ex::set_error_t(std::exception_ptr),                   //

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -28,7 +28,7 @@ namespace {
 
   template <scope_t Scope>
   struct cpo_t {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     constexpr static scope_t scope = Scope;
 
     using completion_signatures = ex::completion_signatures< //
@@ -43,7 +43,7 @@ namespace {
 
   template <class CPO>
   struct free_standing_sender_t {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using __id = free_standing_sender_t;
     using __t = free_standing_sender_t;
     using completion_signatures = ex::completion_signatures< //
@@ -74,7 +74,7 @@ namespace {
     };
 
     struct sender_t {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using __id = sender_t;
       using __t = sender_t;
       using completion_signatures = ex::completion_signatures< //

--- a/test/stdexec/cpos/test_cpo_connect.cpp
+++ b/test/stdexec/cpos/test_cpo_connect.cpp
@@ -39,7 +39,7 @@ namespace {
   };
 
   struct my_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures<ex::set_value_t(int)>;
 
     int value_{0};
@@ -55,7 +55,7 @@ namespace {
   };
 
   struct my_sender_unconstrained {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures<ex::set_value_t(int)>;
 
     int value_{0};
@@ -82,7 +82,7 @@ namespace {
   }
 
   struct strange_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     bool* called_;
 
     friend inline op_state<strange_receiver>

--- a/test/stdexec/cpos/test_cpo_schedule.cpp
+++ b/test/stdexec/cpos/test_cpo_schedule.cpp
@@ -27,7 +27,7 @@ STDEXEC_PRAGMA_IGNORE_GNU("-Wunused-function")
 namespace {
 
   struct my_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures< //
       ex::set_value_t(),                                     //
       ex::set_error_t(std::exception_ptr),                   //

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -32,7 +32,7 @@ namespace {
     };
 
     struct sender {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures =
         ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
 
@@ -75,7 +75,7 @@ namespace {
     };
 
     struct sender {
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures =
         ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
 

--- a/test/test_common/receivers.hpp
+++ b/test/test_common/receivers.hpp
@@ -33,7 +33,7 @@ namespace {
     using ex::set_value_t;
 
     struct recv0 {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
 
       friend void tag_invoke(set_value_t, recv0&&) noexcept {
       }
@@ -50,7 +50,7 @@ namespace {
     };
 
     struct recv_int {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
 
       friend void tag_invoke(set_value_t, recv_int&&, int) noexcept {
       }
@@ -67,7 +67,7 @@ namespace {
     };
 
     struct recv0_ec {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
 
       friend void tag_invoke(set_value_t, recv0_ec&&) noexcept {
       }
@@ -87,7 +87,7 @@ namespace {
     };
 
     struct recv_int_ec {
-      using is_receiver = void;
+      using receiver_concept = stdexec::receiver_t;
 
       friend void tag_invoke(set_value_t, recv_int_ec&&, int) noexcept {
       }
@@ -118,7 +118,7 @@ namespace {
     }
 
    public:
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     base_expect_receiver() = default;
 
     ~base_expect_receiver() {
@@ -172,7 +172,7 @@ namespace {
   };
 
   struct expect_void_receiver_ex {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     expect_void_receiver_ex(bool& executed)
       : executed_(&executed) {
@@ -243,7 +243,7 @@ namespace {
     Env env_{};
 
    public:
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     explicit expect_value_receiver_ex(T& dest)
       : dest_(&dest) {
@@ -301,7 +301,7 @@ namespace {
 
   template <class Env = empty_env>
   struct expect_stopped_receiver_ex {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     explicit expect_stopped_receiver_ex(bool& executed)
       : executed_(&executed) {
@@ -402,7 +402,7 @@ namespace {
 
   template <class T, class Env = empty_env>
   struct expect_error_receiver_ex {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     explicit expect_error_receiver_ex(T& value)
       : value_(&value) {
@@ -441,7 +441,7 @@ namespace {
   };
 
   struct logging_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
 
     logging_receiver(int& state)
       : state_(&state) {
@@ -479,7 +479,7 @@ namespace {
 
   template <typename T>
   struct typecat_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     T* value_;
     typecat* cat_;
 
@@ -517,7 +517,7 @@ namespace {
 
   template <typename F>
   struct fun_receiver {
-    using is_receiver = void;
+    using receiver_concept = stdexec::receiver_t;
     F f_;
 
     template <typename... Ts>

--- a/test/test_common/retry.hpp
+++ b/test/test_common/retry.hpp
@@ -110,7 +110,7 @@ namespace {
 
   template <class S>
   struct _retry_sender {
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     S s_;
 
     explicit _retry_sender(S s)

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -92,7 +92,7 @@ namespace {
       using __id = my_sender;
       using __t = my_sender;
 
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                     //
         ex::set_stopped_t()>;
@@ -193,7 +193,7 @@ namespace {
     struct my_sender {
       using __t = my_sender;
       using __id = my_sender;
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
 
       template <typename R>
@@ -259,7 +259,7 @@ namespace {
       using __id = my_sender;
       using __t = my_sender;
 
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                     //
         ex::set_error_t(E),
@@ -310,7 +310,7 @@ namespace {
       using __id = my_sender;
       using __t = my_sender;
 
-      using is_sender = void;
+      using sender_concept = stdexec::sender_t;
       using completion_signatures = ex::completion_signatures< //
         ex::set_value_t(),                                     //
         ex::set_stopped_t()>;

--- a/test/test_common/senders.hpp
+++ b/test/test_common/senders.hpp
@@ -27,7 +27,7 @@ namespace {
   template <class... Values>
   struct fallible_just {
     std::tuple<Values...> values_;
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures =
       ex::completion_signatures<ex::set_value_t(Values...), ex::set_error_t(std::exception_ptr)>;
 
@@ -69,7 +69,7 @@ namespace {
   struct just_with_env {
     std::remove_cvref_t<Env> env_;
     std::tuple<Values...> values_;
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures<ex::set_value_t(Values...)>;
 
     template <class Receiver>
@@ -98,7 +98,7 @@ namespace {
   struct completes_if {
     using __t = completes_if;
     using __id = completes_if;
-    using is_sender = void;
+    using sender_concept = stdexec::sender_t;
     using completion_signatures = ex::completion_signatures<ex::set_value_t(), ex::set_stopped_t()>;
 
     bool condition_;


### PR DESCRIPTION
... per discussion in LEWG at the Kona '23 meeting