### PR TITLE
Rename `__local` variables to avoid conflict with macro defined by HIP

### DIFF
--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -155,12 +155,12 @@ namespace exec {
           std::unique_lock __guard{__scope->__lock_};
           auto& __active = __scope->__active_;
           if (--__active == 0) {
-            auto __local = std::move(__scope->__waiters_);
+            auto __local_waiters = std::move(__scope->__waiters_);
             __guard.unlock();
             __scope = nullptr;
             // do not access __scope
-            while (!__local.empty()) {
-              auto* __next = __local.pop_front();
+            while (!__local_waiters.empty()) {
+              auto* __next = __local_waiters.pop_front();
               __next->__notify_waiter(__next);
               // __scope must be considered deleted
             }
@@ -525,7 +525,7 @@ namespace exec {
         void __dispatch_result_() noexcept {
           auto& __state = *__state_;
           std::unique_lock __guard{__state.__mutex_};
-          auto __local = std::move(__state.__subscribers_);
+          auto __local_subscribers = std::move(__state.__subscribers_);
           __state.__forward_scope_ = std::nullopt;
           if (__state.__no_future_.get() != nullptr) {
             // nobody is waiting for the results
@@ -536,8 +536,8 @@ namespace exec {
             return;
           }
           __guard.unlock();
-          while (!__local.empty()) {
-            auto* __sub = __local.pop_front();
+          while (!__local_subscribers.empty()) {
+            auto* __sub = __local_subscribers.pop_front();
             __sub->__complete();
           }
         }

--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -258,20 +258,20 @@ namespace stdexec {
       // clang-format on
       template <sender_in<__env> _Sender>
       auto apply_sender(_Sender&& __sndr) const -> std::optional<__sync_wait_result_t<_Sender>> {
-        __state __local{};
+        __state __local_state{};
         std::optional<__sync_wait_result_t<_Sender>> __result{};
 
         // Launch the sender with a continuation that will fill in the __result optional or set the
-        // exception_ptr in __local.
+        // exception_ptr in __local_state.
         auto __op_state =
-          connect(static_cast<_Sender&&>(__sndr), __receiver_t<_Sender>{&__local, &__result});
+          connect(static_cast<_Sender&&>(__sndr), __receiver_t<_Sender>{&__local_state, &__result});
         stdexec::start(__op_state);
 
         // Wait for the variant to be filled in.
-        __local.__loop_.run();
+        __local_state.__loop_.run();
 
-        if (__local.__eptr_) {
-          std::rethrow_exception(static_cast<std::exception_ptr&&>(__local.__eptr_));
+        if (__local_state.__eptr_) {
+          std::rethrow_exception(static_cast<std::exception_ptr&&>(__local_state.__eptr_));
         }
 
         return __result;


### PR DESCRIPTION
When stdexec headers are included in a build with hipcc compilation fails because of a `__local` macro defined by HIP: https://github.com/ROCm/clr/blob/1e4c60f286cb056b4117c72358302a888e65a324/hipamd/include/hip/amd_detail/device_library_decls.h#L123. It's a rather unfortunate macro name, but it's been reported to AMD (https://github.com/ROCm/hipamd/issues/68; though this particular repo is archived, and the replacement repo does not have the same issue reported) and the macro is still defined on the latest development branch of `clr`. I'm proposing to avoid the `__local` name in stdexec. I've changed existing uses to slightly more verbose names. 