### PR TITLE
Update Conan support to Conan 2.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,35 +1,51 @@
-from conans import ConanFile, CMake, tools
-import requests
-import re
-from os import path
+from conan import ConanFile
+from conan.tools.build.cppstd import check_min_cppstd
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.files import copy
+from conan.tools.scm import Git
 
+class StdexecPackage(ConanFile):
+  name = "p2300"
+  description = "std::execution"
+  author = "Michał Dominiak, Lewis Baker, Lee Howes, Kirk Shoop, Michael Garland, Eric Niebler, Bryce Adelstein Lelbach"
+  topics = ("WG21", "concurrency")
+  homepage = "https://github.com/NVIDIA/stdexec"
+  url = "https://github.com/NVIDIA/stdexec"
+  license = "Apache 2.0"
 
-class P2300Recipe(ConanFile):
-    name = "P2300"
-    description = "std::execution"
-    author = "Michał Dominiak, Lewis Baker, Lee Howes, Kirk Shoop, Michael Garland, Eric Niebler, Bryce Adelstein Lelbach"
-    topics = ("WG21", "concurrency")
-    homepage = "https://github.com/NVIDIA/stdexec"
-    url = "https://github.com/NVIDIA/stdexec"
-    license = "Apache 2.0"
-    settings = "compiler"  # Header only - compiler only used for flags
-    tool_requires = "catch2/2.13.6"
-    exports_sources = "include/*"
-    generators = "cmake_find_package"
+  settings = "os", "arch", "compiler", "build_type"
+  exports_sources = "include/*"
+  generators = "CMakeToolchain"
 
-    def validate(self):
-        tools.check_min_cppstd(self,"20")
+  def validate(self):
+    check_min_cppstd(self, "20")
 
-    def set_version(self):
-        # Get the version from the spec file
-        response = requests.get("https://raw.githubusercontent.com/brycelelbach/wg21_p2300_execution/main/execution.bs")
-        rev = re.search(r"Revision: (\d+)", response.text).group(1).strip()
-        self.version = f"0.{rev}.0"
+  def set_version(self):
+    if not self.version:
+      git = Git(self, self.recipe_folder)
+      self.version = git.get_commit()
 
-    def package(self):
-        self.copy("*.hpp")
+  def layout(self):
+    cmake_layout(self)
 
-    def package_info(self):
-        # Make sure to add the correct flags for gcc
-        if self.settings.compiler == "gcc":
-            self.cpp_info.cxxflags = ["-fcoroutines", "-Wno-non-template-friend"]
+  def build(self):
+    if not self.conf.get("tools.build:skip_test", default=False):
+      cmake = CMake(self)
+      cmake.configure()
+      cmake.build()
+      cmake.test()
+
+  def package_id(self):
+    # Clear settings because this package is header-only.
+    self.info.clear()
+
+  def package(self):
+    copy(self, "*.hpp", self.source_folder, self.package_folder)
+
+  def package_info(self):
+    self.cpp_info.set_property("cmake_file_name", "P2300")
+    self.cpp_info.set_property("cmake_target_name", "P2300::P2300")
+
+    # Clear bin and lib dirs because this package is header-only.
+    self.cpp_info.bindirs = []
+    self.cpp_info.libdirs = []

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required( VERSION 3.17 )
-project(PackageTest CXX)
+cmake_minimum_required(VERSION 3.17)
+project(PackageTest)
+enable_testing()
 
-find_package(Threads REQUIRED)
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+find_package(P2300 REQUIRED)
 
 add_executable(test_stdexec test.cpp)
-target_link_libraries(test_stdexec ${CONAN_LIBS} Threads::Threads)
+target_link_libraries(test_stdexec P2300::P2300)
+add_test(test_stdexec test_stdexec)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,17 +1,22 @@
-import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
 
-from conans import ConanFile, CMake, tools
+class StdexecTestPackage(ConanFile):
+  settings = "os", "arch", "compiler", "build_type"
+  generators = "CMakeDeps", "CMakeToolchain"
 
-class P2300TestConan(ConanFile):
-    settings = "compiler"
-    generators = "cmake"
+  def requirements(self):
+    self.requires(self.tested_reference_str)
 
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure()
-        cmake.build()
+  def build(self):
+    cmake = CMake(self)
+    cmake.configure()
+    cmake.build()
 
-    def test(self):
-        if not tools.cross_building(self):
-            os.chdir("bin")
-            self.run(".{}test_p2300".format(os.sep))
+  def layout(self):
+    cmake_layout(self)
+
+  def test(self):
+    if can_run(self):
+      CMake(self).test()

--- a/test_package/test.cpp
+++ b/test_package/test.cpp
@@ -1,9 +1,9 @@
 #include <stdexec/execution.hpp>
 
-int main()
-{
-	auto x = stdexec::just(42);
+#include <cstdlib>
 
-	auto [a] = stdexec::sync_wait(std::move(x)).value();
-	return (a==42)?0:-1;
+int main() {
+  auto x = stdexec::just(42);
+  auto [a] = stdexec::sync_wait(std::move(x)).value();
+  return a == 42 ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
* Rename the package to `p2300` according to [Conan recommendations](https://docs.conan.io/1/migrating_to_2.0/general.html#lowercase-references).
* Change the package versioning to use git revision by default.
  Can be overridden using `conan create ./stdexec --version x.y.z`.
* Execute unit tests during package creation, unless opted out.
  Opt out using `conan create ./stdexec -c tools.build:skip_test=True`.
* Specify the CMake file name as `P2300` (`find_package(P2300)`).
* Specify the CMake target name as `P2300::P2300`.

The existing Conan support is fairly antiquated, but it exists so someone must be (or must have been) using it.
Thus I'm tagging anyone who touched the existing Conan support: @lucteo @paulbendixen @trxcllnt @ericniebler