### PR TITLE
empty tuple members should not take up space

### DIFF
--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -214,10 +214,10 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         using child_op_state =
           exit_operation_state_t<Sender&&, stdexec::__t<receiver_t<CvrefReceiverId, Index>>>;
 
-        using Indices = std::index_sequence_for<SenderIds...>;
+        using Indices = __indices_for<SenderIds...>;
 
         template <size_t... Is>
-        static auto connect_children_(std::index_sequence<Is...>)
+        static auto connect_children_(__indices<Is...>)
           -> std::tuple<child_op_state<stdexec::__t<SenderIds>, Is>...>;
 
         using child_op_states_tuple_t = decltype(operation_t::connect_children_(Indices{}));
@@ -301,7 +301,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
         }
 
         template <size_t... Is>
-        operation_t(WhenAll&& when_all, Receiver rcvr, std::index_sequence<Is...>)
+        operation_t(WhenAll&& when_all, Receiver rcvr, __indices<Is...>)
           : recvr_(static_cast<Receiver&&>(rcvr))
           , stream_providers_{get_context_state<Is>(when_all)...}
           , child_states_{__conv{[&when_all, this]() {

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -296,7 +296,7 @@ namespace stdexec {
         template <std::size_t... _Is, class... _Child>
         auto operator()(__indices<_Is...>, _Child&&... __child) const
           noexcept((__nothrow_connectable<_Child, __receiver_t<_Is>> && ...))
-            -> __tup::__tuple<__indices<_Is...>, connect_result_t<_Child, __receiver_t<_Is>>...> {
+            -> __tup::__tuple_for<connect_result_t<_Child, __receiver_t<_Is>>...> {
           return __tuple{connect(static_cast<_Child&&>(__child), __receiver_t<_Is>{__op_})...};
         }
       };

--- a/include/stdexec/__detail/__concepts.hpp
+++ b/include/stdexec/__detail/__concepts.hpp
@@ -140,14 +140,14 @@ namespace stdexec {
 
   // Avoid using libstdc++'s object concepts because they instantiate a
   // lot of templates.
-#if STDEXEC_HAS_BUILTIN(__is_nothrow_destructible)
+#if STDEXEC_HAS_BUILTIN(__is_nothrow_destructible) || STDEXEC_MSVC()
   template <class _Ty>
   concept destructible = __is_nothrow_destructible(_Ty);
 #else
   template <class _Ty>
   inline constexpr bool __destructible_ = //
-    requires {
-      { (static_cast < _Ty && (*) () noexcept > (nullptr))().~_Ty() } noexcept;
+    requires (_Ty && (&__fn) () noexcept) {
+      { __fn().~_Ty() } noexcept;
     };
   template <class _Ty>
   inline constexpr bool __destructible_<_Ty&> = true;
@@ -160,17 +160,14 @@ namespace stdexec {
   concept destructible = __destructible_<T>;
 #endif
 
-#if STDEXEC_HAS_BUILTIN(__is_constructible)
-  template <class _Ty, class... _As>
-  concept constructible_from = //
-    destructible<_Ty> &&       //
-    __is_constructible(_Ty, _As...);
-#else
-  template <class _Ty, class... _As>
-  concept constructible_from = //
-    destructible<_Ty> &&       //
-    std::is_constructible_v<_Ty, _As...>;
+#if !defined(STDEXEC_IS_CONSTRUCTIBLE)
+#error here
 #endif
+
+  template <class _Ty, class... _As>
+  concept constructible_from = //
+    destructible<_Ty> &&       //
+    STDEXEC_IS_CONSTRUCTIBLE(_Ty, _As...);
 
   template <class _Ty>
   concept default_initializable = //
@@ -279,15 +276,9 @@ namespace stdexec {
       { __decay_t<_Ty>{__decay_t<_Ty>{static_cast<_Ty&&>(__t)}} } noexcept;
     };
 
-#if STDEXEC_HAS_BUILTIN(__is_nothrow_constructible)
   template <class _Ty, class... _As>
   concept __nothrow_constructible_from =
-    constructible_from<_Ty, _As...> && __is_nothrow_constructible(_Ty, _As...);
-#else
-  template <class _Ty, class... _As>
-  concept __nothrow_constructible_from =
-    constructible_from<_Ty, _As...> && std::is_nothrow_constructible_v<_Ty, _As...>;
-#endif
+    constructible_from<_Ty, _As...> && STDEXEC_IS_NOTHROW_CONSTRUCTIBLE(_Ty, _As...);
 
   template <class _Ty>
   concept __nothrow_move_constructible = __nothrow_constructible_from<_Ty, _Ty>;

--- a/include/stdexec/__detail/__concepts.hpp
+++ b/include/stdexec/__detail/__concepts.hpp
@@ -160,10 +160,6 @@ namespace stdexec {
   concept destructible = __destructible_<T>;
 #endif
 
-#if !defined(STDEXEC_IS_CONSTRUCTIBLE)
-#error here
-#endif
-
   template <class _Ty, class... _As>
   concept constructible_from = //
     destructible<_Ty> &&       //

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <cassert>
+#include <type_traits>
 
 #define STDEXEC_STRINGIZE(_ARG)   #_ARG
 
@@ -304,7 +305,7 @@ namespace __coro = std::experimental;
 #if STDEXEC_HAS_BUILTIN(__is_const)
 #  define STDEXEC_IS_CONST(...) __is_const(__VA_ARGS__)
 #else
-#  define STDEXEC_IS_CONST(...) stdexec::__is_const<__VA_ARGS__>
+#  define STDEXEC_IS_CONST(...) stdexec::__is_const_<__VA_ARGS__>
 #endif
 
 #if STDEXEC_HAS_BUILTIN(__is_same)
@@ -313,10 +314,34 @@ namespace __coro = std::experimental;
 #  define STDEXEC_IS_SAME(...) __is_same_as(__VA_ARGS__)
 #elif STDEXEC_MSVC()
 // msvc replaces std::is_same_v with a compile-time constant
-#  include <type_traits>
 #  define STDEXEC_IS_SAME(...) std::is_same_v<__VA_ARGS__>
 #else
 #  define STDEXEC_IS_SAME(...) stdexec::__same_as_v<__VA_ARGS__>
+#endif
+
+#if STDEXEC_HAS_BUILTIN(__is_constructible) || STDEXEC_MSVC()
+#  define STDEXEC_IS_CONSTRUCTIBLE(...) __is_constructible(__VA_ARGS__)
+#else
+#  define STDEXEC_IS_CONSTRUCTIBLE(...) std::is_constructible_v<__VA_ARGS__>
+#endif
+
+#if STDEXEC_HAS_BUILTIN(__is_nothrow_constructible) || STDEXEC_MSVC()
+#  define STDEXEC_IS_NOTHROW_CONSTRUCTIBLE(...) __is_nothrow_constructible(__VA_ARGS__)
+#else
+#  define STDEXEC_IS_NOTHROW_CONSTRUCTIBLE(...) std::is_nothrow_constructible_v<__VA_ARGS__>
+#endif
+
+#if STDEXEC_HAS_BUILTIN(__is_trivially_constructible) || STDEXEC_MSVC()
+#  define STDEXEC_IS_TRIVIALLY_CONSTRUCTIBLE(...) __is_trivially_constructible(__VA_ARGS__)
+#else
+#  define STDEXEC_IS_TRIVIALLY_CONSTRUCTIBLE(...) std::is_trivially_constructible_v<__VA_ARGS__>
+#endif
+
+#if STDEXEC_HAS_BUILTIN(__is_empty) || STDEXEC_MSVC()
+#  define STDEXEC_IS_EMPTY(...) __is_empty(__VA_ARGS__)
+#else
+#  define STDEXEC_IS_EMPTY(...) std::is_empty_v<__VA_ARGS__>
+#endif
 
 namespace stdexec {
   template <class _Ap, class _Bp>
@@ -325,7 +350,6 @@ namespace stdexec {
   template <class _Ap>
   inline constexpr bool __same_as_v<_Ap, _Ap> = true;
 } // namespace stdexec
-#endif
 
 #if defined(__cpp_lib_unreachable) && __cpp_lib_unreachable >= 202202L
 #  define STDEXEC_UNREACHABLE() std::unreachable()

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -96,14 +96,29 @@ namespace stdexec {
   template <std::size_t... _Is>
   using __indices = __pack::__t<_Is...>*;
 
-#if STDEXEC_HAS_BUILTIN(__make_integer_seq) || STDEXEC_MSVC()
+#if STDEXEC_MSVC()
   namespace __pack {
     template <class _Ty, _Ty... _Is>
-    using __indices_t = __indices<_Is...>;
+    struct __idx;
+
+    template <class>
+    extern int __mkidx;
+
+    template <std::size_t... _Is>
+    extern __indices<_Is...> __mkidx<__idx<std::size_t, _Is...>>;
   } // namespace __pack
 
   template <std::size_t _Np>
-  using __make_indices = __make_integer_seq<__pack::__indices_t, std::size_t, _Np>;
+  using __make_indices = //
+    decltype(__pack::__mkidx<__make_integer_seq<__pack::__idx, std::size_t, _Np>>);
+#elif STDEXEC_HAS_BUILTIN(__make_integer_seq)
+  namespace __pack {
+    template <class _Ty, _Ty... _Is>
+    using __idx = __indices<_Is...>;
+  } // namespace __pack
+
+  template <std::size_t _Np>
+  using __make_indices = __make_integer_seq<__pack::__idx, std::size_t, _Np>;
 #elif STDEXEC_HAS_BUILTIN(__integer_pack)
   namespace __pack {
     template <std::size_t _Np>

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -88,11 +88,43 @@ namespace stdexec {
   template <std::size_t _Ip>
   inline constexpr std::size_t __v<char[_Ip]> = _Ip - 1;
 
+  namespace __pack {
+    template <std::size_t... _Is>
+    struct __t;
+  } // namespace __pack
+
   template <std::size_t... _Is>
-  using __indices = std::index_sequence<_Is...>*;
+  using __indices = __pack::__t<_Is...>*;
+
+#if STDEXEC_HAS_BUILTIN(__make_integer_seq) || STDEXEC_MSVC()
+  namespace __pack {
+    template <class _Ty, _Ty... _Is>
+    using __indices_t = __indices<_Is...>;
+  } // namespace __pack
 
   template <std::size_t _Np>
-  using __make_indices = std::make_index_sequence<_Np>*;
+  using __make_indices = __make_integer_seq<__pack::__indices_t, std::size_t, _Np>;
+#elif STDEXEC_HAS_BUILTIN(__integer_pack)
+  namespace __pack {
+    template <std::size_t _Np>
+    extern __indices<__integer_pack(_Np)...> __make_indices;
+  } // namespace __pack
+
+  template <std::size_t _Np>
+  using __make_indices = decltype(__pack::__make_indices<_Np>);
+#else
+  namespace __pack {
+    template <std::size_t... _Is>
+    auto __mk_indices(__indices<0, _Is...>) -> __indices<_Is...>;
+
+    template <std::size_t _Np, class = char[_Np], std::size_t... _Is>
+    auto __mk_indices(__indices<_Np, _Is...>)
+      -> decltype(__mk_indices(__indices<_Np - 1, 0, (_Is + 1)...>{}));
+  } // namespace __pack
+
+  template <std::size_t _Np>
+  using __make_indices = decltype(__pack::__mk_indices(__indices<_Np>{}));
+#endif
 
   template <class... _Ts>
   using __indices_for = __make_indices<sizeof...(_Ts)>;
@@ -814,25 +846,6 @@ namespace stdexec {
     using __f = __t<__mzip_with2_<_Fn, _Continuation, _Cp, _Dp>>;
   };
 
-#if STDEXEC_GCC() && (__GNUC__ < 12)
-  template <class>
-  extern int __mconvert_indices;
-  template <std::size_t... _Indices>
-  extern __types<__msize_t<_Indices>...> __mconvert_indices<std::index_sequence<_Indices...>>;
-  template <std::size_t _Np>
-  using __mmake_index_sequence =
-    decltype(stdexec::__mconvert_indices<std::make_index_sequence<_Np>>);
-#else
-  template <std::size_t... _Indices>
-  auto __mconvert_indices(std::index_sequence<_Indices...>*) -> __types<__msize_t<_Indices>...>;
-  template <std::size_t _Np>
-  using __mmake_index_sequence =
-    decltype(stdexec::__mconvert_indices(static_cast<std::make_index_sequence<_Np>*>(nullptr)));
-#endif
-
-  template <class... _Ts>
-  using __mindex_sequence_for = __mmake_index_sequence<sizeof...(_Ts)>;
-
   template <bool>
   struct __mfind_if_ {
     template <class _Fn, class _Continuation, class _Head, class... _Tail>
@@ -919,7 +932,7 @@ namespace stdexec {
   struct __m_at_;
 
   template <std::size_t... _Is>
-  struct __m_at_<std::index_sequence<_Is...>> {
+  struct __m_at_<__indices<_Is...>> {
     template <class _Up, class... _Us>
     static _Up __f_(__void_ptr<_Is>..., _Up*, _Us*...);
     template <class... _Ts>
@@ -927,7 +940,7 @@ namespace stdexec {
   };
 
   template <std::size_t _Np, class... _Ts>
-  using __m_at_c = __minvoke<__m_at_<std::make_index_sequence<_Np>>, _Ts...>;
+  using __m_at_c = __minvoke<__m_at_<__make_indices<_Np>>, _Ts...>;
 
   template <class _Np, class... _Ts>
   using __m_at = __m_at_c<__v<_Np>, _Ts...>;

--- a/include/stdexec/__detail/__tuple.hpp
+++ b/include/stdexec/__detail/__tuple.hpp
@@ -35,6 +35,9 @@ namespace stdexec {
     concept __empty = //
       STDEXEC_IS_EMPTY(_Ty) && STDEXEC_IS_TRIVIALLY_CONSTRUCTIBLE(_Ty);
 
+    template <__empty _Ty>
+    inline _Ty __value {};
+
     // A specialization for empty types so that they don't take up space.
     template <__empty _Ty, std::size_t _Idx>
     struct __box<_Ty, _Idx> {
@@ -43,11 +46,8 @@ namespace stdexec {
       constexpr __box(__not_decays_to<__box> auto &&) noexcept {
       }
 
-      static _Ty __value;
+      static constexpr _Ty& __value = __tup::__value<_Ty>;
     };
-
-    template <__empty _Ty, std::size_t _Idx>
-    inline _Ty __box<_Ty, _Idx>::__value{};
 
     template <auto _Idx, class... _Ts>
     struct __tuple;

--- a/include/stdexec/__detail/__tuple.hpp
+++ b/include/stdexec/__detail/__tuple.hpp
@@ -26,79 +26,113 @@ namespace stdexec {
   namespace __tup {
     template <class _Ty, std::size_t _Idx>
     struct __box {
-      STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS _Ty __value;
+      // See https://github.com/llvm/llvm-project/issues/93563
+      //STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS
+      _Ty __value;
     };
 
-    template <class _Idx, class... _Ts>
+    template <class _Ty>
+    concept __empty = //
+      STDEXEC_IS_EMPTY(_Ty) && STDEXEC_IS_TRIVIALLY_CONSTRUCTIBLE(_Ty);
+
+    // A specialization for empty types so that they don't take up space.
+    template <__empty _Ty, std::size_t _Idx>
+    struct __box<_Ty, _Idx> {
+      __box() = default;
+
+      constexpr __box(__not_decays_to<__box> auto &&) noexcept {
+      }
+
+      static _Ty __value;
+    };
+
+    template <__empty _Ty, std::size_t _Idx>
+    inline _Ty __box<_Ty, _Idx>::__value{};
+
+    template <auto _Idx, class... _Ts>
     struct __tuple;
 
-    template <std::size_t... _Idx, class... _Ts>
-    struct __tuple<__indices<_Idx...>, _Ts...> : __box<_Ts, _Idx>... { };
+    template <std::size_t... _Is, __indices<_Is...> _Idx, class... _Ts>
+    struct __tuple<_Idx, _Ts...> : __box<_Ts, _Is>... {
+
+      template <class _Fn, class _Self, class... _Us>
+      STDEXEC_ATTRIBUTE((host, device, always_inline))
+      static auto
+        apply(_Fn &&__fn, _Self &&__self, _Us &&...__us) //
+        noexcept(noexcept(static_cast<_Fn &&>(__fn)(
+          static_cast<_Us &&>(__us)...,
+          static_cast<_Self &&>(__self).__box<_Ts, _Is>::__value...)))
+          -> decltype(static_cast<_Fn &&>(__fn)(
+            static_cast<_Us &&>(__us)...,
+            static_cast<_Self &&>(__self).__box<_Ts, _Is>::__value...)) {
+        return static_cast<_Fn &&>(__fn)(
+          static_cast<_Us &&>(__us)..., static_cast<_Self &&>(__self).__box<_Ts, _Is>::__value...);
+      }
+
+      template <class _Fn, class _Self, class... _Us>
+        requires(__callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>> && ...)
+      STDEXEC_ATTRIBUTE((host, device, always_inline))
+      static auto
+        for_each(_Fn &&__fn, _Self &&__self, _Us &&...__us) //
+        noexcept((__nothrow_callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>> && ...)) -> void {
+        return (
+          static_cast<_Fn &&>(__fn)(
+            static_cast<_Us &&>(__us)..., static_cast<_Self &&>(__self).__box<_Ts, _Is>::__value),
+          ...);
+      }
+    };
 
     template <class... _Ts>
     STDEXEC_ATTRIBUTE((host, device))
-    __tuple(_Ts...) -> __tuple<__indices_for<_Ts...>, _Ts...>;
+    __tuple(_Ts...) -> __tuple<__indices_for<_Ts...>{}, _Ts...>;
 
 #if STDEXEC_GCC()
     template <class... _Ts>
     struct __mk_tuple {
-      using __t = __tuple<__indices_for<_Ts...>, _Ts...>;
+      using __t = __tuple<__indices_for<_Ts...>{}, _Ts...>;
     };
     template <class... _Ts>
     using __tuple_for = __t<__mk_tuple<_Ts...>>;
 #else
     template <class... _Ts>
-    using __tuple_for = __tuple<__indices_for<_Ts...>, _Ts...>;
+    using __tuple_for = __tuple<__indices_for<_Ts...>{}, _Ts...>;
 #endif
 
     template <std::size_t _Idx, class _Ty>
     STDEXEC_ATTRIBUTE((always_inline))
-    constexpr _Ty&&
-      __get(__box<_Ty, _Idx>&& __self) noexcept {
-      return static_cast<_Ty&&>(__self.__value);
+    constexpr _Ty &&
+      __get(__box<_Ty, _Idx> &&__self) noexcept {
+      return static_cast<_Ty &&>(__self.__value);
     }
 
     template <std::size_t _Idx, class _Ty>
     STDEXEC_ATTRIBUTE((always_inline))
-    constexpr _Ty&
-      __get(__box<_Ty, _Idx>& __self) noexcept {
+    constexpr _Ty &
+      __get(__box<_Ty, _Idx> &__self) noexcept {
       return __self.__value;
     }
 
     template <std::size_t _Idx, class _Ty>
     STDEXEC_ATTRIBUTE((always_inline))
-    constexpr const _Ty&
-      __get(const __box<_Ty, _Idx>& __self) noexcept {
+    constexpr const _Ty &
+      __get(const __box<_Ty, _Idx> &__self) noexcept {
       return __self.__value;
     }
 
-    template <std::size_t... _Idx, class... _Ts>
-    void __tuple_like_(const __tuple<__indices<_Idx...>, _Ts...>&);
+    template <auto _Idx, class... _Ts>
+    void __tuple_like_(const __tuple<_Idx, _Ts...> &);
 
     template <class _Tup>
-    concept __tuple_like = requires(_Tup& __tup) { __tup::__tuple_like_(__tup); };
-
-    struct __apply_ {
-      template <class _Fun, class _Tuple, std::size_t... _Idx, class... _Ts>
-        requires __callable<_Fun, __copy_cvref_t<_Tuple, _Ts>...>
-      constexpr auto
-        operator()(_Fun&& __fun, _Tuple&& __tup, const __tuple<__indices<_Idx...>, _Ts...>*) //
-        noexcept(__nothrow_callable<_Fun, __copy_cvref_t<_Tuple, _Ts>...>)
-          -> __call_result_t<_Fun, __copy_cvref_t<_Tuple, _Ts>...> {
-        return static_cast<_Fun&&>(__fun)(
-          static_cast<__copy_cvref_t<_Tuple, __box<_Ts, _Idx>>&&>(__tup).__value...);
-      }
-    };
+    concept __tuple_like = requires(_Tup &__tup) { __tup::__tuple_like_(__tup); };
 
     struct __apply_t {
       template <class _Fun, __tuple_like _Tuple>
       STDEXEC_ATTRIBUTE((always_inline))
       constexpr auto
-        operator()(_Fun&& __fun, _Tuple&& __tup) const //
-        noexcept(
-          noexcept(__apply_()(static_cast<_Fun&&>(__fun), static_cast<_Tuple&&>(__tup), &__tup)))
-          -> decltype(__apply_()(static_cast<_Fun&&>(__fun), static_cast<_Tuple&&>(__tup), &__tup)) {
-        return __apply_()(static_cast<_Fun&&>(__fun), static_cast<_Tuple&&>(__tup), &__tup);
+        operator()(_Fun &&__fun, _Tuple &&__tup) const //
+        noexcept(noexcept(__tup.apply(static_cast<_Fun &&>(__fun), static_cast<_Tuple &&>(__tup))))
+          -> decltype(__tup.apply(static_cast<_Fun &&>(__fun), static_cast<_Tuple &&>(__tup))) {
+        return __tup.apply(static_cast<_Fun &&>(__fun), static_cast<_Tuple &&>(__tup));
       }
     };
 
@@ -108,7 +142,7 @@ namespace stdexec {
   using __tup::__tuple;
 
   // So we can use __tuple as a typelist and ignore the first template parameter
-  template <class _Fn, class _Idx, class... _Ts>
+  template <class _Fn, auto _Idx, class... _Ts>
     requires __minvocable<_Fn, _Ts...>
   struct __uncurry_<_Fn, __tuple<_Idx, _Ts...>> {
     using __t = __minvoke<_Fn, _Ts...>;

--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -169,12 +169,10 @@ namespace stdexec {
   template <class _From, class _To>
   using __copy_cvref_t = typename __copy_cvref_fn<_From>::template __f<_To>;
 
-#if !STDEXEC_HAS_BUILTIN(__is_const)
   template <class>
-  inline constexpr bool __is_const = false;
+  inline constexpr bool __is_const_ = false;
   template <class _Up>
-  inline constexpr bool __is_const<_Up const> = true;
-#endif
+  inline constexpr bool __is_const_<_Up const> = true;
 
   namespace __tt {
     template <class _Ty>


### PR DESCRIPTION
also, stop using `std::integer_sequence` because of a nasty nvc++ bug.