### PR TITLE
Added missing include of `cstdlib` header file for `EXIT_SUCCESS` and `EXIT_FAILURE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,8 @@ else()
     #include <sys/syscall.h>
     #include <unistd.h>
 
+    #include <cstdlib>
+
     int main()
     {
       io_uring_params a = {};


### PR DESCRIPTION
The build time check `STDEXEC_FOUND_IO_URING` at https://github.com/NVIDIA/stdexec/blob/main/CMakeLists.txt#L342 is failing on some systems due to undeclared macros `EXIT_SUCCESS` and `EXIT_FAILURE`.
See e.g. https://godbolt.org/z/Y9EaqrWja

The macros are defined in the standard header `<cstdlib>`.
However, the check is not including this header.
See e.g. https://en.cppreference.com/w/cpp/utility/program/EXIT_status

Resolves #1291