### PR TITLE
Allow non-default constructible types in `static_thread_pool` bulk customization

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1179,7 +1179,7 @@ namespace exec {
           CvrefSender,
           env_of_t<Receiver>,
           __q<__decayed_std_tuple>,
-          __q<__std_variant>>;
+          __q<__nullable_std_variant>>;
 
       variant_t data_;
       static_thread_pool_& pool_;
@@ -1201,7 +1201,13 @@ namespace exec {
       template <class F>
       void apply(F f) {
         std::visit(
-          [&](auto& tupl) -> void { std::apply([&](auto&... args) -> void { f(args...); }, tupl); },
+          [&](auto& tupl) -> void {
+            if constexpr (same_as<__decay_t<decltype(tupl)>, std::monostate>) {
+              std::terminate();
+            } else {
+              std::apply([&](auto&... args) -> void { f(args...); }, tupl);
+            }
+          },
           data_);
       }
 

--- a/test/stdexec/algos/adaptors/test_bulk.cpp
+++ b/test/stdexec/algos/adaptors/test_bulk.cpp
@@ -19,6 +19,7 @@
 #include <stdexec/execution.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
+#include <test_common/senders.hpp>
 #include <test_common/type_helpers.hpp>
 #include <exec/static_thread_pool.hpp>
 
@@ -336,5 +337,19 @@ namespace {
 
       CHECK(actual != wrong);
     }
+  }
+
+  TEST_CASE("default bulk works with non-default constructible types", "[adaptors][bulk]") {
+    ex::sender auto s = ex::just(non_default_constructible{42}) | ex::bulk(1, [](int, auto&) {});
+    ex::sync_wait(std::move(s));
+  }
+
+  TEST_CASE("static thread pool works with non-default constructible types", "[adaptors][bulk]") {
+    exec::static_thread_pool pool{4};
+    ex::scheduler auto sch = pool.get_scheduler();
+
+    ex::sender auto s = ex::just(non_default_constructible{42}) | ex::continues_on(sch)
+                      | ex::bulk(1, [](int, auto&) {});
+    ex::sync_wait(std::move(s));
   }
 } // namespace

--- a/test/stdexec/algos/adaptors/test_schedule_from.cpp
+++ b/test/stdexec/algos/adaptors/test_schedule_from.cpp
@@ -18,6 +18,7 @@
 #include <stdexec/execution.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
+#include <test_common/senders.hpp>
 #include <test_common/type_helpers.hpp>
 #include <exec/any_sender_of.hpp>
 #include <exec/static_thread_pool.hpp>
@@ -111,19 +112,6 @@ namespace {
     // the work should be executed
     REQUIRE(called);
   }
-
-  struct non_default_constructible {
-    int x;
-
-    non_default_constructible(int x)
-      : x(x) {
-    }
-
-    friend bool
-      operator==(non_default_constructible const & lhs, non_default_constructible const & rhs) {
-      return lhs.x == rhs.x;
-    }
-  };
 
   TEST_CASE(
     "schedule_from can accept non-default constructible types",

--- a/test/test_common/senders.hpp
+++ b/test/test_common/senders.hpp
@@ -168,4 +168,17 @@ namespace {
       return {self.condition_, std::forward<Receiver>(rcvr)};
     }
   };
+
+  struct non_default_constructible {
+    int x;
+
+    non_default_constructible(int x)
+      : x(x) {
+    }
+
+    friend bool
+      operator==(non_default_constructible const & lhs, non_default_constructible const & rhs) {
+      return lhs.x == rhs.x;
+    }
+  };
 } // namespace


### PR DESCRIPTION
Adds test for `static_thread_pool` customization, as well as default `bulk` implementation (this one already supported non-default-constructible types).