### PR TITLE
(breaking change) simplification of `receiver_adaptor`; migrate more `get_env` to member functions

### DIFF
--- a/examples/algorithms/retry.hpp
+++ b/examples/algorithms/retry.hpp
@@ -136,9 +136,8 @@ struct _retry_sender {
     return {static_cast<S&&>(self.s_), static_cast<R&&>(r)};
   }
 
-  friend auto tag_invoke(stdexec::get_env_t, const _retry_sender& self) //
-    noexcept(noexcept(stdexec::get_env(self.s_))) -> std::invoke_result_t<stdexec::get_env_t, S> {
-    return stdexec::get_env(self.s_);
+  auto get_env() const noexcept -> stdexec::env_of_t<S> {
+    return stdexec::get_env(s_);
   }
 };
 

--- a/examples/algorithms/then.hpp
+++ b/examples/algorithms/then.hpp
@@ -79,9 +79,10 @@ struct _then_sender {
   }
 
   // Connect:
-  template <stdexec::receiver R>
+  template <stdexec::same_as<_then_sender> Self, stdexec::receiver R>
     requires stdexec::sender_to<S, _then_receiver<R, F>>
-  STDEXEC_MEMFN_DECL(auto connect)(this _then_sender&& self, R r) {
+  STDEXEC_MEMFN_DECL(
+    auto connect)(this Self&& self, R r) {
     return stdexec::connect(
       static_cast<S&&>(self.s_),
       _then_receiver<R, F>{static_cast<R&&>(r), static_cast<F&&>(self.f_)});

--- a/examples/benchmark/static_thread_pool_old.hpp
+++ b/examples/benchmark/static_thread_pool_old.hpp
@@ -191,10 +191,6 @@ namespace exec_old {
           }
         };
 
-        friend env tag_invoke(stdexec::get_env_t, const sender& self) noexcept {
-          return env{self.pool_};
-        }
-
         friend struct static_thread_pool::scheduler;
 
         explicit sender(static_thread_pool& pool) noexcept
@@ -202,6 +198,11 @@ namespace exec_old {
         }
 
         static_thread_pool& pool_;
+
+       public:
+        env get_env() const noexcept {
+          return env{pool_};
+        }
       };
 
       friend class static_thread_pool;
@@ -493,9 +494,8 @@ namespace exec_old {
       return {};
     }
 
-    friend auto tag_invoke(stdexec::get_env_t, const bulk_sender& self) noexcept
-      -> stdexec::env_of_t<const Sender&> {
-      return stdexec::get_env(self.sndr_);
+    auto get_env() const noexcept -> stdexec::env_of_t<const Sender&> {
+      return stdexec::get_env(sndr_);
     }
   };
 

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -378,10 +378,8 @@ namespace repeat_n_detail {
     }
 #endif
 
-    friend auto tag_invoke(stdexec::get_env_t, const repeat_n_sender_t& s) //
-      noexcept(stdexec::__nothrow_callable<stdexec::get_env_t, const Sender&>)
-        -> stdexec::env_of_t<const Sender&> {
-      return stdexec::get_env(s.sender_);
+    auto get_env() const noexcept -> stdexec::env_of_t<const Sender&> {
+      return stdexec::get_env(sender_);
     }
   };
 } // namespace repeat_n_detail

--- a/examples/scope.cpp
+++ b/examples/scope.cpp
@@ -28,8 +28,8 @@
 using namespace stdexec;
 using stdexec::sync_wait;
 
