### PR TITLE
switch all queryable types to use `query` member functions instead of `tag_invoke`

### DIFF
--- a/examples/benchmark/static_thread_pool_old.hpp
+++ b/examples/benchmark/static_thread_pool_old.hpp
@@ -149,7 +149,16 @@ namespace exec_old {
       using __id = scheduler;
       bool operator==(const scheduler&) const = default;
 
-     private:
+      stdexec::forward_progress_guarantee
+        query(stdexec::get_forward_progress_guarantee_t) const noexcept {
+        return stdexec::forward_progress_guarantee::parallel;
+      }
+
+      domain query(stdexec::get_domain_t) const noexcept {
+        return {};
+      }
+
+ private:
       template <typename ReceiverId>
       friend class operation;
 
@@ -176,12 +185,8 @@ namespace exec_old {
           static_thread_pool& pool_;
 
           template <class CPO>
-          friend static_thread_pool::scheduler
-            tag_invoke(stdexec::get_completion_scheduler_t<CPO>, const env& self) noexcept {
-            return self.make_scheduler_();
-          }
-
-          static_thread_pool::scheduler make_scheduler_() const {
+          static_thread_pool::scheduler
+            query(stdexec::get_completion_scheduler_t<CPO>) const noexcept {
             return static_thread_pool::scheduler{pool_};
           }
         };
@@ -205,15 +210,6 @@ namespace exec_old {
 
       friend sender tag_invoke(stdexec::schedule_t, const scheduler& s) noexcept {
         return s.make_sender_();
-      }
-
-      friend stdexec::forward_progress_guarantee
-        tag_invoke(stdexec::get_forward_progress_guarantee_t, const static_thread_pool&) noexcept {
-        return stdexec::forward_progress_guarantee::parallel;
-      }
-
-      friend domain tag_invoke(stdexec::get_domain_t, scheduler) noexcept {
-        return {};
       }
 
       friend class static_thread_pool;

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -146,9 +146,9 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { //
       using PredSender = stdexec::__t<PredecessorSenderId>;
       using Receiver = stdexec::__t<ReceiverId>;
       using Scheduler =
-        stdexec::tag_invoke_result_t<stdexec::get_scheduler_t, stdexec::env_of_t<Receiver>>;
+        std::invoke_result_t<stdexec::get_scheduler_t, stdexec::env_of_t<Receiver>>;
       using InnerSender =
-        std::invoke_result_t<Closure, stdexec::tag_invoke_result_t<stdexec::schedule_t, Scheduler>>;
+        std::invoke_result_t<Closure, stdexec::schedule_result_t<Scheduler>>;
 
       using predecessor_op_state_t =
         ex::connect_result_t<PredSender, receiver_1_t<operation_state_t>>;
@@ -287,9 +287,9 @@ namespace repeat_n_detail {
     using PredSender = stdexec::__t<PredecessorSenderId>;
     using Receiver = stdexec::__t<ReceiverId>;
     using Scheduler =
-      stdexec::tag_invoke_result_t<stdexec::get_scheduler_t, stdexec::env_of_t<Receiver>>;
+      std::invoke_result_t<stdexec::get_scheduler_t, stdexec::env_of_t<Receiver>>;
     using InnerSender =
-      std::invoke_result_t<Closure, stdexec::tag_invoke_result_t<stdexec::schedule_t, Scheduler>>;
+      std::invoke_result_t<Closure, stdexec::schedule_result_t<Scheduler>>;
 
     using predecessor_op_state_t =
       ex::connect_result_t<PredSender, receiver_1_t<operation_state_t>>;

--- a/include/exec/__detail/__system_context_if.h
+++ b/include/exec/__detail/__system_context_if.h
@@ -17,6 +17,7 @@
 #ifndef __EXEC__SYSTEM_CONTEXT_IF_H__
 #define __EXEC__SYSTEM_CONTEXT_IF_H__
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -250,8 +250,8 @@ namespace exec {
       class _Vtable,
       class _Allocator,
       bool _Copyable = false,
-      std::size_t _Alignment = alignof(std::max_align_t),
-      std::size_t _InlineSize = 3 * sizeof(void*)>
+      std::size_t _InlineSize = 3 * sizeof(void*),
+      std::size_t _Alignment = alignof(std::max_align_t)>
     struct __storage {
       class __t;
     };
@@ -259,8 +259,8 @@ namespace exec {
     template <
       class _Vtable,
       class _Allocator,
-      std::size_t _Alignment = alignof(std::max_align_t),
-      std::size_t _InlineSize = 3 * sizeof(void*)>
+      std::size_t _InlineSize = 3 * sizeof(void*),
+      std::size_t _Alignment = alignof(std::max_align_t)>
     struct __immovable_storage {
       class __t : __immovable {
         static constexpr std::size_t __buffer_size = std::max(_InlineSize, sizeof(void*));
@@ -377,9 +377,9 @@ namespace exec {
       class _Vtable,
       class _Allocator,
       bool _Copyable,
-      std::size_t _Alignment,
-      std::size_t _InlineSize>
-    class __storage<_Vtable, _Allocator, _Copyable, _Alignment, _InlineSize>::__t
+      std::size_t _InlineSize,
+      std::size_t _Alignment>
+    class __storage<_Vtable, _Allocator, _Copyable, _InlineSize, _Alignment>::__t
       : __if_c<_Copyable, __, __move_only> {
       static_assert(
         STDEXEC_IS_CONVERTIBLE_TO(typename std::allocator_traits<_Allocator>::void_pointer, void*));
@@ -578,8 +578,11 @@ namespace exec {
     template <class _VTable, class _Allocator = std::allocator<std::byte>>
     using __unique_storage_t = __t<__storage<_VTable, _Allocator>>;
 
-    template <class _VTable, class _Allocator = std::allocator<std::byte>>
-    using __copyable_storage_t = __t<__storage<_VTable, _Allocator, true>>;
+    template <
+      class _VTable,
+      std::size_t _InlineSize = 3 * sizeof(void*),
+      class _Allocator = std::allocator<std::byte>>
+    using __copyable_storage_t = __t<__storage<_VTable, _Allocator, true, _InlineSize>>;
 
     template <class _Tag, class... _As>
     auto __tag_type(_Tag (*)(_As...)) -> _Tag;
@@ -623,7 +626,8 @@ namespace exec {
           STDEXEC_MEMFN_DECL(
             auto __create_vtable)(this __mtype<__t>, __mtype<_Rcvr>) noexcept -> const __t* {
             static const __t __vtable_{
-              {__any_::__rcvr_vfun_fn(static_cast<_Rcvr*>(nullptr), static_cast<_Sigs*>(nullptr))}...,
+              {__any_::__rcvr_vfun_fn(
+                static_cast<_Rcvr*>(nullptr), static_cast<_Sigs*>(nullptr))}...,
               {__query_vfun_fn<_Rcvr>{}(static_cast<_Queries>(nullptr))}...};
             return &__vtable_;
           }
@@ -647,15 +651,14 @@ namespace exec {
 
           template <class _Tag, class... _As>
             requires __callable<const __vtable_t&, _Tag, void*, _As...>
-          friend auto tag_invoke(_Tag, const __env_t& __self, _As&&... __as) //
+          auto query(_Tag, _As&&... __as) const //
             noexcept(__nothrow_callable<const __vtable_t&, _Tag, void*, _As...>)
               -> __call_result_t<const __vtable_t&, _Tag, void*, _As...> {
-            return (*__self.__vtable_)(_Tag{}, __self.__rcvr_, static_cast<_As&&>(__as)...);
+            return (*__vtable_)(_Tag{}, __rcvr_, static_cast<_As&&>(__as)...);
           }
 
-          STDEXEC_MEMFN_DECL(auto
-            query)(this const __env_t& __self, get_stop_token_t) noexcept -> inplace_stop_token {
-            return __self.__token_;
+          auto query(get_stop_token_t) const noexcept -> inplace_stop_token {
+            return __token_;
           }
         } __env_;
        public:
@@ -735,11 +738,10 @@ namespace exec {
 
           template <class _Tag, class... _As>
             requires __callable<const __vtable_t&, _Tag, void*, _As...>
-          STDEXEC_MEMFN_DECL(
-            auto query)(this const __env_t& __self, _Tag, _As&&... __as) //
+          auto query(_Tag, _As&&... __as) const //
             noexcept(__nothrow_callable<const __vtable_t&, _Tag, void*, _As...>)
               -> __call_result_t<const __vtable_t&, _Tag, void*, _As...> {
-            return (*__self.__vtable_)(_Tag{}, __self.__rcvr_, static_cast<_As&&>(__as)...);
+            return (*__vtable_)(_Tag{}, __rcvr_, static_cast<_As&&>(__as)...);
           }
         } __env_;
        public:
@@ -991,24 +993,16 @@ namespace exec {
         }
       };
 
-      class __env_t {
-       public:
-        __env_t(const __vtable* __vtable, void* __sender) noexcept
-          : __vtable_{__vtable}
-          , __sender_{__sender} {
-        }
-       private:
+      struct __env_t {
         const __vtable* __vtable_;
         void* __sender_;
 
         template <class _Tag, class... _As>
           requires __callable<const __query_vtable<_SenderQueries>&, _Tag, void*, _As...>
-        STDEXEC_MEMFN_DECL(
-          auto query)(this const __env_t& __self, _Tag, _As&&... __as) //
+        auto query(_Tag, _As&&... __as) const //
           noexcept(__nothrow_callable<const __query_vtable<_SenderQueries>&, _Tag, void*, _As...>)
             -> __call_result_t<const __query_vtable<_SenderQueries>&, _Tag, void*, _As...> {
-          return __self.__vtable_->__queries()(
-            _Tag{}, __self.__sender_, static_cast<_As&&>(__as)...);
+          return __vtable_->__queries()(_Tag{}, __sender_, static_cast<_As&&>(__as)...);
         }
       };
 
@@ -1056,14 +1050,38 @@ namespace exec {
 
     template <class _ScheduleSender, class _SchedulerQueries = __types<>>
     class __scheduler {
+      static constexpr std::size_t __buffer_size = 4 * sizeof(void*);
+      template <class _Ty>
+      static constexpr bool __is_small =
+        sizeof(_Ty) <= __buffer_size && alignof(_Ty) <= alignof(std::max_align_t);
+
      public:
       template <class _Scheduler>
         requires(!__decays_to<_Scheduler, __scheduler>) && scheduler<_Scheduler>
       __scheduler(_Scheduler&& __scheduler)
         : __storage_{static_cast<_Scheduler&&>(__scheduler)} {
+        static_assert(
+          __is_small<_Scheduler>,
+          "any_scheduler<> must have a nothrow copy constructor,"
+          " so the scheduler object must be small enough to be stored in the internal buffer");
       }
 
+      __scheduler(__scheduler&&) noexcept = default;
+      __scheduler(const __scheduler&) noexcept = default;
+      __scheduler& operator=(__scheduler&&) noexcept = default;
+      __scheduler& operator=(const __scheduler&) noexcept = default;
+
       using __sender_t = _ScheduleSender;
+
+      template <class _Tag, class... _As>
+        requires __callable<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...>
+      auto query(_Tag, _As&&... __as) const //
+        noexcept(__nothrow_callable<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...>)
+          -> __call_result_t<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...> {
+        return __storage_.__get_vtable()->__queries()(
+          _Tag{}, __storage_.__get_object_pointer(), static_cast<_As&&>(__as)...);
+      }
+
      private:
       class __vtable : public __query_vtable<_SchedulerQueries> {
        public:
@@ -1101,16 +1119,6 @@ namespace exec {
           __self.__storage_.__get_object_pointer());
       }
 
-      template <class _Tag, same_as<__scheduler> _Self, class... _As>
-        requires __callable<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...>
-      STDEXEC_MEMFN_DECL(
-        auto query)(this const _Self& __self, _Tag, _As&&... __as) //
-        noexcept(__nothrow_callable<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...>)
-          -> __call_result_t<const __query_vtable<_SchedulerQueries>&, _Tag, void*, _As...> {
-        return __self.__storage_.__get_vtable()->__queries()(
-          _Tag{}, __self.__storage_.__get_object_pointer(), static_cast<_As&&>(__as)...);
-      }
-
       friend auto
         operator==(const __scheduler& __self, const __scheduler& __other) noexcept -> bool {
         if (__self.__storage_.__get_vtable() != __other.__storage_.__get_vtable()) {
@@ -1130,7 +1138,7 @@ namespace exec {
         return !(__self == __other);
       }
 
-      __copyable_storage_t<__vtable> __storage_{};
+      __copyable_storage_t<__vtable, __buffer_size> __storage_{};
     };
   } // namespace __any
 

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -173,8 +173,8 @@ namespace exec {
       struct __env {
         const __promise& __promise_;
 
-        STDEXEC_MEMFN_DECL(auto query)(this __env __self, get_scheduler_t) noexcept -> __any_scheduler {
-          return __self.__promise_.__scheduler_;
+        auto query(get_scheduler_t) const noexcept -> __any_scheduler {
+          return __promise_.__scheduler_;
         }
       };
 

--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -180,11 +180,7 @@ namespace exec {
         libdispatch_queue *queue;
 
         template <typename CPO>
-        STDEXEC_MEMFN_DECL(libdispatch_scheduler query)(this env const &self, stdexec::get_completion_scheduler_t<CPO>) noexcept {
-          return self.make_scheduler();
-        }
-
-        auto make_scheduler() const -> libdispatch_scheduler {
+        libdispatch_scheduler query(stdexec::get_completion_scheduler_t<CPO>) const noexcept {
           return libdispatch_scheduler{queue};
         }
       };
@@ -206,12 +202,12 @@ namespace exec {
       return s.make_sender();
     }
 
-    STDEXEC_MEMFN_DECL(domain query)(this libdispatch_scheduler, stdexec::get_domain_t) noexcept {
+    domain query(stdexec::get_domain_t) const noexcept {
       return {};
     }
 
-    STDEXEC_MEMFN_DECL(stdexec::forward_progress_guarantee
-      query)(this libdispatch_queue const &, stdexec::get_forward_progress_guarantee_t) noexcept {
+    stdexec::forward_progress_guarantee
+      query(stdexec::get_forward_progress_guarantee_t) const noexcept {
       return stdexec::forward_progress_guarantee::parallel;
     }
 

--- a/include/exec/on_coro_disposition.hpp
+++ b/include/exec/on_coro_disposition.hpp
@@ -123,8 +123,8 @@ namespace exec {
       struct __env {
         const __promise& __promise_;
 
-        STDEXEC_MEMFN_DECL(auto query)(this __env __self, get_scheduler_t) noexcept -> __any_scheduler {
-          return __self.__promise_.__scheduler_;
+        auto query(get_scheduler_t) const noexcept -> __any_scheduler {
+          return __promise_.__scheduler_;
         }
       };
 

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -415,7 +415,7 @@ namespace exec {
         }
       }
 
-      constexpr STDEXEC_MEMFN_DECL(auto forwarding_query)(this subscribe_t) noexcept -> bool {
+      static constexpr auto query(stdexec::forwarding_query_t) noexcept -> bool {
         return false;
       }
     };

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -320,6 +320,14 @@ namespace exec {
         using __id = scheduler;
         auto operator==(const scheduler&) const -> bool = default;
 
+        auto query(get_forward_progress_guarantee_t) const noexcept -> forward_progress_guarantee {
+          return forward_progress_guarantee::parallel;
+        }
+
+        auto query(get_domain_t) const noexcept -> domain {
+          return {};
+        }
+
        private:
         template <typename ReceiverId>
         friend struct operation;
@@ -351,13 +359,8 @@ namespace exec {
             remote_queue* queue_;
 
             template <class CPO>
-            STDEXEC_MEMFN_DECL(auto query)(this const env& self, get_completion_scheduler_t<CPO>) noexcept
+            auto query(get_completion_scheduler_t<CPO>) const noexcept
               -> static_thread_pool_::scheduler {
-              return self.make_scheduler_();
-            }
-
-            [[nodiscard]]
-            auto make_scheduler_() const -> static_thread_pool_::scheduler {
               return static_thread_pool_::scheduler{pool_, *queue_};
             }
           };
@@ -392,15 +395,6 @@ namespace exec {
 
         STDEXEC_MEMFN_DECL(auto schedule)(this const scheduler& sch) noexcept -> sender {
           return sch.make_sender_();
-        }
-
-        STDEXEC_MEMFN_DECL(auto query)(this const static_thread_pool_&, get_forward_progress_guarantee_t) noexcept
-          -> forward_progress_guarantee {
-          return forward_progress_guarantee::parallel;
-        }
-
-        STDEXEC_MEMFN_DECL(auto query)(this scheduler, get_domain_t) noexcept -> domain {
-          return {};
         }
 
         friend class static_thread_pool_;
@@ -1383,9 +1377,9 @@ namespace exec {
           struct env {
             static_thread_pool_* pool_;
 
-            template <same_as<get_completion_scheduler_t<set_value_t>> Query>
-            friend auto tag_invoke(Query, const env& e) noexcept -> static_thread_pool_::scheduler {
-              return e.pool_->get_scheduler();
+            auto query(get_completion_scheduler_t<set_value_t>) noexcept
+              -> static_thread_pool_::scheduler {
+              return pool_->get_scheduler();
             }
           };
 

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -239,6 +239,15 @@ namespace exec {
       : __scheduler_(__impl) {
     }
 
+    /// Returns the forward progress guarantee of `this`.
+    stdexec::forward_progress_guarantee
+      query(stdexec::get_forward_progress_guarantee_t) const noexcept;
+
+    /// Returns the execution domain of `this`.
+    system_scheduler_domain query(stdexec::get_domain_t) const noexcept {
+      return {};
+    }
+
    private:
     template <stdexec::sender, std::integral, class>
     friend struct system_bulk_sender;
@@ -248,17 +257,6 @@ namespace exec {
     STDEXEC_MEMFN_DECL(
       system_sender schedule)(this const system_scheduler& sched) noexcept {
       return {sched.__scheduler_};
-    }
-
-    /// Returns the forward progress guarantee of `this`.
-    STDEXEC_MEMFN_DECL(
-      stdexec::forward_progress_guarantee
-      query)(this const system_scheduler&, stdexec::get_forward_progress_guarantee_t) noexcept;
-
-    /// Returns the execution domain of `this`.
-    STDEXEC_MEMFN_DECL(
-      system_scheduler_domain query)(this const system_scheduler&, stdexec::get_domain_t) noexcept {
-      return {};
     }
 
     /// The underlying implementation of the scheduler.
@@ -491,8 +489,8 @@ namespace exec {
   }
 
   stdexec::forward_progress_guarantee
-    tag_invoke(stdexec::get_forward_progress_guarantee_t, const system_scheduler& __self) noexcept {
-    switch (__self.__scheduler_->__forward_progress_guarantee) {
+    system_scheduler::query(stdexec::get_forward_progress_guarantee_t) const noexcept {
+    switch (__scheduler_->__forward_progress_guarantee) {
     case 0:
       return stdexec::forward_progress_guarantee::concurrent;
     case 1:

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -100,24 +100,22 @@ namespace exec {
         __scheduler_{exec::inline_scheduler{}};
       inplace_stop_token __stop_token_;
 
-      STDEXEC_MEMFN_DECL(auto query)(this const __default_task_context_impl& __self, get_scheduler_t) noexcept
-        -> const __any_scheduler&
-        requires(__with_scheduler)
-      {
-        return __self.__scheduler_;
-      }
-
-      STDEXEC_MEMFN_DECL(auto query)(this const __default_task_context_impl& __self, get_stop_token_t) noexcept
-        -> inplace_stop_token {
-        return __self.__stop_token_;
-      }
-
      public:
       __default_task_context_impl() = default;
 
       template <scheduler _Scheduler>
       explicit __default_task_context_impl(_Scheduler&& __scheduler)
         : __scheduler_{static_cast<_Scheduler&&>(__scheduler)} {
+      }
+
+      auto query(get_scheduler_t) const noexcept -> const __any_scheduler&
+        requires(__with_scheduler)
+      {
+        return __scheduler_;
+      }
+
+      auto query(get_stop_token_t) const noexcept -> inplace_stop_token {
+        return __stop_token_;
       }
 
       [[nodiscard]]

--- a/include/nvexec/multi_gpu_context.cuh
+++ b/include/nvexec/multi_gpu_context.cuh
@@ -82,11 +82,7 @@ namespace nvexec {
           context_state_t context_state_;
 
           template <class CPO>
-          STDEXEC_MEMFN_DECL(multi_gpu_stream_scheduler query)(this const env& self, get_completion_scheduler_t<CPO>) noexcept {
-            return self.make_scheduler();
-          }
-
-          multi_gpu_stream_scheduler make_scheduler() const {
+          multi_gpu_stream_scheduler query(get_completion_scheduler_t<CPO>) const noexcept {
             return multi_gpu_stream_scheduler{num_devices_, context_state_};
           }
         };
@@ -113,24 +109,27 @@ namespace nvexec {
       };
 
       template <sender S>
-      STDEXEC_MEMFN_DECL(schedule_from_sender_th<S> schedule_from)(this const multi_gpu_stream_scheduler& sch,
+      STDEXEC_MEMFN_DECL(schedule_from_sender_th<S> schedule_from)(
+        this const multi_gpu_stream_scheduler& sch,
         S&& sndr) //
         noexcept {
         return schedule_from_sender_th<S>(sch.context_state_, static_cast<S&&>(sndr));
       }
 
       template <sender S, std::integral Shape, class Fn>
-      STDEXEC_MEMFN_DECL(multi_gpu_bulk_sender_th<S, Shape, Fn> bulk)(this const multi_gpu_stream_scheduler& sch,                  //
-        S&& sndr,                                               //
-        Shape shape,                                            //
-        Fn fun)                                                 //
+      STDEXEC_MEMFN_DECL(multi_gpu_bulk_sender_th<S, Shape, Fn> bulk)(
+        this const multi_gpu_stream_scheduler& sch, //
+        S&& sndr,                                   //
+        Shape shape,                                //
+        Fn fun)                                     //
         noexcept {
         return multi_gpu_bulk_sender_th<S, Shape, Fn>{
           {}, sch.num_devices_, static_cast<S&&>(sndr), shape, static_cast<Fn&&>(fun)};
       }
 
       template <sender S, class Fn>
-      STDEXEC_MEMFN_DECL(then_sender_th<S, Fn> then)(this const multi_gpu_stream_scheduler& sch,
+      STDEXEC_MEMFN_DECL(then_sender_th<S, Fn> then)(
+        this const multi_gpu_stream_scheduler& sch,
         S&& sndr,
         Fn fun) //
         noexcept {
@@ -138,7 +137,8 @@ namespace nvexec {
       }
 
       template <__one_of<let_value_t, let_stopped_t, let_error_t> Let, sender S, class Fn>
-      friend let_xxx_th<Let, S, Fn> tag_invoke(Let, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
+      friend let_xxx_th<Let, S, Fn>
+        tag_invoke(Let, const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
         return let_xxx_th<Let, S, Fn>{{}, static_cast<S&&>(sndr), static_cast<Fn&&>(fun)};
       }
 
@@ -148,21 +148,21 @@ namespace nvexec {
       }
 
       template <sender S, class Fn>
-      STDEXEC_MEMFN_DECL(upon_stopped_sender_th<S, Fn> upon_stopped)(this const multi_gpu_stream_scheduler& sch,
-        S&& sndr,
-        Fn fun) noexcept {
+      STDEXEC_MEMFN_DECL(upon_stopped_sender_th<S, Fn> upon_stopped)(this const multi_gpu_stream_scheduler& sch, S&& sndr, Fn fun) noexcept {
         return upon_stopped_sender_th<S, Fn>{{}, static_cast<S&&>(sndr), static_cast<Fn&&>(fun)};
       }
 
       template <stream_completing_sender... Senders>
-      STDEXEC_MEMFN_DECL(auto transfer_when_all)(this const multi_gpu_stream_scheduler& sch, //
+      STDEXEC_MEMFN_DECL(auto transfer_when_all)(
+        this const multi_gpu_stream_scheduler& sch, //
         Senders&&... sndrs) noexcept {
         return transfer_when_all_sender_th<multi_gpu_stream_scheduler, Senders...>(
           sch.context_state_, static_cast<Senders&&>(sndrs)...);
       }
 
       template <stream_completing_sender... Senders>
-      STDEXEC_MEMFN_DECL(auto transfer_when_all_with_variant)(this const multi_gpu_stream_scheduler& sch, //
+      STDEXEC_MEMFN_DECL(auto transfer_when_all_with_variant)(
+        this const multi_gpu_stream_scheduler& sch, //
         Senders&&... sndrs) noexcept {
         return transfer_when_all_sender_th<
           multi_gpu_stream_scheduler,
@@ -171,8 +171,9 @@ namespace nvexec {
       }
 
       template <sender S, scheduler Sch>
-      STDEXEC_MEMFN_DECL(auto transfer)(this const multi_gpu_stream_scheduler& sch, //
-        S&& sndr,                              //
+      STDEXEC_MEMFN_DECL(auto transfer)(
+        this const multi_gpu_stream_scheduler& sch, //
+        S&& sndr,                                   //
         Sch&& scheduler) noexcept {
         return schedule_from(
           static_cast<Sch&&>(scheduler),
@@ -185,7 +186,8 @@ namespace nvexec {
       }
 
       template <sender S>
-      STDEXEC_MEMFN_DECL(ensure_started_th<S> ensure_started)(this const multi_gpu_stream_scheduler& sch,
+      STDEXEC_MEMFN_DECL(ensure_started_th<S> ensure_started)(
+        this const multi_gpu_stream_scheduler& sch,
         S&& sndr) //
         noexcept {
         return ensure_started_th<S>(static_cast<S&&>(sndr), sch.context_state_);
@@ -200,8 +202,7 @@ namespace nvexec {
         return _sync_wait::sync_wait_t{}(self.context_state_, static_cast<S&&>(sndr));
       }
 
-      STDEXEC_MEMFN_DECL(forward_progress_guarantee query)(this const multi_gpu_stream_scheduler&, get_forward_progress_guarantee_t) //
-        noexcept {
+      forward_progress_guarantee query(get_forward_progress_guarantee_t) const noexcept {
         return forward_progress_guarantee::weakly_parallel;
       }
 

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -59,7 +59,9 @@ namespace nvexec {
   }
 #endif
 
-  inline STDEXEC_ATTRIBUTE((host, device)) bool is_on_gpu() noexcept {
+  inline STDEXEC_ATTRIBUTE((host, device))
+  bool
+    is_on_gpu() noexcept {
     return get_device_type() == device_type::device;
   }
 } // namespace nvexec
@@ -265,7 +267,8 @@ namespace nvexec {
       }
 
       STDEXEC_ATTRIBUTE((host, device))
-      constexpr STDEXEC_MEMFN_DECL(bool forwarding_query)(this const get_stream_provider_t&) noexcept {
+      static constexpr auto
+        query(stdexec::forwarding_query_t) noexcept -> bool {
         return true;
       }
     };
@@ -300,7 +303,8 @@ namespace nvexec {
     struct set_noop {
       template <class... Ts>
       STDEXEC_ATTRIBUTE((host, device))
-      void operator()(Ts&&...) const noexcept {
+      void
+        operator()(Ts&&...) const noexcept {
         // TODO TRAP
         std::printf("ERROR: use of empty variant.");
       }
@@ -326,12 +330,14 @@ namespace nvexec {
       }
 
       STDEXEC_ATTRIBUTE((host, device))
-      auto operator()() const noexcept {
+      auto
+        operator()() const noexcept {
         return stdexec::read(*this);
       }
 
       STDEXEC_ATTRIBUTE((host, device))
-      constexpr STDEXEC_MEMFN_DECL(bool forwarding_query)(this const get_stream_t&) noexcept {
+      static constexpr auto
+        query(stdexec::forwarding_query_t) noexcept -> bool {
         return true;
       }
     };
@@ -399,14 +405,16 @@ namespace nvexec {
 
         template <__one_of<set_value_t, set_stopped_t> Tag, class... As>
         STDEXEC_ATTRIBUTE((host, device))
-        friend void tag_invoke(Tag, __t&& self, As&&... as) noexcept {
+        friend void
+          tag_invoke(Tag, __t&& self, As&&... as) noexcept {
           self.variant_->template emplace<decayed_tuple<Tag, As...>>(Tag(), std::move(as)...);
           self.producer_(self.task_);
         }
 
         template <class Error>
         STDEXEC_ATTRIBUTE((host, device))
-        STDEXEC_MEMFN_DECL(void set_error)(this __t&& self, Error&& e) noexcept {
+        STDEXEC_MEMFN_DECL(
+          void set_error)(this __t&& self, Error&& e) noexcept {
           if constexpr (__decays_to<Error, std::exception_ptr>) {
             // What is `exception_ptr` but death pending
             self.variant_->template emplace<decayed_tuple<set_error_t, cudaError_t>>(

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -138,8 +138,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         return connect((static_cast<Self&&>(self)).sndr_, static_cast<Receiver&&>(rcvr));
       }
 
-      STDEXEC_MEMFN_DECL(auto get_env)(this const source_sender_t& self) noexcept
-        -> env_of_t<const Sender&> {
+      STDEXEC_MEMFN_DECL(auto get_env)(this const source_sender_t& self) noexcept -> env_of_t<const Sender&> {
         // TODO - this code is not exercised by any test
         return get_env(self.sndr_);
       }
@@ -171,8 +170,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       context_state_t context_state_;
 
       template <__one_of<set_value_t, set_stopped_t, set_error_t> _Tag>
-      STDEXEC_MEMFN_DECL(Scheduler query)(this const __env& __self, get_completion_scheduler_t<_Tag>) noexcept {
-        return {__self.context_state_};
+      Scheduler query(get_completion_scheduler_t<_Tag>) const noexcept {
+        return {context_state_};
       }
     };
 
@@ -187,11 +186,12 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
       template <__decays_to<__t> Self, receiver Receiver>
         requires sender_to<__copy_cvref_t<Self, source_sender_th>, Receiver>
-      STDEXEC_MEMFN_DECL(auto connect)(this Self&& self, Receiver rcvr) //
- -> stream_op_state_t<
-        __copy_cvref_t<Self, source_sender_th>,
-        receiver_t<Self, Receiver>,
-        Receiver> {
+      STDEXEC_MEMFN_DECL(
+        auto connect)(this Self&& self, Receiver rcvr) //
+        -> stream_op_state_t<
+          __copy_cvref_t<Self, source_sender_th>,
+          receiver_t<Self, Receiver>,
+          Receiver> {
         return stream_op_state<__copy_cvref_t<Self, source_sender_th>>(
           static_cast<Self&&>(self).sndr_,
           static_cast<Receiver&&>(rcvr),
@@ -207,13 +207,12 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       }
 
       template <__decays_to<__t> _Self, class _Env>
-      STDEXEC_MEMFN_DECL(auto get_completion_signatures)(this _Self&&, _Env&&)
-        -> __try_make_completion_signatures<
-          __copy_cvref_t<_Self, Sender>,
-          _Env,
-          completion_signatures<set_error_t(cudaError_t)>,
-          __q<_sched_from::value_completions_t>,
-          __q<_sched_from::error_completions_t>> {
+      STDEXEC_MEMFN_DECL(auto get_completion_signatures)(this _Self&&, _Env&&) -> __try_make_completion_signatures<
+        __copy_cvref_t<_Self, Sender>,
+        _Env,
+        completion_signatures<set_error_t(cudaError_t)>,
+        __q<_sched_from::value_completions_t>,
+        __q<_sched_from::error_completions_t>> {
         return {};
       }
 

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -22,18 +22,20 @@
 
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
   struct __env {
+    using __t = __env;
+    using __id = __env;
+
     run_loop::__scheduler __sched_;
 
-    STDEXEC_MEMFN_DECL(auto query)(this const __env& __self, get_scheduler_t) noexcept -> run_loop::__scheduler {
-      return __self.__sched_;
+    auto query(get_scheduler_t) const noexcept -> run_loop::__scheduler {
+      return __sched_;
     }
 
-    STDEXEC_MEMFN_DECL(auto query)(this const __env& __self, get_delegatee_scheduler_t) noexcept
-      -> run_loop::__scheduler {
-      return __self.__sched_;
+    auto query(get_delegatee_scheduler_t) const noexcept -> run_loop::__scheduler {
+      return __sched_;
     }
   };
- 
+
   // What should sync_wait(just_stopped()) return?
   template <class Sender>
     requires sender_in<Sender, __env>
@@ -77,7 +79,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
 
       template <class Sender2 = Sender, class... As>
         requires std::constructible_from<sync_wait_result_t<Sender2>, As...>
-      STDEXEC_MEMFN_DECL(void set_value)(this __t&& rcvr, As&&... as) noexcept {
+      STDEXEC_MEMFN_DECL(
+        void set_value)(this __t&& rcvr, As&&... as) noexcept {
         try {
           int dev_id{};
           cudaStream_t stream = rcvr.state_->stream_;
@@ -117,7 +120,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
         }
       }
 
-      STDEXEC_MEMFN_DECL(void set_stopped)(this  __t&& rcvr) noexcept {
+      STDEXEC_MEMFN_DECL(void set_stopped)(this __t&& rcvr) noexcept {
         if (cudaError_t status = STDEXEC_DBG_ERR(cudaStreamSynchronize(rcvr.state_->stream_));
             status == cudaSuccess) {
           rcvr.state_->data_.template emplace<3>(set_stopped_t());

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -70,11 +70,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       using non_values = //
         __concat_completion_signatures_t<
           completion_signatures<set_error_t(cudaError_t), set_stopped_t()>,
-          __try_make_completion_signatures<
-            Senders,
-            Env,
-            completion_signatures<>,
-            __q<swallow_values>>...>;
+          __try_make_completion_signatures<Senders, Env, completion_signatures<>, __q<swallow_values>>...>;
       using values = //
         __minvoke<
           __mconcat<__qf<set_value_t>>,
@@ -96,8 +92,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
         template <__one_of<set_value_t, set_stopped_t> _Tag>
           requires WithCompletionScheduler
-        STDEXEC_MEMFN_DECL(Scheduler query)(this const env& self, get_completion_scheduler_t<_Tag>) noexcept {
-          return Scheduler(self.context_state_);
+        Scheduler query(get_completion_scheduler_t<_Tag>) const noexcept {
+          return Scheduler(context_state_);
         }
       };
      public:
@@ -130,9 +126,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         using WhenAll = __copy_cvref_t<CvrefReceiverId, stdexec::__t<when_all_sender_t>>;
         using Receiver = stdexec::__t<__decay_t<CvrefReceiverId>>;
         using Env = //
-          make_terminal_stream_env_t<exec::make_env_t<
-            env_of_t<Receiver>,
-            exec::with_t<get_stop_token_t, inplace_stop_token>>>;
+          make_terminal_stream_env_t<
+            exec::make_env_t<env_of_t<Receiver>, exec::with_t<get_stop_token_t, inplace_stop_token>>>;
 
         struct __t
           : receiver_adaptor<__t>
@@ -175,8 +170,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
                 if constexpr (stream_receiver<Receiver>) {
                   if (op_state_->status_ == cudaSuccess) {
-                    op_state_->status_ = STDEXEC_DBG_ERR(
-                      cudaEventRecord(op_state_->events_[Index], stream));
+                    op_state_->status_ =
+                      STDEXEC_DBG_ERR(cudaEventRecord(op_state_->events_[Index], stream));
                   }
                 }
               }
@@ -309,8 +304,8 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
         template <size_t Index>
         context_state_t get_context_state(WhenAll& when_all) {
-          auto sch = get_completion_scheduler<set_value_t>(
-            get_env(std::get<Index>(when_all.sndrs_)));
+          auto sch =
+            get_completion_scheduler<set_value_t>(get_env(std::get<Index>(when_all.sndrs_)));
           return sch.context_state_;
         }
 
@@ -333,10 +328,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         }
 
         operation_t(WhenAll&& when_all, Receiver rcvr)
-          : operation_t(
-            static_cast<WhenAll&&>(when_all),
-            static_cast<Receiver&&>(rcvr),
-            Indices{}) {
+          : operation_t(static_cast<WhenAll&&>(when_all), static_cast<Receiver&&>(rcvr), Indices{}) {
           for (int i = 0; i < sizeof...(SenderIds); i++) {
             if (status_ == cudaSuccess) {
               status_ = STDEXEC_DBG_ERR(cudaEventCreate(&events_[i], cudaEventDisableTiming));
@@ -410,8 +402,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
       }
 
       template <__decays_to<__t> Self, class Env>
-      STDEXEC_MEMFN_DECL(auto get_completion_signatures)(this Self&&, Env&&)
-        -> completion_sigs<Env, Self> {
+      STDEXEC_MEMFN_DECL(auto get_completion_signatures)(this Self&&, Env&&) -> completion_sigs<Env, Self> {
         return {};
       }
 

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -110,13 +110,9 @@ namespace nvexec {
       struct env {
         context_state_t context_state_;
 
-        stream_scheduler make_scheduler() const {
-          return stream_scheduler{context_state_};
-        }
-
         template <class CPO>
-        STDEXEC_MEMFN_DECL(stream_scheduler query)(this const env& self, get_completion_scheduler_t<CPO>) noexcept {
-          return self.make_scheduler();
+        stream_scheduler query(get_completion_scheduler_t<CPO>) const noexcept {
+          return stream_scheduler{context_state_};
         }
       };
 
@@ -192,7 +188,8 @@ namespace nvexec {
       }
 
       template <sender S, class Fn>
-      STDEXEC_MEMFN_DECL(upon_stopped_sender_th<S, Fn> upon_stopped)(this const stream_scheduler& sch,
+      STDEXEC_MEMFN_DECL(upon_stopped_sender_th<S, Fn> upon_stopped)(
+        this const stream_scheduler& sch,
         S&& sndr,
         Fn fun) //
         noexcept {
@@ -200,7 +197,8 @@ namespace nvexec {
       }
 
       template <stream_completing_sender... Senders>
-      STDEXEC_MEMFN_DECL(auto transfer_when_all)(this const stream_scheduler& sch,
+      STDEXEC_MEMFN_DECL(auto transfer_when_all)(
+        this const stream_scheduler& sch,
         Senders&&... sndrs) //
         noexcept {
         return transfer_when_all_sender_th<stream_scheduler, Senders...>(
@@ -208,7 +206,8 @@ namespace nvexec {
       }
 
       template <stream_completing_sender... Senders>
-      STDEXEC_MEMFN_DECL(auto transfer_when_all_with_variant)(this const stream_scheduler& sch,      //
+      STDEXEC_MEMFN_DECL(auto transfer_when_all_with_variant)(
+        this const stream_scheduler& sch, //
         Senders&&... sndrs) noexcept {
         return transfer_when_all_sender_th<stream_scheduler, __result_of<into_variant, Senders>...>(
           sch.context_state_, into_variant(static_cast<Senders&&>(sndrs))...);
@@ -242,7 +241,7 @@ namespace nvexec {
         return _sync_wait::sync_wait_t{}(self.context_state_, static_cast<S&&>(sndr));
       }
 
-      STDEXEC_MEMFN_DECL(forward_progress_guarantee query)(this const stream_scheduler&, get_forward_progress_guarantee_t) noexcept {
+      forward_progress_guarantee query(get_forward_progress_guarantee_t) const noexcept {
         return forward_progress_guarantee::weakly_parallel;
       }
 

--- a/include/stdexec/__detail/__debug.hpp
+++ b/include/stdexec/__detail/__debug.hpp
@@ -29,8 +29,7 @@ namespace stdexec {
   // Some utilities for debugging senders
   namespace __debug {
     struct __is_debug_env_t {
-      constexpr STDEXEC_MEMFN_DECL(
-        auto forwarding_query)(this const __is_debug_env_t&) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
       template <class _Env>

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -123,8 +123,7 @@ namespace stdexec {
     concept __allocator_c = true;
 
     struct get_scheduler_t : __query<get_scheduler_t> {
-      constexpr STDEXEC_MEMFN_DECL(
-        auto forwarding_query)(this const get_scheduler_t&) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
 
@@ -138,8 +137,7 @@ namespace stdexec {
     };
 
     struct get_delegatee_scheduler_t : __query<get_delegatee_scheduler_t> {
-      constexpr STDEXEC_MEMFN_DECL(
-        auto query)(this const get_delegatee_scheduler_t&, forwarding_query_t) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
 
@@ -153,8 +151,7 @@ namespace stdexec {
     };
 
     struct get_allocator_t : __query<get_allocator_t> {
-      constexpr STDEXEC_MEMFN_DECL(
-        auto forwarding_query)(this const get_allocator_t&) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
 
@@ -172,8 +169,7 @@ namespace stdexec {
     };
 
     struct get_stop_token_t : __query<get_stop_token_t> {
-      constexpr STDEXEC_MEMFN_DECL(
-        auto forwarding_query)(this const get_stop_token_t&) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
 
@@ -202,9 +198,7 @@ namespace stdexec {
 
     template <__completion_tag _CPO>
     struct get_completion_scheduler_t : __query<get_completion_scheduler_t<_CPO>> {
-      constexpr STDEXEC_MEMFN_DECL(
-        auto
-        query)(this const get_completion_scheduler_t<_CPO>&, forwarding_query_t) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
 
@@ -227,7 +221,7 @@ namespace stdexec {
         return tag_invoke(get_domain_t{}, __ty);
       }
 
-      constexpr STDEXEC_MEMFN_DECL(auto forwarding_query)(this get_domain_t) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
     };
@@ -244,8 +238,7 @@ namespace stdexec {
         }
       }
 
-      constexpr STDEXEC_MEMFN_DECL(
-        auto forwarding_query)(this __is_scheduler_affine_t) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return false;
       }
     };
@@ -258,7 +251,7 @@ namespace stdexec {
         return true;
       }
 
-      constexpr STDEXEC_MEMFN_DECL(auto forwarding_query)(this __root_t) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return false;
       }
     };
@@ -316,7 +309,7 @@ namespace stdexec {
   using __query_result_or_t = __call_result_t<query_or_t, _Tag, _Queryable, _Default>;
 
   /////////////////////////////////////////////////////////////////////////////
-  namespace __env {
+  namespace __get_env {
     // For getting an execution environment from a receiver,
     // or the attributes from a sender.
     struct get_env_t {
@@ -336,7 +329,9 @@ namespace stdexec {
         return {};
       }
     };
+  } // namespace __get_env
 
+  namespace __env {
     // To be kept in sync with the promise type used in __connect_awaitable
     template <class _Env>
     struct __promise {
@@ -372,93 +367,88 @@ namespace stdexec {
         : __value_(static_cast<_Value&&>(__value)) {
       }
 
-      constexpr explicit __with(_Value __value, _Tag, _Tags...) //
-        noexcept(__nothrow_decay_copyable<_Value>)
+      constexpr explicit __with(_Value __value, _Tag, _Tags...) noexcept(
+        __nothrow_decay_copyable<_Value>)
         : __value_(static_cast<_Value&&>(__value)) {
       }
 
       template <__one_of<_Tag, _Tags...> _Key>
-      STDEXEC_MEMFN_DECL(auto query)(this const __with& __self, _Key) //
-        noexcept(__nothrow_decay_copyable<_Value>) -> _Value {
-        return __self.__value_;
+      auto query(_Key) const noexcept(__nothrow_decay_copyable<const _Value&>) -> _Value {
+        return __value_;
       }
     };
 
     template <class _Value, class _Tag, class... _Tags>
     __with(_Value, _Tag, _Tags...) -> __with<_Value, _Tag, _Tags...>;
 
-    template <class _Env>
+    template <class _EnvId>
     struct __fwd {
+      using _Env = __cvref_t<_EnvId>;
       static_assert(__nothrow_move_constructible<_Env>);
-      using __t = __fwd;
-      using __id = __fwd;
-      STDEXEC_ATTRIBUTE((no_unique_address))
-      _Env __env_;
 
-      template <__forwarding_query _Tag>
-        requires tag_invocable<_Tag, const _Env&>
-      STDEXEC_MEMFN_DECL(
-        auto query)(this const __fwd& __self, _Tag) //
-        noexcept(nothrow_tag_invocable<_Tag, const _Env&>)
-          -> tag_invoke_result_t<_Tag, const _Env&> {
-        return _Tag()(__self.__env_);
-      }
-    };
+      struct __t {
+        using __id = __fwd;
+        STDEXEC_ATTRIBUTE((no_unique_address))
+        _Env __env_;
 
-    template <class _Env>
-    __fwd(_Env&&) -> __fwd<_Env>;
+#if STDEXEC_GCC() && __GNUC__ < 12
+      using __cvref_env_t = std::add_const_t<_Env>&;
+#else
+      using __cvref_env_t = const _Env&;
+#endif
 
-    template <class _Env>
-    struct __ref {
-      using __t = __ref;
-      using __id = __ref;
-      const _Env& __env_;
-
-      template <class _Tag>
-        requires tag_invocable<_Tag, const _Env&>
-      STDEXEC_MEMFN_DECL(
-        auto query)(this const __ref& __self, _Tag) //
-        noexcept(nothrow_tag_invocable<_Tag, const _Env&>)
-          -> tag_invoke_result_t<_Tag, const _Env&> {
-        return _Tag()(__self.__env_);
-      }
-    };
-
-    template <class _Env>
-    __ref(_Env&) -> __ref<_Env>;
-
-    struct __ref_fn {
-      template <class _Env>
-      constexpr auto operator()(_Env&& __env) const {
-        if constexpr (same_as<_Env, _Env&>) {
-          return __ref{static_cast<_Env&&>(__env)};
-        } else {
-          return static_cast<_Env&&>(__env);
+        template <__forwarding_query _Tag>
+          requires tag_invocable<_Tag, __cvref_env_t>
+        auto query(_Tag) const noexcept(nothrow_tag_invocable<_Tag, __cvref_env_t>)
+          -> tag_invoke_result_t<_Tag, __cvref_env_t> {
+          return tag_invoke(_Tag(), __env_);
         }
+      };
+    };
+
+    struct __fwd_fn {
+      template <class _Env>
+      auto operator()(_Env&& __env) const {
+        return __t<__fwd<__cvref_id<_Env>>>{static_cast<_Env&&>(__env)};
+      }
+
+      auto operator()(empty_env) const -> empty_env {
+        return {};
       }
     };
 
-    template <class _Env, class _Tag, class... _Tags>
-    struct __without_ : _Env {
+    template <class _EnvId, class _Tag, class... _Tags>
+    struct __without_ {
+      using _Env = __cvref_t<_EnvId>;
       static_assert(__nothrow_move_constructible<_Env>);
-      using __t = __without_;
-      using __id = __without_;
 
-      constexpr explicit __without_(_Env&& __env, _Tag, _Tags...) noexcept
-        : _Env(static_cast<_Env&&>(__env)) {
-      }
+      struct __t {
+        using __id = __without_;
+        _Env __env_;
 
-      template <__one_of<_Tag, _Tags...> _Key, class _Self>
-        requires(std::is_base_of_v<__without_, __decay_t<_Self>>)
-      STDEXEC_MEMFN_DECL(
-        auto query)(this _Self&&, _Key) noexcept = delete;
+#if STDEXEC_GCC() && __GNUC__ < 12
+      using __cvref_env_t = std::add_const_t<_Env>&;
+#else
+      using __cvref_env_t = const _Env&;
+#endif
+
+        template <__none_of<_Tag, _Tags...> _Key>
+          requires tag_invocable<_Key, __cvref_env_t>
+        STDEXEC_ATTRIBUTE((always_inline))
+        auto
+          query(_Key) const noexcept(nothrow_tag_invocable<_Key, __cvref_env_t>)
+            -> tag_invoke_result_t<_Key, __cvref_env_t> {
+          return tag_invoke(_Key(), __env_);
+        }
+      };
     };
 
     struct __without_fn {
       template <class _Env, class _Tag, class... _Tags>
       constexpr auto operator()(_Env&& __env, _Tag, _Tags...) const noexcept -> decltype(auto) {
         if constexpr (tag_invocable<_Tag, _Env> || (tag_invocable<_Tags, _Env> || ...)) {
-          return __without_{__ref_fn()(static_cast<_Env&&>(__env)), _Tag(), _Tags()...};
+          using _Without = __t<__without_<__cvref_id<_Env>, _Tag, _Tags...>>;
+          return _Without{static_cast<_Env&&>(__env)};
         } else {
           return static_cast<_Env>(static_cast<_Env&&>(__env));
         }
@@ -467,40 +457,57 @@ namespace stdexec {
 
     inline constexpr __without_fn __without{};
 
-    template <class _Tag, auto _Value>
-    struct __static_env {
-      using value_type = decltype(_Value);
-
-      static constexpr value_type query(_Tag) noexcept {
-        return _Value;
-      }
-    };
-
     template <class _Env, class _Tag, class... _Tags>
     using __without_t = __result_of<__without, _Env, _Tag, _Tags...>;
 
-    template <class _Second, class _First>
-    struct __joined : _Second {
+    template <class _SecondId, class _FirstId>
+    struct __joined {
+      using _First = stdexec::__cvref_t<_FirstId>;
+      using _Second = stdexec::__cvref_t<_SecondId>;
       static_assert(__nothrow_move_constructible<_First>);
       static_assert(__nothrow_move_constructible<_Second>);
-      using __t = __joined;
-      using __id = __joined;
 
-      STDEXEC_ATTRIBUTE((no_unique_address))
-      _First __env_;
+#if STDEXEC_GCC() && __GNUC__ < 12
+      using __cvref_first_t = std::add_const_t<_First>&;
+      using __cvref_second_t = std::add_const_t<_Second>&;
+#else
+      using __cvref_first_t = const _First&;
+      using __cvref_second_t = const _Second&;
+#endif
 
-      template <class _Tag>
-        requires tag_invocable<_Tag, const _First&>
-      STDEXEC_MEMFN_DECL(
-        auto query)(this const __joined& __self, _Tag) //
-        noexcept(nothrow_tag_invocable<_Tag, const _First&>)
-          -> tag_invoke_result_t<_Tag, const _First&> {
-        return _Tag()(__self.__env_);
-      }
+      struct __t {
+        using __id = __joined;
+
+        STDEXEC_ATTRIBUTE((no_unique_address))
+        _Second __second_;
+        STDEXEC_ATTRIBUTE((no_unique_address))
+        _First __first_;
+
+        template <class _Tag>
+          requires tag_invocable<_Tag, __cvref_first_t> || tag_invocable<_Tag, __cvref_second_t>
+        STDEXEC_ATTRIBUTE((always_inline))
+        auto
+          query(_Tag) const noexcept(nothrow_tag_invocable<_Tag, __cvref_second_t>)
+            -> tag_invoke_result_t<_Tag, __cvref_second_t> {
+          return tag_invoke(_Tag(), __second_);
+        }
+
+        template <class _Tag>
+          requires tag_invocable<_Tag, __cvref_first_t>
+        STDEXEC_ATTRIBUTE((always_inline))
+        auto
+          query(_Tag) const noexcept(nothrow_tag_invocable<_Tag, __cvref_first_t>)
+            -> tag_invoke_result_t<_Tag, __cvref_first_t> {
+          return tag_invoke(_Tag(), __first_);
+        }
+      };
     };
 
     template <class _Second, class _First>
-    __joined(_Second&&, _First&&) -> __joined<_Second, _First>;
+    constexpr auto __mk_joined(_Second&& __second, _First&& __first) noexcept {
+      using _Joined = __t<__joined<__cvref_id<_Second>, __cvref_id<_First>>>;
+      return _Joined{static_cast<_Second&&>(__second), static_cast<_First&&>(__first)};
+    }
 
     template <__nothrow_move_constructible _Fun>
     struct __from {
@@ -511,25 +518,14 @@ namespace stdexec {
 
       template <class _Tag>
         requires __callable<const _Fun&, _Tag>
-      STDEXEC_MEMFN_DECL(auto query)(this const __from& __self, _Tag) //
-        noexcept(__nothrow_callable<const _Fun&, _Tag>) -> __call_result_t<const _Fun&, _Tag> {
-        return __self.__fun_(_Tag());
+      auto query(_Tag) const noexcept(__nothrow_callable<const _Fun&, _Tag>)
+        -> __call_result_t<const _Fun&, _Tag> {
+        return __fun_(_Tag());
       }
     };
 
     template <class _Fun>
     __from(_Fun) -> __from<_Fun>;
-
-    struct __fwd_fn {
-      template <class Env>
-      auto operator()(Env&& env) const {
-        return __fwd{static_cast<Env&&>(env)};
-      }
-
-      auto operator()(empty_env) const -> empty_env {
-        return {};
-      }
-    };
 
     struct __join_fn {
       auto operator()() const -> empty_env {
@@ -561,8 +557,8 @@ namespace stdexec {
 
       template <class First, class... Rest>
       auto operator()(First&& first, Rest&&... rest) const -> decltype(auto) {
-        return __joined{
-          __fwd_fn()(__join_fn()(static_cast<Rest&&>(rest)...)), static_cast<First&&>(first)};
+        return __mk_joined(
+          __fwd_fn()(__join_fn()(static_cast<Rest&&>(rest)...)), static_cast<First&&>(first));
       }
     };
 
@@ -572,7 +568,7 @@ namespace stdexec {
     using __join_t = __result_of<__join, _Envs...>;
   } // namespace __env
 
-  using __env::get_env_t;
+  using __get_env::get_env_t;
   using __env::empty_env;
   inline constexpr get_env_t get_env{};
 

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -49,9 +49,14 @@ namespace stdexec {
   extern const bool enable_receiver;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
-  namespace __env {
+  namespace __get_env {
     struct get_env_t;
+  } // namespace __get_env
 
+  using __get_env::get_env_t;
+  extern const get_env_t get_env;
+
+  namespace __env {
     struct empty_env {
       using __t = empty_env;
       using __id = empty_env;
@@ -59,8 +64,6 @@ namespace stdexec {
   } // namespace __env
 
   using __env::empty_env;
-  using __env::get_env_t;
-  extern const get_env_t get_env;
 
   template <class _EnvProvider>
   using env_of_t = __call_result_t<get_env_t, _EnvProvider>;

--- a/include/stdexec/__detail/__inline_scheduler.hpp
+++ b/include/stdexec/__detail/__inline_scheduler.hpp
@@ -39,8 +39,7 @@ namespace stdexec {
         return __make_sexpr<_Tag>();
       }
 
-      STDEXEC_MEMFN_DECL(auto query)(this __scheduler, get_forward_progress_guarantee_t) noexcept
-        -> forward_progress_guarantee {
+      auto query(get_forward_progress_guarantee_t) const noexcept -> forward_progress_guarantee {
         return forward_progress_guarantee::weakly_parallel;
       }
 

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -448,10 +448,18 @@ namespace stdexec {
             __q<__decayed_tuple>,
             __mk_let_state>;
 
-          _Sched __sched = query_or(
-            get_completion_scheduler<_Set>, stdexec::get_env(__sndr), __unknown_scheduler());
-          return __let_state_t{
-            __sndr.apply(static_cast<_Sender&&>(__sndr), __detail::__get_data()), __sched};
+          return __sndr.apply(
+            static_cast<_Sender&&>(__sndr),
+            [&]<class _Fn, class _Child>(__ignore, _Fn&& __fn, _Child&& __child) {
+              _Sched __sched = query_or(
+                get_completion_scheduler<_Set>, stdexec::get_env(__child), __unknown_scheduler());
+              return __let_state_t{static_cast<_Fn&&>(__fn), __sched};
+            });
+
+          // _Sched __sched = query_or(
+          //   get_completion_scheduler<_Set>, stdexec::get_env(__sndr), __unknown_scheduler());
+          // return __let_state_t{
+          //   __sndr.apply(static_cast<_Sender&&>(__sndr), __detail::__get_data()), __sched};
         };
 
       template <class _State, class _OpState, class... _As>

--- a/include/stdexec/__detail/__on.hpp
+++ b/include/stdexec/__detail/__on.hpp
@@ -76,14 +76,17 @@ namespace stdexec {
 
     template <class _Scheduler>
     struct __with_sched {
+      using __t = __with_sched;
+      using __id = __with_sched;
+
       _Scheduler __sched_;
 
-      STDEXEC_MEMFN_DECL(auto query)(this const __with_sched& __self, get_scheduler_t) noexcept -> _Scheduler {
-        return __self.__sched_;
+      auto query(get_scheduler_t) const noexcept -> _Scheduler {
+        return __sched_;
       }
 
-      STDEXEC_MEMFN_DECL(auto query)(this const __with_sched& __self, get_domain_t) noexcept {
-        return query_or(get_domain, __self.__sched_, default_domain());
+      auto query(get_domain_t) const noexcept {
+        return query_or(get_domain, __sched_, default_domain());
       }
     };
 

--- a/include/stdexec/__detail/__run_loop.hpp
+++ b/include/stdexec/__detail/__run_loop.hpp
@@ -103,6 +103,16 @@ namespace stdexec {
         using __id = __scheduler;
         auto operator==(const __scheduler&) const noexcept -> bool = default;
 
+        auto query(get_forward_progress_guarantee_t) const noexcept
+          -> stdexec::forward_progress_guarantee {
+          return stdexec::forward_progress_guarantee::parallel;
+        }
+
+        // BUGBUG NOT TO SPEC
+        auto query(execute_may_block_caller_t) const noexcept -> bool {
+          return false;
+        }
+
        private:
         struct __schedule_task {
           using __t = __schedule_task;
@@ -129,12 +139,14 @@ namespace stdexec {
           }
 
           struct __env {
+            using __t = __env;
+            using __id = __env;
+
             run_loop* __loop_;
 
             template <class _CPO>
-            STDEXEC_MEMFN_DECL(auto query)(this const __env& __self, get_completion_scheduler_t<_CPO>) noexcept
-              -> __scheduler {
-              return __self.__loop_->get_scheduler();
+            auto query(get_completion_scheduler_t<_CPO>) const noexcept -> __scheduler {
+              return __loop_->get_scheduler();
             }
           };
 
@@ -157,17 +169,6 @@ namespace stdexec {
 
         STDEXEC_MEMFN_DECL(auto schedule)(this const __scheduler& __self) noexcept -> __schedule_task {
           return __self.__schedule();
-        }
-
-        STDEXEC_MEMFN_DECL(auto query)(this const __scheduler&, get_forward_progress_guarantee_t) noexcept
-          -> stdexec::forward_progress_guarantee {
-          return stdexec::forward_progress_guarantee::parallel;
-        }
-
-        // BUGBUG NOT TO SPEC
-        STDEXEC_MEMFN_DECL(
-          auto execute_may_block_caller)(this const __scheduler&) noexcept -> bool {
-          return false;
         }
 
         [[nodiscard]]

--- a/include/stdexec/__detail/__schedule_from.hpp
+++ b/include/stdexec/__detail/__schedule_from.hpp
@@ -104,8 +104,10 @@ namespace stdexec {
           : __t::__with{std::move(__sched)} {
         }
 
-        STDEXEC_MEMFN_DECL(auto query)(this const __t& __self, get_domain_t) noexcept {
-          return query_or(get_domain, __self.__value_, default_domain());
+        using __t::__with::query;
+
+        auto query(get_domain_t) const noexcept {
+          return query_or(get_domain, this->__value_, default_domain());
         }
       };
     };

--- a/include/stdexec/__detail/__schedulers.hpp
+++ b/include/stdexec/__detail/__schedulers.hpp
@@ -39,7 +39,7 @@ namespace stdexec {
         return tag_invoke(schedule_t{}, static_cast<_Scheduler&&>(__sched));
       }
 
-      constexpr STDEXEC_MEMFN_DECL(auto forwarding_query)(this schedule_t) -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return false;
       }
     };
@@ -111,6 +111,16 @@ namespace stdexec {
       return tag_invoke(*this, __env);
     }
   } // namespace __queries
+
+  /////////////////////////////////////////////////////////////////////////////
+  namespace __get_env {
+    // NOT TO SPEC: So that calls to `get_env` on a scheduler succeed and return the scheduler
+    // itself.
+    template <__same_as<get_env_t> Tag, scheduler _Scheduler>
+    auto tag_invoke(Tag, const _Scheduler& __sched) noexcept -> const _Scheduler& {
+      return __sched;
+    }
+  } // namespace __get_env
 
   namespace __detail {
     // A handy utility for augmenting an environment with a scheduler.

--- a/include/stdexec/__detail/__schedulers.hpp
+++ b/include/stdexec/__detail/__schedulers.hpp
@@ -112,16 +112,6 @@ namespace stdexec {
     }
   } // namespace __queries
 
-  /////////////////////////////////////////////////////////////////////////////
-  namespace __get_env {
-    // NOT TO SPEC: So that calls to `get_env` on a scheduler succeed and return the scheduler
-    // itself.
-    template <__same_as<get_env_t> Tag, scheduler _Scheduler>
-    auto tag_invoke(Tag, const _Scheduler& __sched) noexcept -> const _Scheduler& {
-      return __sched;
-    }
-  } // namespace __get_env
-
   namespace __detail {
     // A handy utility for augmenting an environment with a scheduler.
     template <class _Env, class _Scheduler>

--- a/include/stdexec/__detail/__senders.hpp
+++ b/include/stdexec/__detail/__senders.hpp
@@ -208,7 +208,7 @@ namespace stdexec {
         }
       }
 
-      constexpr STDEXEC_MEMFN_DECL(auto forwarding_query)(this connect_t) noexcept -> bool {
+      static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return false;
       }
     };

--- a/include/stdexec/__detail/__tag_invoke.hpp
+++ b/include/stdexec/__detail/__tag_invoke.hpp
@@ -42,14 +42,18 @@ namespace stdexec {
     // For handling queryables with a static constexpr query member function:
     template <class _Tag, class _Env>
       requires true // so this overload is preferred over the one below
-    constexpr auto tag_invoke(_Tag, const _Env&) noexcept -> __mconstant_<_Env::query(_Tag())> {
+    STDEXEC_ATTRIBUTE((always_inline))
+    constexpr auto
+      tag_invoke(_Tag, const _Env&) noexcept -> __mconstant_<_Env::query(_Tag())> {
       return {};
     }
 
     // For handling queryables with a query member function:
     template <class _Tag, class _Env>
-    constexpr auto tag_invoke(_Tag, const _Env& __env) noexcept(noexcept(__env.query(_Tag())))
-      -> decltype(__env.query(_Tag())) {
+    STDEXEC_ATTRIBUTE((always_inline))
+    constexpr auto
+      tag_invoke(_Tag, const _Env& __env) noexcept(noexcept(__env.query(_Tag())))
+        -> decltype(__env.query(_Tag())) {
       return __env.query(_Tag());
     }
 

--- a/include/stdexec/__detail/__write_env.hpp
+++ b/include/stdexec/__detail/__write_env.hpp
@@ -30,17 +30,17 @@ namespace stdexec {
   // __write adaptor
   namespace __write_ {
     struct __write_env_t {
-      template <sender _Sender, class... _Envs>
-      auto operator()(_Sender&& __sndr, _Envs... __envs) const {
+      template <sender _Sender, class _Env>
+      auto operator()(_Sender&& __sndr, _Env __env) const {
         return __make_sexpr<__write_env_t>(
-          __env::__join(static_cast<_Envs&&>(__envs)...), static_cast<_Sender&&>(__sndr));
+          static_cast<_Env&&>(__env), static_cast<_Sender&&>(__sndr));
       }
 
-      template <class... _Envs>
+      template <class _Env>
       STDEXEC_ATTRIBUTE((always_inline))
       auto
-        operator()(_Envs... __envs) const -> __binder_back<__write_env_t, _Envs...> {
-        return {{static_cast<_Envs&&>(__envs)...}, {}, {}};
+        operator()(_Env __env) const -> __binder_back<__write_env_t, _Env> {
+        return {{static_cast<_Env&&>(__env)}, {}, {}};
       }
 
       template <class _Env>

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -689,7 +689,7 @@ namespace {
         return {{}, static_cast<R&&>(r)};
       }
 
-      friend auto tag_invoke(ex::get_completion_scheduler_t<ex::set_value_t>, sender) noexcept
+      auto query(ex::get_completion_scheduler_t<ex::set_value_t>) const noexcept
         -> counting_scheduler {
         return {};
       }

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -120,8 +120,7 @@ namespace {
     struct sender : ex::schedule_result_t<inline_scheduler> {
       struct env {
         template <class Tag>
-        friend custom_scheduler
-          tag_invoke(ex::get_completion_scheduler_t<Tag>, const env&) noexcept {
+        custom_scheduler query(ex::get_completion_scheduler_t<Tag>) const noexcept {
           return {};
         }
       };
@@ -138,7 +137,7 @@ namespace {
       }
     };
 
-    friend domain tag_invoke(ex::get_domain_t, custom_scheduler) noexcept {
+    domain query(ex::get_domain_t) const noexcept {
       return {};
     }
 

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -28,7 +28,7 @@ namespace {
   template <class Scheduler>
   struct default_env {
     template <typename CPO>
-    friend Scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const default_env&) {
+    Scheduler query(ex::get_completion_scheduler_t<CPO>) const noexcept {
       return {};
     }
   };

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -68,7 +68,7 @@ namespace {
 
     struct env_t {
       template <stdexec::__one_of<ex::set_value_t, CompletionSignals...> Tag>
-      friend scheduler_t tag_invoke(ex::get_completion_scheduler_t<Tag>, const env_t&) noexcept {
+      scheduler_t query(ex::get_completion_scheduler_t<Tag>) const noexcept {
         return {};
       }
     };

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -41,9 +41,8 @@ namespace {
       }
 
       struct env {
-        template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-        friend uncustomized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const env&) //
-          noexcept {
+        template <stdexec::__completion_tag Tag>
+        uncustomized_scheduler query(ex::get_completion_scheduler_t<Tag>) const noexcept {
           return {};
         }
       };
@@ -84,9 +83,8 @@ namespace {
       }
 
       struct env {
-        template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-        friend customized_scheduler tag_invoke(ex::get_completion_scheduler_t<CPO>, const env&) //
-          noexcept {
+        template <stdexec::__completion_tag Tag>
+        customized_scheduler query(ex::get_completion_scheduler_t<Tag>) const noexcept {
           return {};
         }
       };
@@ -108,8 +106,8 @@ namespace {
       return false;
     }
 
-    constexpr friend ex::forward_progress_guarantee
-      tag_invoke(ex::get_forward_progress_guarantee_t, customized_scheduler) {
+    constexpr auto query(ex::get_forward_progress_guarantee_t) const noexcept
+      -> ex::forward_progress_guarantee {
       return fpg;
     }
   };

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -33,8 +33,8 @@ namespace ex = stdexec;
 namespace {
   template <class S>
   struct scheduler_env {
-    template <stdexec::__one_of<ex::set_value_t, ex::set_error_t, ex::set_stopped_t> CPO>
-    friend S tag_invoke(ex::get_completion_scheduler_t<CPO>, const scheduler_env&) noexcept {
+    template <stdexec::__completion_tag Tag>
+    S query(ex::get_completion_scheduler_t<Tag>) const noexcept {
       return {};
     }
   };
@@ -96,13 +96,9 @@ namespace {
     struct env {
       data* data_;
 
-      auto make_scheduler() const noexcept {
-        return impulse_scheduler{data_};
-      }
-
       template <stdexec::__one_of<ex::set_value_t, ex::set_stopped_t> Tag>
-      friend auto tag_invoke(ex::get_completion_scheduler_t<Tag>, const env& self) noexcept {
-        return self.make_scheduler();
+      auto query(ex::get_completion_scheduler_t<Tag>) const noexcept {
+        return impulse_scheduler{data_};
       }
     };
 


### PR DESCRIPTION
implementing queries with `tag_invoke` is still supported though