### PR TITLE
Revert "Remove `__destruct_schedule_operation` from system_context ABI (#1332)"

### DIFF
--- a/include/exec/__detail/__system_context_default_impl.hpp
+++ b/include/exec/__detail/__system_context_default_impl.hpp
@@ -42,21 +42,15 @@ namespace exec::__system_context_default_impl {
     __operation<_Sender>* __op_;
 
     void set_value() noexcept {
-      auto __op = __op_;
       __cb_(__data_, 0, nullptr);
-      __op->__destruct();
     }
 
     void set_error(std::exception_ptr __ptr) noexcept {
-      auto __op = __op_;
       __cb_(__data_, 2, *reinterpret_cast<void**>(&__ptr));
-      __op->__destruct();
     }
 
     void set_stopped() noexcept {
-      auto __op = __op_;
       __cb_(__data_, 1, nullptr);
-      __op->__destruct();
     }
   };
 
@@ -108,9 +102,11 @@ namespace exec::__system_context_default_impl {
       __schedule_operation_size = sizeof(__schedule_operation_t),
       __schedule_operation_alignment = alignof(__schedule_operation_t),
       __schedule = __schedule_impl;
+      __destruct_schedule_operation = __destruct_schedule_operation_impl;
       __bulk_schedule_operation_size = sizeof(__bulk_schedule_operation_t),
       __bulk_schedule_operation_alignment = alignof(__bulk_schedule_operation_t),
       __bulk_schedule = __bulk_schedule_impl;
+      __destruct_bulk_schedule_operation = __destruct_bulk_schedule_operation_impl;
     }
 
    private:
@@ -134,7 +130,7 @@ namespace exec::__system_context_default_impl {
       std::declval<unsigned long>(),
       std::declval<__bulk_functor>()))>;
 
