### PR TITLE
System context replaceability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,8 @@ target_include_directories(system_context PRIVATE
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
                            )
 target_compile_features(system_context PRIVATE cxx_std_20)
+add_library(STDEXEC::system_context ALIAS system_context)
+
 
 
 if(CMAKE_CROSSCOMPILING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,15 @@ if (STDEXEC_ENABLE_NUMA)
   target_compile_definitions(stdexec INTERFACE STDEXEC_ENABLE_NUMA)
 endif()
 
+set(SYSTEM_CONTEXT_SOURCES src/system_context/system_context.cpp)
+add_library(system_context STATIC ${SYSTEM_CONTEXT_SOURCES})
+target_include_directories(system_context PRIVATE
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+                           )
+target_compile_features(system_context PRIVATE cxx_std_20)
+
+
 if(CMAKE_CROSSCOMPILING)
   CHECK_INCLUDE_FILE_CXX("linux/io_uring.h" STDEXEC_FOUND_IO_URING)
 else()

--- a/include/exec/__detail/__system_context_default_impl.hpp
+++ b/include/exec/__detail/__system_context_default_impl.hpp
@@ -147,7 +147,9 @@ namespace exec::__system_context_default_impl {
       return __os;
     }
 
-    static void __destruct_schedule_operation_impl(void* __operation) noexcept {
+    static void __destruct_schedule_operation_impl(
+      __exec_system_scheduler_interface* /*__self*/,
+      void* __operation) noexcept {
       auto __op = static_cast<__schedule_operation_t*>(__operation);
       __op->__destruct();
     }
@@ -170,7 +172,9 @@ namespace exec::__system_context_default_impl {
       return __os;
     }
 
-    static void __destruct_bulk_schedule_operation_impl(void* __operation) noexcept {
+    static void __destruct_bulk_schedule_operation_impl(
+      __exec_system_scheduler_interface* /*__self*/,
+      void* __operation) noexcept {
       auto __op = static_cast<__bulk_schedule_operation_t*>(__operation);
       __op->__destruct();
     }

--- a/include/exec/__detail/__system_context_default_impl.hpp
+++ b/include/exec/__detail/__system_context_default_impl.hpp
@@ -200,10 +200,42 @@ namespace exec::__system_context_default_impl {
     }
   };
 
+  /// Keeps track of the object implementing the system context interface.
+  struct __instance_holder {
+
+    /// Get the only instance of this class.
+    static __instance_holder& __singleton() {
+      static __instance_holder __this_instance_;
+      return __this_instance_;
+    }
+
+    /// Get the currently selected system context object.
+    __exec_system_context_interface* __get_current_instance() const noexcept {
+      return __current_instance_;
+    }
+
+    /// Allows changing the currently selected system context object; used for testing.
+    void __set_current_instance(__exec_system_context_interface* __instance) noexcept {
+      __current_instance_ = __instance;
+    }
+
+   private:
+    __instance_holder() {
+      static __system_context_impl __default_instance_;
+      __current_instance_ = &__default_instance_;
+    }
+
+    __exec_system_context_interface* __current_instance_;
+  };
+
   /// Gets the default system context implementation.
-  static __system_context_impl* __get_exec_system_context_impl() {
-    static __system_context_impl __impl_;
-    return &__impl_;
+  static __exec_system_context_interface* __get_exec_system_context_impl() {
+    return __instance_holder::__singleton().__get_current_instance();
+  }
+
+  /// Sets the default system context implementation.
+  static void __set_exec_system_context_impl(__exec_system_context_interface* __instance) {
+    return __instance_holder::__singleton().__set_current_instance(__instance);
   }
 
 } // namespace exec::__system_context_default_impl

--- a/include/exec/__detail/__system_context_default_impl.hpp
+++ b/include/exec/__detail/__system_context_default_impl.hpp
@@ -18,10 +18,9 @@
 #include "__system_context_if.h"
 #include "stdexec/execution.hpp"
 #include "exec/static_thread_pool.hpp"
+#include "__weak_attribute.hpp"
 
 namespace exec::__system_context_default_impl {
-
-  // TODO: move default implementation to weak pointers
 
   using __pool_scheduler_t = decltype(std::declval<exec::static_thread_pool>().get_scheduler());
 
@@ -231,15 +230,5 @@ namespace exec::__system_context_default_impl {
 
     __exec_system_context_interface* __current_instance_;
   };
-
-  /// Gets the default system context implementation.
-  static __exec_system_context_interface* __get_exec_system_context_impl() {
-    return __instance_holder::__singleton().__get_current_instance();
-  }
-
-  /// Sets the default system context implementation.
-  static void __set_exec_system_context_impl(__exec_system_context_interface* __instance) {
-    return __instance_holder::__singleton().__set_current_instance(__instance);
-  }
 
 } // namespace exec::__system_context_default_impl

--- a/include/exec/__detail/__system_context_default_impl_entry.hpp
+++ b/include/exec/__detail/__system_context_default_impl_entry.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// Assumes __EXEC__SYSTEM_CONTEXT__INLINE is defined
+
+#include "__system_context_default_impl.hpp"
+#include "__weak_attribute.hpp"
+
+/// Gets the default system context implementation.
+extern "C" __EXEC__SYSTEM_CONTEXT__INLINE __EXEC_WEAK_ATTRIBUTE __exec_system_context_interface*
+  __get_exec_system_context_impl() {
+  return exec::__system_context_default_impl::__instance_holder::__singleton()
+    .__get_current_instance();
+}
+
+/// Sets the default system context implementation.
+extern "C" __EXEC__SYSTEM_CONTEXT__INLINE __EXEC_WEAK_ATTRIBUTE void __set_exec_system_context_impl(
+  __exec_system_context_interface* __instance) {
+  return exec::__system_context_default_impl::__instance_holder::__singleton()
+    .__set_current_instance(__instance);
+}

--- a/include/exec/__detail/__system_context_if.h
+++ b/include/exec/__detail/__system_context_if.h
@@ -68,7 +68,9 @@ struct __exec_system_scheduler_interface {
     void* /*data*/);
 
   /// Destructs the operation state object.
-  void (*__destruct_schedule_operation)(void* /*operation*/);
+  void (*__destruct_schedule_operation)(
+    struct __exec_system_scheduler_interface* /*self*/,
+    void* /*operation*/);
 
   /// The size of the operation state object on the implementation side.
   uint32_t __bulk_schedule_operation_size;
@@ -88,7 +90,9 @@ struct __exec_system_scheduler_interface {
     long /*size*/);
 
   /// Destructs the operation state object for a bulk_schedule.
-  void (*__destruct_bulk_schedule_operation)(void* /*operation*/);
+  void (*__destruct_bulk_schedule_operation)(
+    struct __exec_system_scheduler_interface* /*self*/,
+    void* /*operation*/);
 };
 
 #ifdef __cplusplus

--- a/include/exec/__detail/__weak_attribute.hpp
+++ b/include/exec/__detail/__weak_attribute.hpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdexec/__detail/__config.hpp>
+
+#if defined(STDEXEC_CLANG) || defined(STDEXEC_GCC)
+#  define __EXEC_WEAK_ATTRIBUTE __attribute__((weak))
+#else
+#  define __EXEC_WEAK_ATTRIBUTE /*nothing*/
+#endif

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -16,7 +16,8 @@
 #pragma once
 
 #include "stdexec/execution.hpp"
-#include "__detail/__system_context_default_impl.hpp"
+#include "__detail/__system_context_if.h"
+#include "__detail/__weak_attribute.hpp"
 
 #ifndef __EXEC__SYSTEM_CONTEXT__SCHEDULE_OP_SIZE
 #  define __EXEC__SYSTEM_CONTEXT__SCHEDULE_OP_SIZE 80
@@ -72,6 +73,13 @@ namespace exec {
     using __sender_data_t = decltype(stdexec::sync_wait(std::declval<__Sender>()).value());
 
   } // namespace __detail
+
+  /// Gets the default system context implementation.
+  __EXEC_WEAK_ATTRIBUTE __exec_system_context_interface* __get_exec_system_context_impl();
+
+  /// Sets the default system context implementation.
+  __EXEC_WEAK_ATTRIBUTE void __set_exec_system_context_impl(
+    __exec_system_context_interface* __instance);
 
   class system_scheduler;
   class system_sender;
@@ -442,7 +450,7 @@ namespace exec {
   };
 
   inline system_context::system_context() {
-    __impl_ = __system_context_default_impl::__get_exec_system_context_impl();
+    __impl_ = __get_exec_system_context_impl();
     // TODO error handling
   }
 
@@ -509,5 +517,9 @@ namespace exec {
     }
     STDEXEC_UNREACHABLE();
   }
