### PR TITLE
Make `__manual_lifetime` and `__indestructible` `constinit` constructible

### DIFF
--- a/include/stdexec/__detail/__operation_states.hpp
+++ b/include/stdexec/__detail/__operation_states.hpp
@@ -24,6 +24,9 @@
 #include <type_traits>
 
 namespace stdexec {
+  // operation state tag type
+  struct operation_state_t { };
+
   /////////////////////////////////////////////////////////////////////////////
   // [execution.op_state]
   namespace __start {

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -144,11 +144,11 @@ namespace stdexec {
   template <class _Ty>
   struct __indestructible {
     template <class... _Us>
-    __indestructible(_Us&&... __us) noexcept(__nothrow_constructible_from<_Ty, _Us...>) {
-      ::new (static_cast<void*>(std::addressof(__value))) _Ty(static_cast<_Us&&>(__us)...);
+    constexpr __indestructible(_Us&&... __us) noexcept(__nothrow_constructible_from<_Ty, _Us...>)
+      : __value(static_cast<_Us&&>(__us)...) {
     }
 
-    ~__indestructible() {
+    constexpr ~__indestructible() {
     }
 
     _Ty& get() noexcept {


### PR DESCRIPTION
also, add the standard `operation_state_t` tag type.