-    static void __schedule_impl(
+    static void* __schedule_impl(
       __exec_system_scheduler_interface* __self,
       void* __preallocated,
       uint32_t __psize,
@@ -146,9 +142,17 @@ namespace exec::__system_context_default_impl {
       auto __os = __schedule_operation_t::__construct_maybe_alloc(
         __preallocated, __psize, std::move(__sndr), __cb, __data);
       stdexec::start(__os->__inner_op_);
+      return __os;
     }
 
-    static void __bulk_schedule_impl(
+    static void __destruct_schedule_operation_impl(
+      __exec_system_scheduler_interface* /*__self*/,
+      void* __operation) noexcept {
+      auto __op = static_cast<__schedule_operation_t*>(__operation);
+      __op->__destruct();
+    }
+
+    static void* __bulk_schedule_impl(
       __exec_system_scheduler_interface* __self,
       void* __preallocated,
       uint32_t __psize,
@@ -163,6 +167,14 @@ namespace exec::__system_context_default_impl {
       auto __os = __bulk_schedule_operation_t::__construct_maybe_alloc(
         __preallocated, __psize, std::move(__sndr), __cb, __data);
       stdexec::start(__os->__inner_op_);
+      return __os;
+    }
+
+    static void __destruct_bulk_schedule_operation_impl(
+      __exec_system_scheduler_interface* /*__self*/,
+      void* __operation) noexcept {
+      auto __op = static_cast<__bulk_schedule_operation_t*>(__operation);
+      __op->__destruct();
     }
   };
 

--- a/include/exec/__detail/__system_context_if.h
+++ b/include/exec/__detail/__system_context_if.h
@@ -60,12 +60,18 @@ struct __exec_system_scheduler_interface {
   uint32_t __schedule_operation_alignment;
 
   /// Schedules new work on the system scheduler, calling `cb` with `data` when the work can start.
-  void (*__schedule)(
+  /// Returns an object that should be passed to __destruct_schedule_operation when the operation completes.
+  void* (*__schedule)(
     struct __exec_system_scheduler_interface* /*self*/,
     void* /*__preallocated*/,
     uint32_t /*__psize*/,
     __exec_system_context_completion_callback_t /*cb*/,
     void* /*data*/);
+
+  /// Destructs the operation state object.
+  void (*__destruct_schedule_operation)(
+    struct __exec_system_scheduler_interface* /*self*/,
+    void* /*operation*/);
 
   /// The size of the operation state object on the implementation side.
   uint32_t __bulk_schedule_operation_size;
@@ -74,7 +80,8 @@ struct __exec_system_scheduler_interface {
 
   /// Schedules new bulk work of size `size` on the system scheduler, calling `cb_item` with `data`
   /// for indices in [0, `size`), and calling `cb` on general completion.
-  void (*__bulk_schedule)(
+  /// Returns the operation state object that should be passed to __destruct_bulk_schedule_operation.
+  void* (*__bulk_schedule)(
     struct __exec_system_scheduler_interface* /*self*/,
     void* /*__preallocated*/,
     uint32_t /*__psize*/,
@@ -82,6 +89,11 @@ struct __exec_system_scheduler_interface {
     __exec_system_context_bulk_item_callback_t /*cb_item*/,
     void* /*data*/,
     unsigned long /*size*/);
+
+  /// Destructs the operation state object for a bulk_schedule.
+  void (*__destruct_bulk_schedule_operation)(
+    struct __exec_system_scheduler_interface* /*self*/,
+    void* /*operation*/);
 };
 
 #ifdef __cplusplus

--- a/test/exec/test_system_context.cpp
+++ b/test/exec/test_system_context.cpp
@@ -243,9 +243,11 @@ struct my_system_scheduler_impl : __exec_system_scheduler_interface {
     __forward_progress_guarantee = base_.__forward_progress_guarantee;
     __schedule_operation_size = base_.__schedule_operation_size;
     __schedule_operation_alignment = base_.__schedule_operation_alignment;
+    __destruct_schedule_operation = base_.__destruct_schedule_operation;
     __bulk_schedule_operation_size = base_.__bulk_schedule_operation_size;
     __bulk_schedule_operation_alignment = base_.__bulk_schedule_operation_alignment;
     __bulk_schedule = base_.__bulk_schedule;
+    __destruct_bulk_schedule_operation = base_.__destruct_bulk_schedule_operation;
 
     __schedule = __schedule_impl; // have our own schedule implementation
   }
@@ -259,7 +261,7 @@ struct my_system_scheduler_impl : __exec_system_scheduler_interface {
   exec::__system_context_default_impl::__system_scheduler_impl base_;
   int count_schedules_ = 0;
 
-  static void __schedule_impl(
+  static void* __schedule_impl(
     __exec_system_scheduler_interface* self_arg,
     void* preallocated,
     uint32_t psize,

--- a/test/exec/test_system_context_replaceability.cpp
+++ b/test/exec/test_system_context_replaceability.cpp
@@ -32,9 +32,11 @@ namespace {
       __forward_progress_guarantee = base_.__forward_progress_guarantee;
       __schedule_operation_size = base_.__schedule_operation_size;
       __schedule_operation_alignment = base_.__schedule_operation_alignment;
+      __destruct_schedule_operation = base_.__destruct_schedule_operation;
       __bulk_schedule_operation_size = base_.__bulk_schedule_operation_size;
       __bulk_schedule_operation_alignment = base_.__bulk_schedule_operation_alignment;
       __bulk_schedule = base_.__bulk_schedule;
+      __destruct_bulk_schedule_operation = base_.__destruct_bulk_schedule_operation;
 
       __schedule = __schedule_impl; // have our own schedule implementation
     }
@@ -43,7 +45,7 @@ namespace {
     exec::static_thread_pool pool_;
     exec::__system_context_default_impl::__system_scheduler_impl base_;
 
-    static void __schedule_impl(
+    static void* __schedule_impl(
       __exec_system_scheduler_interface* self_arg,
       void* preallocated,
       uint32_t psize,
@@ -54,7 +56,7 @@ namespace {
       // increment our counter.
       count_schedules++;
       // delegate to the base implementation.
-      self->base_.__schedule(&self->base_, preallocated, psize, callback, data);
+      return self->base_.__schedule(&self->base_, preallocated, psize, callback, data);
     }
   };
 


### PR DESCRIPTION
This reverts commit bfad35d6f6acc41387b78ead351e20ba7eff52be.

@lucteo Looks like the system context tests got flaky again after landing this. Reverting.