### PR TITLE
fix `repeat_effect_until` and `repeat_n` to copy arguments before destroying the op-state

### DIFF
--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -28,6 +28,8 @@
 
 #include <atomic>
 #include <concepts>
+#include <exception>
+#include <type_traits>
 
 namespace exec {
   namespace __repeat_effect_until {
@@ -164,7 +166,7 @@ namespace exec {
 
       static constexpr auto get_state = //
         []<class _Sender, class _Receiver>(_Sender &&__sndr, _Receiver &__rcvr) {
-          return __repeat_effect_state{std::move(__sndr), __rcvr};
+          return __repeat_effect_state{(_Sender&&) __sndr, __rcvr};
         };
 
       static constexpr auto start = //

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -101,8 +101,8 @@ namespace exec {
       }
 
       template <class _Tag, class... _Args>
-      void __complete(_Tag, _Args &&...__args) noexcept {
-        __child_op_.__destroy();
+      void __complete(_Tag, _Args ...__args) noexcept { // Intentionally by value...
+        __child_op_.__destroy(); // ... because this could potentially invalidate them.
         if constexpr (same_as<_Tag, set_value_t>) {
           // If the sender completed with true, we're done
           try {
@@ -137,6 +137,9 @@ namespace exec {
         completion_signatures<>,
         __mexception<_INVALID_ARGUMENT_TO_REPEAT_EFFECT_UNTIL_<>, _WITH_SENDER_<_Sender>>>;
 
+    template <class _Error>
+    using __error_t = completion_signatures<set_error_t(__decay_t<_Error>)>;
+
     template <class _Sender, class _Env>
     using __completions_t = //
       stdexec::__try_make_completion_signatures<
@@ -145,8 +148,11 @@ namespace exec {
         stdexec::__try_make_completion_signatures<
           stdexec::schedule_result_t<exec::trampoline_scheduler>,
           _Env,
-          __with_exception_ptr>,
-        __mbind_front_q<__values_t, _Sender>>;
+          __with_exception_ptr,
+          __q<__compl_sigs::__default_set_value>,
+          __q<__error_t>>,
+        __mbind_front_q<__values_t, _Sender>,
+        __q<__error_t>>;
 
     struct __repeat_effect_until_tag { };
 

--- a/include/exec/repeat_n.hpp
+++ b/include/exec/repeat_n.hpp
@@ -29,6 +29,8 @@
 #include <atomic>
 #include <concepts>
 #include <cstddef>
+#include <exception>
+#include <type_traits>
 
 namespace exec {
   namespace __repeat_n {
@@ -179,7 +181,7 @@ namespace exec {
 
       static constexpr auto get_state = //
         []<class _Sender, class _Receiver>(_Sender &&__sndr, _Receiver &__rcvr) {
-          return __repeat_n_state{std::move(__sndr), __rcvr};
+          return __repeat_n_state{(_Sender&&) __sndr, __rcvr};
         };
 
       static constexpr auto start = //

--- a/include/exec/repeat_n.hpp
+++ b/include/exec/repeat_n.hpp
@@ -117,9 +117,9 @@ namespace exec {
       }
 
       template <class _Tag, class... _Args>
-      void __complete(_Tag, _Args &&...__args) noexcept {
+      void __complete(_Tag, _Args ...__args) noexcept { // Intentionally by value...
         STDEXEC_ASSERT(__pair_.__count_ > 0);
-        __child_op_.__destroy();
+        __child_op_.__destroy(); // ... because this could potentially invalidate them.
         if constexpr (same_as<_Tag, set_value_t>) {
           try {
             if (--__pair_.__count_ == 0) {
@@ -152,6 +152,9 @@ namespace exec {
         completion_signatures<>,
         __mexception<_INVALID_ARGUMENT_TO_REPEAT_N_<>, _WITH_SENDER_<_Sender>>>;
 
+    template <class _Error>
+    using __error_t = completion_signatures<set_error_t(__decay_t<_Error>)>;
+
     template <class _Pair, class _Env>
     using __completions_t = //
       stdexec::__try_make_completion_signatures<
@@ -160,8 +163,11 @@ namespace exec {
         stdexec::__try_make_completion_signatures<
           stdexec::schedule_result_t<exec::trampoline_scheduler>,
           _Env,
-          __with_exception_ptr>,
-        __mbind_front_q<__values_t, decltype(__decay_t<_Pair>::__child_)>>;
+          __with_exception_ptr,
+          __q<__compl_sigs::__default_set_value>,
+          __q<__error_t>>,
+        __mbind_front_q<__values_t, decltype(__decay_t<_Pair>::__child_)>,
+        __q<__error_t>>;
 
     struct __repeat_n_tag { };
 


### PR DESCRIPTION
This avoids a potential use-after-free if the arguments are references to objects stored in the operation state that is getting destroyed.

fixes #1236