### PR TITLE
Add async-object

### DIFF
--- a/include/exec/__detail/__decl_receiver.hpp
+++ b/include/exec/__detail/__decl_receiver.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Kirk Shoop
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../../stdexec/__detail/__execution_fwd.hpp"
+#include "../../stdexec/__detail/__receivers.hpp"
+
+#include "../../stdexec/concepts.hpp"
+
+namespace exec {
+
+// fake receiver used to calculate whether inner connect is nothrow
+template<class _Env>
+struct __decl_receiver {
+  using __t = __decl_receiver;
+  using __id = __decl_receiver;
+
+  using receiver_concept = stdexec::receiver_t;
+
+  template <stdexec::same_as<stdexec::set_value_t> _Tag, class... _An>
+  friend void tag_invoke(_Tag, __t&& __rcvr, _An&&... __an) noexcept;
+
+  template <stdexec::same_as<stdexec::set_error_t> _Tag, class _Error>
+  friend void tag_invoke(_Tag, __t&& __rcvr, _Error&& __err) noexcept;
+
+  template <stdexec::same_as<stdexec::set_stopped_t> _Tag>
+  friend void tag_invoke(_Tag, __t&& __rcvr) noexcept;
+
+  template <stdexec::same_as<stdexec::get_env_t> _Tag>
+  friend _Env tag_invoke(_Tag, const __t& __rcvr) noexcept;
+};
+
+} // namespace exec

--- a/include/exec/__detail/__tuple_reverse.hpp
+++ b/include/exec/__detail/__tuple_reverse.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Kirk Shoop
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../../stdexec/concepts.hpp"
+#include "../../stdexec/__detail/__tuple.hpp"
+
+#include <type_traits>
+#include <tuple>
+#include <utility>
+
+namespace exec {
+
+template<template<class...> class R, class I, class... Tn>
+struct __apply_reverse_impl;
+
+template<template<class...> class R, std::size_t... In, class... Tn>
+struct __apply_reverse_impl<R, std::index_sequence<In...>, Tn...> {
+  using tn_t = std::tuple<Tn...>;
+  using type = R<typename std::tuple_element<sizeof...(In) - 1 - In, tn_t>::type...>;
+};
+
+template<template<class...> class R, class... Tn>
+using __apply_reverse = typename __apply_reverse_impl<R, std::make_index_sequence<sizeof...(Tn)>, Tn...>::type;
+
+struct __tuple_reverse_t {
+  template<typename T, size_t... I>
+  static auto reverse(T&& t, std::index_sequence<I...>) {
+    return std::make_tuple(std::get<sizeof...(I) - 1 - I>(std::forward<T>(t))...);
+  }
+
+  template<typename T>
+  auto operator()(T&& t) const {
+    return __tuple_reverse_t::reverse(std::forward<T>(t), std::make_index_sequence<std::tuple_size<T>::value>());
+  }
+};
+constexpr inline static __tuple_reverse_t __tuple_reverse;
+
+} // namespace exec

--- a/include/exec/async_object.hpp
+++ b/include/exec/async_object.hpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 Kirk Shoop
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/execution.hpp"
+#include "../stdexec/concepts.hpp"
+
+#include "__detail/__manual_lifetime.hpp"
+
+namespace exec {
+
+struct async_construct_t {
+  template<class _O, class _Stg, class... _An>
+  auto operator()(_O&& __o, _Stg& __stg, _An&&... __an) const 
+    noexcept(noexcept(((_O&&)__o).async_construct(__stg, ((_An&&)__an)...)))
+    -> std::enable_if_t<
+      !stdexec::same_as<decltype(((_O&&)__o).async_construct(__stg, ((_An&&)__an)...)), void>,
+      decltype(((_O&&)__o).async_construct(__stg, ((_An&&)__an)...))> {
+    return ((_O&&)__o).async_construct(__stg, ((_An&&)__an)...);
+  }
+  template<class _O, class _Stg, class... _An>
+  auto operator()(_O&& __o, _Stg& __stg, _An&&... __an) const 
+    noexcept(noexcept(((_O&&)__o).async_construct(__stg, ((_An&&)__an)...)))
+    -> std::enable_if_t<
+      stdexec::same_as<decltype(((_O&&)__o).async_construct(__stg, ((_An&&)__an)...)), void>,
+      decltype(((_O&&)__o).async_construct(__stg, ((_An&&)__an)...))> = delete;
+};
+constexpr inline static async_construct_t async_construct{};
+
+template<class _O, class... _An>
+using async_construct_result_t = stdexec::__call_result_t<async_construct_t, const std::remove_cvref_t<_O>&, typename std::remove_cvref_t<_O>::storage&, _An...>;
+
+struct async_destruct_t {
+  template<class _O, class _Stg>
+  auto operator()(_O&& __o, _Stg& __stg) const 
+    noexcept
+    -> std::enable_if_t<
+      !stdexec::same_as<decltype(((_O&&)__o).async_destruct(__stg)), void>,
+      decltype(((_O&&)__o).async_destruct(__stg))> {
+    static_assert(noexcept(((_O&&)__o).async_destruct(__stg)));
+    return ((_O&&)__o).async_destruct(__stg);
+  }
+  template<class _O, class _Stg>
+  auto operator()(_O&& __o, _Stg& __stg) const 
+    noexcept
+    -> std::enable_if_t<
+      stdexec::same_as<decltype(((_O&&)__o).async_destruct(__stg)), void>,
+      decltype(((_O&&)__o).async_destruct(__stg))> = delete;
+};
+constexpr inline static async_destruct_t async_destruct{};
+
+template<class _O>
+using async_destruct_result_t = stdexec::__call_result_t<async_destruct_t, const std::remove_cvref_t<_O>&, typename std::remove_cvref_t<_O>::storage&>;
+
+namespace __async_object {
+
+template<class _T>
+concept __immovable_object = 
+  !std::is_move_constructible_v<_T> &&
+  !std::is_copy_constructible_v<_T> &&
+  !std::is_move_assignable_v<_T> &&
+  !std::is_copy_assignable_v<_T>;
+
+template<class _T>
+concept __object = 
+  !std::is_default_constructible_v<_T> &&
+  __immovable_object<_T>;
+
+template<class _T>
+concept __storage = 
+  std::is_nothrow_default_constructible_v<_T> &&
+  __immovable_object<_T>;
+
+template<class _S>
+concept __async_destruct_result_valid = 
+  stdexec::__single_typed_sender<_S> &&
+  stdexec::sender_of<_S, stdexec::set_value_t()>;
+
+} // namespace __async_object
+
+template<class _T>
+concept async_object = 
+  requires (){
+    typename _T::object;
+    typename _T::handle;
+    typename _T::storage;
+  } &&
+  std::is_move_constructible_v<_T> &&
+  std::is_nothrow_move_constructible_v<typename _T::handle> &&
+  __async_object::__object<typename _T::object> &&
+  __async_object::__storage<typename _T::storage> &&
+  requires (const _T& __t_clv, typename _T::storage& __s_lv){
+    { async_destruct_t{}(__t_clv, __s_lv) }
+      -> stdexec::__nofail_sender;
+  } && 
+  __async_object::__async_destruct_result_valid<async_destruct_result_t<_T>>;
+
+template<class _T, class... _An>
+concept async_object_constructible_from = 
+  async_object<_T> &&
+  requires (const _T& __t_clv, typename _T::storage& __s_lv, _An... __an){
+    { async_construct_t{}(__t_clv, __s_lv, __an...) } 
+      -> stdexec::sender_of<stdexec::set_value_t(typename _T::handle)>;
+  };
+
+} // namespace exec

