### PR TITLE
extend the `STDEXEC_MEMFN_DECL` macro to support `query` member functions

### DIFF
--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -37,16 +37,16 @@
 #define STDEXEC_EVAL(_MACRO, ...) _MACRO(__VA_ARGS__)
 #define STDEXEC_EAT(...)
 
-#define STDEXEC_NOT(_XP) STDEXEC_CAT(STDEXEC_NOT_, _XP)
+#define STDEXEC_NOT(_XP)          STDEXEC_NOT_CAT(STDEXEC_NOT_, _XP)
+#define STDEXEC_NOT_0             1
+#define STDEXEC_NOT_1             0
+#define STDEXEC_NOT_CAT(_XP, ...) _XP##__VA_ARGS__
 
-enum {
-  STDEXEC_NOT_0 = 1,
-  STDEXEC_NOT_1 = 0
-};
-
-#define STDEXEC_IIF_0(_YP, ...)    __VA_ARGS__
-#define STDEXEC_IIF_1(_YP, ...)    _YP
-#define STDEXEC_IIF(_XP, _YP, ...) STDEXEC_EVAL(STDEXEC_CAT(STDEXEC_IIF_, _XP), _YP, __VA_ARGS__)
+#define STDEXEC_IIF(_XP, _YP, ...)                                                                 \
+  STDEXEC_IIF_EVAL(STDEXEC_CAT(STDEXEC_IIF_, _XP), _YP, __VA_ARGS__)
+#define STDEXEC_IIF_0(_YP, ...)       __VA_ARGS__
+#define STDEXEC_IIF_1(_YP, ...)       _YP
+#define STDEXEC_IIF_EVAL(_MACRO, ...) _MACRO(__VA_ARGS__)
 
 #define STDEXEC_COUNT(...)                                                                         \
   STDEXEC_EXPAND(STDEXEC_COUNT_(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
@@ -80,7 +80,7 @@ enum {
   /**/
 #define STDEXEC_FOR_EACH_HELPER(_MACRO, _A1, ...)                                                  \
   _MACRO(_A1) __VA_OPT__(STDEXEC_FOR_EACH_AGAIN STDEXEC_PARENS(_MACRO, __VA_ARGS__)) /**/
-#define STDEXEC_FOR_EACH_AGAIN()       STDEXEC_FOR_EACH_HELPER
+#define STDEXEC_FOR_EACH_AGAIN()  STDEXEC_FOR_EACH_HELPER
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define STDEXEC_FRONT(...)             __VA_OPT__(STDEXEC_FRONT_HELPER(__VA_ARGS__))

--- a/include/stdexec/__detail/__cpo.hpp
+++ b/include/stdexec/__detail/__cpo.hpp
@@ -34,25 +34,30 @@
 /// }
 /// @endcode
 #define STDEXEC_MEMFN_DECL(...)                                                                    \
-  friend STDEXEC_MEMFN_DECL_TAG_INVOKE(STDEXEC_MEMFN_DECL_WHICH(__VA_ARGS__), __VA_ARGS__)         \
-    STDEXEC_MEMFN_DECL_ARGS
+  friend STDEXEC_EVAL(                                                                             \
+    STDEXEC_MEMFN_DECL_TAG_INVOKE, STDEXEC_MEMFN_DECL_WHICH(__VA_ARGS__), __VA_ARGS__)
 
 #define STDEXEC_MEMFN_DECL_WHICH(_A1, ...)                                                         \
   STDEXEC_CAT(STDEXEC_MEMFN_DECL_WHICH_, STDEXEC_FRONT(__VA_OPT__(1, ) 0))(_A1)
-#define STDEXEC_MEMFN_DECL_WHICH_0(_A1) STDEXEC_CHECK(STDEXEC_MEMFN_DECL_PROBE_##_A1)
-#define STDEXEC_MEMFN_DECL_WHICH_1(_A1) 0
+#define STDEXEC_MEMFN_DECL_WHICH_0(_A1)                                                            \
+  STDEXEC_CHECK(STDEXEC_MEMFN_DECL_PROBE_##_A1), STDEXEC_CHECK(_A1##_STDEXEC_MEMFN_DECL_PROBE)
+#define STDEXEC_MEMFN_DECL_WHICH_1(_A1) 0, 0
 
-#define STDEXEC_MEMFN_DECL_TAG_INVOKE(_WHICH, ...)                                                 \
-  STDEXEC_CAT(STDEXEC_MEMFN_DECL_RETURN_, _WHICH)(__VA_ARGS__) \
-  tag_invoke(const STDEXEC_CAT(STDEXEC_MEMFN_DECL_TAG_, _WHICH)(__VA_ARGS__),
+#define STDEXEC_MEMFN_DECL_TAG_INVOKE(_WHICH, _QUERY, ...)                                         \
+  STDEXEC_MEMFN_DECL_RETURN_ ## _WHICH(__VA_ARGS__)                                                \
+  tag_invoke(STDEXEC_MEMFN_DECL_TAG_ ## _WHICH ## _QUERY(__VA_ARGS__)
 
 #define STDEXEC_MEMFN_DECL_ARGS(...)                                                               \
   STDEXEC_CAT(STDEXEC_EAT_THIS_, __VA_ARGS__))
+
+#define STDEXEC_MEMFN_DECL_QUERY(_SELF, _TAG, ...)                                                 \
+  _TAG, STDEXEC_CAT(STDEXEC_EAT_THIS_, _SELF) __VA_OPT__(, __VA_ARGS__))
 
 #define STDEXEC_EAT_THIS_this
 #define STDEXEC_EAT_AUTO_auto
 #define STDEXEC_EAT_VOID_void
 
+#define query_STDEXEC_MEMFN_DECL_PROBE   STDEXEC_PROBE(~, 1)
 #define STDEXEC_MEMFN_DECL_PROBE_auto    STDEXEC_PROBE(~, 1)
 #define STDEXEC_MEMFN_DECL_PROBE_void    STDEXEC_PROBE(~, 2)
 
@@ -60,9 +65,15 @@
 #define STDEXEC_MEMFN_DECL_RETURN_1(...) auto
 #define STDEXEC_MEMFN_DECL_RETURN_2(...) void
 
-#define STDEXEC_MEMFN_DECL_TAG_0(...)    ::stdexec::__tag_type_t<__VA_ARGS__##_t::*>&
-#define STDEXEC_MEMFN_DECL_TAG_1(...)    STDEXEC_CAT(STDEXEC_EAT_AUTO_##__VA_ARGS__##_t)&
-#define STDEXEC_MEMFN_DECL_TAG_2(...)    STDEXEC_CAT(STDEXEC_EAT_VOID_##__VA_ARGS__##_t)&
+#define STDEXEC_MEMFN_DECL_TAG_00(...)                                                             \
+  const ::stdexec::__tag_type_t<__VA_ARGS__##_t::*>&, STDEXEC_MEMFN_DECL_ARGS
+#define STDEXEC_MEMFN_DECL_TAG_10(...)                                                             \
+  const STDEXEC_EAT_AUTO_##__VA_ARGS__##_t&, STDEXEC_MEMFN_DECL_ARGS
+#define STDEXEC_MEMFN_DECL_TAG_20(...)                                                             \
+  const STDEXEC_EAT_VOID_##__VA_ARGS__##_t&, STDEXEC_MEMFN_DECL_ARGS
+#define STDEXEC_MEMFN_DECL_TAG_01(...) STDEXEC_MEMFN_DECL_QUERY
+#define STDEXEC_MEMFN_DECL_TAG_11(...) STDEXEC_MEMFN_DECL_QUERY
+#define STDEXEC_MEMFN_DECL_TAG_21(...) STDEXEC_MEMFN_DECL_QUERY
 
 #if STDEXEC_MSVC()
 #  pragma deprecated(STDEXEC_CUSTOM)

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -361,7 +361,8 @@ namespace stdexec {
       }
 
       template <__one_of<_Tag, _Tags...> _Key>
-      friend auto tag_invoke(_Key, const __with& __self) //
+      STDEXEC_MEMFN_DECL(auto query)
+      (this const __with& __self, _Key) //
         noexcept(__nothrow_decay_copyable<_Value>) -> _Value {
         return __self.__value_;
       }
@@ -380,7 +381,7 @@ namespace stdexec {
 
       template <__forwarding_query _Tag>
         requires tag_invocable<_Tag, const _Env&>
-      friend auto tag_invoke(_Tag, const __fwd& __self) //
+      STDEXEC_MEMFN_DECL(auto query)(this const __fwd& __self, _Tag) //
         noexcept(nothrow_tag_invocable<_Tag, const _Env&>)
           -> tag_invoke_result_t<_Tag, const _Env&> {
         return _Tag()(__self.__env_);
@@ -398,7 +399,7 @@ namespace stdexec {
 
       template <class _Tag>
         requires tag_invocable<_Tag, const _Env&>
-      friend auto tag_invoke(_Tag, const __ref& __self) //
+      STDEXEC_MEMFN_DECL(auto query)(this const __ref& __self, _Tag) //
         noexcept(nothrow_tag_invocable<_Tag, const _Env&>)
           -> tag_invoke_result_t<_Tag, const _Env&> {
         return _Tag()(__self.__env_);
@@ -431,7 +432,7 @@ namespace stdexec {
 
       template <__one_of<_Tag, _Tags...> _Key, class _Self>
         requires(std::is_base_of_v<__without_, __decay_t<_Self>>)
-      friend auto tag_invoke(_Key, _Self&&) noexcept = delete;
+      STDEXEC_MEMFN_DECL(auto query)(this _Self&&, _Key) noexcept = delete;
     };
 
     struct __without_fn {
@@ -462,7 +463,7 @@ namespace stdexec {
 
       template <class _Tag>
         requires tag_invocable<_Tag, const _First&>
-      friend auto tag_invoke(_Tag, const __joined& __self) //
+      STDEXEC_MEMFN_DECL(auto query)(this const __joined& __self, _Tag) //
         noexcept(nothrow_tag_invocable<_Tag, const _First&>)
           -> tag_invoke_result_t<_Tag, const _First&> {
         return _Tag()(__self.__env_);
@@ -481,7 +482,7 @@ namespace stdexec {
 
       template <class _Tag>
         requires __callable<const _Fun&, _Tag>
-      friend auto tag_invoke(_Tag, const __from& __self) //
+      STDEXEC_MEMFN_DECL(auto query)(this const __from& __self, _Tag) //
         noexcept(__nothrow_callable<const _Fun&, _Tag>) -> __call_result_t<const _Fun&, _Tag> {
         return __self.__fun_(_Tag());
       }


### PR DESCRIPTION
`STDEXEC_MEMFN_DECL(auto query)(this const Foo& self, some_query_t)`

will expand (for now) to:

`friend auto tag_invoke(some_query_t, const Foo& self)`