### PR TITLE
fix Static Initialization Order Fiasco causing flakiness in `static_thread_pool` shutdown

### DIFF
--- a/examples/benchmark/static_thread_pool.cpp
+++ b/examples/benchmark/static_thread_pool.cpp
@@ -32,7 +32,7 @@ struct RunThread {
     numa->bind_to_node(numa_node);
     exec::nodemask mask{};
     mask.set(static_cast<std::size_t>(numa_node));
-    auto scheduler = pool.get_constrained_scheduler(mask);
+    auto scheduler = pool.get_constrained_scheduler(&mask);
     std::mutex mut;
     std::condition_variable cv;
     while (true) {

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -215,8 +215,8 @@ namespace exec {
     struct __default_awaiter_context<_ParentPromise> {
       template <__scheduler_affinity _Affinity>
       explicit __default_awaiter_context(
-        __default_task_context_impl<_Affinity>& __self,
-        _ParentPromise& __parent) noexcept {
+        __default_task_context_impl<_Affinity>&,
+        _ParentPromise&) noexcept {
       }
     };
 
@@ -453,11 +453,11 @@ namespace exec {
       // Make this task awaitable within a particular context:
       template <class _ParentPromise>
         requires constructible_from<
-          awaiter_context_t<__promise, _ParentPromise>,
-          __promise_context_t&,
-          _ParentPromise&>
+                   awaiter_context_t<__promise, _ParentPromise>,
+                   __promise_context_t&,
+                   _ParentPromise&>
       STDEXEC_MEMFN_DECL(
-        auto as_awaitable)(this basic_task&& __self, _ParentPromise& p) noexcept
+        auto as_awaitable)(this basic_task&& __self, _ParentPromise&) noexcept
         -> __task_awaitable<_ParentPromise> {
         return __task_awaitable<_ParentPromise>{std::exchange(__self.__coro_, {})};
       }

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -19,8 +19,9 @@
 #include "__concepts.hpp"
 #include "__type_traits.hpp"
 
-#include <type_traits>
 #include <initializer_list>
+#include <memory> // for addressof
+#include <type_traits>
 
 namespace stdexec {
   constexpr std::size_t __npos = ~0UL;
@@ -139,6 +140,29 @@ namespace stdexec {
 
   template <class _Ty>
   _Ty __decay_copy(_Ty) noexcept;
+
+  template <class _Ty>
+  struct __indestructible {
+    template <class... _Us>
+    __indestructible(_Us&&... __us) noexcept(__nothrow_constructible_from<_Ty, _Us...>) {
+      ::new (static_cast<void*>(std::addressof(__value))) _Ty(static_cast<_Us&&>(__us)...);
+    }
+
+    ~__indestructible() {
+    }
+
+    _Ty& get() noexcept {
+      return __value;
+    }
+
+    const _Ty& get() const noexcept {
+      return __value;
+    }
+
+    union {
+      _Ty __value;
+    };
+  };
 } // namespace stdexec
 
 #if defined(__cpp_auto_cast) && (__cpp_auto_cast >= 202110UL)

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -24,7 +24,6 @@
 
 #include <catch2/catch.hpp>
 
-
 using namespace stdexec;
 using namespace exec;
 


### PR DESCRIPTION
this intentionally leaks one memory block at shutdown. clang's and gcc's leak sanitizers do not flag it.