### PR TITLE
MSVC fixes and warnings cleanup

### DIFF
--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -86,36 +86,35 @@ jobs:
     steps:
       - run: echo "CI (CPU) success"
 
-  # Disabled by @ericniebler on Mar 27, 2024 because of frequent build failures
-  # build-cpu-windows:
-  #   runs-on: windows-latest
-  #   name: ${{ matrix.name }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - { compiler: "cl",       build: "Debug",   name: "CPU (Windows) (msvc, Debug)" }
-  #         - { compiler: "cl",       build: "Release", name: "CPU (Windows) (msvc, Release)" }
-  #         #- { compiler: "clang++",  build: "Debug",   name: "CPU (Windows) (clang, Debug)" }
-  #         #- { compiler: "clang++",  build: "Release", name: "CPU (Windows) (clang, Release)" }
-  #         #- { compiler: "clang-cl", build: "Debug",   name: "CPU (Windows) (clang-cl, Debug)" }
-  #         #- { compiler: "clang-cl", build: "Release", name: "CPU (Windows) (clang-cl, Release)" }
-  #   steps:
-  #     - name: Checkout stdexec (Windows)
-  #       uses: actions/checkout@v4
-  #       with:
-  #         persist-credentials: false
-  #     - name: Build and test CPU schedulers (Windows)
-  #       shell: pwsh
-  #       run: .github/workflows/test-windows.ps1 -Compiler '${{ matrix.compiler }}' -Config '${{ matrix.build }}'
+  build-cpu-windows:
+    runs-on: windows-latest
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { compiler: "cl",       build: "Debug",   name: "CPU (Windows) (msvc, Debug)" }
+          - { compiler: "cl",       build: "Release", name: "CPU (Windows) (msvc, Release)" }
+          #- { compiler: "clang++",  build: "Debug",   name: "CPU (Windows) (clang, Debug)" }
+          #- { compiler: "clang++",  build: "Release", name: "CPU (Windows) (clang, Release)" }
+          #- { compiler: "clang-cl", build: "Debug",   name: "CPU (Windows) (clang-cl, Debug)" }
+          #- { compiler: "clang-cl", build: "Release", name: "CPU (Windows) (clang-cl, Release)" }
+    steps:
+      - name: Checkout stdexec (Windows)
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Build and test CPU schedulers (Windows)
+        shell: pwsh
+        run: .github/workflows/test-windows.ps1 -Compiler '${{ matrix.compiler }}' -Config '${{ matrix.build }}'
 
-  # ci-cpu-windows:
-  #   runs-on: windows-latest
-  #   name: CI (CPU) (Windows)
-  #   needs:
-  #     - build-cpu-windows
-  #   steps:
-  #     - run: echo "CI (CPU) (Windows) success"
+  ci-cpu-windows:
+    runs-on: windows-latest
+    name: CI (CPU) (Windows)
+    needs:
+      - build-cpu-windows
+    steps:
+      - run: echo "CI (CPU) (Windows) success"
 
   build-cpu-macos:
     runs-on: macos-14-large

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -281,10 +281,8 @@ namespace exec {
       /// The operating state on the implementation side.
       void* __impl_os_;
       /// Storage for the arguments passed from the previous receiver to the function object of the bulk sender.
-      std::aligned_storage_t<
-        sizeof(__detail::__sender_data_t<__Previous>),
-        alignof(__detail::__sender_data_t<__Previous>)>
-        __arguments_data_;
+      alignas(__detail::__sender_data_t<__Previous>) unsigned char __arguments_data_[sizeof(
+        __detail::__sender_data_t<__Previous>)];
 
       /// Preallocated space for storing the operation state on the implementation size.
       struct alignas(__EXEC__SYSTEM_CONTEXT__BULK_SCHEDULE_OP_ALIGN) __preallocated {

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -542,8 +542,6 @@ namespace exec {
         "environment on which to schedule bulk work.");
       return __not_a_sender<stdexec::__name_of<__Sender>>();
     }
-
-    STDEXEC_UNREACHABLE();
   }
 } // namespace exec
 

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include "../stdexec/concepts.hpp"
 #include "../stdexec/execution.hpp"
 #include "../stdexec/stop_token.hpp"
 
