### PR TITLE
Add missing include to fix README example.

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -29,6 +29,7 @@
 #include "./sequence_senders.hpp"
 #include "./sequence/iterate.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <condition_variable>
 #include <exception>


### PR DESCRIPTION
On the [latest clang and gcc](https://godbolt.org/z/8njK8a1r8), the [example](https://github.com/NVIDIA/stdexec#example) from the README does not compile, apparently due to a missing `<algorithm>` include. This PR adds that include to `static_thread_pool.hpp`. 