### PR TITLE
Use `-fconcepts-diagnostics-depth` only when compiling C++ files with GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ target_compile_options(stdexec INTERFACE
 
 # Increase the concepts diagnostics depth for GCC
 target_compile_options(stdexec INTERFACE
-                       $<$<CXX_COMPILER_ID:GNU>:-fconcepts-diagnostics-depth=10>
+                       $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fconcepts-diagnostics-depth=10>
                        )
 
 # Do you want a preprocessor that works? Picky, picky.


### PR DESCRIPTION
This allows compilation with GCC as the host compiler and something else that doesn't support `-fconcepts-diagnostics-depth` as the device compiler. For example clang (and hip-clang) does not support the flag.