-
 } // namespace exec
+
+#if defined(__EXEC__SYSTEM_CONTEXT__HEADER_ONLY)
+#  define __EXEC__SYSTEM_CONTEXT__INLINE inline
+#  include "__detail/__system_context_default_impl_entry.hpp"
+#endif

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -34,6 +34,13 @@
 
 // TODO: make these configurable by providing policy to the system context
 
+/// Gets the default system context implementation.
+extern "C" __EXEC_WEAK_ATTRIBUTE __exec_system_context_interface* __get_exec_system_context_impl();
+
+/// Sets the default system context implementation.
+extern "C" __EXEC_WEAK_ATTRIBUTE void __set_exec_system_context_impl(
+  __exec_system_context_interface* __instance);
+
 namespace exec {
   namespace __detail {
     /// Transforms from a C API signal to the `set_xxx` completion signal.
@@ -73,13 +80,6 @@ namespace exec {
     using __sender_data_t = decltype(stdexec::sync_wait(std::declval<__Sender>()).value());
 
   } // namespace __detail
-
-  /// Gets the default system context implementation.
-  __EXEC_WEAK_ATTRIBUTE __exec_system_context_interface* __get_exec_system_context_impl();
-
-  /// Sets the default system context implementation.
-  __EXEC_WEAK_ATTRIBUTE void __set_exec_system_context_impl(
-    __exec_system_context_interface* __instance);
 
   class system_scheduler;
   class system_sender;

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -192,7 +192,7 @@ namespace exec {
       }
 
       ~__op() {
-        __scheduler_->__destruct_schedule_operation(__impl_os_);
+        __scheduler_->__destruct_schedule_operation(__scheduler_, __impl_os_);
       }
 
       __op(const __op&) = delete;
@@ -268,7 +268,7 @@ namespace exec {
     } __preallocated_;
 
     ~__bulk_state() {
-      __snd_.__scheduler_->__destruct_bulk_schedule_operation(__impl_os_);
+      __snd_.__scheduler_->__destruct_bulk_schedule_operation(__snd_.__scheduler_, __impl_os_);
     }
   };
 

--- a/src/system_context/system_context.cpp
+++ b/src/system_context/system_context.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define __EXEC__SYSTEM_CONTEXT__INLINE /*no inline*/
+#include <exec/__detail/__system_context_default_impl_entry.hpp>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,11 +121,26 @@ target_link_libraries(test.scratch
     stdexec_executable_flags
     Catch2::Catch2)
 
