### PR TITLE
devcontainer: replace `VAULT_HOST` with `AWS_ROLE_ARN`

### DIFF
--- a/.devcontainer/llvm18-cuda12.0/devcontainer.json
+++ b/.devcontainer/llvm18-cuda12.0/devcontainer.json
@@ -9,7 +9,7 @@
     "SCCACHE_REGION": "us-east-2",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_S3_KEY_PREFIX": "nvidia-stdexec-dev",
-    "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
+    "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history"
   },
 

--- a/.devcontainer/llvm18-cuda12.0/devcontainer.json
+++ b/.devcontainer/llvm18-cuda12.0/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "rapidsai/devcontainers:24.04-cpp-llvm18-cuda12.0-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.12-cpp-llvm18-cuda12.0-ubuntu22.04",
 
   "hostRequirements": { "gpu": "optional" },
 

--- a/.devcontainer/llvm18-cuda12.4/devcontainer.json
+++ b/.devcontainer/llvm18-cuda12.4/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "rapidsai/devcontainers:24.04-cpp-llvm18-cuda12.4-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.12-cpp-llvm18-cuda12.4-ubuntu22.04",
 
   "hostRequirements": { "gpu": "optional" },
 

--- a/.devcontainer/llvm18-cuda12.4/devcontainer.json
+++ b/.devcontainer/llvm18-cuda12.4/devcontainer.json
@@ -9,7 +9,7 @@
     "SCCACHE_REGION": "us-east-2",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_S3_KEY_PREFIX": "nvidia-stdexec-dev",
-    "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
+    "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history"
   },
 

--- a/.devcontainer/llvm18-cuda12.4/devcontainer.json
+++ b/.devcontainer/llvm18-cuda12.4/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "rapidsai/devcontainers:24.12-cpp-llvm18-cuda12.4-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.12-cpp-llvm18-cuda12.6-ubuntu22.04",
 
   "hostRequirements": { "gpu": "optional" },
 

--- a/.devcontainer/nvhpc24.3/devcontainer.json
+++ b/.devcontainer/nvhpc24.3/devcontainer.json
@@ -9,7 +9,7 @@
     "SCCACHE_REGION": "us-east-2",
     "SCCACHE_BUCKET": "rapids-sccache-devs",
     "SCCACHE_S3_KEY_PREFIX": "nvidia-stdexec-dev",
-    "VAULT_HOST": "https://vault.ops.k8s.rapids.ai",
+    "AWS_ROLE_ARN": "arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs",
     "HISTFILE": "${containerWorkspaceFolder}/.cache/._bash_history"
   },
 

--- a/.devcontainer/nvhpc24.3/devcontainer.json
+++ b/.devcontainer/nvhpc24.3/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "rapidsai/devcontainers:24.04-cpp-nvhpc24.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.12-cpp-nvhpc24.3-ubuntu22.04",
 
   "hostRequirements": { "gpu": "optional" },
 

--- a/.devcontainer/nvhpc24.3/devcontainer.json
+++ b/.devcontainer/nvhpc24.3/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "rapidsai/devcontainers:24.12-cpp-nvhpc24.3-ubuntu22.04",
+  "image": "rapidsai/devcontainers:24.12-cpp-nvhpc24.9-ubuntu22.04",
 
   "hostRequirements": { "gpu": "optional" },
 

--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -20,15 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "CPU (clang 13, Debug, ubuntu 20.04)",       build: "Debug",   tag: llvm13-cuda12.4-ubuntu20.04, cxxflags: "-stdlib=libc++" }
-          - { name: "CPU (clang 13, Release, ubuntu 20.04)",     build: "Release", tag: llvm13-cuda12.4-ubuntu20.04, cxxflags: "-stdlib=libc++" }
-          - { name: "CPU (gcc 11, Debug, ubuntu 22.04)",         build: "Debug",   tag: gcc11-cuda12.4-ubuntu22.04,  cxxflags: "", }
-          - { name: "CPU (gcc 11, Release, ubuntu 22.04)",       build: "Release", tag: gcc11-cuda12.4-ubuntu22.04,  cxxflags: "", }
-          - { name: "CPU (gcc 11, Release, ubuntu 22.04, TSAN)", build: "Release", tag: gcc11-cuda12.4-ubuntu22.04,  cxxflags: "-fsanitize=thread" }
-          - { name: "CPU (gcc 11, Release, ubuntu 22.04, ASAN)", build: "Release", tag: gcc11-cuda12.4-ubuntu22.04,  cxxflags: "-fsanitize=address" }
+          - { name: "CPU (clang 13, Debug, ubuntu 20.04)",       build: "Debug",   tag: llvm13-cuda12.6-ubuntu20.04, cxxflags: "-stdlib=libc++" }
+          - { name: "CPU (clang 13, Release, ubuntu 20.04)",     build: "Release", tag: llvm13-cuda12.6-ubuntu20.04, cxxflags: "-stdlib=libc++" }
+          - { name: "CPU (gcc 11, Debug, ubuntu 22.04)",         build: "Debug",   tag: gcc11-cuda12.6-ubuntu22.04,  cxxflags: "", }
+          - { name: "CPU (gcc 11, Release, ubuntu 22.04)",       build: "Release", tag: gcc11-cuda12.6-ubuntu22.04,  cxxflags: "", }
+          - { name: "CPU (gcc 11, Release, ubuntu 22.04, TSAN)", build: "Release", tag: gcc11-cuda12.6-ubuntu22.04,  cxxflags: "-fsanitize=thread" }
+          - { name: "CPU (gcc 11, Release, ubuntu 22.04, ASAN)", build: "Release", tag: gcc11-cuda12.6-ubuntu22.04,  cxxflags: "-fsanitize=address" }
     container:
       options: -u root
