### PR TITLE
task: mark class as nodiscard

### DIFF
--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -316,7 +316,7 @@ namespace exec {
     ////////////////////////////////////////////////////////////////////////////////
     // basic_task
     template <class _Ty, class _Context = default_task_context<_Ty>>
-    class basic_task {
+    class [[nodiscard]] basic_task {
       struct __promise;
      public:
       using __t = basic_task;


### PR DESCRIPTION
If you have a function that returns a task and forget to `co_await` on
it nothing happens.  By adding a nodiscard on basic task, this ensures
that any missed `co_await` is caught as a compile error.  This gives a
quick alert to a trivial coding bug.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
