### PR TITLE
`split()` cancels the shared op only when no one is waiting for the result

### DIFF
--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -169,6 +169,7 @@ namespace exec {
       }
 
       STDEXEC_MEMFN_FRIEND(connect);
+
       template <stdexec::receiver Receiver>
       STDEXEC_MEMFN_DECL(auto connect)(this sender s, Receiver r)
         -> __libdispatch_details::operation<stdexec::__id<Receiver>> {

--- a/include/stdexec/__detail/__intrusive_ptr.hpp
+++ b/include/stdexec/__detail/__intrusive_ptr.hpp
@@ -31,36 +31,66 @@
 
 namespace stdexec {
   namespace __ptr {
-    template <class _Ty>
+    template <std::size_t _ReservedBits>
+    struct __count_and_bits {
+      static constexpr std::size_t __ref_count_increment = 1ul << _ReservedBits;
+
+      enum struct __bits : std::size_t {};
+
+      friend constexpr std::size_t __count(__bits __b) noexcept {
+        return static_cast<std::size_t>(__b) / __ref_count_increment;
+      }
+
+      template <std::size_t _Bit>
+      friend constexpr bool __bit(__bits __b) noexcept {
+        static_assert(_Bit < _ReservedBits, "Bit index out of range");
+        return (static_cast<std::size_t>(__b) & (1ul << _Bit)) != 0;
+      }
+    };
+
+    template <std::size_t _ReservedBits>
+    using __bits_t = typename __count_and_bits<_ReservedBits>::__bits;
+
+    template <class _Ty, std::size_t _ReservedBits>
     struct __make_intrusive_t;
 
-    template <class _Ty>
+    template <class _Ty, std::size_t _ReservedBits = 0ul>
     class __intrusive_ptr;
 
-    template <class _Ty>
+    template <class _Ty, std::size_t _ReservedBits = 0ul>
     struct __enable_intrusive_from_this {
-      auto __intrusive_from_this() noexcept -> __intrusive_ptr<_Ty>;
-      auto __intrusive_from_this() const noexcept -> __intrusive_ptr<const _Ty>;
+      auto __intrusive_from_this() noexcept -> __intrusive_ptr<_Ty, _ReservedBits>;
+      auto __intrusive_from_this() const noexcept -> __intrusive_ptr<const _Ty, _ReservedBits>;
      private:
+      using __bits_t = typename __count_and_bits<_ReservedBits>::__bits;
       friend _Ty;
-      void __inc_ref() noexcept;
-      void __dec_ref() noexcept;
+      __bits_t __inc_ref() noexcept;
+      __bits_t __dec_ref() noexcept;
+
+      template <std::size_t _Bit>
+      bool __is_set() const noexcept;
+      template <std::size_t _Bit>
+      __bits_t __set_bit() noexcept;
+      template <std::size_t _Bit>
+      __bits_t __clear_bit() noexcept;
     };
 
     STDEXEC_PRAGMA_PUSH()
     STDEXEC_PRAGMA_IGNORE_GNU("-Wtsan")
 
-    template <class _Ty>
+    template <class _Ty, std::size_t _ReservedBits>
     struct __control_block {
+      using __bits_t = typename __count_and_bits<_ReservedBits>::__bits;
+      static constexpr std::size_t __ref_count_increment = 1ul << _ReservedBits;
+
       alignas(_Ty) unsigned char __value_[sizeof(_Ty)];
-      std::atomic<unsigned long> __refcount_;
+      std::atomic<std::size_t> __ref_count_;
 
       template <class... _Us>
       explicit __control_block(_Us&&... __us) noexcept(noexcept(_Ty{__declval<_Us>()...}))
-        : __refcount_(1u) {
-        // Construct the value *after* the initialization of the
-        // atomic in case the constructor of _Ty calls
-        // __intrusive_from_this() (which increments the atomic):
+        : __ref_count_(__ref_count_increment) {
+        // Construct the value *after* the initialization of the atomic in case the constructor of
+        // _Ty calls __intrusive_from_this() (which increments the ref count):
         ::new (static_cast<void*>(__value_)) _Ty{static_cast<_Us&&>(__us)...};
       }
 
@@ -72,32 +102,58 @@ namespace stdexec {
         return *reinterpret_cast<_Ty*>(__value_);
       }
 
-      void __inc_ref_() noexcept {
-        __refcount_.fetch_add(1, std::memory_order_relaxed);
+      __bits_t __inc_ref_() noexcept {
+        auto __old = __ref_count_.fetch_add(__ref_count_increment, std::memory_order_relaxed);
+        return static_cast<__bits_t>(__old);
       }
 
-      void __dec_ref_() noexcept {
-        if (1u == __refcount_.fetch_sub(1, std::memory_order_release)) {
-          std::atomic_thread_fence(std::memory_order_acquire);
-          // TSan does not support std::atomic_thread_fence, so we
-          // need to use the TSan-specific __tsan_acquire instead:
-          STDEXEC_TSAN(__tsan_acquire(&__refcount_));
+      __bits_t __dec_ref_() noexcept {
+        auto __old = __ref_count_.fetch_sub(__ref_count_increment, std::memory_order_acq_rel);
+        if (__count(static_cast<__bits_t>(__old)) == 1) {
           delete this;
         }
+        return static_cast<__bits_t>(__old);
+      }
+
+      // Returns true if the bit was set, false if it was already set.
+      template <std::size_t _Bit>
+      [[nodiscard]]
+      bool __is_set_() const noexcept {
+        auto __old = __ref_count_.load(std::memory_order_relaxed);
+        return __bit<_Bit>(static_cast<__bits_t>(__old));
+      }
+
+      template <std::size_t _Bit>
+      __bits_t __set_bit_() noexcept {
+        static_assert(_Bit < _ReservedBits, "Bit index out of range");
+        constexpr std::size_t __mask = 1ul << _Bit;
+        auto __old = __ref_count_.fetch_or(__mask, std::memory_order_acq_rel);
+        return static_cast<__bits_t>(__old);
+      }
+
+      // Returns true if the bit was cleared, false if it was already cleared.
+      template <std::size_t _Bit>
+      __bits_t __clear_bit_() noexcept {
+        static_assert(_Bit < _ReservedBits, "Bit index out of range");
+        constexpr std::size_t __mask = 1ul << _Bit;
+        auto __old = __ref_count_.fetch_and(~__mask, std::memory_order_acq_rel);
+        return static_cast<__bits_t>(__old);
       }
     };
 
     STDEXEC_PRAGMA_POP()
 
-    template <class _Ty>
+    template <class _Ty, std::size_t _ReservedBits /* = 0ul */>
     class __intrusive_ptr {
       using _UncvTy = std::remove_cv_t<_Ty>;
-      friend struct __make_intrusive_t<_Ty>;
-      friend struct __enable_intrusive_from_this<_UncvTy>;
+      using __enable_intrusive_t = __enable_intrusive_from_this<_UncvTy, _ReservedBits>;
+      friend _Ty;
+      friend struct __make_intrusive_t<_Ty, _ReservedBits>;
+      friend struct __enable_intrusive_from_this<_UncvTy, _ReservedBits>;
 
-      __control_block<_UncvTy>* __data_{nullptr};
+      __control_block<_UncvTy, _ReservedBits>* __data_{nullptr};
 
-      explicit __intrusive_ptr(__control_block<_UncvTy>* __data) noexcept
+      explicit __intrusive_ptr(__control_block<_UncvTy, _ReservedBits>* __data) noexcept
         : __data_(__data) {
       }
 
@@ -111,6 +167,14 @@ namespace stdexec {
         if (__data_) {
           __data_->__dec_ref_();
         }
+      }
+
+      // For use when types want to take over manual control of the reference count.
+      // Very unsafe, but useful for implementing custom reference counting.
+      [[nodiscard]]
+      __enable_intrusive_t* __release_() noexcept {
+        auto* __data = std::exchange(__data_, nullptr);
+        return __data ? &__c_upcast<__enable_intrusive_t>(__data->__value()) : nullptr;
       }
 
      public:
@@ -127,7 +191,7 @@ namespace stdexec {
         __inc_ref_();
       }
 
-      __intrusive_ptr(__enable_intrusive_from_this<_Ty>* __that) noexcept
+      __intrusive_ptr(__enable_intrusive_from_this<_Ty, _ReservedBits>* __that) noexcept
         : __intrusive_ptr(__that ? __that->__intrusive_from_this() : __intrusive_ptr()) {
       }
 
@@ -141,7 +205,7 @@ namespace stdexec {
         return operator=(__intrusive_ptr(__that));
       }
 
-      auto operator=(__enable_intrusive_from_this<_Ty>* __that) noexcept -> __intrusive_ptr& {
+      auto operator=(__enable_intrusive_from_this<_Ty, _ReservedBits>* __that) noexcept -> __intrusive_ptr& {
         return operator=(__that ? __that->__intrusive_from_this() : __intrusive_ptr());
       }
 
@@ -184,48 +248,70 @@ namespace stdexec {
       }
     };
 
-    template <class _Ty>
+    template <class _Ty, std::size_t _ReservedBits>
     auto
-      __enable_intrusive_from_this<_Ty>::__intrusive_from_this() noexcept -> __intrusive_ptr<_Ty> {
-      auto* __data = reinterpret_cast<__control_block<_Ty>*>(static_cast<_Ty*>(this));
+      __enable_intrusive_from_this<_Ty, _ReservedBits>::__intrusive_from_this() noexcept -> __intrusive_ptr<_Ty, _ReservedBits> {
+      auto* __data = reinterpret_cast<__control_block<_Ty, _ReservedBits>*>(&__c_downcast<_Ty>(*this));
       __data->__inc_ref_();
-      return __intrusive_ptr<_Ty>{__data};
+      return __intrusive_ptr<_Ty, _ReservedBits>{__data};
     }
 
-    template <class _Ty>
-    auto __enable_intrusive_from_this<_Ty>::__intrusive_from_this() const noexcept
-      -> __intrusive_ptr<const _Ty> {
-      auto* __data = reinterpret_cast<__control_block<_Ty>*>(static_cast<const _Ty*>(this));
+    template <class _Ty, std::size_t _ReservedBits>
+    auto __enable_intrusive_from_this<_Ty, _ReservedBits>::__intrusive_from_this() const noexcept
+      -> __intrusive_ptr<const _Ty, _ReservedBits> {
+      auto* __data = reinterpret_cast<__control_block<_Ty, _ReservedBits>*>(&__c_downcast<_Ty>(*this));
       __data->__inc_ref_();
-      return __intrusive_ptr<const _Ty>{__data};
+      return __intrusive_ptr<const _Ty, _ReservedBits>{__data};
     }
 
-    template <class _Ty>
-    void __enable_intrusive_from_this<_Ty>::__inc_ref() noexcept {
-      auto* __data = reinterpret_cast<__control_block<_Ty>*>(static_cast<_Ty*>(this));
-      __data->__inc_ref_();
+    template <class _Ty, std::size_t _ReservedBits>
+    __bits_t<_ReservedBits> __enable_intrusive_from_this<_Ty, _ReservedBits>::__inc_ref() noexcept {
+      auto* __data = reinterpret_cast<__control_block<_Ty, _ReservedBits>*>(&__c_downcast<_Ty>(*this));
+      return __data->__inc_ref_();
     }
 
-    template <class _Ty>
-    void __enable_intrusive_from_this<_Ty>::__dec_ref() noexcept {
-      auto* __data = reinterpret_cast<__control_block<_Ty>*>(static_cast<_Ty*>(this));
-      __data->__dec_ref_();
+    template <class _Ty, std::size_t _ReservedBits>
+    __bits_t<_ReservedBits> __enable_intrusive_from_this<_Ty, _ReservedBits>::__dec_ref() noexcept {
+
+      auto* __data = reinterpret_cast<__control_block<_Ty, _ReservedBits>*>(&__c_downcast<_Ty>(*this));
+      return __data->__dec_ref_();
     }
 
-    template <class _Ty>
+    template <class _Ty, std::size_t _ReservedBits>
+    template <std::size_t _Bit>
+    bool __enable_intrusive_from_this<_Ty, _ReservedBits>::__is_set() const noexcept {
+      auto* __data = reinterpret_cast<const __control_block<_Ty, _ReservedBits>*>(&__c_downcast<_Ty>(*this));
+      return __data->template __is_set_<_Bit>();
+    }
+
+    template <class _Ty, std::size_t _ReservedBits>
+    template <std::size_t _Bit>
+    __bits_t<_ReservedBits> __enable_intrusive_from_this<_Ty, _ReservedBits>::__set_bit() noexcept {
+      auto* __data = reinterpret_cast<__control_block<_Ty, _ReservedBits>*>(&__c_downcast<_Ty>(*this));
+      return __data->template __set_bit_<_Bit>();
+    }
+
+    template <class _Ty, std::size_t _ReservedBits>
+    template <std::size_t _Bit>
+    __bits_t<_ReservedBits> __enable_intrusive_from_this<_Ty, _ReservedBits>::__clear_bit() noexcept {
+      auto* __data = reinterpret_cast<__control_block<_Ty, _ReservedBits>*>(&__c_downcast<_Ty>(*this));
+      return __data->template __clear_bit_<_Bit>();
+    }
+
+    template <class _Ty, std::size_t _ReservedBits>
     struct __make_intrusive_t {
       template <class... _Us>
         requires constructible_from<_Ty, _Us...>
-      auto operator()(_Us&&... __us) const -> __intrusive_ptr<_Ty> {
+      auto operator()(_Us&&... __us) const -> __intrusive_ptr<_Ty, _ReservedBits> {
         using _UncvTy = std::remove_cv_t<_Ty>;
-        return __intrusive_ptr<_Ty>{::new __control_block<_UncvTy>{static_cast<_Us&&>(__us)...}};
+        return __intrusive_ptr<_Ty, _ReservedBits>{::new __control_block<_UncvTy, _ReservedBits>{static_cast<_Us&&>(__us)...}};
       }
     };
   } // namespace __ptr
 
   using __ptr::__intrusive_ptr;
   using __ptr::__enable_intrusive_from_this;
-  template <class _Ty>
-  inline constexpr __ptr::__make_intrusive_t<_Ty> __make_intrusive{};
+  template <class _Ty, std::size_t _ReservedBits = 0ul>
+  inline constexpr __ptr::__make_intrusive_t<_Ty, _ReservedBits> __make_intrusive{};
 
 } // namespace stdexec

--- a/include/stdexec/__detail/__intrusive_slist.hpp
+++ b/include/stdexec/__detail/__intrusive_slist.hpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021-2022 Facebook, Inc. and its affiliates
+ * Copyright (c) 2021-2022 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "__config.hpp"
+
+#include <cstddef>
+#include <cassert>
+#include <utility>
+
+namespace stdexec {
+  namespace __queue {
+    template <auto _Next>
+    class __intrusive_slist;
+
+    template <class _Item, _Item* _Item::*_Next>
+    class __intrusive_slist<_Next> {
+     public:
+      __intrusive_slist() noexcept = default;
+
+      __intrusive_slist(__intrusive_slist&& __other) noexcept
+        : __head_(std::exchange(__other.__head_, nullptr)) {
+      }
+
+      __intrusive_slist(_Item* __head) noexcept
+        : __head_(__head) {
+      }
+
+      auto swap(__intrusive_slist& __other) noexcept -> void {
+        std::swap(__head_, __other.__head_);
+      }
+
+      auto operator=(__intrusive_slist __other) noexcept -> __intrusive_slist& {
+        swap(__other);
+        return *this;
+      }
+
+      [[nodiscard]]
+      auto empty() const noexcept -> bool {
+        return __head_ == nullptr;
+      }
+
+      auto front() const noexcept -> _Item* {
+        return __head_;
+      }
+
+      void clear() noexcept {
+        __head_ = nullptr;
+      }
+
+      [[nodiscard]]
+      auto pop_front() noexcept -> _Item* {
+        STDEXEC_ASSERT(!empty());
+        return std::exchange(__head_, __head_->*_Next);
+      }
+
+      void push_front(_Item* __item) noexcept {
+        STDEXEC_ASSERT(__item != nullptr);
+        __item->*_Next = std::exchange(__head_, __item);
+      }
+
+      [[nodiscard]]
+      _Item* remove(_Item* __item) noexcept {
+        STDEXEC_ASSERT(__item != nullptr);
+        if (__head_ == __item) {
+          return pop_front();
+        }
+
+        for (_Item* __current: *this) {
+          if (__current->*_Next == __item) {
+            __current->*_Next = __item->*_Next;
+            return __item;
+          }
+        }
+
+        return nullptr;
+      }
+
+      struct iterator {
+        using difference_type = std::ptrdiff_t;
+        using value_type = _Item*;
+
+        _Item* __item_ = nullptr;
+
+        iterator() noexcept = default;
+
+        explicit iterator(_Item* __item) noexcept
+          : __item_(__item) {
+        }
+
+        [[nodiscard]]
+        auto
+          operator*() const noexcept -> _Item* {
+          STDEXEC_ASSERT(__item_ != nullptr);
+          return __item_;
+        }
+
+        [[nodiscard]]
+        auto
+          operator->() const noexcept -> _Item** {
+          STDEXEC_ASSERT(__item_ != nullptr);
+          return &__item_;
+        }
+
+        auto operator++() noexcept -> iterator& {
+          STDEXEC_ASSERT(__item_ != nullptr);
+          __item_ = __item_->*_Next;
+          return *this;
+        }
+
+        auto operator++(int) noexcept -> iterator {
+          iterator __result = *this;
+          ++*this;
+          return __result;
+        }
+
+        auto operator==(const iterator&) const noexcept -> bool = default;
+      };
+
+      [[nodiscard]]
+      auto begin() const noexcept -> iterator {
+        return iterator(__head_);
+      }
+
+      [[nodiscard]]
+      auto end() const noexcept -> iterator {
+        return iterator(nullptr);
+      }
+
+     private:
+      _Item* __head_ = nullptr;
+    };
+  } // namespace __queue
+
+  using __queue::__intrusive_slist;
+
+} // namespace stdexec

--- a/include/stdexec/__detail/__intrusive_slist.hpp
+++ b/include/stdexec/__detail/__intrusive_slist.hpp
@@ -91,8 +91,11 @@ namespace stdexec {
       }
 
       struct iterator {
+        using iterator_category = std::forward_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using value_type = _Item*;
+        using reference = _Item*;
+        using pointer = _Item**;
 
         _Item* __item_ = nullptr;
 

--- a/include/stdexec/__detail/__intrusive_slist.hpp
+++ b/include/stdexec/__detail/__intrusive_slist.hpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Facebook, Inc. and its affiliates
- * Copyright (c) 2021-2022 NVIDIA Corporation
+ * Copyright (c) 2024 NVIDIA Corporation
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
  * (the "License"); you may not use this file except in compliance with

--- a/include/stdexec/__detail/__intrusive_slist.hpp
+++ b/include/stdexec/__detail/__intrusive_slist.hpp
@@ -23,7 +23,7 @@
 #include <utility>
 
 namespace stdexec {
-  namespace __queue {
+  namespace __slist {
     template <auto _Next>
     class __intrusive_slist;
 
@@ -144,8 +144,8 @@ namespace stdexec {
      private:
       _Item* __head_ = nullptr;
     };
-  } // namespace __queue
+  } // namespace __slist
 
-  using __queue::__intrusive_slist;
+  using __slist::__intrusive_slist;
 
 } // namespace stdexec

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -20,47 +20,13 @@
 #include <exception>
 #include <type_traits>
 #include <utility>
+
 #include "__config.hpp"
-#include "__type_traits.hpp"
 #include "__concepts.hpp"
+#include "__type_traits.hpp"
+#include "__utility.hpp"
 
 namespace stdexec {
-
-  template <class...>
-  struct __undefined;
-
-  struct __ { };
-
-  struct __ignore {
-    __ignore() = default;
-
-    STDEXEC_ATTRIBUTE((always_inline))
-    constexpr __ignore(auto&&...) noexcept {
-    }
-  };
-
-  struct __none_such { };
-
-  namespace {
-    struct __anon { };
-  } // namespace
-
-  struct __immovable {
-    __immovable() = default;
-   private:
-    STDEXEC_IMMOVABLE(__immovable);
-  };
-
-  struct __move_only {
-    __move_only() = default;
-
-    __move_only(__move_only&&) noexcept = default;
-    auto operator=(__move_only&&) noexcept -> __move_only& = default;
-
-    __move_only(const __move_only&) = delete;
-    auto operator=(const __move_only&) -> __move_only& = delete;
-  };
-
   template <class _Tp>
   using __t = typename _Tp::__t;
 

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -21,6 +21,41 @@
 #include <type_traits>
 
 namespace stdexec {
+  template <class...>
+  struct __undefined;
+
+  struct __ { };
+
+  struct __ignore {
+    __ignore() = default;
+
+    STDEXEC_ATTRIBUTE((always_inline))
+    constexpr __ignore(auto&&...) noexcept {
+    }
+  };
+
+  struct __none_such { };
+
+  namespace {
+    struct __anon { };
+  } // namespace
+
+  struct __immovable {
+    __immovable() = default;
+   private:
+    STDEXEC_IMMOVABLE(__immovable);
+  };
+
+  struct __move_only {
+    __move_only() = default;
+
+    __move_only(__move_only&&) noexcept = default;
+    auto operator=(__move_only&&) noexcept -> __move_only& = default;
+
+    __move_only(const __move_only&) = delete;
+    auto operator=(const __move_only&) -> __move_only& = delete;
+  };
+
   namespace __detail {
     template <class _Cpcvref>
     inline constexpr auto __forward_like = []<class _Uy>(_Uy&& __uy) noexcept -> auto&& {
@@ -31,8 +66,39 @@ namespace stdexec {
   template <class _Ty>
   inline constexpr auto const & __forward_like = __detail::__forward_like<__copy_cvref_fn<_Ty&&>>;
 
-  inline constexpr auto __decay_copy = //
-    []<class _Ty>(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>) {
-      return static_cast<_Ty&&>(__ty);
-    };
+  STDEXEC_PRAGMA_PUSH()
+  STDEXEC_PRAGMA_IGNORE_GNU("-Wold-style-cast")
+
+  // A derived-to-base cast that works even when the base is not accessible from derived.
+  template <class _Tp, class _Up>
+  STDEXEC_ATTRIBUTE((host, device))
+  auto
+    __c_upcast(_Up&& u) noexcept -> __copy_cvref_t<_Up&&, _Tp>
+    requires __decays_to<_Tp, _Tp>
+  {
+    static_assert(STDEXEC_IS_BASE_OF(_Tp, __decay_t<_Up>));
+    return (__copy_cvref_t<_Up&&, _Tp>) static_cast<_Up&&>(u);
+  }
+
+  // A base-to-derived cast that works even when the base is not accessible from derived.
+  template <class _Tp, class _Up>
+  STDEXEC_ATTRIBUTE((host, device))
+  auto
+    __c_downcast(_Up&& u) noexcept -> __copy_cvref_t<_Up&&, _Tp>
+    requires __decays_to<_Tp, _Tp>
+  {
+    static_assert(STDEXEC_IS_BASE_OF(__decay_t<_Up>, _Tp));
+    return (__copy_cvref_t<_Up&&, _Tp>) static_cast<_Up&&>(u);
+  }
+
+  STDEXEC_PRAGMA_POP()
+
+  template <class _Ty>
+  _Ty __decay_copy(_Ty) noexcept;
 } // namespace stdexec
+
+#if defined(__cpp_auto_cast) && (__cpp_auto_cast >= 202110UL)
+#  define STDEXEC_DECAY_COPY(...) auto(__VA_ARGS__)
+#else
+#  define STDEXEC_DECAY_COPY(...) (true ? (__VA_ARGS__) : stdexec::__decay_copy(__VA_ARGS__))
+#endif

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -33,6 +33,6 @@ namespace stdexec {
 
   inline constexpr auto __decay_copy = //
     []<class _Ty>(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>) {
-      return static_cast<_Ty &&>(__ty);
+      return static_cast<_Ty&&>(__ty);
     };
 } // namespace stdexec

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -30,4 +30,9 @@ namespace stdexec {
 
   template <class _Ty>
   inline constexpr auto const & __forward_like = __detail::__forward_like<__copy_cvref_fn<_Ty&&>>;
+
+  inline constexpr auto __decay_copy = //
+    []<class _Ty>(_Ty&& __ty) noexcept(__nothrow_decay_copyable<_Ty>) {
+      return static_cast<_Ty &&>(__ty);
+    };
 } // namespace stdexec

--- a/include/stdexec/stop_token.hpp
+++ b/include/stdexec/stop_token.hpp
@@ -438,6 +438,9 @@ namespace stdexec {
     } && //
     (!_Token::stop_possible());
 
+  template <class _Token, class _Callback>
+  using stop_callback_for_t = typename _Token::template callback_type<_Callback>;
+
   using in_place_stop_token
     [[deprecated("in_place_stop_token has been renamed inplace_stop_token")]] = inplace_stop_token;
 

--- a/test/stdexec/algos/adaptors/test_split.cpp
+++ b/test/stdexec/algos/adaptors/test_split.cpp
@@ -73,7 +73,6 @@ namespace {
       REQUIRE(counter == 1);
       ex::start(op2);
       // The receiver will ensure that the right value is produced
-
       REQUIRE(counter == 1);
     }
 
@@ -147,7 +146,7 @@ namespace {
     auto split = ex::split(ex::just() | ex::then([&] { called = true; }));
     auto sndr = exec::write(
       ex::upon_stopped(
-        split,
+        std::move(split),
         [&] {
           ++counter;
           return 42;
@@ -156,12 +155,13 @@ namespace {
     auto op1 = ex::connect(sndr, expect_value_receiver{42});
     auto op2 = ex::connect(std::move(sndr), expect_value_receiver{42});
     ssource.request_stop();
-    REQUIRE(counter == 0);
+    CHECK(counter == 0);
     ex::start(op1);
-    REQUIRE(counter == 1);
-    REQUIRE(!called);
+    CHECK(counter == 1);
+    CHECK(!called);
     ex::start(op2);
-    REQUIRE(counter == 2);
+    CHECK(counter == 2);
+    CHECK(!called);
   }
 
   TEST_CASE("split forwards external stop signal (2)", "[adaptors][split]") {
@@ -176,7 +176,7 @@ namespace {
         }));
     auto sndr = exec::write(
       ex::upon_stopped(
-        split,
+        std::move(split),
         [&] {
           ++counter;
           return 42;
@@ -207,22 +207,23 @@ namespace {
           })));
     auto sndr = exec::write(
       ex::upon_stopped(
-        split,
+        std::move(split),
         [&] {
           ++counter;
           return 42;
         }),
       exec::with(ex::get_stop_token, ssource.get_token()));
     auto op1 = ex::connect(sndr, expect_value_receiver{42});
-    auto op2 = ex::connect(sndr, expect_value_receiver{42});
+    auto op2 = ex::connect(std::move(sndr), expect_value_receiver{42});
     REQUIRE(counter == 0);
     ex::start(op1); // puts a unit of work on the impulse_scheduler and
                     // op1 into the list of waiting operations.
     REQUIRE(counter == 0);
     REQUIRE(!called);
     ssource.request_stop();
-    ex::start(op2); // puts op2 in the list of waiting operations.
-    REQUIRE(counter == 0);
+    ex::start(op2); // Should immediately call set_stopped without
+                    // getting added to the list of waiting operations.
+    REQUIRE(counter == 1);
     REQUIRE(!called);
     sched.start_next(); // Impulse scheduler notices stop has been requested
                         // and completes op1 with "stopped", which notifies
@@ -253,14 +254,14 @@ namespace {
       ex::on(
         sched,
         ex::upon_stopped(
-          split,
+          std::move(split),
           [&] {
             ++counter;
             return 42;
           })),
       exec::with(ex::get_stop_token, ssource.get_token()));
-    auto op1 = ex::connect(sndr1, expect_value_receiver{7});
-    auto op2 = ex::connect(sndr2, expect_stopped_receiver{});
+    auto op1 = ex::connect(std::move(sndr1), expect_value_receiver{7});
+    auto op2 = ex::connect(std::move(sndr2), expect_stopped_receiver{});
     REQUIRE(counter == 0);
     ex::start(op1); // puts a unit of work on the impulse_scheduler.
     REQUIRE(counter == 0);
@@ -289,9 +290,6 @@ namespace {
     auto [val] = stdexec::sync_wait(split).value();
     REQUIRE(val == 42);
   }
-
-  template <class>
-  struct undef;
 
   TEST_CASE("split is thread-safe", "[adaptors][split]") {
     exec::static_thread_pool pool{1};

--- a/test/stdexec/algos/adaptors/test_split.cpp
+++ b/test/stdexec/algos/adaptors/test_split.cpp
@@ -183,14 +183,14 @@ namespace {
         }),
       exec::with(ex::get_stop_token, ssource.get_token()));
     auto op1 = ex::connect(sndr, expect_value_receiver{7});
-    auto op2 = ex::connect(sndr, expect_value_receiver{7});
+    auto op2 = ex::connect(sndr, expect_value_receiver{42});
     REQUIRE(counter == 0);
     ex::start(op1); // operation starts and finishes.
     REQUIRE(counter == 0);
     REQUIRE(called);
     ssource.request_stop();
-    ex::start(op2); // operation is done, result is delivered.
-    REQUIRE(counter == 0);
+    ex::start(op2); // operation completes immediately with stopped.
+    REQUIRE(counter == 1);
   }
 
   TEST_CASE("split forwards external stop signal (3)", "[adaptors][split]") {

--- a/test/stdexec/algos/adaptors/test_split.cpp
+++ b/test/stdexec/algos/adaptors/test_split.cpp
@@ -220,14 +220,16 @@ namespace {
                     // op1 into the list of waiting operations.
     REQUIRE(counter == 0);
     REQUIRE(!called);
-    ssource.request_stop();
-    ex::start(op2); // Should immediately call set_stopped without
-                    // getting added to the list of waiting operations.
+    ssource.request_stop(); // This executes op1's stop callback, which
+                            // completes op1 with "stopped". counter == 1
     REQUIRE(counter == 1);
+    ex::start(op2); // Should immediately call set_stopped without getting
+                    // added to the list of waiting operations. counter == 2
+    REQUIRE(counter == 2);
     REQUIRE(!called);
     sched.start_next(); // Impulse scheduler notices stop has been requested
-                        // and completes op1 with "stopped", which notifies
-                        // all waiting states.
+                        // and completes the underlying operation (just | then(...))
+                        // with "stopped".
     REQUIRE(counter == 2);
     REQUIRE(!called);
   }


### PR DESCRIPTION
This is a _behavior change_, and NOT TO SPEC.

The previous cancellation behavior was that if any `split` sender is cancelled, the shared operation is cancelled also, even if there are other observers wanting and waiting for the result.

This PR changes it so that the underlying operation will be cancelled _only_ when there is nobody left who is interested in the result. They have all either been cancelled themselves or been dropped.
