### PR TITLE
Reproduce split race/crash

### DIFF
--- a/include/stdexec/__detail/__shared.hpp
+++ b/include/stdexec/__detail/__shared.hpp
@@ -342,6 +342,7 @@ namespace stdexec {
 
         // Set the "completed" bit in the ref count. If the ref count is 1, then there are no more
         // waiters. Release the final reference.
+        usleep(1000);
         if (__count(this->template __set_bit<__completed_bit>()) == 1) {
           this->__dec_ref(); // release the extra ref count, deletes this
         }

--- a/include/stdexec/stop_token.hpp
+++ b/include/stdexec/stop_token.hpp
@@ -303,6 +303,7 @@ namespace stdexec {
     inplace_stop_source::__try_lock_unless_stop_requested_(bool __set_stop_requested) const noexcept
     -> bool {
     __stok::__spin_wait __spin;
+    usleep(2000);
     auto __old_state = __state_.load(std::memory_order_relaxed);
     do {
       while (true) {


### PR DESCRIPTION
https://gist.github.com/ccotter/c0504455c7d54240758a34dc99d620f0 is the ASAN report.

From https://github.com/NVIDIA/stdexec/blob/54b38c99e8cbb348c1dd3508fa540728882247db/include/stdexec/__detail/__shared.hpp#L247 the shared state becomes a dangling pointer if if https://github.com/NVIDIA/stdexec/blob/54b38c99e8cbb348c1dd3508fa540728882247db/include/stdexec/__detail/__shared.hpp#L346 frees the memory from another thread.

I'm not quite sure how to fix this, but this PR manages to reproduce this bug reliably with ASAN in the "split forwards results from a different thread"" test.