--- a/include/exec/async_tuple.hpp
+++ b/include/exec/async_tuple.hpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 Kirk Shoop
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "stdexec/__detail/__execution_fwd.hpp"
+
+#include "stdexec/concepts.hpp"
+#include "stdexec/functional.hpp"
+
+#include "__detail/__tuple_reverse.hpp"
+
+#include "async_object.hpp"
+
+namespace exec {
+
+//
+// implementation of async_tuple
+//
+
+template <class... _FynId>
+struct __async_tuple {
+
+  struct __t {
+    using __id = __async_tuple;
+
+    using __fyn_t = stdexec::__decayed_tuple<stdexec::__t<_FynId>...>;
+    using __hn_t = std::tuple<typename stdexec::__t<_FynId>::handle...>;
+    using __stgn_t = stdexec::__decayed_tuple<typename stdexec::__t<_FynId>::storage...>;
+
+    STDEXEC_ATTRIBUTE((no_unique_address)) __fyn_t __fyn_;
+
+    
+    explicit __t(__fyn_t __fyn) : __fyn_(std::move(__fyn)) {}
+    explicit __t(stdexec::__t<_FynId>... __fyn) : __fyn_(std::move(__fyn)...) {}
+
+    struct object : stdexec::__immovable { 
+      object() = delete;
+      __hn_t handles;
+    private:
+      friend struct __t;
+      explicit object(__hn_t hn) noexcept : handles(hn) {}
+    };
+    class handle {
+      object* source;
+      friend struct __async_tuple;
+      explicit handle(object& s) : source(&s) {}
+    public:
+      handle() = delete;
+      handle(const handle&) = default;
+      handle(handle&&) = default;
+      handle& operator=(const handle&) = default;
+      handle& operator=(handle&&) = default;
+
+      __hn_t& handles() & {return source->handles;}
+      const __hn_t& handles() const& {return source->handles;}
+    };
+struct storage : stdexec::__immovable { 
+      STDEXEC_ATTRIBUTE((no_unique_address)) std::optional<__fyn_t> __fyn_;
+      STDEXEC_ATTRIBUTE((no_unique_address)) __stgn_t __stgn_;
+      std::optional<object> o;
+    };
+
+    auto async_construct(storage& stg) noexcept {
+      stg.__fyn_.emplace(__fyn_);
+      auto mc = stdexec::__apply(
+        [&](typename stdexec::__t<_FynId>&... __fyn) noexcept {
+          return stdexec::__apply(
+            [&](typename stdexec::__t<_FynId>::storage&... __stgn) noexcept {
+              return stdexec::when_all(
+                stdexec::just(std::ref(stg)),
+                exec::async_construct(__fyn, __stgn)...
+              ); 
+            }, stg.__stgn_);
+        }, stg.__fyn_.value());
+      auto oc = stdexec::then(mc, [](storage& stg, typename stdexec::__t<_FynId>::handle... hn) noexcept {
+        auto construct = [&]() noexcept { return object{__hn_t{hn...}}; };
+        stg.o.emplace(stdexec::__conv{construct}); 
+        return handle{stg.o.value()};
+      });
+      return oc;
+    }
+    auto async_destruct(storage& stg) noexcept { 
+      auto md = stdexec::__apply(
+        [&](typename stdexec::__t<_FynId>&&... __fyn) noexcept {
+          return stdexec::__apply(
+            [&](typename stdexec::__t<_FynId>::storage&... __stgn) noexcept {
+              return stdexec::__apply(
+                [&](auto&&... __d) noexcept {
+                  return stdexec::when_all(
+                    stdexec::just(std::ref(stg)),
+                    __d...);
+                }, exec::__tuple_reverse(std::make_tuple(exec::async_destruct(__fyn, __stgn)...))); 
+            }, stg.__stgn_);
+        }, std::move(stg.__fyn_.value()));
+      auto od = stdexec::then(md, [](storage& stg) noexcept {
+        stg.o.reset();
+      });
+      return od;
+    }
+
+  };
+};
+
+template<class... _Fyn>
+using __async_tuple_t = stdexec::__t<__async_tuple<stdexec::__id<std::remove_cvref_t<_Fyn>>...>>;
+
+// make_async_tuple is an algorithm that creates an async-object that 
+// contains a tuple of the given async-objects.
+// the async_tuple object will compose the async-constructors and 
+// async-destructors of all the given async-objects
+struct make_async_tuple_t {
+  template<class... _Fyn>
+  __async_tuple_t<_Fyn...> operator()(_Fyn&&... __fyn) const {
+    using __fyn_t = typename __async_tuple_t<_Fyn...>::__fyn_t;
+    return __async_tuple_t<_Fyn...>{__fyn_t{(_Fyn&&)__fyn...}};
+  }
+};
+constexpr inline static make_async_tuple_t make_async_tuple{};
+
+} // namespace exec

