### PR TITLE
change the system context to be replaceable at runtime

### DIFF
--- a/include/exec/__detail/__system_context_default_impl_entry.hpp
+++ b/include/exec/__detail/__system_context_default_impl_entry.hpp
@@ -37,27 +37,6 @@ namespace exec {
       __new_system_context_handler{[]() -> system_context_interface* {
         return new __detail::__system_context_impl{};
       }};
-
-    // The job of this object is to hold a reference to whatever object
-    // is the current system context from the time the first system
-    // context object is created until after main exits.
-    struct __system_context_keep_alive {
-      __system_context_keep_alive() {
-        (void) get_system_context_instance();
-      }
-
-      ~__system_context_keep_alive() {
-        release_system_context_instance(__system_context_instance.load());
-      }
-    };
-
-    struct __system_context_base {
-      __system_context_base() {
-        // This static will create the system context, and decrement its
-        // ref count after main exits.
-        static __system_context_keep_alive __s_keep_alive;
-      }
-    };
   } // namespace __detail
 
   /// Gets the default system context implementation.

--- a/include/exec/__detail/__system_context_default_impl_entry.hpp
+++ b/include/exec/__detail/__system_context_default_impl_entry.hpp
@@ -23,23 +23,111 @@
 
 #include "__system_context_default_impl.hpp"
 
-STDEXEC_PRAGMA_PUSH()
-STDEXEC_PRAGMA_IGNORE_GNU("-Wattributes") // warning: inline function '[...]' declared weak
+#include <atomic>
+#include <thread>
 
-/// Gets the default system context implementation.
-extern "C" STDEXEC_SYSTEM_CONTEXT_INLINE STDEXEC_ATTRIBUTE((weak))
-__exec_system_context_interface*
-  __get_exec_system_context_impl() {
-  return exec::__system_context_default_impl::__instance_holder::__singleton()
-    .__get_current_instance();
-}
+namespace exec {
+  namespace __detail {
+    STDEXEC_SYSTEM_CONTEXT_INLINE constinit __spin_lock __system_context_mutex{};
 
-/// Sets the default system context implementation.
-extern "C" STDEXEC_SYSTEM_CONTEXT_INLINE STDEXEC_ATTRIBUTE((weak))
-  void
-  __set_exec_system_context_impl(__exec_system_context_interface* __instance) {
-  return exec::__system_context_default_impl::__instance_holder::__singleton()
-    .__set_current_instance(__instance);
-}
+    STDEXEC_SYSTEM_CONTEXT_INLINE constinit std::atomic<system_context_interface*>
+      __system_context_instance{nullptr};
 
-STDEXEC_PRAGMA_POP()
+    STDEXEC_SYSTEM_CONTEXT_INLINE constinit std::atomic<new_system_context_handler>
+      __new_system_context_handler{[]() -> system_context_interface* {
+        return new __detail::__system_context_impl{};
+      }};
+
+    // The job of this object is to hold a reference to whatever object
+    // is the current system context from the time the first system
+    // context object is created until after main exits.
+    struct __system_context_keep_alive {
+      __system_context_keep_alive() {
+        (void) get_system_context_instance();
+      }
+
+      ~__system_context_keep_alive() {
+        release_system_context_instance(__system_context_instance.load());
+      }
+    };
+
+    struct __system_context_base {
+      __system_context_base() {
+        // This static will create the system context, and decrement its
+        // ref count after main exits.
+        static __system_context_keep_alive __s_keep_alive;
+      }
+    };
+  } // namespace __detail
+
+  /// Gets the default system context implementation.
+  extern "C" STDEXEC_SYSTEM_CONTEXT_INLINE system_context_interface* get_system_context_instance() {
+    // spin until we get the lock:
+    __detail::__system_context_mutex.__lock();
+    // load the instance
+    auto* __instance = __detail::__system_context_instance.load();
+    // if it is not null, increment the reference count and return the ptr
+    if (__instance != nullptr) {
+      ++__instance->ref_count;
+      __detail::__system_context_mutex.__unlock();
+      return __instance;
+    }
+    __detail::__system_context_mutex.__unlock();
+
+    // create a new instance:
+    auto* __new_instance = __detail::__new_system_context_handler.load()();
+
+    // spin until we get the lock:
+    __detail::__system_context_mutex.__lock();
+
+    // try to set the new instance. if this fails, we have been usurped.
+    // increment the ref count on the usurper, destroy the instance we
+    // just created, and return the usurper.
+    if (!__detail::__system_context_instance.compare_exchange_strong(__instance, __new_instance)) {
+      ++__instance->ref_count;
+      __detail::__system_context_mutex.__unlock();
+      __new_instance->destroy_fn(__new_instance);
+      return __instance;
+    }
+
+    __detail::__system_context_mutex.__unlock();
+    return __new_instance;
+  }
+
+  /// Releases a reference to the specified system context object.
+  /// If the ref count drops to zero, then
+  ///   - if the specified object is the active global object, set
+  ///     the active global object to null.
+  ///   - destroy the instance
+  extern "C" STDEXEC_SYSTEM_CONTEXT_INLINE void
+    release_system_context_instance(system_context_interface* __instance) noexcept {
+    // spin until we get the lock:
+    __detail::__system_context_mutex.__lock();
+    if (0 != --__instance->ref_count) {
+      __detail::__system_context_mutex.__unlock();
+      return;
+    }
+
+    // if we have just released the last reference on the global system
+    // context, set the global pointer to null:
+    auto* __instance_copy = __instance;
+    (void) __detail::__system_context_instance.compare_exchange_strong(__instance_copy, nullptr);
+
+    __detail::__system_context_mutex.__unlock();
+    __instance->destroy_fn(__instance);
+  }
+
+  /// Sets the default system context implementation.
+  extern "C" STDEXEC_SYSTEM_CONTEXT_INLINE new_system_context_handler
+    set_new_system_context_handler(new_system_context_handler __handler) {
+    auto __old_handler = __detail::__new_system_context_handler.exchange(__handler);
+    auto* __new_instance = __handler();
+
+    auto* __instance = __detail::__system_context_instance.exchange(__new_instance);
+
+    if (__instance != nullptr) {
+      release_system_context_instance(__instance);
+    }
+    return __old_handler;
+  }
+} // namespace exec

--- a/src/system_context/system_context.cpp
+++ b/src/system_context/system_context.cpp
@@ -15,4 +15,5 @@
  */
 
 #define STDEXEC_SYSTEM_CONTEXT_INLINE /*no inline*/
+#include <exec/system_context.hpp>
 #include <exec/__detail/__system_context_default_impl_entry.hpp>


### PR DESCRIPTION
also, fix static initialization order fiasco issues wrt the system context at shutdown.

this design for the system context has a few nice properties:

* lazily constructed at first use
* accessible by default-constructing a `system_context` object, which grabs a ref-count to the current global system context in its ctor and releases it in its dtor.
* is usable at _all_ points during the execution of the program, even before/after `main`, with no Static Initialization Order Fiasco.
* is replaceable at runtime as many times as you like.
* replacing the global system context does not affect any existing `system_context` objects.
* shuts down cleanly with no leaks

this commit changes the ABI of the system context interfaces, so it bumps the version number. it also reserves space in the `system_context_interface` and `system_scheduler_interface` for additional "virtual" functions.

adds two helper types: `system_context_base` and `system_scheduler_base`, which automate the population of the `system_context_interface` and `system_scheduler_interface` "vtables", respectively.

it also adds `static_system_context_instance` to make it simple to safely put a custom system context into static storage.
