### PR TITLE
Fix race in asyn_scope::request_stop

### DIFF
--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -21,6 +21,7 @@
 #include "env.hpp"
 
 #include <mutex>
+#include <optional>
 
 namespace exec {
   /////////////////////////////////////////////////////////////////////////////
@@ -313,6 +314,7 @@ namespace exec {
 
         void __complete_() noexcept {
           try {
+            __forward_consumer_.reset();
             auto __state = std::move(__state_);
             STDEXEC_ASSERT(__state != nullptr);
             std::unique_lock __guard{__state->__mutex_};
@@ -354,7 +356,7 @@ namespace exec {
         _Receiver __rcvr_;
         std::unique_ptr<__future_state<_Sender, _Env>> __state_;
         STDEXEC_ATTRIBUTE((no_unique_address))
-        __forward_consumer __forward_consumer_;
+        std::optional<__forward_consumer> __forward_consumer_;
 
        public:
         using __id = __future_op;
@@ -383,7 +385,7 @@ namespace exec {
             }}
           , __rcvr_(static_cast<_Receiver2&&>(__rcvr))
           , __state_(std::move(__state))
-          , __forward_consumer_(get_stop_token(get_env(__rcvr_)),
+          , __forward_consumer_(std::in_place, get_stop_token(get_env(__rcvr_)),
               __forward_stopped{&__state_->__stop_source_}) {
         }
 

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -18,10 +18,10 @@
 #include "../stdexec/execution.hpp"
 #include "../stdexec/stop_token.hpp"
 #include "../stdexec/__detail/__intrusive_queue.hpp"
+#include "../stdexec/__detail/__optional.hpp"
 #include "env.hpp"
 
 #include <mutex>
-#include <optional>
 
 namespace exec {
   /////////////////////////////////////////////////////////////////////////////
@@ -356,7 +356,7 @@ namespace exec {
         _Receiver __rcvr_;
         std::unique_ptr<__future_state<_Sender, _Env>> __state_;
         STDEXEC_ATTRIBUTE((no_unique_address))
-        std::optional<__forward_consumer> __forward_consumer_;
+        stdexec::__optional<__forward_consumer> __forward_consumer_;
 
        public:
         using __id = __future_op;
@@ -505,7 +505,7 @@ namespace exec {
       }
 
       inplace_stop_source __stop_source_;
-      std::optional<inplace_stop_callback<__forward_stopped>> __forward_scope_;
+      stdexec::__optional<inplace_stop_callback<__forward_stopped>> __forward_scope_;
       std::mutex __mutex_;
       __future_step __step_ = __future_step::__created;
       std::unique_ptr<__future_state_base, __dynamic_delete<__future_state_base>> __no_future_;
@@ -527,7 +527,7 @@ namespace exec {
         void __dispatch_result_(std::unique_lock<std::mutex>& __guard) noexcept {
           auto& __state = *__state_;
           auto __local_subscribers = std::move(__state.__subscribers_);
-          __state.__forward_scope_ = std::nullopt;
+          __state.__forward_scope_.reset();
           if (__state.__no_future_.get() != nullptr) {
             // nobody is waiting for the results
             // delete this and return

--- a/test/exec/test_type_async_scope.cpp
+++ b/test/exec/test_type_async_scope.cpp
@@ -108,5 +108,15 @@ namespace {
       stdexec::sync_wait(scope.on_empty());
       expect_empty(scope);
     }
+
+    SECTION("request_stop nested spawn_future") {
+      exec::static_thread_pool ctx{1};
+      exec::async_scope scope;
+      ex::sender auto begin = ex::schedule(sch);
+      ex::sender auto ftr = scope.spawn_future(scope.spawn_future(begin));
+      scope.request_stop();
+      stdexec::sync_wait(ex::when_all(scope.on_empty(), std::move(ftr)));
+      // Verify the program finishes without crashing
+    }
   }
 } // namespace

--- a/test/rrd/Makefile
+++ b/test/rrd/Makefile
@@ -29,19 +29,6 @@ all: tests
 .PHONY: tests
 tests: $(test_exe_files)
 
-$(build_dir)/%.check-result: $(build_dir)/% always-run
-	@ \
-	printf '%s%s ...%s\n' $(ansi_term_bold) $(*) $(ansi_term_reset) >&2; \
-	$(<); \
-	status="$${?}"; \
-	printf %d "$${status}" >$(@); \
-	if [ "$${status}" -eq 0 ]; then \
-		printf '%s%s %s%s\n' $(ansi_term_green) $(*) OK $(ansi_term_reset); \
-	else \
-		printf '%s%s %s%s\n' $(ansi_term_red) $(*) FAIL $(ansi_term_reset); \
-	fi >&2; \
-	exit "$${status}"
-
 $(build_dir)/%: $(build_dir)/%.cpp.o
 	$(LINK.cpp) $(^) -o $(@)
 
@@ -52,8 +39,5 @@ $(build_dir)/%.cpp.o: %.cpp
 .PHONY: clean
 clean:
 	rm -fr -- $(build_dir)/
-
-.PHONY: always-run
-always-run:
 
 -include $(o_files:=.d)

--- a/test/rrd/README.md
+++ b/test/rrd/README.md
@@ -1,13 +1,13 @@
 ## Relacy tests
 
 [Relacy (RRD)](https://www.1024cores.net/home/relacy-race-detector/rrd-introduction)
-is a data race detector. It replaces the OS scheduler with an scheduler that
+is a data race detector. It replaces the OS scheduler with a scheduler that
 explores many different thread interleavings, and logs detected races or assertion
 failures. Relacy can also simulate relaxed hardware by simulating old values of a
 variable as allowed by the C++11 memory model.
 
 Relacy requires a specialized build. In particular, it is a header only library that
-replaces the standard library and pthread APIs at compile time. Since it places some
+replaces the standard library and pthread APIs at compile time. Since it replaces some
 standard library includes, writing new tests may require working around certain
 limitations in terms of what the replacement headers and accompanying runtime can
 support. For example, Relacy's atomic replacements cannot support `++x`, so the
@@ -18,10 +18,10 @@ stdexec library could needs to use `x.fetch_add(1)` to be compatible with Relacy
 Run the following commands from within this directory (`./tests/rrd`).
 
 ```
-# TODO: Merge patches into upstream Relacy @ dvyukov's version
-git clone -b stdexec https://github.com/ccotter/relacy
+git clone -b stdexec https://github.com/dvyukov/relacy
 CXX=g++-11 make -j 4
 ./build/split
+./build/async_scope
 ```
 
 ## Recommended use

--- a/test/rrd/async_scope.cpp
+++ b/test/rrd/async_scope.cpp
@@ -4,12 +4,10 @@
 #include <stdexec/execution.hpp>
 #include <exec/async_scope.hpp>
 #include <exec/static_thread_pool.hpp>
-#include <test_common/schedulers.hpp>
-#include <test_common/type_helpers.hpp>
+#include <exec/single_thread_context.hpp>
 
-#include <chrono>
-#include <random>
-#include <iostream>
+#include <optional>
+#include <stdexcept>
 
 using rl::nvar;
 using rl::nvolatile;
@@ -18,14 +16,13 @@ using rl::mutex;
 namespace ex = stdexec;
 using exec::async_scope;
 
-struct async_scope_bug : rl::test_suite<async_scope_bug, 1>
+struct drop_async_scope_future : rl::test_suite<drop_async_scope_future, 1>
 {
-    static size_t const dynamic_thread_count = 2;
+    static size_t const dynamic_thread_count = 1;
 
     void thread(unsigned)
     {
-        exec::static_thread_pool ctx{1};
-
+        exec::single_thread_context ctx;
         ex::scheduler auto sch = ctx.get_scheduler();
 
         exec::async_scope scope;
@@ -41,11 +38,94 @@ struct async_scope_bug : rl::test_suite<async_scope_bug, 1>
     }
 };
 
+struct attach_async_scope_future : rl::test_suite<attach_async_scope_future, 1>
+{
+    static size_t const dynamic_thread_count = 1;
+
+    void thread(unsigned)
+    {
+        exec::single_thread_context ctx;
+        ex::scheduler auto sch = ctx.get_scheduler();
+
+        exec::async_scope scope;
+        std::atomic_bool produced{false};
+        ex::sender auto begin = ex::schedule(sch);
+        ex::sender auto ftr = scope.spawn_future(begin | stdexec::then([&]() { produced.store(true); }));
+        ex::sender auto ftr_then = std::move(ftr) | stdexec::then([&] {
+            RL_ASSERT(produced.load());
+        });
+        stdexec::sync_wait(stdexec::when_all(scope.on_empty(), std::move(ftr_then)));
+    }
+};
+
+struct async_scope_future_set_result : rl::test_suite<async_scope_future_set_result, 1>
+{
+    static size_t const dynamic_thread_count = 1;
+
+    void thread(unsigned)
+    {
+        struct throwing_copy {
+            throwing_copy() = default;
+            throwing_copy(const throwing_copy&) {
+                throw std::logic_error("");
+            }
+        };
+        exec::single_thread_context ctx;
+        ex::scheduler auto sch = ctx.get_scheduler();
+
+        exec::async_scope scope;
+        ex::sender auto begin = ex::schedule(sch);
+        ex::sender auto ftr = scope.spawn_future(begin | stdexec::then([] { return throwing_copy(); }));
+        bool threw = false;
+        try {
+            stdexec::sync_wait(std::move(ftr));
+            RL_ASSERT(false);
+        } catch (const std::logic_error&) {
+            threw = true;
+        }
+        RL_ASSERT(threw);
+        stdexec::sync_wait(scope.on_empty());
+    }
+};
+
+template <int test_case>
+struct async_scope_request_stop : rl::test_suite<async_scope_request_stop<test_case>, 1>
+{
+    static size_t const dynamic_thread_count = 1;
+
+    void thread(unsigned)
+    {
+        exec::single_thread_context ctx;
+        ex::scheduler auto sch = ctx.get_scheduler();
+
+        if constexpr (test_case == 0) {
+            exec::async_scope scope;
+            ex::sender auto begin = ex::schedule(sch);
+            ex::sender auto ftr = scope.spawn_future(scope.spawn_future(begin));
+            scope.request_stop();
+            stdexec::sync_wait(ex::when_all(scope.on_empty(), std::move(ftr)));
+        } else {
+            exec::async_scope scope;
+            ex::sender auto begin = ex::schedule(sch);
+            {
+                // Drop the future on the floor
+                ex::sender auto ftr = scope.spawn_future(scope.spawn_future(begin));
+            }
+            scope.request_stop();
+            stdexec::sync_wait(scope.on_empty());
+        }
+    }
+};
+
 int main()
 {
     rl::test_params p;
-    p.iteration_count = 50000;
+    p.iteration_count = 100000;
     p.execution_depth_limit = 10000;
-    rl::simulate<async_scope_bug>(p);
+    rl::simulate<drop_async_scope_future>(p);
+    rl::simulate<attach_async_scope_future>(p);
+    rl::simulate<async_scope_future_set_result>(p);
+    rl::simulate<async_scope_request_stop<0>>(p);
+    rl::simulate<async_scope_request_stop<1>>(p);
     return 0;
 }

--- a/test/rrd/split.cpp
+++ b/test/rrd/split.cpp
@@ -2,20 +2,13 @@
 #include "../../relacy/relacy_cli.hpp"
 
 #include <stdexec/execution.hpp>
-#include <exec/async_scope.hpp>
 #include <exec/static_thread_pool.hpp>
-#include <test_common/schedulers.hpp>
-
-#include <chrono>
-#include <random>
-#include <iostream>
 
 using rl::nvar;
 using rl::nvolatile;
 using rl::mutex;
 
 namespace ex = stdexec;
-using exec::async_scope;
 
 struct split_bug : rl::test_suite<split_bug, 1>
 {


### PR DESCRIPTION
```
=================================================================
==37940==ERROR: AddressSanitizer: heap-use-after-free on address 0x612000000ac0 at pc 0x000103305bac bp 0x7ff7bcf721b0 sp 0x7ff7bcf721a8
READ of size 1 at 0x612000000ac0 thread T0
    #0 0x103305bab in unsigned char std::__1::__cxx_atomic_load[abi:ue170006]<unsigned char>(std::__1::__cxx_atomic_base_impl<unsigned char> const*, std::__1::memory_order) cxx_atomic_impl.h:363
    #1 0x103305b1a in std::__1::__atomic_base<unsigned char, false>::load[abi:ue170006](std::__1::memory_order) const atomic_base.h:60
    #2 0x10330feb0 in stdexec::inplace_stop_source::__try_lock_unless_stop_requested_(bool) const stop_token.hpp:313
    #3 0x10330f84a in stdexec::inplace_stop_source::request_stop() stop_token.hpp:255
    #4 0x10330f724 in exec::__scope::__forward_stopped::operator()() async_scope.hpp:290
    #5 0x10330f4a8 in stdexec::inplace_stop_callback<exec::__scope::__forward_stopped>::__execute_impl_(stdexec::__stok::__inplace_stop_callback_base*) stop_token.hpp:229
    #6 0x10331017a in stdexec::__stok::__inplace_stop_callback_base::__execute() stop_token.hpp:39
    #7 0x10330fc09 in stdexec::inplace_stop_source::request_stop() stop_token.hpp:274
    #8 0x1032aa024 in exec::__scope::async_scope::request_stop() async_scope.hpp:804
    #9 0x1032a582f in (anonymous namespace)::____C_A_T_C_H____T_E_S_T____0() test_type_async_scope.cpp:117
    #10 0x102fe0de2 in Catch::TestInvokerAsFunction::invoke() const catch.hpp:14317
    #11 0x102fc92ee in Catch::TestCase::invoke() const catch.hpp:14156
    #12 0x102fc90ee in Catch::RunContext::invokeActiveTestCase() catch.hpp:13016
    #13 0x102fc2b88 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:12989
    #14 0x102fc0af9 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12750
    #15 0x102fd0cc9 in Catch::(anonymous namespace)::TestGroup::execute() catch.hpp:13343
    #16 0x102fcf7a6 in Catch::Session::runInternal() catch.hpp:13549
    #17 0x102fcf1b2 in Catch::Session::run() catch.hpp:13505
    #18 0x10301a4cf in int Catch::Session::run<char>(int, char const* const*) catch.hpp:13227
    #19 0x10301a205 in main catch.hpp:17504
    #20 0x7ff80cee2365 in start+0x795 (dyld:x86_64+0xfffffffffff5c365)

0x612000000ac0 is located 0 bytes inside of 296-byte region [0x612000000ac0,0x612000000be8)
freed by thread T0 here:
    #0 0x104227a1d in wrap__ZdlPv+0x7d (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xeba1d)
    #1 0x1033382b3 in std::__1::default_delete<exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>>::operator()[abi:ue170006](exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>*) const unique_ptr.h:68
    #2 0x103338275 in std::__1::unique_ptr<exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>, std::__1::default_delete<exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>>>::reset[abi:ue170006](exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>*) unique_ptr.h:300
    #3 0x1033381b8 in std::__1::unique_ptr<exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>, std::__1::default_delete<exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>>>::~unique_ptr[abi:ue170006]() unique_ptr.h:266
    #4 0x1033352b4 in std::__1::unique_ptr<exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>, std::__1::default_delete<exec::__scope::__future_state<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>::__t, stdexec::__env::env<>>>>::~unique_ptr[abi:ue170006]() unique_ptr.h:266
    #5 0x10333623a in exec::__scope::__future_op<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>, stdexec::__env::env<>, exec::__scope::__nest_rcvr<exec::__scope::__future_rcvr<stdexec::completion_signatures<stdexec::__rcvrs::set_value_t (), stdexec::__rcvrs::set_stopped_t (), stdexec::__rcvrs::set_error_t (std::exception_ptr)>, stdexec::__env::env<>>>>::__t::__complete_() async_scope.hpp:347
    #6 0x103339862 in exec::__scope::__future_op<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>, stdexec::__env::env<>, exec::__scope::__nest_rcvr<exec::__scope::__future_rcvr<stdexec::completion_signatures<stdexec::__rcvrs::set_value_t (), stdexec::__rcvrs::set_stopped_t (), stdexec::__rcvrs::set_error_t (std::exception_ptr)>, stdexec::__env::env<>>>>::__t::start() & async_scope.hpp:396
    #7 0x103339664 in exec::__scope::__nest_op<exec::__scope::__future<exec::__scope::__nest_sender<exec::_pool_::static_thread_pool_::scheduler::_sender>, stdexec::__env::env<>>, exec::__scope::__future_rcvr<stdexec::completion_signatures<stdexec::__rcvrs::set_value_t (), stdexec::__rcvrs::set_stopped_t (), stdexec::__rcvrs::set_error_t (std::exception_ptr)>, stdexec::__env::env<>>>::__t::start() & async_scope.hpp:230
    #8 0x1032a9b26 in _ZN4exec7__scope11async_scope12spawn_futureIN7stdexec5__env3envIJEEENS0_8__futureINS0_13__nest_senderINS_6_pool_19static_thread_pool_9scheduler7_senderEEES6_E3__tEEENS7_INS3_3__iIXL_ZNS3_3_OkIJNS8_INSG_IXL_ZNSH_IJu7__decayIT0_EEEEEEXL_ZNSH_IJNS3_5__id_IXL_ZNS3_8__has_idISJ_EEEEEEEEEEEE3__fISM_E3__fISJ_EEE3__tEEEEEEXL_ZNSH_IJNSK_IXL_ZNSL_IST_EEEEEEEEEEEE3__fISU_E3__fIST_EENSG_IXL_ZNSH_IJu7__decayIT_EEEEEEXL_ZNSH_IJNSK_IXL_ZNSL_IS11_EEEEEEEEEEEE3__fIS12_E3__fIS11_EEE3__tEOSI_S10_ async_scope.hpp:791
    #9 0x1032a5804 in (anonymous namespace)::____C_A_T_C_H____T_E_S_T____0() test_type_async_scope.cpp:116
    #10 0x102fe0de2 in Catch::TestInvokerAsFunction::invoke() const catch.hpp:14317
    #11 0x102fc92ee in Catch::TestCase::invoke() const catch.hpp:14156
    #12 0x102fc90ee in Catch::RunContext::invokeActiveTestCase() catch.hpp:13016
    #13 0x102fc2b88 in Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) catch.hpp:12989
    #14 0x102fc0af9 in Catch::RunContext::runTest(Catch::TestCase const&) catch.hpp:12750
    #15 0x102fd0cc9 in Catch::(anonymous namespace)::TestGroup::execute() catch.hpp:13343
    #16 0x102fcf7a6 in Catch::Session::runInternal() catch.hpp:13549
    #17 0x102fcf1b2 in Catch::Session::run() catch.hpp:13505
    #18 0x10301a4cf in int Catch::Session::run<char>(int, char const* const*) catch.hpp:13227
```

What's happening is that 

 1. The main thread calls https://github.com/NVIDIA/stdexec/blob/main/include/stdexec/stop_token.hpp#L267, but before the call completes
 2. The thread pool thread executes `__complete_`, leading to the destruction of the future state: https://github.com/NVIDIA/stdexec/blob/main/include/exec/async_scope.hpp#L316
 3. The main thread is now referencing freed memory