### PR TITLE
start_now() allows stoppable work to be started with no allocation

### DIFF
--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -31,12 +31,9 @@ namespace exec {
     struct __impl;
     struct async_scope;
 
-    template<class _A> 
-    concept __async_scope = 
-      !std::is_copy_constructible_v<_A> && !std::is_move_constructible_v<_A> && 
-      !std::is_copy_assignable_v<_A> && !std::is_move_assignable_v<_A> && 
-      requires (_A& __a) {
-      {__a.nest(stdexec::just())} -> sender_of<stdexec::set_value_t()>;
+    template <class _A>
+    concept __async_scope = requires(_A& __a) {
+      { __a.nest(stdexec::just()) } -> sender_of<stdexec::set_value_t()>;
     };
 
     struct __task : __immovable {
@@ -811,4 +808,8 @@ namespace exec {
   } // namespace __scope
 
   using __scope::async_scope;
+
+  template <class _AsyncScope, class _Sender>
+  using nest_result_t =
+    decltype(stdexec::__declval<_AsyncScope&>().nest(stdexec::__declval<_Sender&&>()));
 } // namespace exec

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -46,10 +46,6 @@ namespace exec {
     using __env_t = make_env_t<_BaseEnv, with_t<get_stop_token_t, inplace_stop_token>>;
 
     struct __impl {
-      #if STDEXEC_NVHPC()
-      // part of a workaround for NVHPC codegen bug:
-      unsigned int const __cookie_ = 0xDEADBEEF;
-      #endif
       inplace_stop_source __stop_source_{};
       mutable std::mutex __lock_{};
       mutable std::ptrdiff_t __active_ = 0;
@@ -225,10 +221,6 @@ namespace exec {
 
         void start() & noexcept {
           STDEXEC_ASSERT(this->__scope_);
-          #if STDEXEC_NVHPC()
-          // work around for NVHPC codegen bug:
-          void(this->__scope_->__cookie_ == 0xDEADBEEF ? void() : std::terminate());
-          #endif
           std::unique_lock __guard{this->__scope_->__lock_};
           auto& __active = this->__scope_->__active_;
           ++__active;

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -46,6 +46,10 @@ namespace exec {
     using __env_t = make_env_t<_BaseEnv, with_t<get_stop_token_t, inplace_stop_token>>;
 
     struct __impl {
+      #if STDEXEC_NVHPC()
+      // part of a workaround for NVHPC codegen bug:
+      unsigned int const __cookie_ = 0xDEADBEEF;
+      #endif
       inplace_stop_source __stop_source_{};
       mutable std::mutex __lock_{};
       mutable std::ptrdiff_t __active_ = 0;
@@ -221,6 +225,10 @@ namespace exec {
 
         void start() & noexcept {
           STDEXEC_ASSERT(this->__scope_);
+          #if STDEXEC_NVHPC()
+          // work around for NVHPC codegen bug:
+          void(this->__scope_->__cookie_ == 0xDEADBEEF ? void() : std::terminate());
+          #endif
           std::unique_lock __guard{this->__scope_->__lock_};
           auto& __active = this->__scope_->__active_;
           ++__active;

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -31,6 +31,14 @@ namespace exec {
     struct __impl;
     struct async_scope;
 
+    template<class _A> 
+    concept __async_scope = 
+      !std::is_copy_constructible_v<_A> && !std::is_move_constructible_v<_A> && 
+      !std::is_copy_assignable_v<_A> && !std::is_move_assignable_v<_A> && 
+      requires (_A& __a) {
+      {__a.nest(stdexec::just())} -> sender_of<stdexec::set_value_t()>;
+    };
+
     struct __task : __immovable {
       const __impl* __scope_;
       void (*__notify_waiter)(__task*) noexcept;

--- a/include/exec/start_now.hpp
+++ b/include/exec/start_now.hpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2021-2024 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "stdexec/__detail/__execution_fwd.hpp"
+
+#include "stdexec/__detail/__concepts.hpp"
+#include "stdexec/__detail/__env.hpp"
+#include "stdexec/__detail/__receivers.hpp"
+#include "stdexec/__detail/__senders.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__type_traits.hpp"
+
+namespace exec {
+  /////////////////////////////////////////////////////////////////////////////
+  // NOT TO SPEC: __start_now
+  namespace __start_now_ {
+    namespace {
+      inline constexpr auto __ref = []<class _Ty>(_Ty& __ty) noexcept {
+        return [__ty = &__ty]() noexcept -> decltype(auto) {
+          return (*__ty);
+        };
+      };
+    } // namespace
+
+    template <class _Ty>
+    using __ref_t = decltype(__ref(__declval<_Ty&>()));
+
+    struct __joiner {
+      virtual ~__joiner() {}
+      virtual void join() const noexcept {}
+    };
+
+    template <class _StgRef>
+    struct __receiver {
+      using receiver_concept = receiver_t;
+      using __t = __receiver;
+      using __id = __receiver;
+
+      using _Storage = __decay_t<__call_result_t<_StgRef>>;
+      using _Env = typename _Storage::__env_t;
+
+      _StgRef __stgref_;
+
+      template <class... _As>
+      void set_value(_As&&... __as) noexcept {
+        auto __joiner = __stgref_().__joiner_.exchange(nullptr);
+        if (__joiner) {__joiner->join();}
+      }
+
+      template <class _Error>
+      void set_error(_Error&& __err) noexcept = delete;
+
+      void set_stopped() noexcept {
+        auto __joiner = __stgref_().__joiner_.exchange(nullptr);
+        if (__joiner) {__joiner->join();}
+      }
+
+      // Forward all receiever queries.
+      auto get_env() const noexcept -> _Env {
+        return __stgref_().__env_;
+      }
+    };
+
+    static inline const __joiner __empty_joiner_{};
+
+    template <class _StgRef, class _Receiver>
+    struct __operation : __joiner {
+      using __id = __operation;
+      using __t = __operation;
+
+      using _Storage = __decay_t<__call_result_t<_StgRef>>;
+
+      _StgRef __stgref_;
+      mutable _Receiver __rcvr_;
+
+      template<class _R>
+      __operation(_StgRef __stgref, _R&& __r) : __stgref_(__stgref), __rcvr_((_R&&)__r) {}
+
+      void join() const noexcept override {
+        set_value(std::move(__rcvr_));
+      }
+
+      template <__decays_to<__operation> _Self>
+      STDEXEC_MEMFN_DECL(
+        auto start)(this _Self& __self) noexcept //
+          -> void {
+        const __joiner* expected = &__empty_joiner_;
+        if (!__self.__stgref_().__joiner_.compare_exchange_strong(expected, &__self)) {
+          __self.join();
+        }
+      }
+    };
+
+    template <class _StgRef>
+    struct __sender {
+      using sender_concept = sender_t;
+      using __id = __sender;
+      using __t = __sender;
+
+      using _Storage = __decay_t<__call_result_t<_StgRef>>;
+
+      template <class _Env>
+      using __completions_t = completion_signatures<set_value_t(), set_stopped_t()>;
+
+      _StgRef __stgref_;
+
+      template <__decays_to<__sender> _Self, class _Receiver>
+        requires receiver_of<_Receiver, __completions_t<env_of_t<_Receiver>>>
+      STDEXEC_MEMFN_DECL(
+        auto connect)(this _Self&& __self, _Receiver __rcvr) //
+        noexcept(std::is_nothrow_move_constructible_v<_Receiver>)
+          -> __operation<_StgRef, std::remove_cvref_t<_Receiver>> {
+        return {static_cast<_Self&&>(__self).__stgref_, static_cast<_Receiver&&>(__rcvr)};
+      }
+
+      template <class _Env>
+      auto get_completion_signatures(_Env&&) -> __completions_t<_Env> {
+        return {};
+      }
+    };
+
+    template <class _SenderId, class _EnvId>
+    struct __storage {
+      using _Sender = stdexec::__t<_SenderId>;
+      using _Env = stdexec::__t<_EnvId>;
+      using __receiver_t = __receiver<__ref_t<__storage>>;
+      using __sender_t = __sender<__ref_t<const __storage>>;
+      using __env_t = __env::__join_t<_Env, __env::__with<inplace_stop_token, get_stop_token_t>>;
+
+      static_assert(sender_to<_Sender, __receiver_t>, "The sender passed to start_now does not satisfy the constraints");
+
+      mutable std::atomic<const __joiner*> __joiner_{&__empty_joiner_};
+
+      STDEXEC_ATTRIBUTE((no_unique_address))
+      inplace_stop_source source;
+      STDEXEC_ATTRIBUTE((no_unique_address))
+      __env_t __env_;
+      STDEXEC_ATTRIBUTE((no_unique_address))
+      connect_result_t<_Sender, __receiver_t> __op_state_;
+
+      __storage(_Sender&& __sndr, _Env __env)
+        : __env_(__env::__join(std::move(__env), __env::__with{source.get_token(), get_stop_token}))
+        , __op_state_(connect(static_cast<_Sender&&>(__sndr), __receiver_t{__ref(*this)})) {
+        start(__op_state_);
+      }
+
+      bool request_stop() noexcept {
+        return source.request_stop();
+      }
+
+      inplace_stop_token get_token() const noexcept {
+        return source.get_token();
+      }
+
+      auto join() const noexcept -> __sender_t {
+        return __sender_t{__ref(*this)};
+      }
+    };
+
+    struct start_now_t {
+      template <sender _Sender, class _Env = __root_env_t>
+      __storage<__id<_Sender>, __id<_Env>> operator()(_Sender&& __sndr, _Env&& __env = {}) const noexcept(false) {
+        return __storage<__id<_Sender>, __id<_Env>>{
+                  static_cast<_Sender&&>(__sndr), static_cast<_Env&&>(__env)};
+      }
+    };
+  } // namespace __start_now_
+
+  using __start_now_::start_now_t;
+  inline constexpr start_now_t start_now{};
+} // namespace exec

--- a/include/exec/start_now.hpp
+++ b/include/exec/start_now.hpp
@@ -214,21 +214,21 @@ namespace exec {
         noexcept(
           stdexec::__nothrow_move_constructible<std::unwrap_reference_t<_Env>>
           && (stdexec::__nothrow_move_constructible<_Sender> && ...)) {
-        using __env_t = stdexec::__as_root_env_t<std::unwrap_reference_t<_Env>>;
+        using __local_env_t = stdexec::__as_root_env_t<std::unwrap_reference_t<_Env>>;
         static_assert(
           !stdexec::sender<_Env>,
           "The first argument to start_now() must be either an environment or an async_scope");
         static_assert(
-          stdexec::unstoppable_token<stdexec::stop_token_of_t<__env_t>>,
+          stdexec::unstoppable_token<stdexec::stop_token_of_t<__local_env_t>>,
           "start_now() requires that the given environment does not have a stoppable token");
         static_assert(
-          (stdexec::__nofail_sender<_Sender, __env_t> && ...),
+          (stdexec::__nofail_sender<_Sender, __local_env_t> && ...),
           "start_now() requires that the given senders have no set_error(..) completions");
         using __receiver_t = stdexec::__t<__receiver<stdexec::__id<_Env>>>;
         static_assert(
           (stdexec::sender_to<_Sender, __receiver_t> && ...),
           "The senders passed to start_now do not satisfy the constraints");
-        return __storage_t<__env_t, _AsyncScope, _Sender...>{
+        return __storage_t<__local_env_t, _AsyncScope, _Sender...>{
           stdexec::__as_root_env(static_cast<std::unwrap_reference_t<_Env>&&>(__env)),
           __scope,
           static_cast<_Sender&&>(__sndr)...};

--- a/include/exec/start_now.hpp
+++ b/include/exec/start_now.hpp
@@ -48,6 +48,12 @@ namespace exec {
       void (*__op_)(void*) noexcept = nullptr;
       void* __ptr_ = nullptr;
 
+#if STDEXEC_NVHPC()
+      // workaround for NVHPC bug:
+      constexpr ~__joiner() {
+      }
+#endif
+
       void join() const noexcept {
         if (__op_) {
           __op_(__ptr_);

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -570,17 +570,18 @@ namespace stdexec {
     template <class _First, class _Second>
     using __join_t = __result_of<__join, _First, _Second>;
 
-    template <class _Env>
-    using __as_root_env_t = __join_t<__root_env, _Env>;
-
     struct __as_root_env_fn {
       template <class _Env>
-      constexpr auto operator()(_Env&& __env) const noexcept -> __as_root_env_t<_Env> {
-        return __join(__root_env{}, static_cast<_Env&&>(__env));
+      constexpr auto operator()(_Env __env) const noexcept
+        -> __join_t<__root_env, std::unwrap_reference_t<_Env>> {
+        return __join(__root_env{}, static_cast<std::unwrap_reference_t<_Env>&&>(__env));
       }
     };
 
     inline constexpr __as_root_env_fn __as_root_env{};
+
+    template <class _Env>
+    using __as_root_env_t = __result_of<__as_root_env, _Env>;
   } // namespace __env
 
   using __get_env::get_env_t;

--- a/include/stdexec/__detail/__start_detached.hpp
+++ b/include/stdexec/__detail/__start_detached.hpp
@@ -64,7 +64,7 @@ namespace stdexec {
     using __detached_receiver_t = __t<__detached_receiver<__id<__decay_t<_Env>>>>;
 
     struct start_detached_t {
-      template <sender_in<__root_env_t> _Sender>
+      template <sender_in<__root_env> _Sender>
         requires __callable<apply_sender_t, __early_domain_of_t<_Sender>, start_detached_t, _Sender>
       void operator()(_Sender&& __sndr) const {
         auto __domain = __get_early_domain(__sndr);
@@ -95,7 +95,7 @@ namespace stdexec {
           _Sender),
         tag_invoke_t(start_detached_t, _Sender)>;
 
-      template <class _Sender, class _Env = __root_env_t>
+      template <class _Sender, class _Env = __root_env>
         requires sender_to<_Sender, __detached_receiver_t<_Env>>
       void apply_sender(_Sender&& __sndr, _Env&& __env = {}) const {
         __submit(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,7 @@ set(stdexec_test_sources
     exec/async_scope/test_dtor.cpp
     exec/async_scope/test_spawn.cpp
     exec/async_scope/test_spawn_future.cpp
+    exec/async_scope/test_start_now.cpp
     exec/async_scope/test_empty.cpp
     exec/async_scope/test_stop.cpp
     exec/test_when_any.cpp

--- a/test/exec/async_scope/test_start_now.cpp
+++ b/test/exec/async_scope/test_start_now.cpp
@@ -30,7 +30,8 @@ namespace {
     async_scope scope;
 
     // This will be a blocking call
-    auto stg = start_now(scope, 
+    auto stg = start_now(
+      scope,
       ex::just() | ex::then([&]() noexcept { executedA = true; }),
       ex::just() | ex::then([&]() noexcept { executedB = true; }));
     sync_wait(stg.async_wait());
@@ -44,7 +45,9 @@ namespace {
     async_scope scope;
 
     // This will be a blocking call
-    auto stg = start_now(stdexec::__root_env_t{}, scope, 
+    auto stg = start_now(
+      stdexec::__root_env{},
+      scope,
       ex::just() | ex::then([&]() noexcept { executedA = true; }),
       ex::just() | ex::then([&]() noexcept { executedB = true; }));
     sync_wait(stg.async_wait());
@@ -59,7 +62,8 @@ namespace {
     exec::static_thread_pool pool{2};
 
     // This will be a blocking call
-    auto stg = start_now(scope, 
+    auto stg = start_now(
+      scope,
       ex::schedule(pool.get_scheduler()) | ex::then([&]() noexcept { executedA = true; }),
       ex::schedule(pool.get_scheduler()) | ex::then([&]() noexcept { executedB = true; }));
     sync_wait(ex::on(pool.get_scheduler(), stg.async_wait()));

--- a/test/exec/async_scope/test_start_now.cpp
+++ b/test/exec/async_scope/test_start_now.cpp
@@ -1,0 +1,70 @@
+#include <catch2/catch.hpp>
+#include <exec/async_scope.hpp>
+#include <exec/start_now.hpp>
+#include <exec/static_thread_pool.hpp>
+
+#include "test_common/schedulers.hpp"
+#include "test_common/receivers.hpp"
+#include "test_common/type_helpers.hpp"
+
+namespace ex = stdexec;
+using exec::async_scope;
+using exec::start_now;
+using stdexec::sync_wait;
+
+namespace {
+
+  TEST_CASE("start_now one", "[async_scope][start_now]") {
+    bool executed{false};
+    async_scope scope;
+
+    // This will be a blocking call
+    auto stg = start_now(scope, ex::just() | ex::then([&]() noexcept { executed = true; }));
+    sync_wait(stg.async_wait());
+    REQUIRE(executed);
+  }
+
+  TEST_CASE("start_now two", "[async_scope][start_now]") {
+    bool executedA{false};
+    bool executedB{false};
+    async_scope scope;
+
+    // This will be a blocking call
+    auto stg = start_now(scope, 
+      ex::just() | ex::then([&]() noexcept { executedA = true; }),
+      ex::just() | ex::then([&]() noexcept { executedB = true; }));
+    sync_wait(stg.async_wait());
+    REQUIRE(executedA);
+    REQUIRE(executedB);
+  }
+
+  TEST_CASE("start_now two __root_env", "[async_scope][start_now]") {
+    bool executedA{false};
+    bool executedB{false};
+    async_scope scope;
+
+    // This will be a blocking call
+    auto stg = start_now(stdexec::__root_env_t{}, scope, 
+      ex::just() | ex::then([&]() noexcept { executedA = true; }),
+      ex::just() | ex::then([&]() noexcept { executedB = true; }));
+    sync_wait(stg.async_wait());
+    REQUIRE(executedA);
+    REQUIRE(executedB);
+  }
+
+  TEST_CASE("start_now two on pool", "[async_scope][start_now]") {
+    bool executedA{false};
+    bool executedB{false};
+    async_scope scope;
+    exec::static_thread_pool pool{2};
+
+    // This will be a blocking call
+    auto stg = start_now(scope, 
+      ex::schedule(pool.get_scheduler()) | ex::then([&]() noexcept { executedA = true; }),
+      ex::schedule(pool.get_scheduler()) | ex::then([&]() noexcept { executedB = true; }));
+    sync_wait(ex::on(pool.get_scheduler(), stg.async_wait()));
+    REQUIRE(executedA);
+    REQUIRE(executedB);
+  }
+
+} // namespace


### PR DESCRIPTION
I think that there is an algorithm that works for the embedded use case that is also useful in many other cases. I do not think that this algorithm needs to allocate.

Here is an implementation of start_now() 

After we remove start_detached() and ensure_started() and add counting_scope - I think that this facility will be another important way to start senders.

`start_now()` returns an immovable object that contains the operation and that connects and starts the operation in its constructor.

The returned object has `request_stop()` and `get_token()` because it has an `inplace_stop_source` and it has provided that `inplace_stop_token` to the given sender through the receiver environment.  

The returned object has `join() -> sender` so that the destruction of the returned object can be ordered after the contained operation completes.