### PR TITLE
Fix system_context linking with Conan package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,7 @@ endif()
 
 include(CPack)
 
-install(TARGETS stdexec
+install(TARGETS stdexec system_context
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         EXPORT stdexec-exports)
 

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -34,12 +34,12 @@
 // TODO: make these configurable by providing policy to the system context
 
 /// Gets the default system context implementation.
-extern "C" STDEXEC_ATTRIBUTE((weak))
+extern "C"
 __exec_system_context_interface*
   __get_exec_system_context_impl();
 
 /// Sets the default system context implementation.
-extern "C" STDEXEC_ATTRIBUTE((weak))
+extern "C"
   void
   __set_exec_system_context_impl(__exec_system_context_interface* __instance);
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -13,6 +13,7 @@ class StdexecTestPackage(ConanFile):
     cmake = CMake(self)
     cmake.configure()
     cmake.build()
+    cmake.test()
 
   def layout(self):
     cmake_layout(self)

--- a/test_package/test.cpp
+++ b/test_package/test.cpp
@@ -1,9 +1,12 @@
+#include <exec/system_context.hpp>
 #include <stdexec/execution.hpp>
 
 #include <cstdlib>
 
 int main() {
-  auto x = stdexec::just(42);
+  auto x = stdexec::on(
+    exec::system_context().get_scheduler(),
+    stdexec::just(42));
   auto [a] = stdexec::sync_wait(std::move(x)).value();
   return a == 42 ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
* The Conan package now includes the system context.
* The Conan test package now uses the system context.

The Conan package is created using CMake install. This requires the `system_context` library install to be configured. I added it where the `stdexec` library install is configured, but I'm not sure if that's where it should be.

When testing on WSL Ubuntu 22.04 with Clang 18, my `test_package` executable (see [here](https://github.com/vasama/stdexec/blob/450a55358a9aedf2e43edff982e73b529698780e/test_package/test.cpp)) would segfault when calling `__get_exec_system_context_impl`. Removing the `STDEXEC_ATTRIBUTE((weak))` from the declaration [here](https://github.com/NVIDIA/stdexec/commit/450a55358a9aedf2e43edff982e73b529698780e#diff-125f4090fb987bfec99abcee661b93ad7e229f8a3108bab6954f65f268079ba2) solved the issue. I'm not sure why.