### PR TITLE
Refactor task_context construction

### DIFF
--- a/include/stdexec/__detail/__optional.hpp
+++ b/include/stdexec/__detail/__optional.hpp
@@ -119,6 +119,16 @@ namespace stdexec {
         return static_cast<_Tp&&>(__value);
       }
 
+      _Tp* operator->() & noexcept {
+        STDEXEC_ASSERT(__has_value);
+        return &__value;
+      }
+
+      const _Tp* operator->() const & noexcept {
+        STDEXEC_ASSERT(__has_value);
+        return &__value;
+      }
+
       bool has_value() const noexcept {
         return __has_value;
       }

--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -79,15 +79,11 @@ namespace stdexec {
         if (__variant_npos != __index) {
 #if STDEXEC_NVHPC()
           // Unknown nvc++ name lookup bug
-          ((_Is == __index ? reinterpret_cast<const __at<_Is> *>(__storage_)->_Ts::~_Ts()
-                           : void(0)),
-           ...);
+          ((_Is == __index ? static_cast<_Ts *>(__get_ptr())->_Ts::~_Ts() : void(0)), ...);
 #else
           // casting the destructor expression to void is necessary for MSVC in
           // /permissive- mode.
-          ((_Is == __index ? void(reinterpret_cast<const __at<_Is> *>(__storage_)->~_Ts())
-                           : void(0)),
-           ...);
+          ((_Is == __index ? void(static_cast<_Ts *>(__get_ptr())->~_Ts()) : void(0)), ...);
 #endif
         }
       }

--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -83,7 +83,7 @@ namespace stdexec {
 #else
           // casting the destructor expression to void is necessary for MSVC in
           // /permissive- mode.
-          ((_Is == __index ? void(static_cast<_Ts *>(__get_ptr())->~_Ts()) : void(0)), ...);
+          ((_Is == __index ? void((*static_cast<_Ts *>(__get_ptr())).~_Ts()) : void(0)), ...);
 #endif
         }
       }

--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -53,7 +53,7 @@ namespace stdexec {
       }
 
       STDEXEC_ATTRIBUTE((host, device))
-      static constexpr bool
+      static constexpr std::size_t
         index() noexcept {
         return __variant_npos;
       }


### PR DESCRIPTION
* Delay construction of the task context until await.
* Add `__parent_promise_t` to disambiguate the context constructor.

This makes it easier to define task contexts which require querying the environment.