+    add_executable(test.system_context_replaceability test_main.cpp test_system_context_replaceability.cpp)
+    set_target_properties(test.system_context_replaceability PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF)
+    target_include_directories(test.system_context_replaceability PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+    target_link_libraries(test.system_context_replaceability
+        PUBLIC
+        STDEXEC::stdexec
+        STDEXEC::system_context
+        $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
+        stdexec_executable_flags
+        Catch2::Catch2)
+    
 # Discover the Catch2 test built by the application
 include(${Catch2_SOURCE_DIR}/contrib/Catch.cmake)
 
 catch_discover_tests(test.stdexec)
 catch_discover_tests(test.scratch)
+catch_discover_tests(test.system_context_replaceability)
 
 if(STDEXEC_ENABLE_CUDA)
     add_subdirectory(nvexec)

--- a/test/exec/test_system_context.cpp
+++ b/test/exec/test_system_context.cpp
@@ -18,8 +18,11 @@
 #include <iostream>
 #include <chrono>
 
+#define __EXEC__SYSTEM_CONTEXT__HEADER_ONLY 1
+
 #include <catch2/catch.hpp>
 #include <exec/system_context.hpp>
+#include <exec/static_thread_pool.hpp>
 #include <exec/async_scope.hpp>
 #include <stdexec/execution.hpp>
 
@@ -293,7 +296,7 @@ struct my_system_context_impl : __exec_system_context_interface {
 TEST_CASE("can change the implementation of system context", "[types][system_scheduler]") {
   // Not to spec.
   my_system_context_impl ctx_impl;
-  exec::__system_context_default_impl::__set_exec_system_context_impl(&ctx_impl);
+  exec::__set_exec_system_context_impl(&ctx_impl);
 
   std::thread::id this_id = std::this_thread::get_id();
   std::thread::id pool_id{};

--- a/test/exec/test_system_context.cpp
+++ b/test/exec/test_system_context.cpp
@@ -239,9 +239,11 @@ struct my_system_scheduler_impl : __exec_system_scheduler_interface {
     __forward_progress_guarantee = base_.__forward_progress_guarantee;
     __schedule_operation_size = base_.__schedule_operation_size;
     __schedule_operation_alignment = base_.__schedule_operation_alignment;
+    __destruct_schedule_operation = base_.__destruct_schedule_operation;
     __bulk_schedule_operation_size = base_.__bulk_schedule_operation_size;
     __bulk_schedule_operation_alignment = base_.__bulk_schedule_operation_alignment;
     __bulk_schedule = base_.__bulk_schedule;
+    __destruct_bulk_schedule_operation = base_.__destruct_bulk_schedule_operation;
 
     __schedule = __schedule_impl; // have our own schedule implementation
   }
@@ -255,7 +257,7 @@ struct my_system_scheduler_impl : __exec_system_scheduler_interface {
   exec::__system_context_default_impl::__system_scheduler_impl base_;
   int count_schedules_ = 0;
 
-  static void __schedule_impl(
+  static void* __schedule_impl(
     __exec_system_scheduler_interface* self_arg,
     void* preallocated,
     uint32_t psize,
@@ -265,7 +267,7 @@ struct my_system_scheduler_impl : __exec_system_scheduler_interface {
     // increment our counter.
     self->count_schedules_++;
     // delegate to the base implementation.
-    self->base_.__schedule(&self->base_, preallocated, psize, callback, data);
+    return self->base_.__schedule(&self->base_, preallocated, psize, callback, data);
   }
 };
 

--- a/test/exec/test_system_context.cpp
+++ b/test/exec/test_system_context.cpp
@@ -296,7 +296,7 @@ struct my_system_context_impl : __exec_system_context_interface {
 TEST_CASE("can change the implementation of system context", "[types][system_scheduler]") {
   // Not to spec.
   my_system_context_impl ctx_impl;
-  exec::__set_exec_system_context_impl(&ctx_impl);
+  __set_exec_system_context_impl(&ctx_impl);
 
   std::thread::id this_id = std::this_thread::get_id();
   std::thread::id pool_id{};

--- a/test/exec/test_system_context.cpp
+++ b/test/exec/test_system_context.cpp
@@ -232,3 +232,78 @@ TEST_CASE("simple bulk chaining on system context", "[types][system_scheduler]")
   CHECK(res.has_value());
   CHECK(std::get<0>(res.value()) == pool_id);
 }
+
+struct my_system_scheduler_impl : __exec_system_scheduler_interface {
+  my_system_scheduler_impl()
+    : base_{pool_} {
+    __forward_progress_guarantee = base_.__forward_progress_guarantee;
+    __schedule_operation_size = base_.__schedule_operation_size;
+    __schedule_operation_alignment = base_.__schedule_operation_alignment;
+    __bulk_schedule_operation_size = base_.__bulk_schedule_operation_size;
+    __bulk_schedule_operation_alignment = base_.__bulk_schedule_operation_alignment;
+    __bulk_schedule = base_.__bulk_schedule;
+
+    __schedule = __schedule_impl; // have our own schedule implementation
+  }
+
+  int num_schedules() const {
+    return count_schedules_;
+  }
+
+ private:
+  exec::static_thread_pool pool_;
+  exec::__system_context_default_impl::__system_scheduler_impl base_;
+  int count_schedules_ = 0;
+
+  static void __schedule_impl(
+    __exec_system_scheduler_interface* self_arg,
+    void* preallocated,
+    uint32_t psize,
+    __exec_system_context_completion_callback_t callback,
+    void* data) noexcept {
+    auto self = static_cast<my_system_scheduler_impl*>(self_arg);
+    // increment our counter.
+    self->count_schedules_++;
+    // delegate to the base implementation.
+    self->base_.__schedule(&self->base_, preallocated, psize, callback, data);
+  }
+};
+
+struct my_system_context_impl : __exec_system_context_interface {
+  my_system_context_impl() {
+    __version = 202402;
+    __get_scheduler = __get_scheduler_impl;
+  }
+
+  int num_schedules() const {
+    return scheduler_.num_schedules();
+  }
+
+ private:
+  my_system_scheduler_impl scheduler_{};
+
+  static __exec_system_scheduler_interface* __get_scheduler_impl(
+    __exec_system_context_interface* __self) noexcept {
+    return &static_cast<my_system_context_impl*>(__self)->scheduler_;
+  }
+};
+
+TEST_CASE("can change the implementation of system context", "[types][system_scheduler]") {
+  // Not to spec.
+  my_system_context_impl ctx_impl;
+  exec::__system_context_default_impl::__set_exec_system_context_impl(&ctx_impl);
+
+  std::thread::id this_id = std::this_thread::get_id();
+  std::thread::id pool_id{};
+  exec::system_context ctx;
+  exec::system_scheduler sched = ctx.get_scheduler();
+
+  auto snd = ex::then(ex::schedule(sched), [&] { pool_id = std::this_thread::get_id(); });
+
+  REQUIRE(ctx_impl.num_schedules() == 0);
+  ex::sync_wait(std::move(snd));
+  REQUIRE(ctx_impl.num_schedules() == 1);
+
+  REQUIRE(pool_id != std::thread::id{});
+  REQUIRE(this_id != pool_id);
+}

--- a/test/test_system_context_replaceability.cpp
+++ b/test/test_system_context_replaceability.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Lucian Radu Teodorescu
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch.hpp>
+#include <stdexec/execution.hpp>
+#include <exec/system_context.hpp>
+#include <exec/static_thread_pool.hpp>
+#include <exec/__detail/__system_context_default_impl.hpp>
+
+namespace ex = stdexec;
+
+namespace {
+
+  static int count_schedules = 0;
+
+  struct my_system_scheduler_impl : __exec_system_scheduler_interface {
+    my_system_scheduler_impl()
+      : base_{pool_} {
+      __forward_progress_guarantee = base_.__forward_progress_guarantee;
+      __schedule_operation_size = base_.__schedule_operation_size;
+      __schedule_operation_alignment = base_.__schedule_operation_alignment;
+      __destruct_schedule_operation = base_.__destruct_schedule_operation;
+      __bulk_schedule_operation_size = base_.__bulk_schedule_operation_size;
+      __bulk_schedule_operation_alignment = base_.__bulk_schedule_operation_alignment;
+      __bulk_schedule = base_.__bulk_schedule;
+      __destruct_bulk_schedule_operation = base_.__destruct_bulk_schedule_operation;
+
+      __schedule = __schedule_impl; // have our own schedule implementation
+    }
+
+   private:
+    exec::static_thread_pool pool_;
+    exec::__system_context_default_impl::__system_scheduler_impl base_;
+
+    static void* __schedule_impl(
+      __exec_system_scheduler_interface* self_arg,
+      void* preallocated,
+      uint32_t psize,
+      __exec_system_context_completion_callback_t callback,
+      void* data) noexcept {
+      printf("Using my_system_scheduler_impl::__schedule_impl\n");
+      auto self = static_cast<my_system_scheduler_impl*>(self_arg);
+      // increment our counter.
+      count_schedules++;
+      // delegate to the base implementation.
+      return self->base_.__schedule(&self->base_, preallocated, psize, callback, data);
+    }
+  };
+
+  struct my_system_context_impl : __exec_system_context_interface {
+    my_system_context_impl() {
+      __version = 202402;
+      __get_scheduler = __get_scheduler_impl;
+    }
+
+   private:
+    my_system_scheduler_impl scheduler_{};
+
+    static __exec_system_scheduler_interface* __get_scheduler_impl(
+      __exec_system_context_interface* __self) noexcept {
+      return &static_cast<my_system_context_impl*>(__self)->scheduler_;
+    }
+  };
+} // namespace
+
+// Should replace the function defined in __system_context_default_impl.hpp
+extern "C" __EXEC_WEAK_ATTRIBUTE __exec_system_context_interface* __get_exec_system_context_impl() {
+  printf("Using my_system_context_impl\n");
+  static my_system_context_impl instance;
+  return &instance;
+}
+
+TEST_CASE(
+  "Check that we are using a replaced system context (with weak linking)",
+  "[system_scheduler][replaceability]") {
+  std::thread::id this_id = std::this_thread::get_id();
+  std::thread::id pool_id{};
+  exec::system_context ctx;
+  exec::system_scheduler sched = ctx.get_scheduler();
+
+  auto snd = ex::then(ex::schedule(sched), [&] { pool_id = std::this_thread::get_id(); });
+
+  REQUIRE(count_schedules == 0);
+  ex::sync_wait(std::move(snd));
+  REQUIRE(count_schedules == 1);
+
+  REQUIRE(pool_id != std::thread::id{});
+  REQUIRE(this_id != pool_id);
+}


### PR DESCRIPTION
Add ability to replace the default implementation of system context.

system_context can be delivered in two ways:
* with a static library implementing the default behaviour (this is the default)
* header-only, for convenience (user needs to specify with a define)

The static library comes with the getter of the system context specified with weak linking. This allows users to overwrite the default implementation. Adding a test that shows that this behaviour can be changed at user level. The test needs a new executable, and links the default system_context library.