### PR TITLE
Implement receiver_ref for let_value

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -605,9 +605,6 @@ namespace exec {
     using __is_not_stop_token_query_v = __mbool<__is_not_stop_token_query<_Query>>;
 
     namespace __rec {
-      template <class _Sig>
-      struct __rcvr_vfun;
-
       template <class _Sigs, class... _Queries>
       struct __vtable {
         class __t;
@@ -616,25 +613,10 @@ namespace exec {
       template <class _Sigs, class... _Queries>
       struct __ref;
 
-      template <class _Tag, class... _As>
-      struct __rcvr_vfun<_Tag(_As...)> {
-        void (*__fn_)(void*, _As...) noexcept;
-      };
-
-      template <class _Rcvr>
-      struct __rcvr_vfun_fn {
-        template <class _Tag, class... _As>
-        constexpr void (*operator()(_Tag (*)(_As...)) const noexcept)(void*, _As...) noexcept {
-          return +[](void* __rcvr, _As... __as) noexcept -> void {
-            _Tag{}(static_cast<_Rcvr&&>(*static_cast<_Rcvr*>(__rcvr)), static_cast<_As&&>(__as)...);
-          };
-        }
-      };
-
       template <class... _Sigs, class... _Queries>
       struct __vtable<completion_signatures<_Sigs...>, _Queries...> {
         class __t
-          : public __rcvr_vfun<_Sigs>...
+          : public __any_::__rcvr_vfun<_Sigs>...
           , public __query_vfun<_Queries>... {
          public:
           using __query_vfun<_Queries>::operator()...;
@@ -646,7 +628,7 @@ namespace exec {
           friend auto tag_invoke(__create_vtable_t, __mtype<__t>, __mtype<_Rcvr>) noexcept
             -> const __t* {
             static const __t __vtable_{
-              {__rcvr_vfun_fn<_Rcvr>{}(static_cast<_Sigs*>(nullptr))}...,
+              {__any_::__rcvr_vfun_fn<_Rcvr>(static_cast<_Sigs*>(nullptr))}...,
               {__query_vfun_fn<_Rcvr>{}(static_cast<_Queries>(nullptr))}...};
             return &__vtable_;
           }
@@ -699,7 +681,7 @@ namespace exec {
         template <__completion_tag _Tag, __decays_to<__ref> _Self, class... _As>
           requires __one_of<_Tag(_As...), _Sigs...>
         friend void tag_invoke(_Tag, _Self&& __self, _As&&... __as) noexcept {
-          (*static_cast<const __rcvr_vfun<_Tag(_As...)>*>(__self.__env_.__vtable_)->__fn_)(
+          (*static_cast<const __any_::__rcvr_vfun<_Tag(_As...)>*>(__self.__env_.__vtable_)->__complete_)(
             static_cast<_Self&&>(__self).__env_.__rcvr_, static_cast<_As&&>(__as)...);
         }
 
@@ -762,7 +744,7 @@ namespace exec {
         template <__completion_tag _Tag, __decays_to<__ref> _Self, class... _As>
           requires __one_of<_Tag(_As...), _Sigs...>
         friend void tag_invoke(_Tag, _Self&& __self, _As&&... __as) noexcept {
-          (*static_cast<const __rcvr_vfun<_Tag(_As...)>*>(__self.__env_.__vtable_)->__fn_)(
+          (*static_cast<const __any_::__rcvr_vfun<_Tag(_As...)>*>(__self.__env_.__vtable_)->__complete_)(
             static_cast<_Self&&>(__self).__env_.__rcvr_, static_cast<_As&&>(__as)...);
         }
 

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -59,7 +59,7 @@ namespace exec {
 
         struct __t
           : public __rcvr_next_vfun<_NextSigs>
-          , public __rec::__rcvr_vfun<_Sigs>...
+          , public __any_::__rcvr_vfun<_Sigs>...
           , public __query_vfun<_Queries>... {
           using __id = __next_vtable;
           using __query_vfun<_Queries>::operator()...;
@@ -71,7 +71,7 @@ namespace exec {
             -> const __t* {
             static const __t __vtable_{
               {__rcvr_next_vfun_fn<_Rcvr>{}(static_cast<_NextSigs*>(nullptr))},
-              {__rec::__rcvr_vfun_fn<_Rcvr>{}(static_cast<_Sigs*>(nullptr))}...,
+              {__any_::__rcvr_vfun_fn<_Rcvr>(static_cast<_Sigs*>(nullptr))}...,
               {__query_vfun_fn<_Rcvr>{}(static_cast<_Queries>(nullptr))}...};
             return &__vtable_;
           }
@@ -115,7 +115,7 @@ namespace exec {
           using __vtable_t = stdexec::__t<__next_vtable<__next_sigs, __compl_sigs, _Queries...>>;
 
           template <class Sig>
-          using __vfun = __rec::__rcvr_vfun<Sig>;
+          using __vfun = __any_::__rcvr_vfun<Sig>;
 
           using __env_t = stdexec::__t<__env<__next_sigs, _Queries...>>;
           __env_t __env_;
@@ -140,14 +140,14 @@ namespace exec {
           template <same_as<set_value_t> _SetValue, same_as<__t> _Self>
           // set_value_t() is always valid for a sequence
           friend void tag_invoke(_SetValue, _Self&& __self) noexcept {
-            (*static_cast<const __vfun<_SetValue()>*>(__self.__env_.__vtable_)->__fn_)(
+            (*static_cast<const __vfun<_SetValue()>*>(__self.__env_.__vtable_)->__complete_)(
               __self.__env_.__rcvr_);
           }
 
           template <same_as<set_error_t> _SetError, same_as<__t> _Self, class Error>
             requires __v<__mapply<__contains<set_error_t(Error)>, __compl_sigs>>
           friend void tag_invoke(_SetError, _Self&& __self, Error&& __error) noexcept {
-            (*static_cast<const __vfun<set_error_t(Error)>*>(__self.__env_.__vtable_)->__fn_)(
+            (*static_cast<const __vfun<set_error_t(Error)>*>(__self.__env_.__vtable_)->__complete_)(
               __self.__env_.__rcvr_, static_cast<Error&&>(__error));
           }
 
@@ -156,7 +156,7 @@ namespace exec {
           friend void tag_invoke(_SetStopped, _Self&& __self) noexcept
 
           {
-            (*static_cast<const __vfun<set_stopped_t()>*>(__self.__env_.__vtable_)->__fn_)(
+            (*static_cast<const __vfun<set_stopped_t()>*>(__self.__env_.__vtable_)->__complete_)(
               __self.__env_.__rcvr_);
           }
 

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -417,10 +417,8 @@ namespace stdexec {
         __complete(_Index, _Tag2, _Args&&... __args) noexcept {
         using __tag_t = typename __op_state::__tag_t;
         auto&& __rcvr = this->__rcvr();
-        if constexpr (requires {
-                        __sexpr_impl<__tag_t>::complete(
-                          _Index(), *this, _Tag2(), static_cast<_Args&&>(__args)...);
-                      }) {
+        using _CompleteFn = __mtypeof<__sexpr_impl<__tag_t>::complete>;
+        if constexpr (__callable<_CompleteFn, _Index, __op_state&, _Tag2, _Args...>) {
           __sexpr_impl<__tag_t>::complete(
             _Index(), *this, _Tag2(), static_cast<_Args&&>(__args)...);
         } else {

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -417,8 +417,16 @@ namespace stdexec {
         __complete(_Index, _Tag2, _Args&&... __args) noexcept {
         using __tag_t = typename __op_state::__tag_t;
         auto&& __rcvr = this->__rcvr();
-        __sexpr_impl<__tag_t>::complete(
-          _Index(), this->__state_, __rcvr, _Tag2(), static_cast<_Args&&>(__args)...);
+        if constexpr (requires {
+                        __sexpr_impl<__tag_t>::complete(
+                          _Index(), *this, _Tag2(), static_cast<_Args&&>(__args)...);
+                      }) {
+          __sexpr_impl<__tag_t>::complete(
+            _Index(), *this, _Tag2(), static_cast<_Args&&>(__args)...);
+        } else {
+          __sexpr_impl<__tag_t>::complete(
+            _Index(), this->__state_, __rcvr, _Tag2(), static_cast<_Args&&>(__args)...);
+        }
       }
 
       template <class _Index>

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -191,7 +191,7 @@ namespace stdexec {
 
     inline constexpr auto __connect = //
       []<class _Sender, class _Receiver>(_Sender&& __sndr, _Receiver __rcvr) noexcept(
-        std::is_nothrow_constructible_v<__op_state<_Sender, _Receiver>, _Sender&&, _Receiver&&>)
+        __nothrow_constructible_from<__op_state<_Sender, _Receiver>, _Sender&&, _Receiver&&>)
       -> __op_state<_Sender, _Receiver>
       requires __connectable<_Sender, _Receiver>
     {
@@ -393,7 +393,7 @@ namespace stdexec {
       // }
 
       __op_state(_Sexpr&& __sexpr, _Receiver __rcvr) noexcept(
-        std::is_nothrow_constructible_v<__op_base<_Sexpr, _Receiver>, _Sexpr&&, _Receiver&&>
+        __nothrow_constructible_from<__op_base<_Sexpr, _Receiver>, _Sexpr&&, _Receiver&&>
         && __nothrow_callable<__sexpr_apply_t, _Sexpr&&, __connect_fn<_Sexpr, _Receiver>>)
         : __op_state::__op_base{static_cast<_Sexpr&&>(__sexpr), static_cast<_Receiver&&>(__rcvr)}
         , __inner_ops_(

--- a/include/stdexec/__detail/__domain.hpp
+++ b/include/stdexec/__detail/__domain.hpp
@@ -80,22 +80,21 @@ namespace stdexec {
     template <class _Sender>
     constexpr bool __is_nothrow_transform_sender() {
       if constexpr (__callable<__sexpr_apply_t, _Sender, __domain::__legacy_customization>) {
-        return noexcept(
-          stdexec::__sexpr_apply(__declval<_Sender&&>(), __domain::__legacy_customization()));
+        return __nothrow_callable<__sexpr_apply_t, _Sender, __domain::__legacy_customization>;
       } else if constexpr (__domain::__has_default_transform_sender<_Sender>) {
-        return noexcept(tag_of_t<_Sender>().transform_sender(__declval<_Sender&&>()));
+        return noexcept(tag_of_t<_Sender>().transform_sender(__declval<_Sender>()));
       } else {
-        return noexcept(static_cast<_Sender>(__declval<_Sender&&>()));
+        return __nothrow_constructible_from<_Sender, _Sender>;
       }
     }
 
     template <class _Sender, class _Env>
-    constexpr bool __is_nothrow_transform_sender() {
+    constexpr bool __is_nothrow_transform_sender() noexcept {
       if constexpr (__domain::__has_default_transform_sender<_Sender, _Env>) {
         return noexcept(
-          tag_of_t<_Sender>().transform_sender(__declval<_Sender&&>(), __declval<const _Env&>()));
+          tag_of_t<_Sender>().transform_sender(__declval<_Sender>(), __declval<const _Env&>()));
       } else {
-        return noexcept(static_cast<_Sender>(__declval<_Sender&&>()));
+        return __nothrow_constructible_from<_Sender, _Sender>;
       }
     }
   } // namespace __domain

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -3547,8 +3547,8 @@ namespace stdexec {
 
       template <class _Receiver>
       explicit constexpr __receiver_vtable_for(const _Receiver*) noexcept
-        : stdexec::__any_::__rcvr_vfun<
-          _Sigs>{stdexec::__any_::__rcvr_vfun_fn<_Receiver>((_Sigs*) nullptr)}...
+        : stdexec::__any_::__rcvr_vfun<_Sigs>{stdexec::__any_::__rcvr_vfun_fn<_Receiver>(
+          (_Sigs*) nullptr)}...
         , __do_get_env{+[](const void* __rcvr) noexcept -> _Env {
           return stdexec::get_env(*static_cast<const _Receiver*>(__rcvr));
         }} {
@@ -3756,7 +3756,7 @@ namespace stdexec {
           __minvoke<__result_sender_fn<_Fun, _Set, _Env, _Sched>, _Args...>,
           __result_env_t<_Env, _Sched>,
           __if_c<
-            __nothrow_callable<_Fun, _Args...>
+            (__nothrow_decay_copyable<_Args> && ...) && __nothrow_callable<_Fun, _Args...>
               && __nothrow_connectable_receiver_ref<
                 __minvoke<__result_sender_fn<_Fun, _Set, _Env, _Sched>, _Args...>,
                 _Env,
@@ -3990,7 +3990,7 @@ namespace stdexec {
         using _ResultSender =
           __minvoke<__result_sender_fn<_Fun, _Set, env_of_t<_Receiver>, _Sched>, _As...>;
         if constexpr (
-          __nothrow_callable<_Fun, _As...>
+          (__nothrow_decay_copyable<_As> && ...) && __nothrow_callable<_Fun, _As...>
           && __nothrow_connectable_receiver_ref<_ResultSender, env_of_t<_Receiver>, _Sched>) {
           __bind_(__state, __rcvr, static_cast<_As&&>(__as)...);
         } else {

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -575,15 +575,14 @@ namespace stdexec {
     struct __transform_sender_1 {
       template <class _Domain, class _Sender, class... _Env>
       STDEXEC_ATTRIBUTE((always_inline))
-      /*constexpr*/
       static constexpr bool
         __is_nothrow() noexcept {
         if constexpr (__domain::__has_transform_sender<_Domain, _Sender, _Env...>) {
           return noexcept(__declval<_Domain&>().transform_sender(
-            __declval<_Sender&&>(), __declval<const _Env&>()...));
+            __declval<_Sender>(), __declval<const _Env&>()...));
         } else {
           return noexcept(
-            default_domain().transform_sender(__declval<_Sender&&>(), __declval<const _Env&>()...));
+            default_domain().transform_sender(__declval<_Sender>(), __declval<const _Env&>()...));
         }
       }
 
@@ -592,7 +591,7 @@ namespace stdexec {
       /*constexpr*/
       decltype(auto)
         operator()(_Domain __dom, _Sender&& __sndr, const _Env&... __env) const
-        noexcept(__is_nothrow<_Domain, _Sender&&, const _Env&...>()) {
+        noexcept(__is_nothrow<_Domain, _Sender, const _Env&...>()) {
         if constexpr (__domain::__has_transform_sender<_Domain, _Sender, _Env...>) {
           return __dom.transform_sender(static_cast<_Sender&&>(__sndr), __env...);
         } else {
@@ -610,7 +609,7 @@ namespace stdexec {
       /*constexpr*/
       decltype(auto)
         operator()(_Domain __dom, _Sender&& __sndr, const _Env&... __env) const noexcept(
-          noexcept(__transform_sender_1()(__dom, static_cast<_Sender&&>(__sndr), __env...))) {
+          __nothrow_callable<__transform_sender_1, _Domain, _Sender, const _Env&...>) {
         using _Sender2 = __call_result_t<__transform_sender_1, _Domain, _Sender, const _Env&...>;
         // If the transformation doesn't change the sender's type, then do not
         // apply the transform recursively.
@@ -665,20 +664,20 @@ namespace stdexec {
     using _Env2 = decltype(transform_env(
       __declval<dependent_domain&>(), __declval<_Sender&&>(), __declval<_Env>()));
     return decltype(__sexpr_apply(
-      __declval<_Sender&&>(),
+      __declval<_Sender>(),
       []<class _Tag, class _Data, class... _Childs>(_Tag, _Data&&, _Childs&&...) {
         constexpr bool __first_transform_is_nothrow = noexcept(__make_sexpr<_Tag>(
           __declval<_Data>(),
           __domain::__transform_sender()(
-            __declval<dependent_domain&>(), __declval<_Childs&&>(), __declval<const _Env2&>())...));
+            __declval<dependent_domain&>(), __declval<_Childs>(), __declval<const _Env2&>())...));
         using _Sender2 = decltype(__make_sexpr<_Tag>(
           __declval<_Data>(),
           __domain::__transform_sender()(
-            __declval<dependent_domain&>(), __declval<_Childs&&>(), __declval<const _Env2&>())...));
+            __declval<dependent_domain&>(), __declval<_Childs>(), __declval<const _Env2&>())...));
         using _Domain2 =
           decltype(__sexpr_apply(__declval<_Sender2&>(), __domain::__common_domain_fn()));
         constexpr bool __second_transform_is_nothrow = noexcept(__domain::__transform_sender()(
-          __declval<_Domain2&>(), __declval<_Sender2&&>(), __declval<const _Env&>()));
+          __declval<_Domain2&>(), __declval<_Sender2>(), __declval<const _Env&>()));
         return __mbool < __first_transform_is_nothrow && __second_transform_is_nothrow > ();
       }))::value;
   }

--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -3514,10 +3514,10 @@ namespace stdexec {
 
   namespace __any_ {
     template <class _Sig>
-    struct __receiver_signature_for;
+    struct __rcvr_vfun;
 
     template <class _Tag, class... _Args>
-    struct __receiver_signature_for<_Tag(_Args...)> {
+    struct __rcvr_vfun<_Tag(_Args...)> {
       void (*__complete_)(void*, _Args&&...) noexcept;
 
       void operator()(void* __rcvr, _Tag __tag, _Args&&... __args) const noexcept {
@@ -3526,7 +3526,7 @@ namespace stdexec {
     };
 
     template <class _Receiver, class _Tag, class... _Args>
-    constexpr auto __receiver_signature_for_fn(_Tag (*)(_Args...)) noexcept {
+    constexpr auto __rcvr_vfun_fn(_Tag (*)(_Args...)) noexcept {
       return +[](void* __pointer, _Args&&... __args) noexcept {
         _Receiver* __rcvr = static_cast<_Receiver*>(__pointer);
         _Tag{}(static_cast<_Receiver&&>(*__rcvr), static_cast<_Args&&>(__args)...);
@@ -3541,20 +3541,20 @@ namespace stdexec {
 
     template <class _Env, class... _Sigs>
     struct __receiver_vtable_for<completion_signatures<_Sigs...>, _Env>
-      : stdexec::__any_::__receiver_signature_for<_Sigs>... {
+      : stdexec::__any_::__rcvr_vfun<_Sigs>... {
 
       _Env (*__do_get_env)(const void* __rcvr) noexcept;
 
       template <class _Receiver>
       explicit constexpr __receiver_vtable_for(const _Receiver*) noexcept
-        : stdexec::__any_::__receiver_signature_for<
-          _Sigs>{stdexec::__any_::__receiver_signature_for_fn<_Receiver>((_Sigs*) nullptr)}...
+        : stdexec::__any_::__rcvr_vfun<
+          _Sigs>{stdexec::__any_::__rcvr_vfun_fn<_Receiver>((_Sigs*) nullptr)}...
         , __do_get_env{+[](const void* __rcvr) noexcept -> _Env {
           return stdexec::get_env(*static_cast<const _Receiver*>(__rcvr));
         }} {
       }
 
-      using stdexec::__any_::__receiver_signature_for<_Sigs>::operator()...;
+      using stdexec::__any_::__rcvr_vfun<_Sigs>::operator()...;
 
       auto __get_env(const void* __rcvr) const noexcept -> _Env {
         return __do_get_env(__rcvr);

--- a/test/exec/test_on.cpp
+++ b/test/exec/test_on.cpp
@@ -182,11 +182,11 @@ namespace {
     error_scheduler sched2{};
     error_scheduler<int> sched3{43};
 
-    check_err_types<type_array<std::exception_ptr&&>>(
+    check_err_types<type_array<>>(
       exec::on(sched1, ex::just(1)) | _with_scheduler());
     check_err_types<type_array<std::exception_ptr&&>>(
       exec::on(sched2, ex::just(2)) | _with_scheduler());
-    check_err_types<type_array<int&&, std::exception_ptr&&>>(
+    check_err_types<type_array<int&&>>(
       exec::on(sched3, ex::just(3)) | _with_scheduler());
   }
 

--- a/test/stdexec/algos/adaptors/test_let_value.cpp
+++ b/test/stdexec/algos/adaptors/test_let_value.cpp
@@ -287,6 +287,13 @@ namespace {
       ex::transfer_just(sched2) | ex::let_value([] { return ex::just(); }));
     check_err_types<type_array<int, std::exception_ptr>>( //
       ex::transfer_just(sched3) | ex::let_value([] { return ex::just(); }));
+
+    check_err_types<type_array<>>( //
+      ex::transfer_just(sched1) | ex::let_value([]() noexcept { return ex::just(); }));
+    check_err_types<type_array<std::exception_ptr>>( //
+      ex::transfer_just(sched2) | ex::let_value([]() noexcept { return ex::just(); }));
+    check_err_types<type_array<int>>( //
+      ex::transfer_just(sched3) | ex::let_value([]() noexcept { return ex::just(); }));
   }
 
   TEST_CASE("let_value keeps sends_stopped from input sender", "[adaptors][let_value]") {

--- a/test/stdexec/algos/adaptors/test_on.cpp
+++ b/test/stdexec/algos/adaptors/test_on.cpp
@@ -170,9 +170,9 @@ namespace {
     error_scheduler sched2{};
     error_scheduler<int> sched3{43};
 
-    check_err_types<type_array<std::exception_ptr>>(ex::on(sched1, ex::just(1)));
+    check_err_types<type_array<>>(ex::on(sched1, ex::just(1)));
     check_err_types<type_array<std::exception_ptr>>(ex::on(sched2, ex::just(2)));
-    check_err_types<type_array<std::exception_ptr, int>>(ex::on(sched3, ex::just(3)));
+    check_err_types<type_array<int>>(ex::on(sched3, ex::just(3)));
   }
 
   TEST_CASE("on keeps sends_stopped from scheduler's sender", "[adaptors][on]") {

--- a/test/stdexec/algos/adaptors/test_stopped_as_error.cpp
+++ b/test/stdexec/algos/adaptors/test_stopped_as_error.cpp
@@ -67,7 +67,7 @@ namespace {
     ex::sender auto snd = ex::transfer_just(sched, 11)
                         | ex::stopped_as_error(std::error_code(1, std::generic_category()));
     check_val_types<type_array<type_array<int&&>>>(snd);
-    check_err_types<type_array<std::exception_ptr, std::error_code>>(snd);
+    check_err_types<type_array<std::error_code>>(snd);
     check_sends_stopped<false>(snd);
 
     auto op = ex::connect(std::move(snd), expect_value_receiver{11});
@@ -82,7 +82,7 @@ namespace {
     std::error_code errcode(1, std::generic_category());
     ex::sender auto snd = ex::transfer_just(sched, 11) | ex::stopped_as_error(errcode);
     check_val_types<type_array<type_array<int&&>>>(snd);
-    check_err_types<type_array<std::exception_ptr, std::error_code>>(snd);
+    check_err_types<type_array<std::error_code>>(snd);
     check_sends_stopped<false>(snd);
 
     auto op = ex::connect(std::move(snd), expect_error_receiver{errcode});
@@ -128,7 +128,7 @@ namespace {
     check_err_types<type_array<std::exception_ptr, int>>( //
       ex::transfer_just(sched2, 13) | ex::stopped_as_error(-1));
 
-    check_err_types<type_array<int, std::exception_ptr>>( //
+    check_err_types<type_array<int>>( //
       ex::transfer_just(sched3, 13) | ex::stopped_as_error(-1));
 
     check_err_types<type_array<>>(  //


### PR DESCRIPTION
This PR adds a type-erased receiver to the `let_` algorithms. Its purpose is to transparently compute whether the delayed call to `connect` will throw or not. 

The implementation strategy is as follows:

1. First compute whether the second call to connect between every resulting sender and the type erased `receiver_ref <ResultSenderSigs, Env, Scheduler>` will throw.

2. In the final operation state check whether connecting with the resulting Receiver improves or retains noexceptness. If yes, then connect with that one and otherwise we use the indirection via `receiver_ref` to keep `noexcept` for the call to `connect`.

For well-behaved senders and receivers it is expected to practically never need to really connect to the receiver ref. 
This strategy can be used in every algorithm that manages a variant operation states with multiple stages.

This is related to https://github.com/cplusplus/sender-receiver/issues/88 