### PR TITLE
replace use of `std::variant` with `stdexec::__variant` in `when_all`

### DIFF
--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -49,6 +49,7 @@ namespace stdexec {
       STDEXEC_ATTRIBUTE((host, device))
       void
         visit(_Fn &&, _Us &&...) const noexcept {
+        STDEXEC_ASSERT(false);
       }
 
       STDEXEC_ATTRIBUTE((host, device))


### PR DESCRIPTION
for approx 2% compile time win when compiling `test_when_all.cpp`.