### PR TITLE
I noticed P2300R10 renames get_delegatee_scheduler to get_delegation_schduler

### DIFF
--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -31,7 +31,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
       return __sched_;
     }
 
-    auto query(get_delegatee_scheduler_t) const noexcept -> run_loop::__scheduler {
+    auto query(get_delegation_scheduler_t) const noexcept -> run_loop::__scheduler {
       return __sched_;
     }
   };

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -151,17 +151,17 @@ namespace stdexec {
       auto operator()() const noexcept;
     };
 
-    struct get_delegatee_scheduler_t : __query<get_delegatee_scheduler_t> {
+    struct get_delegation_scheduler_t : __query<get_delegation_scheduler_t> {
       static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;
       }
 
       template <class _Env>
-        requires tag_invocable<get_delegatee_scheduler_t, const _Env&>
+        requires tag_invocable<get_delegation_scheduler_t, const _Env&>
       auto operator()(const _Env& __t) const noexcept
-        -> tag_invoke_result_t<get_delegatee_scheduler_t, const _Env&>;
+        -> tag_invoke_result_t<get_delegation_scheduler_t, const _Env&>;
 
-      template <class _Tag = get_delegatee_scheduler_t>
+      template <class _Tag = get_delegation_scheduler_t>
       auto operator()() const noexcept;
     };
 
