### PR TITLE
Fixed swappable concept

### DIFF
--- a/include/stdexec/concepts.hpp
+++ b/include/stdexec/concepts.hpp
@@ -159,7 +159,9 @@ namespace stdexec {
 
   template <class _Ty>
   concept swappable = //
-    swappable_with<_Ty, _Ty>;
+    requires(_Ty& a, _Ty& b) {
+      swap(a, b);
+    };
 
   template <class _Ty>
   concept movable =               //

--- a/test/exec/test_io_uring_context.cpp
+++ b/test/exec/test_io_uring_context.cpp
@@ -118,6 +118,16 @@ namespace {
   }
 
   TEST_CASE(
+    "io_uring_context Call now(io_uring) is running clock",
+    "[types][io_uring][schedulers]") {
+    io_uring_context context;
+    io_uring_scheduler scheduler = context.get_scheduler();
+    auto start = now(scheduler);
+    std::this_thread::sleep_for(10ms);
+    CHECK(start + 10ms <= now(scheduler));
+  }
+
+  TEST_CASE(
     "io_uring_context Call io_uring::run_until_empty with sync_wait",
     "[types][io_uring][schedulers]") {
     io_uring_context context;


### PR DESCRIPTION
### Tiny fix of swappable concept

Issue: ```stdexec::swappable<int>``` evaluates to false (it must not) [godbolt](https://godbolt.org/z/oKPKcxTfb)

As a result exec::now (from timed scheduler) failures with any reasonable implementation