--- a/include/exec/async_using.hpp
+++ b/include/exec/async_using.hpp
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) 2024 Kirk Shoop
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "stdexec/__detail/__execution_fwd.hpp"
+#include "stdexec/__detail/__transform_completion_signatures.hpp"
+
+#include "stdexec/concepts.hpp"
+#include "stdexec/functional.hpp"
+
+#include "__detail/__decl_receiver.hpp"
+#include "__detail/__tuple_reverse.hpp"
+
+#include "async_object.hpp"
+
+namespace exec {
+
+//
+// implementation of async_using
+//
+
+namespace __async_using {
+
+template <class _Sigs>
+using __variant_for_t = stdexec::__compl_sigs::__maybe_for_all_sigs<
+  _Sigs,
+  stdexec::__q<stdexec::__decayed_tuple>,
+  stdexec::__nullable_variant_t>;
+
+template <class... _Tys>
+using __omit_set_value_t = stdexec::completion_signatures<>;
+
+template <class _Sender, class _Env>
+using __non_value_completion_signatures_t = stdexec::make_completion_signatures<
+  _Sender,
+  _Env,
+  stdexec::completion_signatures<>,
+  __omit_set_value_t>;
+
+template <class _ResultId, class _ReceiverId>
+struct __destructed {
+  using _Result = stdexec::__t<_ResultId>;
+  using _Receiver = stdexec::__t<_ReceiverId>;
+
+  struct __t {
+    using __id = __destructed;
+
+    using receiver_concept = stdexec::receiver_t;
+
+    _Result* __result_;
+    _Receiver* __rcvr_;
+
+    template <stdexec::same_as<stdexec::set_value_t> _Tag>
+    friend void tag_invoke(_Tag, __t&& __rcvr) noexcept {
+      STDEXEC_ASSERT(!__rcvr.__result_->valueless_by_exception());
+      std::visit(
+        [__rcvr = __rcvr]<class _Tup>(_Tup& __tupl) noexcept -> void {
+          if constexpr (stdexec::same_as<_Tup, std::monostate>) {
+            std::terminate(); // reaching this indicates a bug
+          } else {
+            stdexec::__apply(
+              [&]<class... _Args>(auto __tag, _Args&... __args) noexcept -> void {
+                __tag(std::move(*__rcvr.__rcvr_), (_Args&&) __args...);
+              },
+              __tupl);
+          }
+        },
+        *__rcvr.__result_);
+    }
+
+    template <stdexec::same_as<stdexec::set_stopped_t> _Tag>
+    friend void tag_invoke(_Tag __d, __t&& __rcvr) noexcept {
+      STDEXEC_ASSERT(!__rcvr.__result_->valueless_by_exception());
+      std::visit(
+        [__rcvr = __rcvr]<class _Tup>(_Tup& __tupl) noexcept -> void {
+          if constexpr (stdexec::same_as<_Tup, std::monostate>) {
+            std::terminate(); // reaching this indicates a bug
+          } else {
+            stdexec::__apply(
+              [&]<class... _Args>(auto __tag, _Args&... __args) noexcept -> void {
+                __tag(std::move(*__rcvr.__rcvr_), (_Args&&) __args...);
+              },
+              __tupl);
+          }
+        },
+        *__rcvr.__result_);
+    }
+
+    friend stdexec::env_of_t<_Receiver> tag_invoke(stdexec::get_env_t, const __t& __rcvr) noexcept {
+      return stdexec::get_env(*__rcvr.__rcvr_);
+    }
+  };
+};
+
+template <class _ResultId, class _DestructStateId, class _ReceiverId>
+struct __outside {
+  using _Result = stdexec::__t<_ResultId>;
+  using _DestructState = stdexec::__t<_DestructStateId>;
+  using _Receiver = stdexec::__t<_ReceiverId>;
+
+  struct __t {
+    using __id = __outside;
+
+    using receiver_concept = stdexec::receiver_t;
+
+    _Result* __result_;
+    _DestructState* __destruct_state_; 
+    _Receiver* __rcvr_;
+
+    template <stdexec::same_as<stdexec::set_value_t> _Tag, class... _An>
+    friend void tag_invoke(_Tag, __t&& __rcvr, _An&&... __an) noexcept {
+      using __async_result = stdexec::__decayed_tuple<_Tag, _An...>;
+      __rcvr.__result_->template emplace<__async_result>(_Tag(), (_An&&)__an...);
+      stdexec::start(*__rcvr.__destruct_state_);
+    }
+
+    template <stdexec::same_as<stdexec::set_error_t> _Tag, class _Error>
+    friend void tag_invoke(_Tag, __t&& __rcvr, _Error&& __err) noexcept {
+      using __async_result = stdexec::__decayed_tuple<_Tag, _Error>;
+      __rcvr.__result_->template emplace<__async_result>(_Tag(), (_Error&&) __err);
+      stdexec::start(*__rcvr.__destruct_state_);
+    }
+
+    template <stdexec::same_as<stdexec::set_stopped_t> _Tag>
+    friend void tag_invoke(_Tag __d, __t&& __rcvr) noexcept {
+      using __async_result = stdexec::__decayed_tuple<_Tag>;
+      __rcvr.__result_->template emplace<__async_result>(_Tag());
+      stdexec::start(*__rcvr.__destruct_state_);
+    }
+
+    friend stdexec::env_of_t<_Receiver> tag_invoke(stdexec::get_env_t, const __t& __rcvr) noexcept {
+      return stdexec::get_env(*__rcvr.__rcvr_);
+    }
+  };
+};
+
+template <class _ResultId, class _InnerFnId, class _InsideStateId, class _DestructStateId, class _ReceiverId, class... _FynId>
+struct __constructed {
+  using _Result = stdexec::__t<_ResultId>;
+  using _InnerFn = stdexec::__t<_InnerFnId>;
+  using _InsideState = stdexec::__t<_InsideStateId>;
+  using _DestructState = stdexec::__t<_DestructStateId>;
+  using _Receiver = stdexec::__t<_ReceiverId>;
+
+  struct __t {
+    using __id = __constructed;
+
+    using receiver_concept = stdexec::receiver_t;
+
+    using __fyn_t = stdexec::__decayed_tuple<stdexec::__t<_FynId>...>;
+    using __stgn_t = stdexec::__decayed_tuple<typename stdexec::__t<_FynId>::storage...>;
+
+    using __inside = stdexec::__call_result_t<_InnerFn, typename stdexec::__t<_FynId>::handle...>;
+
+    using __destructed_t = stdexec::__t<__destructed<_ResultId, _ReceiverId>>;
+    using __outside_t = stdexec::__t<__outside<_ResultId, _DestructStateId, _ReceiverId>>;
+
+    __fyn_t* __fyn_;
+    __stgn_t* __stgn_;
+    _Result* __result_;
+    _InnerFn* __inner_;
+    std::optional<_InsideState>* __inside_state_; 
+    _DestructState* __destruct_state_; 
+    _Receiver* __rcvr_;
+
+    template<class _O>
+    using __destruction_n = stdexec::__call_result_t<async_destruct_t, _O&, typename _O::storage&>;
+    using __destruction = stdexec::__call_result_t<stdexec::when_all_t, __destruction_n<stdexec::__t<_FynId>>...>;
+
+    template <stdexec::same_as<stdexec::set_value_t> _Tag>
+    friend void tag_invoke(_Tag, __t&& __rcvr, typename stdexec::__t<_FynId>::handle... __o) noexcept {
+      // launch nested function
+      auto inside = [&] {
+        auto inner = (*__rcvr.__inner_)(typename stdexec::__t<_FynId>::handle{__o}...);
+        return stdexec::connect(std::move(inner), __outside_t{__rcvr.__result_, __rcvr.__destruct_state_, __rcvr.__rcvr_});
+      };
+      if constexpr (
+        stdexec::__nothrow_callable<_InnerFn, typename stdexec::__t<_FynId>::handle...> && 
+        stdexec::__nothrow_callable<stdexec::connect_t, __inside, __outside_t>) {
+        __rcvr.__inside_state_->emplace(stdexec::__conv{inside});
+      } else {
+        try {
+          __rcvr.__inside_state_->emplace(stdexec::__conv{inside});
+        } catch (...) {
+          using __async_result = stdexec::__decayed_tuple<stdexec::set_error_t, std::exception_ptr>;
+          __rcvr.__result_->template emplace<__async_result>(stdexec::set_error, std::current_exception());
+          stdexec::start(*__rcvr.__destruct_state_);
+          return;
+        }
+      }
+      stdexec::start(__rcvr.__inside_state_->value());
+    }
+
+    template <stdexec::same_as<stdexec::set_error_t> _Tag, class _Error>
+    friend void tag_invoke(_Tag, __t&& __rcvr, _Error&& __err) noexcept {
+      using __async_result = stdexec::__decayed_tuple<_Tag, _Error>;
+      __rcvr.__result_->template emplace<__async_result>(_Tag(), (_Error&&) __err);
+      stdexec::start(*__rcvr.__destruct_state_);
+    }
+
+    template <stdexec::same_as<stdexec::set_stopped_t> _Tag>
+    friend void tag_invoke(_Tag __d, __t&& __rcvr) noexcept {
+      using __async_result = stdexec::__decayed_tuple<_Tag>;
+      __rcvr.__result_->template emplace<__async_result>(_Tag());
+      stdexec::start(*__rcvr.__destruct_state_);
+    }
+
+    friend stdexec::env_of_t<_Receiver> tag_invoke(stdexec::get_env_t, const __t& __rcvr) noexcept {
+      return stdexec::get_env(*__rcvr.__rcvr_);
+    }
+  };
+};
+
+// async-using operation state. 
+// constructs all the async-objects into reserved storage
+// destructs all the async-objects in the reserved storage
+template <class _InnerFnId, class _ReceiverId, class... _FynId>
+struct __operation {
+  using _InnerFn = stdexec::__t<_InnerFnId>;
+  using _Receiver = stdexec::__t<_ReceiverId>;
+  using fyn_t = stdexec::__decayed_tuple<stdexec::__t<_FynId>...>;
+  using stgn_t = stdexec::__decayed_tuple<typename stdexec::__t<_FynId>::storage...>;
+
+  struct __t {
+    using __id = __operation;
+
+    template<class _O>
+    using __construction_n = stdexec::__call_result_t<async_construct_t, _O&, typename _O::storage&>;
+    using __construction = stdexec::__call_result_t<stdexec::when_all_t, __construction_n<stdexec::__t<_FynId>>...>;
+
+    using __inside = stdexec::__call_result_t<_InnerFn, typename stdexec::__t<_FynId>::handle...>;
+    using __result_t = __async_using::__variant_for_t<
+      stdexec::__concat_completion_signatures_t<
+        __async_using::__non_value_completion_signatures_t<__construction, stdexec::env_of_t<_Receiver>>,
+        stdexec::completion_signatures_of_t<__inside, stdexec::env_of_t<_Receiver>>,
+        // always reserve storage for exception_ptr so that the actual 
+        // completion-signatures can be calculated
+        stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>>>;
+
+    using __destructed_t = stdexec::__t<__destructed<stdexec::__id<__result_t>, _ReceiverId>>;
+    template<class _O>
+    using __destruction_n = stdexec::__call_result_t<async_destruct_t, _O&, typename _O::storage&>;
+    template<class... _Dn>
+    using __destruct_all = stdexec::__call_result_t<stdexec::when_all_t, _Dn...>;
+    using __destruction = exec::__apply_reverse<__destruct_all, __destruction_n<stdexec::__t<_FynId>>...>;
+    using __destruct_state = stdexec::connect_result_t<__destruction, __destructed_t>;
+
+    using __outside_t = stdexec::__t<__outside<stdexec::__id<__result_t>, stdexec::__id<__destruct_state>, _ReceiverId>>;
+    using __inside_state = stdexec::connect_result_t<__inside, __outside_t>;
+
+    using __constructed_t = stdexec::__t<__constructed<stdexec::__id<__result_t>, _InnerFnId, stdexec::__id<__inside_state>, stdexec::__id<__destruct_state>, _ReceiverId, _FynId...>>;
+    using __construct_state = stdexec::connect_result_t<__construction, __constructed_t>;
+
+    STDEXEC_ATTRIBUTE((no_unique_address)) _Receiver __rcvr_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) _InnerFn __inner_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) fyn_t __fyn_;
+
+    STDEXEC_ATTRIBUTE((no_unique_address)) stgn_t __stgn_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) __result_t __result_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) __construct_state __construct_state_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) __destruct_state __destruct_state_;
+    STDEXEC_ATTRIBUTE((no_unique_address)) std::optional<__inside_state> __inside_state_;
+
+    __t(_Receiver __r_, _InnerFn __i_, fyn_t __fy_) : 
+      __rcvr_(std::move(__r_)), __inner_(std::move(__i_)), 
+      __fyn_(std::move(__fy_)), __construct_state_(
+        stdexec::connect(
+          stdexec::__apply(
+            [this](auto&&... __fy_){ 
+              return stdexec::__apply(
+                [&](auto&&... __stg_){ 
+                  return stdexec::when_all(async_construct(__fy_, __stg_)...); 
+                }, __stgn_);
+            }, __fyn_), __constructed_t{&__fyn_, &__stgn_, &__result_, &__inner_, &__inside_state_, &__destruct_state_, &__rcvr_})),
+      __destruct_state_(
+        stdexec::connect(
+          stdexec::__apply(
+            [&](auto&&... __fy_){ 
+              return stdexec::__apply(
+                [&](auto&... __stg_){ 
+                  return stdexec::__apply(
+                    [&](auto&&... __d_){ 
+                      return stdexec::when_all(__d_...);
+                    }, exec::__tuple_reverse(std::make_tuple(async_destruct(__fy_, __stg_)...)));
+                }, __stgn_);
+            }, __fyn_), __destructed_t{&__result_, &__rcvr_})) {
+    }
+
+    friend void tag_invoke(stdexec::start_t, __t& __self) noexcept {
+      __self.__start_();
+    }
+
+    void __start_() noexcept;
+  };
+};
+
+template<class _InnerFnId, class... _FynId>
+struct __sender {
+  using _InnerFn = stdexec::__t<_InnerFnId>;
+
+  struct __t {
+    using __id = __sender;
+
+    using __fyn_t = stdexec::__decayed_tuple<stdexec::__t<_FynId>...>;
+
+    _InnerFn __inner_;
+    __fyn_t __fyn_;
+    explicit __t(_InnerFn __i, __fyn_t __fy_) : __inner_(std::move(__i)), __fyn_(std::move(__fy_)) {}
+
+    using sender_concept = stdexec::sender_t;
+
+    template<class _O>
+    using __construction_n = stdexec::__call_result_t<async_construct_t, _O&, typename _O::storage&>;
+    using __construction = stdexec::__call_result_t<stdexec::when_all_t, __construction_n<stdexec::__t<_FynId>>...>;
+
+    using __inside = stdexec::__call_result_t<_InnerFn, typename stdexec::__t<_FynId>::handle...>;
+
+    template <class _Receiver>
+    using __result_t = __async_using::__variant_for_t<
+      stdexec::__concat_completion_signatures_t<
+        __async_using::__non_value_completion_signatures_t<__construction, stdexec::env_of_t<_Receiver>>,
+        stdexec::completion_signatures_of_t<__inside, stdexec::env_of_t<_Receiver>>,
+        // always reserve *storage* for exception_ptr so that the actual 
+        // completion-signatures can be calculated
+        stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>>>;
+
+    template <class _Receiver>
+    using __destructed_t = stdexec::__t<__destructed<stdexec::__id<__result_t<_Receiver>>, _Receiver>>;
+    template<class _O>
+    using __destruction_n = stdexec::__call_result_t<async_destruct_t, _O&, typename _O::storage&>;
+    using __destruction = stdexec::__call_result_t<stdexec::when_all_t, __destruction_n<stdexec::__t<_FynId>>...>;
+    template <class _Receiver>
+    using __destruct_state = stdexec::connect_result_t<__destruction, __destructed_t<_Receiver>>;
+
+    template <class _Receiver>
+    using __outside_t = stdexec::__t<__outside<stdexec::__id<__result_t<_Receiver>>, stdexec::__id<__destruct_state<_Receiver>>, _Receiver>>;
+
+    template <class _Env>
+    using __fake_rcvr = stdexec::__t<exec::__decl_receiver<_Env>>;
+
+    template < stdexec::same_as<stdexec::get_completion_signatures_t> _Tag, stdexec::__decays_to<__t> _Self, class _Env>
+    STDEXEC_ATTRIBUTE((always_inline))                                  //
+    friend auto tag_invoke(_Tag, _Self&& __self, _Env&& __env) noexcept //
+      -> stdexec::__concat_completion_signatures_t<
+          // add completions of sender returned from InnerFn  
+          stdexec::completion_signatures_of_t<__inside, _Env>,
+          // add non-set_value completions of all the async-constructors  
+          __async_using::__non_value_completion_signatures_t<__construction, _Env>,
+          // add std::exception_ptr if using InnerFn can throw 
+          stdexec::__if_c<
+            stdexec::__nothrow_callable<_InnerFn, typename stdexec::__t<_FynId>::handle...> &&
+            stdexec::__nothrow_callable<stdexec::connect_t, __inside, __outside_t<__fake_rcvr<_Env>>>,
+            stdexec::completion_signatures<>,
+            stdexec::completion_signatures<stdexec::set_error_t(std::exception_ptr)>>> {
+      return {};
+    }
+
+  private:
+    template <class _Receiver>
+    using __operation = stdexec::__t<__operation<_InnerFnId, stdexec::__id<std::remove_cvref_t<_Receiver>>, _FynId...>>;
+
+    template <class _Receiver>
+    friend __operation<_Receiver> tag_invoke(
+      stdexec::connect_t,
+      const __t& __self,
+      _Receiver __rcvr) {
+      return __self.__connect_((_Receiver&&) __rcvr);
+    }
+    template <class _Receiver>
+    __operation<_Receiver> __connect_(_Receiver&& __rcvr) const {
+      return {(_Receiver&&) __rcvr, __inner_, __fyn_};
+    }
+  };
+};
+template<class _InnerFn, class... _Fyn>
+using __sender_t = stdexec::__t<__sender<stdexec::__id<std::remove_cvref_t<_InnerFn>>, stdexec::__id<std::remove_cvref_t<_Fyn>>...>>;
+
+template <class _InnerFnId, class _ReceiverId, class... _FynId>
+inline void __operation<_InnerFnId, _ReceiverId, _FynId...>::__t::__start_() noexcept {
+  stdexec::start(__construct_state_);
+}
+
+} // namespace __async_using
+
+// async_using is an algorithm that creates a set of async-objects
+// and provides handles to the constructed objects to a given async-function
+struct async_using_t {
+  template<class _InnerFn, class... _Fyn>
+  using sender_t = __async_using::__sender_t<_InnerFn, _Fyn...>;
+
+  template<class _InnerFn, class... _Fyn>
+  sender_t<_InnerFn, _Fyn...> operator()(_InnerFn&& __inner, _Fyn&&... __fyn) const {
+    using __fyn_t = typename sender_t<_InnerFn, _Fyn...>::__fyn_t;
+    return sender_t<_InnerFn, _Fyn...>{(_InnerFn&&)__inner, __fyn_t{(_Fyn&&)__fyn...}};
+  }
+};
+constexpr inline static async_using_t async_using{};
+
+} // namespace exec

