### PR TITLE
Create CUDA events with cudaEventDisableTiming

### DIFF
--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -288,11 +288,11 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         , ready_to_complete_(new cudaEvent_t[num_devices_]) {
         // TODO Manage errors
         cudaGetDevice(&current_device_);
-        cudaEventCreate(&ready_to_launch_);
+        cudaEventCreate(&ready_to_launch_, cudaEventDisableTiming);
         for (int dev = 0; dev < num_devices_; dev++) {
           cudaSetDevice(dev);
           cudaStreamCreate(streams_.get() + dev);
-          cudaEventCreate(ready_to_complete_.get() + dev);
+          cudaEventCreate(ready_to_complete_.get() + dev, cudaEventDisableTiming);
         }
         cudaSetDevice(current_device_);
       }

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -142,7 +142,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         , op_state1_{nullptr}
         , op_state2_(connect((Sender&&) sndr, inner_receiver_t{*this})) {
         if (stream_provider_.status_ == cudaSuccess) {
-          stream_provider_.status_ = STDEXEC_DBG_ERR(cudaEventCreate(&event_));
+          stream_provider_.status_ = STDEXEC_DBG_ERR(cudaEventCreate(&event_, cudaEventDisableTiming));
         }
 
         start(op_state2_);

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -139,7 +139,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         , data_(malloc_managed<variant_t>(stream_provider_.status_))
         , op_state2_(connect((Sender&&) sndr, inner_receiver_t{*this})) {
         if (stream_provider_.status_ == cudaSuccess) {
-          stream_provider_.status_ = STDEXEC_DBG_ERR(cudaEventCreate(&event_));
+          stream_provider_.status_ = STDEXEC_DBG_ERR(cudaEventCreate(&event_, cudaEventDisableTiming));
         }
       }
 

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -336,7 +336,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           : operation_t((WhenAll&&) when_all, (Receiver&&) rcvr, Indices{}) {
           for (int i = 0; i < sizeof...(SenderIds); i++) {
             if (status_ == cudaSuccess) {
-              status_ = STDEXEC_DBG_ERR(cudaEventCreate(&events_[i]));
+              status_ = STDEXEC_DBG_ERR(cudaEventCreate(&events_[i], cudaEventDisableTiming));
             }
           }
         }


### PR DESCRIPTION
CUDA events enable timing by default, which may introduce superfluous synchronizations when timing is not needed