### PR TITLE
Fix `split`/`ensure_started` with non-stdexec senders

### DIFF
--- a/include/stdexec/execution.hpp
+++ b/include/stdexec/execution.hpp
@@ -3279,13 +3279,13 @@ namespace stdexec {
       }
     };
 
-    template <class _Cvref, class _CvrefSenderId, class _EnvId>
+    template <class _Cvref, class _CvrefSender, class _Env>
     using __completions_t = //
       __try_make_completion_signatures<
         // NOT TO SPEC:
         // See https://github.com/cplusplus/sender-receiver/issues/23
-        __cvref_t<_CvrefSenderId>,
-        __env_t<__t<_EnvId>>,
+        _CvrefSender,
+        __env_t<_Env>,
         completion_signatures<
           set_error_t(__minvoke<_Cvref, std::exception_ptr>),
           set_stopped_t()>, // NOT TO SPEC

--- a/test/stdexec/algos/adaptors/test_ensure_started.cpp
+++ b/test/stdexec/algos/adaptors/test_ensure_started.cpp
@@ -308,4 +308,34 @@ namespace {
     auto op = ex::connect(std::move(snd), expect_void_receiver{});
     ex::start(op);
   }
+
+  struct my_sender {
+    using sender_concept = stdexec::sender_t;
+    using is_sender = void;
+
+    using completion_signatures = ex::completion_signatures_of_t<decltype(ex::just())>;
+
+    template <class Recv>
+    friend auto tag_invoke(ex::connect_t, my_sender&& self, Recv&& recv) {
+      return ex::connect(ex::just(), std::forward<Recv>(recv));
+    }
+
+    template <class Recv>
+    friend auto tag_invoke(ex::connect_t, const my_sender& self, Recv&& recv) {
+      return ex::connect(ex::just(), std::forward<Recv>(recv));
+    }
+  };
+
+  TEST_CASE("ensure_started accepts a custom sender", "[adaptors][ensure_started]") {
+    auto snd1 = my_sender();
+    auto snd2 = ex::ensure_started(std::move(snd1));
+    static_assert(stdexec::__well_formed_sender<decltype(snd1)>);
+    static_assert(stdexec::__well_formed_sender<decltype(snd2)>);
+    using Snd = decltype(snd2);
+    static_assert(ex::enable_sender<Snd>);
+    static_assert(ex::sender<Snd>);
+    static_assert(ex::same_as<ex::env_of_t<Snd>, empty_env>);
+    (void) snd1;
+    (void) snd2;
+  }
 } // namespace


### PR DESCRIPTION
It looks like the computation of the completion signatures for `split`/`ensure_started` assumed that the sender and env types were ADL-hidden when they in fact aren't. This happens to compile with stdexec-senders (that have a `__t` typedef), but doesn't compile with user-provided senders. I've added tests with "custom senders", and removed the un-hiding of types. Or should it be the converse: the sender and env types should actually be hidden? It's unclear to me if the types will show up in a `tag_invoke` call somewhere.