### PR TITLE
Scheduler for grand central libdispatch queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,13 @@ if (STDEXEC_ENABLE_TBB)
         STDEXEC::stdexec
         TBB::tbb
         )
-endif ()
+endif()
+
+include(CheckIncludeFileCXX)
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  CHECK_INCLUDE_FILE_CXX("dispatch/dispatch.h" STDEXEC_FOUND_LIBDISPATCH)
+  option(STDEXEC_ENABLE_LIBDISPATCH "Enable the tests for the Grand Central Dispatch scheduler" ${STDEXEC_FOUND_LIBDISPATCH})
+endif()
 
 option (STDEXEC_ENABLE_NUMA "Enable NUMA affinity for static_thread_pool" OFF)
 if (STDEXEC_ENABLE_NUMA)
@@ -320,7 +326,6 @@ if (STDEXEC_ENABLE_NUMA)
 endif()
 
 if(CMAKE_CROSSCOMPILING)
-  include(CheckIncludeFileCXX)
   CHECK_INCLUDE_FILE_CXX("linux/io_uring.h" STDEXEC_FOUND_IO_URING)
 else()
   include(CheckCXXSourceRuns)

--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2024 Rishabh Dwivedi <rishabhdwivedi17@gmail.com>
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// TODO: This is needed for libdispatch to compile with GCC. Need to look for
+// workaround.
+#ifndef __has_feature
+#  define __has_feature(x) false
+#endif
+#ifndef __has_extension
+#  define __has_extension(x) false
+#endif
+
+#include "stdexec/execution.hpp"
+#include <dispatch/dispatch.h>
+
+namespace exec {
+  struct libdispatch_queue;
+
+  namespace __libdispatch_details {
+    template <class>
+    struct not_a_sender {
+      using sender_concept = stdexec::sender_t;
+    };
+
+    struct task_base {
+      void (*execute)(task_base *) noexcept;
+    };
+
+    template <typename ReceiverId>
+    struct operation;
+  } // namespace __libdispatch_details
+
+  namespace __libdispatch_bulk {
+    template <class SenderId, std::integral Shape, class Fun>
+    struct bulk_sender {
+      using Sender = stdexec::__t<SenderId>;
+      struct __t;
+    };
+
+    template <stdexec::sender Sender, std::integral Shape, class Fun>
+    using bulk_sender_t =
+      stdexec::__t<bulk_sender<stdexec::__id<stdexec::__decay_t<Sender>>, Shape, Fun>>;
+
+    template <class CvrefSender, class Receiver, class Shape, class Fun, bool MayThrow>
+    struct bulk_shared_state;
+
+    template <class Fun, class Shape, class... Args>
+      requires stdexec::__callable<Fun, Shape, Args &...>
+    using bulk_non_throwing = //
+      stdexec::__mbool<
+        stdexec::__nothrow_callable<Fun, Shape, Args &...>
+        && noexcept(stdexec::__decayed_tuple<Args...>(std::declval<Args>()...))>;
+
+    template <class CvrefSenderId, class ReceiverId, class Shape, class Fun, bool MayThrow>
+    struct bulk_receiver {
+      using CvrefSender = stdexec::__cvref_t<CvrefSenderId>;
+      using Receiver = stdexec::__t<ReceiverId>;
+      struct __t;
+    };
+
+    template <class CvrefSender, class Receiver, class Shape, class Fun, bool MayThrow>
+    using bulk_receiver_t = stdexec::__t<
+      bulk_receiver<stdexec::__cvref_id<CvrefSender>, stdexec::__id<Receiver>, Shape, Fun, MayThrow>>;
+
+    template <class CvrefSenderId, class ReceiverId, std::integral Shape, class Fun>
+    struct bulk_op_state {
+      using CvrefSender = stdexec::__cvref_t<CvrefSenderId>;
+      using Receiver = stdexec::__t<ReceiverId>;
+      struct __t;
+    };
+
+    template <class Sender, class Receiver, std::integral Shape, class Fun>
+    using bulk_op_state_t = stdexec::__t<bulk_op_state<
+      stdexec::__id<stdexec::__decay_t<Sender>>,
+      stdexec::__id<stdexec::__decay_t<Receiver>>,
+      Shape,
+      Fun>>;
+
+    struct transform_bulk {
+      template <class Data, class Sender>
+      auto operator()(stdexec::bulk_t, Data &&data, Sender &&sndr) {
+        auto [shape, fun] = std::forward<Data>(data);
+        return bulk_sender_t<Sender, decltype(shape), decltype(fun)>{
+          queue_, std::forward<Sender>(sndr), shape, std::move(fun)};
+      }
+
+      libdispatch_queue &queue_;
+    };
+  } // namespace __libdispatch_bulk
+
+  struct libdispatch_scheduler {
+    using __t = libdispatch_scheduler;
+    using __id = libdispatch_scheduler;
+    bool operator==(libdispatch_scheduler const &) const = default;
+
+    struct domain {
+      // For eager customization
+      template <stdexec::sender_expr_for<stdexec::bulk_t> Sender>
+      auto transform_sender(Sender &&sndr) const noexcept {
+        if constexpr (stdexec::__completes_on<Sender, libdispatch_scheduler>) {
+          auto sched = stdexec::get_completion_scheduler<stdexec::set_value_t>(
+            stdexec::get_env(sndr));
+          return stdexec::__sexpr_apply(
+            std::forward<Sender>(sndr), __libdispatch_bulk::transform_bulk{*sched.queue_});
+        } else {
+          static_assert(
+            stdexec::__completes_on<Sender, libdispatch_scheduler>,
+            "No libdispatch_queue instance can be found in the "
+            "sender's environment "
+            "on which to schedule bulk work.");
+          return __libdispatch_details::not_a_sender<stdexec::__name_of<Sender>>();
+        }
+      }
+
+      // transform the generic bulk sender into a parallel libdispatch bulk sender
+      template <stdexec::sender_expr_for<stdexec::bulk_t> Sender, class Env>
+      auto transform_sender(Sender &&sndr, const Env &env) const noexcept {
+        if constexpr (stdexec::__completes_on<Sender, libdispatch_scheduler>) {
+          auto sched = stdexec::get_completion_scheduler<stdexec::set_value_t>(
+            stdexec::get_env(sndr));
+          return stdexec::__sexpr_apply(
+            std::forward<Sender>(sndr), __libdispatch_bulk::transform_bulk{*sched.queue_});
+        } else if constexpr (stdexec::__starts_on<Sender, libdispatch_scheduler, Env>) {
+          auto sched = stdexec::get_scheduler(env);
+          return stdexec::__sexpr_apply(
+            std::forward<Sender>(sndr), __libdispatch_bulk::transform_bulk{*sched.queue_});
+        } else {
+          static_assert( //
+            stdexec::__starts_on<Sender, libdispatch_scheduler, Env>
+              || stdexec::__completes_on<Sender, libdispatch_scheduler>,
+            "No libdispatch_queue instance can be found in the sender's or "
+            "receiver's "
+            "environment on which to schedule bulk work.");
+          return __libdispatch_details::not_a_sender<stdexec::__name_of<Sender>>();
+        }
+      }
+    };
+
+    struct sender {
+      using __t = sender;
+      using __id = sender;
+      using sender_concept = stdexec::sender_t;
+      using completion_signatures =
+        stdexec::completion_signatures<stdexec::set_value_t(), stdexec::set_stopped_t()>;
+
+      template <typename Receiver>
+      auto make_operation(Receiver r) const
+        -> __libdispatch_details::operation<stdexec::__id<Receiver>> {
+        return __libdispatch_details::operation<stdexec::__id<Receiver>>(queue, std::move(r));
+      }
+
+      template <stdexec::receiver Receiver>
+      friend auto tag_invoke(stdexec::connect_t, sender s, Receiver r)
+        -> __libdispatch_details::operation<stdexec::__id<Receiver>> {
+        return s.make_operation(std::move(r));
+      }
+
+      struct env {
+        libdispatch_queue *queue;
+
+        template <typename CPO>
+        friend libdispatch_scheduler
+          tag_invoke(stdexec::get_completion_scheduler_t<CPO>, env const &self) noexcept {
+          return self.make_scheduler();
+        }
+
+        auto make_scheduler() const -> libdispatch_scheduler {
+          return libdispatch_scheduler{queue};
+        }
+      };
+
+      friend env tag_invoke(stdexec::get_env_t, sender const &self) noexcept {
+        return env{self.queue};
+      }
+
+      libdispatch_queue *queue;
+    };
+
+    sender make_sender() const {
+      return sender{queue_};
+    }
+
+    friend sender tag_invoke(stdexec::schedule_t, libdispatch_scheduler const &s) noexcept {
+      return s.make_sender();
+    }
+
+    friend domain tag_invoke(stdexec::get_domain_t, libdispatch_scheduler) noexcept {
+      return {};
+    }
+
+    friend stdexec::forward_progress_guarantee
+      tag_invoke(stdexec::get_forward_progress_guarantee_t, libdispatch_queue const &) noexcept {
+      return stdexec::forward_progress_guarantee::parallel;
+    }
+
+    libdispatch_queue *queue_;
+  };
+
+  struct libdispatch_queue {
+    bool operator==(libdispatch_queue const &) const = default;
+
+    void submit(__libdispatch_details::task_base *f) {
+      auto queue = dispatch_get_global_queue(priority, 0);
+      dispatch_async_f(queue, f, reinterpret_cast<void (*)(void *) noexcept>(f->execute));
+    }
+
+    auto get_scheduler() {
+      return libdispatch_scheduler{this};
+    }
+
+    int priority{DISPATCH_QUEUE_PRIORITY_DEFAULT};
+  };
+
+  template <typename ReceiverId>
+  struct __libdispatch_details::operation : public __libdispatch_details::task_base {
+    using Receiver = stdexec::__t<ReceiverId>;
+    libdispatch_queue &queue;
+    Receiver receiver;
+
+    operation(libdispatch_queue *queue_arg, Receiver r)
+      : queue(*queue_arg)
+      , receiver(std::move(r)) {
+      this->execute = [](__libdispatch_details::task_base *t) noexcept {
+        auto &op = *static_cast<operation *>(t);
+        auto stoken = stdexec::get_stop_token(stdexec::get_env(op.receiver));
+        if constexpr (std::unstoppable_token<decltype(stoken)>) {
+          stdexec::set_value(std::move(op.receiver));
+        } else if (stoken.stop_requested()) {
+          stdexec::set_stopped(std::move(op.receiver));
+        } else {
+          stdexec::set_value(std::move(op.receiver));
+        }
+      };
+    }
+
+    void enqueue(task_base *op) const {
+      queue.submit(op);
+    }
+
+    friend void tag_invoke(stdexec::start_t, operation &op) noexcept {
+      op.enqueue(&op);
+    }
+  };
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // What follows is the implementation for parallel bulk execution on
+  // libdispatch queue.
+  template <class SenderId, std::integral Shape, class Fun>
+  struct __libdispatch_bulk::bulk_sender<SenderId, Shape, Fun>::__t {
+    using __id = bulk_sender;
+    using sender_concept = stdexec::sender_t;
+
+    libdispatch_queue &queue_;
+    Sender sndr_;
+    Shape shape_;
+    Fun fun_;
+
+    template <class Sender, class Env>
+    using with_error_invoke_t = //
+      stdexec::__if_c<
+        stdexec::__v<stdexec::__value_types_of_t<
+          Sender,
+          Env,
+          stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
+          stdexec::__q<stdexec::__mand>>>,
+        stdexec::completion_signatures<>,
+        stdexec::__with_exception_ptr>;
+
+    template <class... Tys>
+    using set_value_t =
+      stdexec::completion_signatures<stdexec::set_value_t(stdexec::__decay_t<Tys>...)>;
+
+    template <class Self, class Env>
+    using __completions_t = //
+      stdexec::__try_make_completion_signatures<
+        stdexec::__copy_cvref_t<Self, Sender>,
+        Env,
+        with_error_invoke_t<stdexec::__copy_cvref_t<Self, Sender>, Env>,
+        stdexec::__q<set_value_t>>;
+
+    template <class Self, class Receiver>
+    using bulk_op_state_t = //
+      stdexec::__t<
+        bulk_op_state<stdexec::__cvref_id<Self, Sender>, stdexec::__id<Receiver>, Shape, Fun>>;
+
+    template <stdexec::__decays_to<__t> Self, stdexec::receiver Receiver>
+      requires stdexec::receiver_of<Receiver, __completions_t<Self, stdexec::env_of_t<Receiver>>>
+    friend bulk_op_state_t<Self, Receiver>                       //
+      tag_invoke(stdexec::connect_t, Self &&self, Receiver rcvr) //
+      noexcept(stdexec::__nothrow_constructible_from<
+               bulk_op_state_t<Self, Receiver>,
+               libdispatch_queue &,
+               Shape,
+               Fun,
+               Sender,
+               Receiver>) {
+      return bulk_op_state_t<Self, Receiver>{
+        self.queue_,
+        self.shape_,
+        self.fun_,
+        (std::forward<Self>(self)).sndr_,
+        (std::forward<Receiver>(rcvr))};
+    }
+
+    template <stdexec::__decays_to<__t> Self, class Env>
+    friend auto tag_invoke(stdexec::get_completion_signatures_t, Self &&, Env &&)
+      -> __completions_t<Self, Env> {
+      return {};
+    }
+
+    friend auto tag_invoke(stdexec::get_env_t, const __t &self) noexcept
+      -> stdexec::env_of_t<const Sender &> {
+      return stdexec::get_env(self.sndr_);
+    }
+  };
+
+  template <class CvrefSender, class Receiver, class Shape, class Fun, bool MayThrow>
+  struct __libdispatch_bulk::bulk_shared_state {
+    struct bulk_task : __libdispatch_details::task_base {
+      bulk_shared_state *sh_state_;
+      Shape task_id_;
+
+      bulk_task(bulk_shared_state *sh_state_arg, Shape task_id_arg)
+        : sh_state_(sh_state_arg)
+        , task_id_(task_id_arg) {
+        this->execute = [](task_base *t) noexcept {
+          auto &sh_state = *static_cast<bulk_task *>(t)->sh_state_;
+          auto task_id = static_cast<bulk_task *>(t)->task_id_;
+          auto total_tasks = static_cast<std::uint32_t>(sh_state.num_tasks());
+
+          auto computation = [&sh_state, task_id](auto &...args) {
+            sh_state.fun_(task_id, args...);
+          };
+
+          auto completion = [&](auto &...args) {
+            stdexec::set_value(std::move(sh_state.rcvr_), std::move(args)...);
+          };
+
+          if constexpr (MayThrow) {
+            try {
+              sh_state.apply(computation);
+            } catch (...) {
+              std::uint32_t expected = total_tasks;
+
+              if (sh_state.task_with_exception_.compare_exchange_strong(
+                    expected,
+                    static_cast<std::uint32_t>(task_id),
+                    std::memory_order_relaxed,
+                    std::memory_order_relaxed)) {
+                sh_state.exception_ = std::current_exception();
+              }
+            }
+
+            const bool is_last_task = sh_state.finished_tasks_.fetch_add(1) == (total_tasks - 1);
+
+            if (is_last_task) {
+              if (sh_state.exception_) {
+                stdexec::set_error(std::move(sh_state.rcvr_), std::move(sh_state.exception_));
+              } else {
+                sh_state.apply(completion);
+              }
+            }
+          } else {
+            sh_state.apply(computation);
+
+            bool const is_last_task = sh_state.finished_tasks_.fetch_add(1) == (total_tasks - 1);
+
+            if (is_last_task) {
+              sh_state.apply(completion);
+            }
+          }
+        };
+      }
+    };
+
+    using variant_t = //
+      stdexec::__value_types_of_t<
+        CvrefSender,
+        stdexec::env_of_t<Receiver>,
+        stdexec::__q<stdexec::__decayed_tuple>,
+        stdexec::__q<stdexec::__variant>>;
+
+    variant_t data_;
+    Receiver rcvr_;
+    Shape shape_;
+    Fun fun_;
+
+    std::atomic<std::uint32_t> finished_tasks_{0};
+    std::atomic<std::uint32_t> task_with_exception_{0};
+    std::exception_ptr exception_;
+    std::vector<bulk_task> tasks_;
+
+    Shape num_tasks() const {
+      return shape_;
+    }
+
+    template <class F>
+    void apply(F f) {
+      std::visit(
+        [&](auto &tupl) -> void { std::apply([&](auto &...args) -> void { f(args...); }, tupl); },
+        data_);
+    }
+
+    bulk_shared_state(Receiver rcvr, Shape shape, Fun fun)
+      : rcvr_{std::move(rcvr)}
+      , shape_{shape}
+      , fun_{fun}
+      , task_with_exception_{static_cast<std::uint32_t>(num_tasks())} {
+    }
+  };
+
+  template <class CvrefSenderId, class ReceiverId, class Shape, class Fun, bool MayThrow>
+  struct __libdispatch_bulk::bulk_receiver<CvrefSenderId, ReceiverId, Shape, Fun, MayThrow>::__t {
+    using __id = bulk_receiver;
+    using receiver_concept = stdexec::receiver_t;
+
+    using shared_state = bulk_shared_state<CvrefSender, Receiver, Shape, Fun, MayThrow>;
+
+    shared_state &shared_state_;
+    libdispatch_queue &queue_;
+
+    void enqueue() noexcept {
+      using bulk_task = typename shared_state::bulk_task;
+      shared_state_.tasks_.reserve(static_cast<std::size_t>(shared_state_.shape_));
+      for (Shape i{}; i != shared_state_.shape_; ++i) {
+        shared_state_.tasks_.push_back(bulk_task(&shared_state_, i));
+        queue_.submit(&(shared_state_.tasks_.back()));
+      }
+    }
+
+    template <class... As>
+    friend void
+      tag_invoke(stdexec::same_as<stdexec::set_value_t> auto, __t &&self, As &&...as) noexcept {
+      using tuple_t = stdexec::__decayed_tuple<As...>;
+
+      shared_state &state = self.shared_state_;
+
+      if constexpr (MayThrow) {
+        try {
+          state.data_.template emplace<tuple_t>(std::move(as)...);
+        } catch (...) {
+          stdexec::set_error(std::move(state.rcvr_), std::current_exception());
+        }
+      } else {
+        state.data_.template emplace<tuple_t>(std::move(as)...);
+      }
+
+      if (state.shape_) {
+        self.enqueue();
+      } else {
+        state.apply([&](auto &...args) {
+          stdexec::set_value(std::move(state.rcvr_), std::move(args)...);
+        });
+      }
+    }
+
+    template <stdexec::__one_of<stdexec::set_error_t, stdexec::set_stopped_t> Tag, class... As>
+    friend void tag_invoke(Tag tag, __t &&self, As &&...as) noexcept {
+      shared_state &state = self.shared_state_;
+      tag(std::move(state.rcvr_), std::move(as...));
+    }
+
+    friend auto tag_invoke(stdexec::get_env_t, const __t &self) noexcept
+      -> stdexec::env_of_t<Receiver> {
+      return stdexec::get_env(self.shared_state_.rcvr_);
+    }
+  };
+
+  template <class CvrefSenderId, class ReceiverId, std::integral Shape, class Fun>
+  struct __libdispatch_bulk::bulk_op_state<CvrefSenderId, ReceiverId, Shape, Fun>::__t {
+    using __id = bulk_op_state;
+
+    static constexpr bool may_throw = //
+      !stdexec::__v<stdexec::__value_types_of_t<
+        CvrefSender,
+        stdexec::env_of_t<Receiver>,
+        stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
+        stdexec::__q<stdexec::__mand>>>;
+
+    using bulk_rcvr = bulk_receiver_t<CvrefSender, Receiver, Shape, Fun, may_throw>;
+    using shared_state = bulk_shared_state<CvrefSender, Receiver, Shape, Fun, may_throw>;
+    using inner_op_state = stdexec::connect_result_t<CvrefSender, bulk_rcvr>;
+
+    shared_state shared_state_;
+
+    inner_op_state inner_op_;
+
+    friend void tag_invoke(stdexec::start_t, __t &op) noexcept {
+      stdexec::start(op.inner_op_);
+    }
+
+    __t(libdispatch_queue &queue, Shape shape, Fun fun, CvrefSender &&sndr, Receiver rcvr)
+      : shared_state_(std::move(rcvr), shape, fun)
+      , inner_op_{stdexec::connect(std::move(sndr), bulk_rcvr{shared_state_, queue})} {
+    }
+  };
+
+} // namespace exec

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,11 +90,8 @@ set(stdexec_test_sources
     exec/sequence/test_iterate.cpp
     exec/sequence/test_transform_each.cpp
     $<$<BOOL:${STDEXEC_ENABLE_TBB}>:tbbexec/test_tbb_thread_pool.cpp>
+    $<$<BOOL:${STDEXEC_ENABLE_LIBDISPATCH}>:exec/test_libdispatch.cpp>
     )
