### PR TITLE
Prevent CMake from attempting to configure test executables without Catch2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,13 +79,24 @@ rapids_cmake_build_type(Release)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 # Don't build tests if configuring stdexec as a submodule of another
-# CMake project, unless they explicitly set STDEXEC_BUILD_TESTS=TRUE
-if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+# CMake project, unless they explicitly set STDEXEC_BUILD_TESTS=TRUE,
+# or they enabled CTest's BUILD_TESTING option
+if ((CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME) OR BUILD_TESTING)
     set(STDEXEC_BUILD_TESTS_DEFAULT ON)
 else()
     set(STDEXEC_BUILD_TESTS_DEFAULT OFF)
 endif()
 option(STDEXEC_BUILD_TESTS "Build stdexec tests" ${STDEXEC_BUILD_TESTS_DEFAULT})
+
+# STDEXEC_BUILD_TESTS is used solely to configure CTest's BUILD_TESTING option,
+# which is CMake's preferred option for enabling testing when using CTest.
+set(BUILD_TESTING ${STDEXEC_BUILD_TESTS})
+
+if (BUILD_TESTING)
+  # CTest automatically calls enable_testing() if BUILD_TESTING is ON
+  # https://cmake.org/cmake/help/latest/module/CTest.html#module:CTest
+  include(CTest)
+endif()
 
 ##############################################################################
 # - Dependencies -------------------------------------------------------------
@@ -93,7 +104,7 @@ option(STDEXEC_BUILD_TESTS "Build stdexec tests" ${STDEXEC_BUILD_TESTS_DEFAULT})
 # Initialize CPM
 rapids_cpm_init(OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/versions.json)
 
-if (STDEXEC_BUILD_TESTS)
+if (BUILD_TESTING)
     # Add Catch2
     set(Catch2_VERSION 2.13.6)
     # Always download it, don't attempt to do `find_package(Catch2)` first
@@ -388,14 +399,6 @@ option(STDEXEC_ENABLE_IO_URING_TESTS "Enable io_uring tests" ${STDEXEC_FOUND_IO_
 
 option(STDEXEC_BUILD_DOCS "Build stdexec documentation" OFF)
 option(STDEXEC_BUILD_EXAMPLES "Build stdexec examples" ON)
-
-if (STDEXEC_BUILD_TESTS)
-  set(BUILD_TESTING ON)
-
-  # CTest automatically calls enable_testing() if BUILD_TESTING is ON
-  # https://cmake.org/cmake/help/latest/module/CTest.html#module:CTest
-  include(CTest)
-endif()
 
 # Configure documentation
 if(STDEXEC_BUILD_DOCS)


### PR DESCRIPTION
Previously, the CMake would check whether STDEXEC_BUILD_TESTS was set when determining whether CPM should add Catch2, but it would then check BUILD_TESTING when determining whether to add the CMake for the test subdirectory. If STDEXEC_BUILD_TESTS was enabled, this would work, because the CMake would enable BUILD_TESTING whenever STDEXEC_BUILD_TESTS was enabled. However, if BUILD_TESTING was enabled but STDEXEC_BUILD_TESTS was disabled, then the CMake would attempt to configure the tests without having added Catch2, causing the build configuration to fail.

This was a particular problem when adding stdexec as a submodule of another project, since if that project had an include(CTest) command invocation before it added stdexec, and it did not explicitly enable STDEXEC_BUILD_TESTS, the build configuration would fail, since STDEXEC_BUILD_TESTS is disabled by default when stdexec is a submodule, and include(CTest) automatically sets BUILD_TESTING.

This commit addresses the issue by setting BUILD_TESTING to whatever STDEXEC_BUILD_TESTS was set to, and then relying on BUILD_TESTING to decide both whether to add Catch2 and whether to configure the test executables. It also adds a check for BUILD_TESTING when determining how to set the default for STDEXEC_BUILD_TESTS when the user doesn't configure it. The outcome is that, if the user explicitly enables or disables STDEXEC_BUILD_TESTS, then the CMake will use it to override the preexisting BUILD_TESTING setting; but otherwise, the CMake will enable tests only if BUILD_TESTING is set or if stdexec is not a submodule.