--- a/include/exec/packaged_async_object.hpp
+++ b/include/exec/packaged_async_object.hpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 Kirk Shoop
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "stdexec/__detail/__execution_fwd.hpp"
+#include "stdexec/__detail/__transform_completion_signatures.hpp"
+
+#include "stdexec/concepts.hpp"
+#include "stdexec/functional.hpp"
+
+#include "async_object.hpp"
+
+namespace exec {
+
+//
+// packaged_async_object
+// A utility to allow async_using to take a pack of 
+// async-objects that have a defaulted async_constructor
+//
+template<class _O, class... _An>
+struct packaged_async_object {
+  using object = typename _O::object;
+  using handle = typename _O::handle;
+  using storage = typename _O::storage;
+  using arguments = stdexec::__decayed_tuple<_An...>;
+
+  packaged_async_object() = delete;
+  template<stdexec::__decays_to<_O> _T, class... _Tn>
+  explicit packaged_async_object(_T&& __t, _Tn&&... __tn) : 
+    __o_((_T&&)__t), 
+    __an_((_Tn&&)__tn...) {
+  }
+private:
+  _O __o_;
+  arguments __an_;
+
+public:
+
+  auto async_construct(storage& stg) noexcept(noexcept(__o_.async_construct(std::declval<storage&>(), std::declval<_An&&>()...))) { 
+    return stdexec::__apply(
+      [&]<class... _Args>(_Args&&... __args) noexcept(noexcept(__o_.async_construct(std::declval<storage&>(), (_Args&&) __args...))) {
+        return this->__o_.async_construct(stg, (_Args&&) __args...);
+      },
+      __an_);
+  }
+
+  auto async_destruct(storage& stg) noexcept { 
+    return __o_.async_destruct(stg);
+  }
+};
+
+template<class _O, class... _An>
+packaged_async_object(_O&&, _An&&...) -> packaged_async_object<std::remove_cvref_t<_O>, std::remove_cvref_t<_An>...>;
+
+struct pack_async_object_t {
+  template<typename T, typename... Tn>
+  auto operator()(T&& t, Tn&&... tn) const 
+    -> packaged_async_object<std::remove_cvref_t<T>, std::remove_cvref_t<Tn>...> {
+    return packaged_async_object{std::forward<T>(t), std::forward<Tn>(tn)...};
+  }
+};
+constexpr inline static pack_async_object_t pack_async_object;
+
+} // namespace exec

