### PR TITLE
Add missing includes

### DIFF
--- a/include/stdexec/__detail/__bulk.hpp
+++ b/include/stdexec/__detail/__bulk.hpp
@@ -26,6 +26,7 @@
 #include "__sender_adaptor_closure.hpp"
 #include "__transform_completion_signatures.hpp"
 #include "__transform_sender.hpp"
+#include "__senders.hpp"
 
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")

--- a/include/stdexec/__detail/__then.hpp
+++ b/include/stdexec/__detail/__then.hpp
@@ -25,6 +25,7 @@
 #include "__sender_adaptor_closure.hpp"
 #include "__transform_completion_signatures.hpp"
 #include "__transform_sender.hpp"
+#include "__senders.hpp"
 
 // include these after __execution_fwd.hpp
 namespace stdexec {

--- a/include/stdexec/__detail/__upon_error.hpp
+++ b/include/stdexec/__detail/__upon_error.hpp
@@ -25,6 +25,7 @@
 #include "__sender_adaptor_closure.hpp"
 #include "__transform_completion_signatures.hpp"
 #include "__transform_sender.hpp"
+#include "__senders.hpp"
 
 // include these after __execution_fwd.hpp
 namespace stdexec {

--- a/include/stdexec/__detail/__upon_stopped.hpp
+++ b/include/stdexec/__detail/__upon_stopped.hpp
@@ -25,6 +25,7 @@
 #include "__sender_adaptor_closure.hpp"
 #include "__transform_completion_signatures.hpp"
 #include "__transform_sender.hpp"
+#include "__senders.hpp"
 
 // include these after __execution_fwd.hpp
 namespace stdexec {


### PR DESCRIPTION
These files can use an #include "__senders.hpp"

Otherwise __well_formed_sender declaration is missing.
