### PR TITLE
Proof of concept: Relacy tests

### DIFF
--- a/include/exec/__detail/__bwos_lifo_queue.hpp
+++ b/include/exec/__detail/__bwos_lifo_queue.hpp
@@ -152,7 +152,7 @@ namespace exec::bwos {
       block_type(block_size, allocator),
       allocator_of_t<block_type>(allocator))
     , mask_(blocks_.size() - 1) {
-    blocks_[owner_block_].reclaim();
+    blocks_[owner_block_.load()].reclaim();
   }
 
   template <class Tp, class Allocator>

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -781,7 +781,7 @@ namespace exec {
         // after this, which means we can rely on its self-ownership to ensure
         // that it is eventually deleted
         stdexec::start(
-          *new __op_t{nest(static_cast<_Sender&&>(__sndr)), static_cast<_Env&&>(__env), &__impl_});
+          *(new __op_t{nest(static_cast<_Sender&&>(__sndr)), static_cast<_Env&&>(__env), &__impl_}));
       }
 
       template <__movable_value _Env = empty_env, sender_in<__env_t<_Env>> _Sender>

--- a/include/exec/start_now.hpp
+++ b/include/exec/start_now.hpp
@@ -71,7 +71,7 @@ namespace exec {
       }
 
       void __complete() noexcept {
-        if (--__pending_ == 0) {
+        if (__pending_.fetch_sub(1) == 1) {
           auto __joiner = __joiner_.exchange(nullptr);
           if (__joiner) {
             __joiner->join();

--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -191,7 +191,7 @@ namespace stdexec {
 
       template <class _Receiver>
       void __arrive(_Receiver& __rcvr) noexcept {
-        if (0 == --__count_) {
+        if (1 == __count_.fetch_sub(1)) {
           __complete(__rcvr);
         }
       }
@@ -361,7 +361,7 @@ namespace stdexec {
         } else if constexpr (!__same_as<decltype(_State::__values_), __ignore>) {
           // We only need to bother recording the completion values
           // if we're not already in the "error" or "stopped" state.
-          if (__state.__state_ == __started) {
+          if (__state.__state_.load() == __started) {
             auto& __opt_values = __tup::get<__v<_Index>>(__state.__values_);
             using _Tuple = __decayed_tuple<_Args...>;
             static_assert(

--- a/test/rrd/Makefile
+++ b/test/rrd/Makefile
@@ -1,0 +1,59 @@
+# User-customizable variables:
+CXX ?= c++
+CXX_STD ?= c++20
+CXXFLAGS ?= -I relacy -I relacy/relacy/fakestd -O1 -std=$(CXX_STD) -I ../../include -I ../../test -g
+DEPFLAGS ?= -MD -MF $(@).d -MP -MT $(@)
+build_dir = build
+
+.SECONDARY:
+
+test_programs = split async_scope
+
+test_exe_files = $(foreach name,$(test_programs),$(build_dir)/$(name))
+
+exe_files = $(test_exe_files)
+o_files = $(exe_files:=.cpp.o)
+
+ansi_term_csi = [
+ansi_term_bold = $(ansi_term_csi)1m
+ansi_term_green = $(ansi_term_csi)32m
+ansi_term_red = $(ansi_term_csi)31m
+ansi_term_reset = $(ansi_term_csi)m
+
+COMPILE.cpp = $(CXX) $(DEPFLAGS) $(CXXFLAGS) -c
+LINK.cpp = $(CXX) $(CXXFLAGS)
+
+.PHONY: all
+all: tests
+
+.PHONY: tests
+tests: $(test_exe_files)
+
+$(build_dir)/%.check-result: $(build_dir)/% always-run
+	@ \
+	printf '%s%s ...%s\n' $(ansi_term_bold) $(*) $(ansi_term_reset) >&2; \
+	$(<); \
+	status="$${?}"; \
+	printf %d "$${status}" >$(@); \
+	if [ "$${status}" -eq 0 ]; then \
+		printf '%s%s %s%s\n' $(ansi_term_green) $(*) OK $(ansi_term_reset); \
+	else \
+		printf '%s%s %s%s\n' $(ansi_term_red) $(*) FAIL $(ansi_term_reset); \
+	fi >&2; \
+	exit "$${status}"
+
+$(build_dir)/%: $(build_dir)/%.cpp.o
+	$(LINK.cpp) $(^) -o $(@)
+
+$(build_dir)/%.cpp.o: %.cpp
+	@mkdir -p $(dir $(@))
+	$(COMPILE.cpp) -o $(@) $(<)
+
+.PHONY: clean
+clean:
+	rm -fr -- $(build_dir)/
+
+.PHONY: always-run
+always-run:
+
+-include $(o_files:=.d)

--- a/test/rrd/README.md
+++ b/test/rrd/README.md
@@ -1,0 +1,42 @@
+## Relacy tests
+
+[Relacy (RRD)](https://www.1024cores.net/home/relacy-race-detector/rrd-introduction)
+is a data race detector. It replaces the OS scheduler with an scheduler that
+explores many different thread interleavings, and logs detected races or assertion
+failures. Relacy can also simulate relaxed hardware by simulating old values of a
+variable as allowed by the C++11 memory model.
+
+Relacy requires a specialized build. In particular, it is a header only library that
+replaces the standard library and pthread APIs at compile time. Since it places some
+standard library includes, writing new tests may require working around certain
+limitations in terms of what the replacement headers and accompanying runtime can
+support. For example, Relacy's atomic replacements cannot support `++x`, so the
+stdexec library could needs to use `x.fetch_add(1)` to be compatible with Relacy.
+
+## Instructions
+
+Run the following commands from within this directory (`./tests/rrd`).
+
+```
+# TODO: Merge patches into upstream Relacy @ dvyukov's version
+git clone -b stdexec https://github.com/ccotter/relacy
+CXX=g++-11 make -j 4
+./build/split
+```
+
+## Recommended use
+
+The Relacy tests can be manually built and executed. New tests can be written for
+new algorithms, or new use cases in the stdexec library.
+
+At this time, integrating the tests into CI is not yet recommended. If we can figure
+out a more stable build on all environments/compilers, we should revisit this.
+
+## Supported platforms
+
+The stdexec Relacy tests have been verified to build and run on
+ * Linux based GCC+11 with libstdc++ (`x86_64`)
+ * Mac with Apple Clang 15 with libc++ (`x86_64`)
+
+G++12 and newer are known to have issues that could be addressed with patches
+to Relacy.

--- a/test/rrd/async_scope.cpp
+++ b/test/rrd/async_scope.cpp
@@ -1,0 +1,51 @@
+#include "../../relacy/relacy_std.hpp"
+#include "../../relacy/relacy_cli.hpp"
+
+#include <stdexec/execution.hpp>
+#include <exec/async_scope.hpp>
+#include <exec/static_thread_pool.hpp>
+#include <test_common/schedulers.hpp>
+#include <test_common/type_helpers.hpp>
+
+#include <chrono>
+#include <random>
+#include <iostream>
+
+using rl::nvar;
+using rl::nvolatile;
+using rl::mutex;
+
+namespace ex = stdexec;
+using exec::async_scope;
+
+struct async_scope_bug : rl::test_suite<async_scope_bug, 1>
+{
+    static size_t const dynamic_thread_count = 2;
+
+    void thread(unsigned)
+    {
+        exec::static_thread_pool ctx{1};
+
+        ex::scheduler auto sch = ctx.get_scheduler();
+
+        exec::async_scope scope;
+        std::atomic_bool produced{false};
+        ex::sender auto begin = ex::schedule(sch);
+        {
+            ex::sender auto ftr = scope.spawn_future(begin | stdexec::then([&]() { produced.store(true); }));
+            (void) ftr;
+        }
+        stdexec::sync_wait(scope.on_empty() | stdexec::then([&]() {
+            RL_ASSERT(produced.load());
+        }));
+    }
+};
+
+int main()
+{
+    rl::test_params p;
+    p.iteration_count = 50000;
+    p.execution_depth_limit = 10000;
+    rl::simulate<async_scope_bug>(p);
+    return 0;
+}

--- a/test/rrd/split.cpp
+++ b/test/rrd/split.cpp
@@ -1,0 +1,45 @@
+#include "../../relacy/relacy_std.hpp"
+#include "../../relacy/relacy_cli.hpp"
+
+#include <stdexec/execution.hpp>
+#include <exec/async_scope.hpp>
+#include <exec/static_thread_pool.hpp>
+#include <test_common/schedulers.hpp>
+
+#include <chrono>
+#include <random>
+#include <iostream>
+
+using rl::nvar;
+using rl::nvolatile;
+using rl::mutex;
+
+namespace ex = stdexec;
+using exec::async_scope;
+
+struct split_bug : rl::test_suite<split_bug, 1>
+{
+    static size_t const dynamic_thread_count = 2;
+
+    void thread(unsigned)
+    {
+        exec::static_thread_pool pool{1};
+        auto split = ex::schedule(pool.get_scheduler()) //
+                | ex::then([] {
+                    return 42;
+                    })
+                | ex::split();
+
+        auto [val] = ex::sync_wait(split).value();
+        RL_ASSERT(val == 42);
+    }
+};
+
+int main()
+{
+    rl::test_params p;
+    p.iteration_count = 50000;
+    p.execution_depth_limit = 10000;
+    rl::simulate<split_bug>(p);
+    return 0;
+}


### PR DESCRIPTION
[Relacy](https://www.1024cores.net/home/relacy-race-detector) is a runtime race detector preceding ThreadSanitizer, developed by the same author @dvyukov. Relacy simulates threads as fibers and uses a special scheduling algorithm to force as many different interleavings as possible. Relacy is well suited for unit testing concurrent data structures.

I originally found #1395 by using a modified TSAN that changed `pthread_mutex_unlock` to insert a random `usleep` for up to 1000 milliseconds. A colleague pointed me to Relacy as far superior tool to hit rare thread interleavings, so as an exercise, I wanted to see if I could catch the same bug with Relacy. This draft PR contains instructions below for catching the same bug in #1395.

Relacy's output for the `split_bug` shows the full history of the variables that it is able to track, with a limited snippet shown below, including commentary added by me:

```
// Thread 0 decrements the state ref count from 2 to 1
// note: the first two bits of the atomic are reserved bits, so value=9 -> ref count 2, value=5 -> ref count 1
[363] 0: <0x71e130> fetch_sub , prev=9, arg=4, new=5, order=acq_rel, in __dec_ref_, stdexec/include/stdexec/__detail/__intrusive_ptr.hpp(111)

// Thread 2 decrements the ref count from 1 to 0, triggering the deallocation of the shared state
[365] 2: <0x71e130> fetch_sub , prev=7, arg=4, new=3, order=acq_rel, in __dec_ref_, stdexec/include/stdexec/__detail/__intrusive_ptr.hpp(111)
[366] 2: <0x71e080> atomic load, value=^@, order=relaxed, in ~inplace_stop_source, stdexec/include/stdexec/__detail/../stop_token.hpp(244)
[367] 2: memory deallocation: addr=0x71e080, in , (0)

// Thread 0 tries to access the state object which was just freed by thread 2 above.
[368] 0: <0x71e094> access to freed memory, in __try_lock_unless_stop_requested_, stdexec/include/stdexec/__detail/../stop_token.hpp(306)
[369] 0: ACCESS TO FREED MEMORY (access to freed memory), in __try_lock_unless_stop_requested_, stdexec/include/stdexec/__detail/../stop_token.hpp(306
```

Much of Relacy is macro based and hijacks standard library names with tricks like defining aliases from `std::atomic` to `rl::atomic`. As such, it's not as robust as ThreadSanitizer for instance. For concurrent data structures/algorithms like those in stdexec, I think it'd be worth having a build that can support Relacy tests (e.g., replacing `std::lock_guard lock(__mutex_)` with `STDEXEC_LOCK_GUARD(lock, __mutex_)` that conditionally expands to the Relacy version of the atomic/mutex/lock guards etc). If we do it right, the tests could verify a full search path of all possible thread interleavings (depending on the complexity of the unit test and algorithm), or at the very least, trigger a large sample of randomly chosen interleavings. Let me know what you think and I can work on a polished PR.

### Modifications to stdexec

~For example, `cv.notify_one()` is replaced with `cv($).notify_one()`, where `$` is a macro that expands to an object containing file/line information for Relacy's runtime. I wonder if a defaulted `std::source_location` could actually replace the need for much of the source code changes to stdexec?~

I was able to modify Relacy in https://github.com/dvyukov/relacy/pull/20 to minimize the number of changes to stdexec to allow writing Relacy tests. The changes to stdexec are
 - Remove stop_token's asserts, since they are fired in the Relacy test depending on which thread interleavings are tried first, to allow Relacy' runtime to print the interleaving history when it detects the use after free.
 - Replacing implicit `atomic::operator T()` and `int operator--()` with explicit calls to `load`/`fetch_sub`, which is able to leverage defaulting `std::source_location` to provide file/line info to the Relacy runtime.
 - Refactoring a cv notify (this is a limitation in Relacy which can easily be fixed in Relacy itself).

Note: Ideally, ThreadSanitizer (or a peer clang -fsanitize option) could do compiler based instrumentation. Relacy has not been in active development for a long time, with effort shifted towards TSAN. That said, Relacy still appears to offer a lot of value in being able to hit rare interleavings that TSAN itself does not support.

I think I found another bug with `async_scope` in `async_scope_bug`, which I'll provide more details (and try for a fix as well).

## Instructions

 > [!CAUTION]
Only verified to work on Linux based x86_64 with GCC-11.
Below gives me a segfault on Mac with Apple Clang (not sure why).

```
git clone -b stdexec https://github.com/ccotter/relacy && cd relacy
git clone -b relacy https://github.com/ccotter/stdexec
CXX_STD=c++20 make build/test/stdexec/{async_scope_bug,split_bug}
./build/test/stdexec/split_bug
```