### PR TITLE
Fix thread safety bug in split sender notify

### DIFF
--- a/include/stdexec/__detail/__shared.hpp
+++ b/include/stdexec/__detail/__shared.hpp
@@ -329,7 +329,14 @@ namespace stdexec {
         }
 
         STDEXEC_ASSERT(__waiters_copy.front() != __get_tombstone());
-        for (__local_state_base* __item: __waiters_copy) {
+        for (auto __itr = __waiters_copy.begin(); __itr != __waiters_copy.end(); ) {
+          __local_state_base* __item = *__itr;
+
+          // We must increment the iterator before calling notify, since notify
+          // may end up triggering *__item to be destructed on another thread,
+          // and the intrusive slist's iterator increment relies on __item.
+          ++__itr;
+
           __item->__notify_(__item);
         }
 


### PR DESCRIPTION
Notifying the `local_state` might cause it to be destructed, whiich means the instrusive list's increment might be accessing uninitialized memory.

Fixes #1354

Test plan: I was able to fairly reliably reproduce the TSAN and MSAN diagnostics by defining `local_state_base`'s destructor to set `__next_=nullptr` and adding a `sleep(25ms)` as the first line in `__notify_waiters`. With the fix, I could run the TSAN and MSAN executables for a few minutes and never saw any errors.