-class noop_receiver : receiver_adaptor<noop_receiver> {
-  friend receiver_adaptor<noop_receiver>;
+struct noop_receiver {
+  using receiver_concept = receiver_t;
 
   template <class... _As>
   void set_value(_As&&...) noexcept {
@@ -42,7 +42,7 @@ class noop_receiver : receiver_adaptor<noop_receiver> {
   }
 
   auto get_env() const & noexcept {
-    return exec::make_env(exec::with(get_stop_token, stdexec::never_stop_token{}));
+    return exec::with(get_stop_token, stdexec::never_stop_token{});
   }
 };
 

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -360,9 +360,8 @@ namespace exec {
         static_cast<__sender_base&&>(__self.__sender_), static_cast<_Rcvr&&>(__rcvr));
     }
 
-    template <stdexec::same_as<stdexec::get_env_t> _GetEnv, stdexec::__decays_to<__t> _Self>
-    friend auto tag_invoke(_GetEnv, _Self&& __self) noexcept -> stdexec::env_of_t<__sender_base> {
-      return stdexec::get_env(__self.__sender_);
+    auto get_env() const noexcept -> stdexec::env_of_t<__sender_base> {
+      return stdexec::get_env(__sender_);
     }
   };
 

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -335,8 +335,7 @@ namespace exec {
       static constexpr auto __select_impl() noexcept {
         using _Domain = __late_domain_of_t<_Sender, env_of_t<_Receiver&>>;
         constexpr bool _NothrowTfxSender =
-          __nothrow_callable<get_env_t, _Receiver&>
-          && __nothrow_callable<transform_sender_t, _Domain, _Sender, env_of_t<_Receiver&>>;
+          __nothrow_callable<transform_sender_t, _Domain, _Sender, env_of_t<_Receiver&>>;
         using _TfxSender = __tfx_sndr<_Sender, _Receiver>;
         if constexpr (__next_connectable_with_tag_invoke<_TfxSender, _Receiver>) {
           using _Result = tag_invoke_result_t<

--- a/include/stdexec/__detail/__receiver_adaptor.hpp
+++ b/include/stdexec/__detail/__receiver_adaptor.hpp
@@ -114,11 +114,11 @@ namespace stdexec {
       template <class _Self>
       using __base_from_derived_t = decltype(__declval<_Self>().base());
 
-      using __get_base_t =
+      using __get_base_fn =
         __if_c<__has_base, __mbind_back_q<__copy_cvref_t, _Base>, __q<__base_from_derived_t>>;
 
       template <class _Self>
-      using __base_t = __minvoke<__get_base_t, _Self&&>;
+      using __base_t = __minvoke<__get_base_fn, _Self&&>;
 
       template <class _Self>
       STDEXEC_ATTRIBUTE((host, device))
@@ -140,27 +140,33 @@ namespace stdexec {
       template <class... _As, class _Self = _Derived>
         requires __callable<set_value_t, __base_t<_Self>, _As...>
       STDEXEC_ATTRIBUTE((host, device))
-      void set_value(_As&&... __as) && noexcept {
-        return stdexec::set_value(__get_base(static_cast<_Self&&>(*this)), static_cast<_As&&>(__as)...);
+      void
+        set_value(_As&&... __as) && noexcept {
+        return stdexec::set_value(
+          __get_base(static_cast<_Self&&>(*this)), static_cast<_As&&>(__as)...);
       }
 
       template <class _Error, class _Self = _Derived>
         requires __callable<set_error_t, __base_t<_Self>, _Error>
       STDEXEC_ATTRIBUTE((host, device))
-      void set_error(_Error&& __err) && noexcept {
-        return stdexec::set_error(__get_base(static_cast<_Self&&>(*this)), static_cast<_Error&&>(__err));
+      void
+        set_error(_Error&& __err) && noexcept {
+        return stdexec::set_error(
+          __get_base(static_cast<_Self&&>(*this)), static_cast<_Error&&>(__err));
       }
 
       template <class _Self = _Derived>
         requires __callable<set_stopped_t, __base_t<_Self>>
       STDEXEC_ATTRIBUTE((host, device))
-      void set_stopped() && noexcept {
+      void
+        set_stopped() && noexcept {
         return stdexec::set_stopped(__get_base(static_cast<_Self&&>(*this)));
       }
 
       template <class _Self = _Derived>
       STDEXEC_ATTRIBUTE((host, device))
-      auto get_env() const noexcept -> env_of_t<__base_t<const _Self&>> {
+      auto
+        get_env() const noexcept -> env_of_t<__base_t<const _Self&>> {
         return stdexec::get_env(__get_base(static_cast<const _Self&>(*this)));
       }
     };

--- a/include/stdexec/__detail/__receiver_adaptor.hpp
+++ b/include/stdexec/__detail/__receiver_adaptor.hpp
@@ -31,13 +31,11 @@ namespace stdexec {
 
       struct __receiver : __nope {
         using receiver_concept = receiver_t;
-      };
 
-      template <same_as<set_error_t> _Tag>
-      void tag_invoke(_Tag, __receiver, std::exception_ptr) noexcept;
-      template <same_as<set_stopped_t> _Tag>
-      void tag_invoke(_Tag, __receiver) noexcept;
-      auto tag_invoke(get_env_t, __receiver) noexcept -> empty_env;
+        void set_error(std::exception_ptr) noexcept;
+        void set_stopped() noexcept;
+        auto get_env() const noexcept -> empty_env;
+      };
     } // namespace __no
 
     using __not_a_receiver = __no::__receiver;
@@ -110,124 +108,61 @@ namespace stdexec {
     struct receiver_adaptor
       : __adaptor_base<_Base>
       , receiver_t {
-      friend _Derived;
-      STDEXEC_DEFINE_MEMBER(set_value);
-      STDEXEC_DEFINE_MEMBER(set_error);
-      STDEXEC_DEFINE_MEMBER(set_stopped);
-      STDEXEC_DEFINE_MEMBER(get_env);
 
       static constexpr bool __has_base = !derived_from<_Base, __no::__nope>;
 
-      template <class _Dp>
-      using __base_from_derived_t = decltype(__declval<_Dp>().base());
+      template <class _Self>
+      using __base_from_derived_t = decltype(__declval<_Self>().base());
 
       using __get_base_t =
         __if_c<__has_base, __mbind_back_q<__copy_cvref_t, _Base>, __q<__base_from_derived_t>>;
 
-      template <class _Dp>
-      using __base_t = __minvoke<__get_base_t, _Dp&&>;
+      template <class _Self>
+      using __base_t = __minvoke<__get_base_t, _Self&&>;
 
-      template <class _Dp>
+      template <class _Self>
       STDEXEC_ATTRIBUTE((host, device))
       static auto
-        __get_base(_Dp&& __self) noexcept -> __base_t<_Dp> {
+        __get_base(_Self&& __self) noexcept -> __base_t<_Self> {
         if constexpr (__has_base) {
-          return __c_upcast<receiver_adaptor>(static_cast<_Dp&&>(__self)).base();
+          return __c_upcast<receiver_adaptor>(static_cast<_Self&&>(__self)).base();
         } else {
-          return static_cast<_Dp&&>(__self).base();
+          return static_cast<_Self&&>(__self).base();
         }
       }
 
-      template <__same_as<set_value_t> _SetValue, class... _As>
-      STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend auto
-        tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept //
-        -> __msecond<                                                    //
-          __if_c<__same_as<set_value_t, _SetValue>>,
-          decltype(STDEXEC_CALL_MEMBER(
-            set_value,
-            static_cast<_Derived&&>(__self),
-            static_cast<_As&&>(__as)...))> {
-        static_assert(noexcept(STDEXEC_CALL_MEMBER(
-          set_value, static_cast<_Derived&&>(__self), static_cast<_As&&>(__as)...)));
-        STDEXEC_CALL_MEMBER(set_value, static_cast<_Derived&&>(__self), static_cast<_As&&>(__as)...);
-      }
-
-      template <__same_as<set_value_t> _SetValue, class _Dp = _Derived, class... _As>
-        requires STDEXEC_MISSING_MEMBER(_Dp, set_value) && tag_invocable<_SetValue, __base_t<_Dp>, _As...>
-      STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend void
-        tag_invoke(_SetValue, _Derived&& __self, _As&&... __as) noexcept {
-        stdexec::set_value(__get_base(static_cast<_Dp&&>(__self)), static_cast<_As&&>(__as)...);
-      }
-
-      template <__same_as<set_error_t> _SetError, class _Error>
-      STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend auto
-        tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept //
-        -> __msecond<                                                     //
-          __if_c<__same_as<set_error_t, _SetError>>,
-          decltype(STDEXEC_CALL_MEMBER(
-            set_error,
-            static_cast<_Derived&&>(__self),
-            static_cast<_Error&&>(__err)))> {
-        static_assert(noexcept(STDEXEC_CALL_MEMBER(
-          set_error, static_cast<_Derived&&>(__self), static_cast<_Error&&>(__err))));
-        STDEXEC_CALL_MEMBER(
-          set_error, static_cast<_Derived&&>(__self), static_cast<_Error&&>(__err));
-      }
-
-      template <__same_as<set_error_t> _SetError, class _Error, class _Dp = _Derived>
-        requires STDEXEC_MISSING_MEMBER(_Dp, set_error) && tag_invocable<_SetError, __base_t<_Dp>, _Error>
-      STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend void
-        tag_invoke(_SetError, _Derived&& __self, _Error&& __err) noexcept {
-        stdexec::set_error(
-          __get_base(static_cast<_Derived&&>(__self)), static_cast<_Error&&>(__err));
-      }
-
-      template <__same_as<set_stopped_t> _SetStopped, class _Dp = _Derived>
-      STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend auto
-        tag_invoke(_SetStopped, _Derived&& __self) noexcept //
-        -> __msecond<                                       //
-          __if_c<__same_as<set_stopped_t, _SetStopped>>,
-          decltype(STDEXEC_CALL_MEMBER(set_stopped, static_cast<_Dp&&>(__self)))> {
-        static_assert(noexcept(STDEXEC_CALL_MEMBER(set_stopped, static_cast<_Derived&&>(__self))));
-        STDEXEC_CALL_MEMBER(set_stopped, static_cast<_Derived&&>(__self));
-      }
-
-      template <__same_as<set_stopped_t> _SetStopped, class _Dp = _Derived>
-        requires STDEXEC_MISSING_MEMBER(_Dp, set_stopped) && tag_invocable<_SetStopped, __base_t<_Dp>>
-      STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend void
-        tag_invoke(_SetStopped, _Derived&& __self) noexcept {
-        stdexec::set_stopped(__get_base(static_cast<_Derived&&>(__self)));
-      }
-
-      // Pass through the get_env receiver query
-      template <__same_as<get_env_t> _GetEnv, class _Dp = _Derived>
-      STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend auto
-        tag_invoke(_GetEnv, const _Derived& __self) noexcept
-        -> decltype(STDEXEC_CALL_MEMBER(get_env, static_cast<const _Dp&>(__self))) {
-        static_assert(noexcept(STDEXEC_CALL_MEMBER(get_env, __self)));
-        return STDEXEC_CALL_MEMBER(get_env, __self);
-      }
-
-      template <__same_as<get_env_t> _GetEnv, class _Dp = _Derived>
-        requires STDEXEC_MISSING_MEMBER(_Dp, get_env)
-          STDEXEC_ATTRIBUTE((host, device, always_inline))
-      friend auto
-        tag_invoke(_GetEnv, const _Derived& __self) noexcept -> env_of_t<__base_t<const _Dp&>> {
-        return stdexec::get_env(__get_base(__self));
-      }
-
      public:
+      using receiver_concept = receiver_t;
+
       receiver_adaptor() = default;
       using __adaptor_base<_Base>::__adaptor_base;
 
-      using receiver_concept = receiver_t;
+      template <class... _As, class _Self = _Derived>
+        requires __callable<set_value_t, __base_t<_Self>, _As...>
+      STDEXEC_ATTRIBUTE((host, device))
+      void set_value(_As&&... __as) && noexcept {
+        return stdexec::set_value(__get_base(static_cast<_Self&&>(*this)), static_cast<_As&&>(__as)...);
+      }
+
+      template <class _Error, class _Self = _Derived>
+        requires __callable<set_error_t, __base_t<_Self>, _Error>
+      STDEXEC_ATTRIBUTE((host, device))
+      void set_error(_Error&& __err) && noexcept {
+        return stdexec::set_error(__get_base(static_cast<_Self&&>(*this)), static_cast<_Error&&>(__err));
+      }
+
+      template <class _Self = _Derived>
+        requires __callable<set_stopped_t, __base_t<_Self>>
+      STDEXEC_ATTRIBUTE((host, device))
+      void set_stopped() && noexcept {
+        return stdexec::set_stopped(__get_base(static_cast<_Self&&>(*this)));
+      }
+
+      template <class _Self = _Derived>
+      STDEXEC_ATTRIBUTE((host, device))
+      auto get_env() const noexcept -> env_of_t<__base_t<const _Self&>> {
+        return stdexec::get_env(__get_base(static_cast<const _Self&>(*this)));
+      }
     };
   } // namespace __adaptors
 

--- a/include/stdexec/__detail/__senders.hpp
+++ b/include/stdexec/__detail/__senders.hpp
@@ -148,8 +148,7 @@ namespace stdexec {
       static constexpr auto __select_impl() noexcept {
         using _Domain = __late_domain_of_t<_Sender, env_of_t<_Receiver&>>;
         constexpr bool _NothrowTfxSender =
-          __nothrow_callable<get_env_t, _Receiver&>
-          && __nothrow_callable<transform_sender_t, _Domain, _Sender, env_of_t<_Receiver&>>;
+          __nothrow_callable<transform_sender_t, _Domain, _Sender, env_of_t<_Receiver&>>;
         using _TfxSender = __tfx_sender<_Sender, _Receiver&>;
 
 #if STDEXEC_ENABLE_EXTRA_TYPE_CHECKING()

--- a/test/exec/sequence/test_any_sequence_of.cpp
+++ b/test/exec/sequence/test_any_sequence_of.cpp
@@ -31,9 +31,8 @@ namespace {
     using receiver_concept = stdexec::receiver_t;
     Receiver rcvr;
 
-    friend stdexec::env_of_t<Receiver>
-      tag_invoke(stdexec::get_env_t, const ignore_all_item_rcvr& self) noexcept {
-      return stdexec::get_env(self.rcvr);
+    auto get_env() const noexcept -> stdexec::env_of_t<Receiver> {
+      return stdexec::get_env(rcvr);
     }
 
     template <class... As>

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -32,9 +32,8 @@ namespace {
     Receiver rcvr;
     int* sum_;
 
-    friend stdexec::env_of_t<Receiver>
-      tag_invoke(stdexec::get_env_t, const sum_item_rcvr& self) noexcept {
-      return stdexec::get_env(self.rcvr);
+    auto get_env() const noexcept -> stdexec::env_of_t<Receiver> {
+      return stdexec::get_env(rcvr);
     }
 
     template <class... As>
@@ -93,8 +92,8 @@ namespace {
     void set_error(std::exception_ptr) noexcept {
     }
 
-    friend Env tag_invoke(stdexec::get_env_t, const sum_receiver& self) noexcept {
-      return self.env_;
+    Env get_env() const noexcept {
+      return env_;
     }
   };
 

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -75,8 +75,8 @@ namespace {
       value_ = set_stopped_t();
     }
 
-    friend env tag_invoke(get_env_t, const sink_receiver& r) noexcept {
-      return {static_cast<const void*>(&r)};
+    env get_env() const noexcept {
+      return {static_cast<const void*>(this)};
     }
   };
 
@@ -395,8 +395,8 @@ namespace {
       CHECK(expect_stop_);
     }
 
-    friend stopped_receiver_env<Token> tag_invoke(get_env_t, const stopped_receiver& r) noexcept {
-      return {&r};
+    stopped_receiver_env<Token> get_env() const noexcept {
+      return {this};
     }
   };
 
@@ -692,8 +692,8 @@ namespace {
         return {};
       }
 
-      friend const sender& tag_invoke(ex::get_env_t, const sender& self) noexcept {
-        return self;
+      auto get_env() const noexcept -> const sender& {
+        return *this;
       }
     };
 

--- a/test/stdexec/algos/adaptors/test_on.cpp
+++ b/test/stdexec/algos/adaptors/test_on.cpp
@@ -251,8 +251,7 @@ namespace {
         return {{}, static_cast<R&&>(r)};
       }
 
-      friend auto tag_invoke(ex::get_env_t, const my_sender&) noexcept
-        -> scheduler_env<move_checking_inline_scheduler> {
+      auto get_env() const noexcept -> scheduler_env<move_checking_inline_scheduler> {
         return {};
       }
     };

--- a/test/stdexec/algos/adaptors/test_upon_error.cpp
+++ b/test/stdexec/algos/adaptors/test_upon_error.cpp
@@ -89,10 +89,6 @@ namespace {
     friend oper<R> tag_invoke(ex::connect_t, many_error_sender, R&& r) {
       return {{}, static_cast<R&&>(r)};
     }
-
-    friend auto tag_invoke(ex::get_env_t, const many_error_sender&) noexcept -> ex::empty_env {
-      return {};
-    }
   };
 
   TEST_CASE("upon_error many input error types", "[adaptors][upon_error]") {

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -121,7 +121,7 @@ namespace {
         }
       };
 
-      friend env tag_invoke(ex::get_env_t, const sender&) noexcept {
+      env get_env() const noexcept {
         return {};
       }
     };

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -235,7 +235,7 @@ namespace {
   struct awaitable_with_get_env {
     Awaiter operator co_await();
 
-    friend awaitable_env tag_invoke(ex::get_env_t, const awaitable_with_get_env&) noexcept {
+    awaitable_env get_env() const noexcept {
       return {};
     }
   };

--- a/test/stdexec/concepts/test_concept_scheduler.cpp
+++ b/test/stdexec/concepts/test_concept_scheduler.cpp
@@ -41,7 +41,7 @@ namespace {
         ex::set_error_t(std::exception_ptr),                   //
         ex::set_stopped_t()>;
 
-      friend default_env<my_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+      default_env<my_scheduler> get_env() const noexcept {
         return {};
       }
     };
@@ -81,7 +81,7 @@ namespace {
         ex::set_error_t(std::exception_ptr),                   //
         ex::set_stopped_t()>;
 
-      friend default_env<my_scheduler_except> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+      default_env<my_scheduler_except> get_env() const noexcept {
         return {};
       }
     };
@@ -112,7 +112,7 @@ namespace {
         ex::set_error_t(std::exception_ptr),                   //
         ex::set_stopped_t()>;
 
-      friend default_env<noeq_sched> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+      default_env<noeq_sched> get_env() const noexcept {
         return {};
       }
     };
@@ -142,7 +142,7 @@ namespace {
         }
       };
 
-      friend env tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+      env get_env() const noexcept {
         return {};
       }
     };

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -74,7 +74,7 @@ namespace {
         ex::set_error_t(std::exception_ptr),                   //
         ex::set_stopped_t()>;
 
-      friend env_t tag_invoke(ex::get_env_t, const sender_t&) noexcept {
+      env_t get_env() const noexcept {
         return {};
       }
     };

--- a/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
+++ b/test/stdexec/queries/test_get_forward_progress_guarantee.cpp
@@ -83,7 +83,7 @@ namespace {
         }
       };
 
-      friend env tag_invoke(ex::get_env_t, const sender&) noexcept {
+      env get_env() const noexcept {
         return {};
       }
     };

--- a/test/test_common/retry.hpp
+++ b/test/test_common/retry.hpp
@@ -143,9 +143,8 @@ namespace {
       return {static_cast<S&&>(self.s_), static_cast<R&&>(r)};
     }
 
-    friend auto tag_invoke(stdexec::get_env_t, const _retry_sender& self) //
-      noexcept(noexcept(stdexec::get_env(self.s_))) -> std::invoke_result_t<stdexec::get_env_t, S> {
-      return stdexec::get_env(self.s_);
+    auto get_env() const noexcept -> stdexec::env_of_t<S> {
+      return stdexec::get_env(s_);
     }
   };
 

--- a/test/test_common/schedulers.hpp
+++ b/test/test_common/schedulers.hpp
@@ -117,12 +117,8 @@ namespace {
         return {self.data_, static_cast<R&&>(r)};
       }
 
-      auto make_env() const noexcept {
+      auto get_env() const noexcept -> env {
         return env{data_};
-      }
-
-      friend auto tag_invoke(ex::get_env_t, const my_sender& self) noexcept {
-        return self.make_env();
       }
     };
 
@@ -217,8 +213,7 @@ namespace {
         return {{}, static_cast<R&&>(r)};
       }
 
-      friend scheduler_env<basic_inline_scheduler>
-        tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+      auto get_env() const noexcept -> scheduler_env<basic_inline_scheduler> {
         return {};
       }
     };
@@ -325,7 +320,7 @@ namespace {
         return {{}, static_cast<R&&>(r)};
       }
 
-      friend scheduler_env<stopped_scheduler> tag_invoke(ex::get_env_t, const my_sender&) noexcept {
+      scheduler_env<stopped_scheduler> get_env() const noexcept {
         return {};
       }
     };

--- a/test/test_common/senders.hpp
+++ b/test/test_common/senders.hpp
@@ -102,8 +102,8 @@ namespace {
       return {{}, std::move(self.values_), std::forward<Receiver>(rcvr)};
     }
 
-    friend Env tag_invoke(ex::get_env_t, const just_with_env& self) noexcept {
-      return self.env_;
+    Env get_env() const noexcept {
+      return env_;
     }
   };
 


### PR DESCRIPTION
`receiver_adaptor` now requires that derived types inherit **publicly** from it, and also that they define their `set_[value|error|stopped]` and `get_env` members publicly.