--- a/include/exec/stop_object.hpp
+++ b/include/exec/stop_object.hpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024 Kirk Shoop
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "stdexec/__detail/__execution_fwd.hpp"
+
+#include "stdexec/concepts.hpp"
+#include "stdexec/functional.hpp"
+#include "stdexec/stop_token.hpp"
+
+#include "finally.hpp"
+
+#include "async_object.hpp"
+#include "async_using.hpp"
+#include "packaged_async_object.hpp"
+
+#include <array>
+
+namespace exec {
+
+template<class _Token, class _Callback>
+struct stop_callback_object {
+  using object = typename _Token::template callback_type<_Callback>;
+  class handle {
+    friend struct stop_callback_object;
+    explicit handle() {}
+  };
+  using storage = std::optional<object>;
+
+  template<class _T, class _C>
+  auto async_construct(storage& stg, _T&& __t, _C&& __c) const noexcept {
+    auto construct = [](storage& stg, auto&& __t, auto&& __c) noexcept -> handle {
+      stg.emplace(static_cast<_T&&>(__t), static_cast<_C&&>(__c));
+      return handle{};
+    };
+    return stdexec::then(stdexec::just(std::ref(stg), static_cast<_T&&>(__t), static_cast<_C&&>(__c)), construct);
+  }
+  auto async_destruct(storage& stg) const noexcept {
+    auto destruct = [](storage& stg) noexcept {
+      stg.reset();
+    };
+    return stdexec::then(stdexec::just(std::ref(stg)), destruct);
+  }
+};
+
+struct stop_object {
+  using object = stdexec::inplace_stop_source;
+  class handle {
+    object* source;
+    friend struct stop_object;
+    explicit handle(object& s) : source(&s) {}
+  public:
+    handle() = delete;
+    handle(const handle&) = default;
+    handle(handle&&) = default;
+    handle& operator=(const handle&) = default;
+    handle& operator=(handle&&) = default;
+
+    stdexec::inplace_stop_token get_token() const noexcept {
+      return source->get_token();
+    }
+    bool stop_requested() const noexcept {
+      return source->stop_requested();
+    }
+    static constexpr bool stop_possible() noexcept {
+      return true;
+    }
+    bool request_stop() noexcept {
+      return source->request_stop();
+    }
+    // chain has two effects
+    // 1. chain applies the stop_token for this stop-source to the env of 
+    // the given sender.
+    // 2. chain retrieves the stop_token from the environment of the receiver 
+    // connected to the returned sender, and uses a stop_callback_object 
+    // to forward a stop_request from the external stop-source to this 
+    // stop-source  
+    auto chain(auto sender) noexcept {
+      auto stop_token = source->get_token();
+      auto bind = [sender, stop_token, source = this->source](auto ext_stop) noexcept {
+        auto callback = [source]() noexcept {source->request_stop();};
+        auto with_callback = [sender, stop_token](auto cb) {
+          return stdexec::__write_env(
+            std::move(sender), 
+            stdexec::__env::__with(stop_token, stdexec::get_stop_token));
+        };
+        exec::packaged_async_object cb{stop_callback_object<decltype(ext_stop), decltype(callback)>{}, ext_stop, callback};
+        return exec::async_using(with_callback, cb);
+      };
+      return stdexec::let_value(stdexec::read_env(stdexec::get_stop_token), bind);
+    }
+  };
+  using storage = std::optional<object>;
+
+  auto async_construct(storage& stg) const noexcept {
+    auto construct = [](storage& stg) noexcept -> handle {
+      stg.emplace();
+      return handle{stg.value()};
+    };
+    return stdexec::then(stdexec::just(std::ref(stg)), construct);
+  }
+  auto async_destruct(storage& stg) const noexcept {
+    auto destruct = [](storage& stg) noexcept {
+      stg.reset();
+    };
+    return stdexec::then(stdexec::just(std::ref(stg)), destruct);
+  }
+};
+
+
+} // namespace exec 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,10 @@ set(stdexec_test_sources
     exec/test_on3.cpp
     exec/test_repeat_effect_until.cpp
     exec/test_repeat_n.cpp