-
-if (LIBDISPATCH)
-  set(stdexec_test_sources ${stdexec_test_sources} exec/test_libdispatch.cpp)
-endif (LIBDISPATCH)
 
 add_executable(test.stdexec ${stdexec_test_sources})
 set_target_properties(test.stdexec PROPERTIES
@@ -106,12 +103,9 @@ target_link_libraries(test.stdexec
     PUBLIC
     STDEXEC::stdexec
     $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
+    $<$<BOOL:${STDEXEC_ENABLE_LIBDISPATCH}>:dispatch>
     stdexec_executable_flags
     Catch2::Catch2)
-
-if (LIBDISPATCH)
-  target_link_libraries(test.stdexec PRIVATE dispatch)
-endif (LIBDISPATCH)
 
 add_executable(test.scratch test_main.cpp test_scratch.cpp)
 set_target_properties(test.scratch PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,7 +103,6 @@ target_link_libraries(test.stdexec
     PUBLIC
     STDEXEC::stdexec
     $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
-    #$<$<BOOL:${STDEXEC_ENABLE_LIBDISPATCH}>:dispatch>
     stdexec_executable_flags
     Catch2::Catch2)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,6 +92,10 @@ set(stdexec_test_sources
     $<$<BOOL:${STDEXEC_ENABLE_TBB}>:tbbexec/test_tbb_thread_pool.cpp>
     )
 
+if (LIBDISPATCH)
+  set(stdexec_test_sources ${stdexec_test_sources} exec/test_libdispatch.cpp)
+endif (LIBDISPATCH)
+
 add_executable(test.stdexec ${stdexec_test_sources})
 set_target_properties(test.stdexec PROPERTIES
     CXX_STANDARD 20
@@ -104,6 +108,10 @@ target_link_libraries(test.stdexec
     $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
     stdexec_executable_flags
     Catch2::Catch2)
+
+if (LIBDISPATCH)
+  target_link_libraries(test.stdexec PRIVATE dispatch)
+endif (LIBDISPATCH)
 
 add_executable(test.scratch test_main.cpp test_scratch.cpp)
 set_target_properties(test.scratch PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,7 +103,7 @@ target_link_libraries(test.stdexec
     PUBLIC
     STDEXEC::stdexec
     $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
-    $<$<BOOL:${STDEXEC_ENABLE_LIBDISPATCH}>:dispatch>
+    #$<$<BOOL:${STDEXEC_ENABLE_LIBDISPATCH}>:dispatch>
     stdexec_executable_flags
     Catch2::Catch2)
 

--- a/test/exec/test_libdispatch.cpp
+++ b/test/exec/test_libdispatch.cpp
@@ -44,8 +44,8 @@ namespace {
 
     std::vector<int> data{1, 2, 3, 4, 5};
     auto size = data.size();
-    auto expensive_computation = [](auto i, auto data) {
-      return 2 * data[i];
+    auto expensive_computation = [](auto i, auto& data) {
+      data[i] = 2 * data[i];
     };
     auto add = [](auto const & data) {
       return std::accumulate(std::begin(data), std::end(data), 0);

--- a/test/exec/test_libdispatch.cpp
+++ b/test/exec/test_libdispatch.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 Rishabh Dwivedi <rishabhdwivedi17@gmail.com>
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "catch2/catch.hpp"
+#include "exec/libdispatch_queue.hpp"
+#include "stdexec/execution.hpp"
+
+namespace {
+  TEST_CASE("libdispatch queue should be able to process tasks") {
+    exec::libdispatch_queue queue;
+    auto sch = queue.get_scheduler();
+
+    std::vector<int> data{1, 2, 3, 4, 5};
+    auto add = [](auto const & data) {
+      return std::accumulate(std::begin(data), std::end(data), 0);
+    };
+    auto sender = stdexec::transfer_just(sch, std::move(data)) | stdexec::then(add);
+
+    auto completion_scheduler = stdexec::get_completion_scheduler<stdexec::set_value_t>(
+      stdexec::get_env(sender));
+
+    CHECK(completion_scheduler == sch);
+    auto [res] = stdexec::sync_wait(sender).value();
+    CHECK(res == 15);
+  }
+
+  TEST_CASE(
+    "libdispatch queue bulk algorithm should call callback function with all allowed shapes") {
+    exec::libdispatch_queue queue;
+    auto sch = queue.get_scheduler();
+
+    std::vector<int> data{1, 2, 3, 4, 5};
+    auto size = data.size();
+    auto expensive_computation = [](auto i, auto data) {
+      return 2 * data[i];
+    };
+    auto add = [](auto const & data) {
+      return std::accumulate(std::begin(data), std::end(data), 0);
+    };
+    auto sender = stdexec::transfer_just(sch, std::move(data)) //
+                | stdexec::bulk(size, expensive_computation)   //
+                | stdexec::then(add);
+
+    auto completion_scheduler = stdexec::get_completion_scheduler<stdexec::set_value_t>(
+      stdexec::get_env(sender));
+
+    CHECK(completion_scheduler == sch);
+    auto [res] = stdexec::sync_wait(sender).value();
+    CHECK(res == 30);
+  }
+
+  TEST_CASE("libdispatch bulk should handle exceptions gracefully") {
+    exec::libdispatch_queue queue;
+    auto sch = queue.get_scheduler();
+
+    std::vector<int> data{1, 2, 3, 4, 5};
+    auto size = data.size();
+    auto expensive_computation = [](auto i, auto data) {
+      if (i == 0)
+        throw 999;
+      return 2 * data[i];
+    };
+    auto add = [](auto const & data) {
+      return std::accumulate(std::begin(data), std::end(data), 0);
+    };
+    auto sender = stdexec::transfer_just(sch, std::move(data)) //
+                | stdexec::bulk(size, expensive_computation)   //
+                | stdexec::then(add);
+
+
+    try {
+      stdexec::sync_wait(sender);
+      CHECK(false);
+    } catch (int e) {
+      CHECK(e == 999);
+    }
+  }
+} // namespace


### PR DESCRIPTION
In his talk "Better Code: Concurrency", @sean-parent said that a tasking system built upon libdispatch would be his 1.0 for the performance. So, just thought implement the same as I needed it for one of my project.

This can be helpful for people who want to use library and have high performance requirements.

I have profiled the libdispatch queue code over a ray tracing application against already existing static_thread_pool implementation. My usecase may not cover all the scenarios but can be good to look into some real applications.

My machine have 8 cores with 8 gigs ram.

### libdispatch
 - cpu core usage graph
![libdispatchcpu](https://github.com/NVIDIA/stdexec/assets/26287448/5caa9d4e-48fb-4390-9c7e-f1d3a6b91f0e)
 - cpu core usage summary 
![dispatchutilization](https://github.com/NVIDIA/stdexec/assets/26287448/0150cc53-967e-470b-985d-e2eaa38d9917)

### static_thread_pool
 - cpu core usage graph
![static_thread_pool_cores](https://github.com/NVIDIA/stdexec/assets/26287448/f5b72ca5-15e0-47a0-8b34-6b4e95650a62)
 - cpu core usage summary
![static_thread_pool_usage](https://github.com/NVIDIA/stdexec/assets/26287448/1fe4d7b9-79ed-4393-8aa1-6c4acea8e68e)

PS: I know the current bulk implementation of static_thread_pool is not the most optimal approach for my usecase.



