### PR TITLE
[minor]: add `stdexec` qualifier to avoid ambiguity error

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1052,7 +1052,7 @@ namespace exec {
           __with_exception_ptr>;
 
       template <class... Tys>
-      using set_value_t = completion_signatures< set_value_t(__decay_t<Tys>...)>;
+      using set_value_t = completion_signatures< set_value_t(stdexec::__decay_t<Tys>...)>;
 
       template <class Self, class Env>
       using __completions_t = //


### PR DESCRIPTION
Hi stdexec developers,

I was building some of my [stdexec apps](https://github.com/NERSC/hpcpp/blob/main/apps/fft/fft-stdexec.cpp) and was getting a compiler error . Quick looking into it revealed it was coming from an ambiguous `__decay_t` [here](https://github.com/NVIDIA/stdexec/blob/main/include/exec/static_thread_pool.hpp#L1055). Adding a `stdexec::` qualifier to it resolves the issue. Please feel free to merge or delete the PR if this is not the correct solution. Thank you.

Setup: same as #1128.

Error log:
```bash
mhaseeb@login34:~/repos/hpcpp/build-multicore/apps/fft$ make
[ 33%] Built target fmt
Consolidate compiler generated dependencies of target fft-serial
[ 44%] Building CXX object apps/fft/CMakeFiles/fft-serial.dir/fft-serial.cpp.o
"/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/mdspan_formatter-src/include/mdspan_fmt_formatter.hpp", line 64: warning: a user-provided literal suffix must begin with "_" [lit_suffix_no_underscore]
          return [&]<std::size_t... I>(std::index_sequence<I...>){
                                    ^

Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"

"/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/static_thread_pool.hpp", line 1055: error: "__decay_t" is ambiguous
        using set_value_t = completion_signatures< set_value_t(__decay_t<Tys>...)>;
                                                               ^
          detected during:
            instantiation of class "exec::_pool_::static_thread_pool_::bulk_sender<SenderId, Shape, Fun>::__t [with SenderId=exec::_pool_::static_thread_pool_::scheduler::sender::__id, Shape=int, Fun=lambda [](int)->void]" at line 236
            instantiation of "auto exec::_pool_::static_thread_pool_::transform_bulk::operator()(stdexec::__bulk::bulk_t, Data &&, Sender &&) [with Data=stdexec::__bulk::__data<int, lambda [](int)->void>, Sender=exec::_pool_::static_thread_pool_::scheduler::sender]" at line 337 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>)) &&, stdexec::__cp, exec::_pool_::static_thread_pool_::transform_bulk>]" at line 261
            instantiation of "auto exec::_pool_::static_thread_pool_::domain::transform_sender(Sender &&) const noexcept [with Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>]" at line 588 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::__domain::__transform_sender_1::operator()(_Domain, _Sender &&, const _Env &...) const [with _Domain=exec::_pool_::static_thread_pool_::domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<>]" at line 337 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/__detail/__meta.hpp"
            instantiation of class "stdexec::__mdefer<_Fn, _Args...> [with _Fn=stdexec::__q<stdexec::__call_result_>, _Args=<stdexec::__domain::__transform_sender_1, exec::_pool_::static_thread_pool_::domain, stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>>]" at line 60 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/__detail/__meta.hpp"
            instantiation of type "stdexec::__t<stdexec::__mdefer<stdexec::__q<stdexec::__call_result_>, stdexec::__domain::__transform_sender_1, exec::_pool_::static_thread_pool_::domain, stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>>>" at line 718 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/__detail/__meta.hpp"
            instantiation of type "stdexec::__call_result_t<stdexec::__domain::__transform_sender_1, exec::_pool_::static_thread_pool_::domain, stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>>" at line 604 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/execution.hpp"
            instantiation of "decltype(auto) stdexec::__domain::__transform_sender::operator()(_Domain, _Sender &&, const _Env &...) const [with _Self=stdexec::__domain::__transform_sender, _Domain=exec::_pool_::static_thread_pool_::domain, _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, _Env=<>]" at line 2781 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/execution.hpp"
            instantiation of "auto stdexec::__bulk::bulk_t::operator()(_Sender &&, _Shape, _Fun) const [with _Sender=exec::_pool_::static_thread_pool_::scheduler::sender &, _Shape=int, _Fun=lambda [](int)->void]" at line 153 of "/global/homes/m/mhaseeb/repos/hpcpp/apps/fft/fft.hpp"

"/global/homes/m/mhaseeb/repos/hpcpp/apps/fft/fft.hpp", line 223: error: function "stdexec::__sync_wait::sync_wait_t::operator()(_Sender &&, _Error) const->std::optional<std::tuple<int>> [with _Sender=exec::_pool_::static_thread_pool_::bulk_sender<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, int, lambda [](int, auto)->auto>::__t &, _Error=stdexec::_ERROR_<stdexec::_BAD_SUBSTITUTION_<stdexec::__mstring<76UL>{{'T', 'h', 'e', ' ', 's', 'p', 'e', 'c', 'i', 'f', 'i', 'e', 'd', ' ', 'm', 'e', 't', 'a', '-', 'f', 'u', 'n', 'c', 't', 'i', 'o', 'n', ' ', 'c', 'o', 'u', 'l', 'd', ' ', 'n', 'o', 't', ' ', 'b', 'e', ' ', 'e', 'v', 'a', 'l', 'u', 'a', 't', 'e', 'd', ' ', 'w', 'i', 't', 'h', ' ', 't', 'h', 'e', ' ', 't', 'y', 'p', 'e', 's', ' ', 'p', 'r', 'o', 'v', 'i', 'd', 'e', 'd', '.', '\000'}}>, stdexec::_WITH_META_FUNCTION_T_<stdexec::__try_value_types_of_t>, stdexec::_WITH_TYPES_<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))> &, stdexec::__sync_wait::__env, stdexec::__q<exec::_pool_::static_thread_pool_::bulk_sender<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, int, lambda [](int, auto)->auto>::__t::set_value_t>, stdexec::__q<stdexec::__compl_sigs::__ensure_concat>>>]" (declared at line 5540 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/execution.hpp") cannot be referenced -- it is a deleted function
          ex::sync_wait(init);
                       ^
          detected during instantiation of "bool signal::isFFT(signal &, stdexec::scheduler auto, int) [with <auto-1>=exec::_pool_::static_thread_pool_::scheduler]" at line 149 of "/global/homes/m/mhaseeb/repos/hpcpp/apps/fft/fft-serial.cpp"

"/global/homes/m/mhaseeb/repos/hpcpp/apps/fft/fft.hpp", line 240: error: function "stdexec::__sync_wait::sync_wait_t::operator()(_Sender &&, _Error) const->std::optional<std::tuple<int>> [with _Sender=stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))> &, _Error=stdexec::_ERROR_<stdexec::_BAD_SUBSTITUTION_<stdexec::__mstring<76UL>{{'T', 'h', 'e', ' ', 's', 'p', 'e', 'c', 'i', 'f', 'i', 'e', 'd', ' ', 'm', 'e', 't', 'a', '-', 'f', 'u', 'n', 'c', 't', 'i', 'o', 'n', ' ', 'c', 'o', 'u', 'l', 'd', ' ', 'n', 'o', 't', ' ', 'b', 'e', ' ', 'e', 'v', 'a', 'l', 'u', 'a', 't', 'e', 'd', ' ', 'w', 'i', 't', 'h', ' ', 't', 'h', 'e', ' ', 't', 'y', 'p', 'e', 's', ' ', 'p', 'r', 'o', 'v', 'i', 'd', 'e', 'd', '.', '\000'}}>, stdexec::_WITH_META_FUNCTION_T_<stdexec::__try_value_types_of_t>, stdexec::_WITH_TYPES_<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))> &, stdexec::__sync_wait::__env, stdexec::__q<exec::_pool_::static_thread_pool_::bulk_sender<stdexec::__sexpr<lambda [](_Cvref, _Fun &&) mutable->decltype((<expression>))>, int, lambda [](int, auto &, auto, auto)->auto>::__t::set_value_t>, stdexec::__q<stdexec::__compl_sigs::__ensure_concat>>>]" (declared at line 5540 of "/global/homes/m/mhaseeb/repos/hpcpp/build-multicore/_deps/stdexec-src/include/exec/../stdexec/execution.hpp") cannot be referenced -- it is a deleted function
          auto [re] = ex::sync_wait(verify).value();
                                   ^
          detected during instantiation of "bool signal::isFFT(signal &, stdexec::scheduler auto, int) [with <auto-1>=exec::_pool_::static_thread_pool_::scheduler]" at line 149 of "/global/homes/m/mhaseeb/repos/hpcpp/apps/fft/fft-serial.cpp"

3 errors detected in the compilation of "/global/homes/m/mhaseeb/repos/hpcpp/apps/fft/fft-serial.cpp".
make[2]: *** [apps/fft/CMakeFiles/fft-serial.dir/build.make:76: apps/fft/CMakeFiles/fft-serial.dir/fft-serial.cpp.o] Error 2
make[1]: *** [CMakeFiles/Makefile2:750: apps/fft/CMakeFiles/fft-serial.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```