+    exec/async_object/test_async_tuple.cpp
+    exec/async_object/test_stop_object0.cpp
+    exec/async_object/test_stop_object1.cpp
+    exec/async_object/test_stop_object2.cpp
     exec/async_scope/test_dtor.cpp
     exec/async_scope/test_spawn.cpp
     exec/async_scope/test_spawn_future.cpp
@@ -101,6 +105,7 @@ set_target_properties(test.stdexec PROPERTIES
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF)
 target_include_directories(test.stdexec PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_compile_options(test.stdexec PRIVATE -ftime-trace)
 target_link_libraries(test.stdexec
     PUBLIC
     STDEXEC::stdexec

--- a/test/exec/async_object/test_async_tuple.cpp
+++ b/test/exec/async_object/test_async_tuple.cpp
@@ -1,0 +1,31 @@
+#include <catch2/catch.hpp>
+#include <exec/async_object.hpp>
+#include <exec/stop_object.hpp>
+#include <exec/async_using.hpp>
+#include <exec/async_tuple.hpp>
+
+#include "test_common/schedulers.hpp"
+#include "test_common/receivers.hpp"
+
+namespace ex = stdexec;
+using exec::stop_object;
+using exec::async_using;
+using stdexec::sync_wait;
+
+namespace {
+
+  TEST_CASE("async_tuple simple", "[stop_object][async_object][async_tuple]") {
+    auto with_tuple = [](auto tpl) {
+      auto [s0, s1] = tpl.handles();
+      return s0.chain(ex::just(false));
+    };
+    ex::sender auto snd = async_using(
+      with_tuple, 
+      exec::make_async_tuple(stop_object{}, stop_object{}));
+    auto r = sync_wait(std::move(snd));
+    REQUIRE(r.has_value());
+    auto [v] = r.value();
+    REQUIRE(v == false);
+  }
+
+}

--- a/test/exec/async_object/test_stop_object0.cpp
+++ b/test/exec/async_object/test_stop_object0.cpp
@@ -1,0 +1,26 @@
+#include <catch2/catch.hpp>
+#include <exec/stop_object.hpp>
+#include <exec/async_using.hpp>
+#include "test_common/schedulers.hpp"
+#include "test_common/receivers.hpp"
+
+namespace ex = stdexec;
+using exec::stop_object;
+using exec::async_using;
+using stdexec::sync_wait;
+
+namespace {
+  using handle = typename stop_object::handle;
+
+  TEST_CASE("stop_object unused", "[stop_object][async_object]") {
+    auto with_stop_object = [](handle s0) {
+      return s0.chain(ex::just(false));
+    };
+    ex::sender auto snd = async_using(with_stop_object, stop_object{});
+    auto r = sync_wait(std::move(snd));
+    REQUIRE(r.has_value());
+    auto [v] = r.value();
+    REQUIRE(v == false);
+  }
+
+}

--- a/test/exec/async_object/test_stop_object1.cpp
+++ b/test/exec/async_object/test_stop_object1.cpp
@@ -1,0 +1,28 @@
+#include <catch2/catch.hpp>
+#include <exec/stop_object.hpp>
+#include <exec/async_using.hpp>
+#include "test_common/schedulers.hpp"
+#include "test_common/receivers.hpp"
+
+namespace ex = stdexec;
+using exec::stop_object;
+using exec::async_using;
+using stdexec::sync_wait;
+
+namespace {
+  using handle = typename stop_object::handle;
+
+  TEST_CASE("chained stop_object is not stopped", "[stop_object][async_object]") {
+    auto with_stop_objects = [](handle s0, handle s1) {
+      auto with_s1_stop_token = [](auto stp) noexcept { return stp.stop_requested(); };
+      auto inside = ex::then(ex::read_env(ex::get_stop_token), with_s1_stop_token);
+      return s0.chain(s1.chain(inside));
+    };
+    ex::sender auto snd = async_using(with_stop_objects, stop_object{}, stop_object{});
+    auto r = sync_wait(std::move(snd));
+    REQUIRE(r.has_value());
+    auto [v] = r.value();
+    REQUIRE(v == false);
+  }
+
+}

--- a/test/exec/async_object/test_stop_object2.cpp
+++ b/test/exec/async_object/test_stop_object2.cpp
@@ -1,0 +1,33 @@
+#include <catch2/catch.hpp>
+#include <exec/stop_object.hpp>
+#include <exec/async_using.hpp>
+#include "test_common/schedulers.hpp"
+#include "test_common/receivers.hpp"
+
+namespace ex = stdexec;
+using exec::stop_object;
+using exec::async_using;
+using stdexec::sync_wait;
+
+namespace {
+  using handle = typename stop_object::handle;
+
+  TEST_CASE("chained stop_object is stopped", "[stop_object][async_object]") {
+    auto with_stop_objects = [](handle s0, handle s1) {
+      auto with_s1_stop_token = [s0](auto stp) mutable noexcept { 
+        REQUIRE(s0.stop_requested() == false);
+        REQUIRE(stp.stop_requested() == false);
+        s0.request_stop();
+        return stp.stop_requested(); 
+      };
+      auto inside = ex::then(ex::read_env(ex::get_stop_token), with_s1_stop_token);
+      return s0.chain(s1.chain(inside));
+    };
+    ex::sender auto snd = async_using(with_stop_objects, stop_object{}, stop_object{});
+    auto r = sync_wait(std::move(snd));
+    REQUIRE(r.has_value());
+    auto [v] = r.value();
+    REQUIRE(v == true);
+  }
+
+  } // namespace


### PR DESCRIPTION
This adds async-object as proposed in [p2849r0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2849r0.pdf).

There are a few issues with this PR

The worst issue is that `test_stop_object2.cpp` takes 4m to compile. I had to make three cpp files with one test each to get that. When one cpp had all three test cases the compiler never completed. I did add `-ftime-trace` and loaded the 97mb json produced for `test_stop_object2.cpp`. It might be the `std::visit`/`std::variant`/`std::tuple` usage that is exploding compile times, but I do not have a solution yet.

The other issue is that the build has warnings:

``sh
In file included from /Users/kirkshoop/source/stdexec/test/exec/async_object/test_stop_object1.cpp:2:
In file included from /Users/kirkshoop/source/stdexec/include/exec/stop_object.hpp:28:
In file included from /Users/kirkshoop/source/stdexec/include/exec/async_using.hpp:25:
/Users/kirkshoop/source/stdexec/include/exec/__detail/__decl_receiver.hpp:44:15: warning: function 'exec::tag_invoke<stdexec::__get_env::get_env_t>' has internal linkage but is not defined [-Wundefined-internal]
  friend _Env tag_invoke(_Tag, const __t& __rcvr) noexcept;
              ^
/Users/kirkshoop/source/stdexec/include/stdexec/__detail/__tag_invoke.hpp:104:16: note: used here
        return tag_invoke(static_cast<_Tag&&>(__tag), static_cast<_Args&&>(__args)...);
               ^
393 warnings generated.
```

I am pretty sure that these are spurious since the `__decl_receiver` type is only used to test for nothrow connect and that is why it does not implement the functions.