@@ -289,7 +289,10 @@ namespace stdexec {
   using __queries::get_forward_progress_guarantee_t;
   using __queries::get_allocator_t;
   using __queries::get_scheduler_t;
-  using __queries::get_delegatee_scheduler_t;
+  using __queries::get_delegation_scheduler_t;
+  using get_delegatee_scheduler_t
+    [[deprecated("get_delegatee_scheduler_t has been renamed get_delegation_scheduler_t")]] =
+      get_delegation_scheduler_t;
   using __queries::get_stop_token_t;
   using __queries::get_completion_scheduler_t;
   using __queries::get_domain_t;
@@ -303,7 +306,10 @@ namespace stdexec {
   inline constexpr __has_algorithm_customizations_t __has_algorithm_customizations{};
   inline constexpr get_forward_progress_guarantee_t get_forward_progress_guarantee{};
   inline constexpr get_scheduler_t get_scheduler{};
-  inline constexpr get_delegatee_scheduler_t get_delegatee_scheduler{};
+  inline constexpr get_delegation_scheduler_t get_delegation_scheduler{};
+  inline constexpr auto& get_delegatee_scheduler
+    [[deprecated("get_delegatee_scheduler has been renamed get_delegation_scheduler")]] =
+      get_delegation_scheduler;
   inline constexpr get_allocator_t get_allocator{};
   inline constexpr get_stop_token_t get_stop_token{};
 #if !STDEXEC_GCC() || defined(__OPTIMIZE_SIZE__)
@@ -577,8 +583,8 @@ namespace stdexec {
 
       template <class _Tag>
         requires __callable<const _Fun&, _Tag>
-      auto query(_Tag) const
-        noexcept(__nothrow_callable<const _Fun&, _Tag>) -> __call_result_t<const _Fun&, _Tag> {
+      auto query(_Tag) const noexcept(__nothrow_callable<const _Fun&, _Tag>)
+        -> __call_result_t<const _Fun&, _Tag> {
         return __fun_(_Tag());
       }
 

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -151,6 +151,9 @@ namespace stdexec {
       auto operator()() const noexcept;
     };
 
+    //! The type for `get_delegation_scheduler` [exec.get.delegation.scheduler]
+    //! A query object that asks for a scheduler that can be used to delegate
+    //! work to for the purpose of forward progress delegation ([intro.progress]).
     struct get_delegation_scheduler_t : __query<get_delegation_scheduler_t> {
       static constexpr auto query(forwarding_query_t) noexcept -> bool {
         return true;

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -84,7 +84,7 @@ namespace stdexec {
     struct get_forward_progress_guarantee_t;
     struct __has_algorithm_customizations_t;
     struct get_scheduler_t;
-    struct get_delegatee_scheduler_t;
+    struct get_delegation_scheduler_t;
     struct get_allocator_t;
     struct get_stop_token_t;
     template <__completion_tag _CPO>
@@ -97,7 +97,7 @@ namespace stdexec {
   using __queries::get_forward_progress_guarantee_t;
   using __queries::get_allocator_t;
   using __queries::get_scheduler_t;
-  using __queries::get_delegatee_scheduler_t;
+  using __queries::get_delegation_scheduler_t;
   using __queries::get_stop_token_t;
   using __queries::get_completion_scheduler_t;
 
@@ -106,7 +106,7 @@ namespace stdexec {
   extern const __has_algorithm_customizations_t __has_algorithm_customizations;
   extern const get_forward_progress_guarantee_t get_forward_progress_guarantee;
   extern const get_scheduler_t get_scheduler;
-  extern const get_delegatee_scheduler_t get_delegatee_scheduler;
+  extern const get_delegation_scheduler_t get_delegation_scheduler;
   extern const get_allocator_t get_allocator;
   extern const get_stop_token_t get_stop_token;
   template <__completion_tag _CPO>

--- a/include/stdexec/__detail/__read_env.hpp
+++ b/include/stdexec/__detail/__read_env.hpp
@@ -132,8 +132,8 @@ namespace stdexec {
     }
 
     template <class _Tag>
-    inline auto get_delegatee_scheduler_t::operator()() const noexcept {
-      return read_env(get_delegatee_scheduler);
+    inline auto get_delegation_scheduler_t::operator()() const noexcept {
+      return read_env(get_delegation_scheduler);
     }
 
     template <class _Tag>

--- a/include/stdexec/__detail/__schedulers.hpp
+++ b/include/stdexec/__detail/__schedulers.hpp
@@ -101,12 +101,12 @@ namespace stdexec {
     }
 
     template <class _Env>
-      requires tag_invocable<get_delegatee_scheduler_t, const _Env&>
-    inline auto get_delegatee_scheduler_t::operator()(const _Env& __env) const noexcept
-      -> tag_invoke_result_t<get_delegatee_scheduler_t, const _Env&> {
-      static_assert(nothrow_tag_invocable<get_delegatee_scheduler_t, const _Env&>);
-      static_assert(scheduler<tag_invoke_result_t<get_delegatee_scheduler_t, const _Env&>>);
-      return tag_invoke(get_delegatee_scheduler_t{}, __env);
+      requires tag_invocable<get_delegation_scheduler_t, const _Env&>
+    inline auto get_delegation_scheduler_t::operator()(const _Env& __env) const noexcept
+      -> tag_invoke_result_t<get_delegation_scheduler_t, const _Env&> {
+      static_assert(nothrow_tag_invocable<get_delegation_scheduler_t, const _Env&>);
+      static_assert(scheduler<tag_invoke_result_t<get_delegation_scheduler_t, const _Env&>>);
+      return tag_invoke(get_delegation_scheduler_t{}, __env);
     }
 
     template <__completion_tag _Tag>

--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -51,7 +51,7 @@ namespace stdexec {
         return __loop_->get_scheduler();
       }
 
-      auto query(get_delegatee_scheduler_t) const noexcept -> run_loop::__scheduler {
+      auto query(get_delegation_scheduler_t) const noexcept -> run_loop::__scheduler {
         return __loop_->get_scheduler();
       }
 
@@ -238,7 +238,7 @@ namespace stdexec {
       /// `sync_wait` connects and starts the given sender, and then drives a
       ///         `run_loop` instance until the sender completes. Additional work
       ///         can be delegated to the `run_loop` by scheduling work on the
-      ///         scheduler returned by calling `get_delegatee_scheduler` on the
+      ///         scheduler returned by calling `get_delegation_scheduler` on the
       ///         receiver's environment.
       ///
       /// @pre The sender must have a exactly one value completion signature. That

--- a/test/stdexec/queries/test_forwarding_queries.cpp
+++ b/test/stdexec/queries/test_forwarding_queries.cpp
@@ -39,7 +39,10 @@ namespace {
     static_assert(ex::forwarding_query(ex::get_allocator));
     static_assert(ex::forwarding_query(ex::get_stop_token));
     static_assert(ex::forwarding_query(ex::get_scheduler));
-    static_assert(ex::forwarding_query(ex::get_delegatee_scheduler));
+    static_assert(ex::forwarding_query(ex::get_delegation_scheduler));
+    static_assert(std::is_same_v<ex::get_delegatee_scheduler_t, ex::get_delegation_scheduler_t>,
+        "Deprecated type is the same type.");
+    static_assert(&ex::get_delegatee_scheduler == &ex::get_delegation_scheduler);
     static_assert(ex::forwarding_query(ex::get_completion_scheduler<ex::set_value_t>));
     static_assert(ex::forwarding_query(ex::get_completion_scheduler<ex::set_error_t>));
     static_assert(ex::forwarding_query(ex::get_completion_scheduler<ex::set_stopped_t>));


### PR DESCRIPTION
This does that rename leaving deprecated names.