### PR TITLE
Fix template template parameter of `make_completion_signatures`

### DIFF
--- a/include/stdexec/__detail/__transform_completion_signatures.hpp
+++ b/include/stdexec/__detail/__transform_completion_signatures.hpp
@@ -452,7 +452,7 @@ namespace stdexec {
     class _Env = empty_env,                                            //
     class _Sigs = completion_signatures<>,                             //
     template <class...> class _SetValue = __sigs::__default_set_value, //
-    template <class> class _SetError = __sigs::__default_set_error,    //
+    template <class...> class _SetError = __sigs::__default_set_error, //
     class _SetStopped = completion_signatures<set_stopped_t()>>
   using make_completion_signatures =
     transform_completion_signatures_of<_Sender, _Env, _Sigs, _SetValue, _SetError, _SetStopped>;


### PR DESCRIPTION
I realize `transform_completion_signatures_of` is preferred so this is a minor fix (GCC seems to not care if it's a pack or single template parameter, but clang complains if the template template parameter and default argument have different template parameters). Perhaps `make_completion_signatures` can be marked deprecated?