-      image: rapidsai/devcontainers:24.04-cpp-${{matrix.tag}}
+      image: rapidsai/devcontainers:24.12-cpp-${{matrix.tag}}
       env:
         SCCACHE_REGION: "us-east-2"
         SCCACHE_BUCKET: "rapids-sccache-devs"
@@ -109,8 +109,8 @@ jobs:
       - name: Build and test CPU schedulers (Windows)
         shell: pwsh
         run: |
-          docker pull rapidsai/devcontainers:24.08-cuda12.4-cl14.39-windows2022
-          docker run --isolation=process -v "$(pwd):C:/stdexec" rapidsai/devcontainers:24.08-cuda12.4-cl14.39-windows2022 powershell C:/stdexec/.github/workflows/test-windows.ps1 -Compiler '${{ matrix.compiler }}' -Config '${{ matrix.build }}'
+          docker pull rapidsai/devcontainers:24.12-cuda12.6-cl14.39-windows2022
+          docker run --isolation=process -v "$(pwd):C:/stdexec" rapidsai/devcontainers:24.12-cuda12.6-cl14.39-windows2022 powershell C:/stdexec/.github/workflows/test-windows.ps1 -Compiler '${{ matrix.compiler }}' -Config '${{ matrix.build }}'
 
   ci-cpu-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: linux-${{ matrix.arch }}-gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1
     container:
       options: -u root
-      image: rapidsai/devcontainers:24.04-cpp-${{ matrix.tag }}-ubuntu22.04
+      image: rapidsai/devcontainers:24.12-cpp-${{ matrix.tag }}-ubuntu22.04
       env:
         SCCACHE_REGION: "us-east-2"
         SCCACHE_BUCKET: "rapids-sccache-devs"

--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -21,9 +21,9 @@ jobs:
       matrix:
         include:
           - { name: "clang 18",   cuda: "12.0", cxx: "clang++", build: "Release", tag: "llvm18-cuda12.0", gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
-          - { name: "clang 18",   cuda: "12.4", cxx: "clang++", build: "Release", tag: "llvm18-cuda12.4", gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 24.3", cuda: "12.4", cxx: "mpic++",  build: "Release", tag: "nvhpc24.3",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 24.3", cuda: "12.4", cxx: "mpic++",  build: "Debug",   tag: "nvhpc24.3",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
+          - { name: "clang 18",   cuda: "12.6", cxx: "clang++", build: "Release", tag: "llvm18-cuda12.6", gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
+          - { name: "nvc++ 24.3", cuda: "12.6", cxx: "mpic++",  build: "Release", tag: "nvhpc24.3",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
+          - { name: "nvc++ 24.3", cuda: "12.6", cxx: "mpic++",  build: "Debug",   tag: "nvhpc24.3",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
     runs-on: linux-${{ matrix.arch }}-gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1
     container:
       options: -u root

--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -22,8 +22,8 @@ jobs:
         include:
           - { name: "clang 18",   cuda: "12.0", cxx: "clang++", build: "Release", tag: "llvm18-cuda12.0", gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
           - { name: "clang 18",   cuda: "12.6", cxx: "clang++", build: "Release", tag: "llvm18-cuda12.6", gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 24.3", cuda: "12.6", cxx: "mpic++",  build: "Release", tag: "nvhpc24.3",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 24.3", cuda: "12.6", cxx: "mpic++",  build: "Debug",   tag: "nvhpc24.3",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
+          - { name: "nvc++ 24.9", cuda: "12.6", cxx: "mpic++",  build: "Release", tag: "nvhpc24.9",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
+          - { name: "nvc++ 24.9", cuda: "12.6", cxx: "mpic++",  build: "Debug",   tag: "nvhpc24.9",       gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
     runs-on: linux-${{ matrix.arch }}-gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1
     container:
       options: -u root


### PR DESCRIPTION
This PR is replacing the `VAULT_HOST` variable with `AWS_ROLE_ARN`. This is required to use the new token service to get AWS credentials.