@@ -252,7 +253,7 @@ namespace exec {
         using __id = __sender;
         using sender_concept = stdexec::sender_t;
 
-        template <class... _Senders>
+        template <__not_decays_to<__t>... _Senders>
         explicit(sizeof...(_Senders) == 1)
           __t(_Senders&&... __senders) noexcept((__nothrow_decay_copyable<_Senders> && ...))
           : __senders_(static_cast<_Senders&&>(__senders)...) {

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -16,7 +16,15 @@
 #pragma once
 
 #if __cplusplus < 202002L
-#  error This library requires the use of C++20.
+#  if defined(_MSC_VER) && !defined(__clang__)
+#    error This library requires the use of C++20. Use /Zc:__cplusplus to enable __cplusplus conformance.
+#  else
+#    error This library requires the use of C++20.
+#  endif
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
+#  error This library requires the use of the new conforming preprocessor enabled by /Zc:preprocessor.
 #endif
 
 #if __has_include(<version>)

--- a/test/exec/async_scope/test_spawn.cpp
+++ b/test/exec/async_scope/test_spawn.cpp
@@ -28,7 +28,6 @@ namespace {
     friend auto tag_invoke(ex::connect_t, throwing_sender&& self, Receiver&& rcvr)
       -> operation<std::decay_t<Receiver>> {
       throw std::logic_error("cannot connect");
-      return {std::forward<Receiver>(rcvr)};
     }
 
     friend empty_env tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {

--- a/test/exec/async_scope/test_spawn_future.cpp
+++ b/test/exec/async_scope/test_spawn_future.cpp
@@ -39,7 +39,6 @@ namespace {
     friend auto tag_invoke(ex::connect_t, throwing_sender&& self, Receiver&& rcvr)
       -> operation<std::decay_t<Receiver>> {
       throw std::logic_error("cannot connect");
-      return {std::forward<Receiver>(rcvr)};
     }
 
     friend empty_env tag_invoke(stdexec::get_env_t, const throwing_sender&) noexcept {

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -291,9 +291,8 @@ namespace {
     auto [value] = *sync_wait(std::move(sender));
     CHECK(value == 42);
 
-    sender = just(21) | then([&](int v) {
+    sender = just(21) | then([&](int v) -> int {
                throw 420;
-               return 2 * v;
              });
     CHECK_THROWS_AS(sync_wait(std::move(sender)), int);
   }

--- a/test/exec/test_finally.cpp
+++ b/test/exec/test_finally.cpp
@@ -61,9 +61,8 @@ namespace {
     bool called = false;
 
     auto s = exec::finally(
-      just(21) | then([](int x) {
+      just(21) | then([](int x) -> int {
         throw 42;
-        return x;
       }),
       just() | then([&called]() noexcept { called = true; }));
     STATIC_REQUIRE(set_equivalent<

--- a/test/stdexec/algos/adaptors/test_let_error.cpp
+++ b/test/stdexec/algos/adaptors/test_let_error.cpp
@@ -85,9 +85,8 @@ namespace {
   TEST_CASE("let_error can be used to produce values (error to value)", "[adaptors][let_error]") {
     ex::sender auto snd =
       ex::just() //
-      | ex::then([] {
+      | ex::then([]() -> std::string {
           throw std::logic_error{"error description"};
-          return std::string{"ok"};
         }) //
       | ex::let_error([](std::exception_ptr eptr) {
           try {
@@ -102,11 +101,10 @@ namespace {
 
   TEST_CASE("let_error can be used to transform errors", "[adaptors][let_error]") {
     ex::sender auto snd = ex::just_error(1) //
-                        | ex::let_error([](int error_code) {
+                        | ex::let_error([](int error_code) -> decltype(ex::just_error(std::exception_ptr{})) {
                             char buf[20];
                             std::snprintf(buf, 20, "%d", error_code);
                             throw std::logic_error(buf);
-                            return ex::just_error(std::exception_ptr{}); // not reached
                           });
 
     auto op = ex::connect(std::move(snd), expect_error_receiver{});

--- a/test/stdexec/algos/adaptors/test_let_stopped.cpp
+++ b/test/stdexec/algos/adaptors/test_let_stopped.cpp
@@ -75,9 +75,8 @@ namespace {
 
   TEST_CASE("let_stopped can throw, calling set_error", "[adaptors][let_stopped]") {
     auto snd = ex::just_stopped() //
-             | ex::let_stopped([] {
+             | ex::let_stopped([]() -> decltype(ex::just(0)) {
                  throw std::logic_error{"err"};
-                 return ex::just(1);
                });
     auto op = ex::connect(std::move(snd), expect_error_receiver{});
     ex::start(op);

--- a/test/stdexec/algos/adaptors/test_let_value.cpp
+++ b/test/stdexec/algos/adaptors/test_let_value.cpp
@@ -131,9 +131,8 @@ namespace {
 
   TEST_CASE("let_value can throw, and set_error will be called", "[adaptors][let_value]") {
     auto snd = ex::just(13) //
-             | ex::let_value([](int& x) {
+             | ex::let_value([](int& x) -> decltype(ex::just(0)) {
                  throw std::logic_error{"err"};
-                 return ex::just(x + 5);
                });
     auto op = ex::connect(std::move(snd), expect_error_receiver{});
     ex::start(op);

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -77,7 +77,6 @@ namespace {
     auto snd = ex::just(13) //
              | ex::then([](int x) -> int {
                  throw std::logic_error{"err"};
-                 return x + 5;
                });
     auto op = ex::connect(std::move(snd), expect_error_receiver{});
     ex::start(op);


### PR DESCRIPTION
Fix for another MSVC compiler bug and cleanup of warnings. With this PR the MSVC build works again, at least using the latest preview version of Visual Studio.

One more warning remains due to the use `long` instead of `size_t` in `system_context` ([here](https://github.com/NVIDIA/stdexec/blob/main/include/exec/__detail/__system_context_if.h#L90)), but I'm not sure if there's a reason for using `long` instead of `size_t`.