### PR TITLE
Improve EDG detection and workarounds

### DIFF
--- a/include/exec/__detail/intrusive_heap.hpp
+++ b/include/exec/__detail/intrusive_heap.hpp
@@ -54,7 +54,7 @@ namespace exec {
 #  endif
 #endif
 
-  template <auto Key, auto Prev, auto Left, auto Right>
+  template <class Node, class KeyT, auto Key, auto Prev, auto Left, auto Right>
   class intrusive_heap;
 
   template <
@@ -64,7 +64,7 @@ namespace exec {
     Node* Node::*Prev,
     Node* Node::*Left,
     Node* Node::*Right>
-  class intrusive_heap<Key, Prev, Left, Right> {
+  class intrusive_heap<Node, KeyT, Key, Prev, Left, Right> {
    public:
     void insert(Node* node) noexcept {
       node->*Prev = nullptr;

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -410,7 +410,7 @@ namespace exec {
       };
     };
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
     template <class _Fn>
     struct __completion_as_tuple2_;
 

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -132,9 +132,15 @@ namespace exec {
      public:
       using promise_type = __promise;
 
+#if STDEXEC_EDG()
+      __task(__coro::coroutine_handle<__promise> __coro) noexcept
+        : __coro_(__coro) {
+      }
+#else
       explicit __task(__coro::coroutine_handle<__promise> __coro) noexcept
         : __coro_(__coro) {
       }
+#endif
 
       __task(__task&& __that) noexcept
         : __coro_(std::exchange(__that.__coro_, {})) {
@@ -184,10 +190,17 @@ namespace exec {
       };
 
       struct __promise : with_awaitable_senders<__promise> {
+#if STDEXEC_EDG()
+        template <class _Action>
+        __promise(_Action&&, _Ts&&... __ts) noexcept
+          : __args_{__ts...} {
+        }
+#else
         template <class _Action>
         explicit __promise(_Action&&, _Ts&... __ts) noexcept
           : __args_{__ts...} {
         }
+#endif
 
         auto initial_suspend() noexcept -> __coro::suspend_always {
           return {};

--- a/include/exec/timed_thread_scheduler.hpp
+++ b/include/exec/timed_thread_scheduler.hpp
@@ -206,7 +206,13 @@ namespace exec {
     }
 
     stdexec::__intrusive_mpsc_queue<&command_type::next_> command_queue_;
-    intrusive_heap<&task_type::when_, &task_type::prev_, &task_type::left_, &task_type::right_>
+    intrusive_heap<
+      task_type,
+      _time_thrd_sched::when_type<time_point>,
+      &task_type::when_,
+      &task_type::prev_,
+      &task_type::left_,
+      &task_type::right_>
       heap_;
     std::atomic<std::ptrdiff_t> n_submissions_in_flight_{0};
     std::mutex ready_mutex_;

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -181,7 +181,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS { namespace _sync_wait {
       return std::move(std::get<1>(state.data_));
     }
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
     // For reporting better diagnostics with nvc++
     template <class _Sender, class _Error = stdexec::__sync_wait::__error_description_t<_Sender>>
     auto operator()(

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -63,7 +63,7 @@ namespace stdexec {
     }
   } // namespace
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
 #  define STDEXEC_SEXPR_DESCRIPTOR(_Tag, _Data, _Child)                                            \
     stdexec::__descriptor_fn<_Tag, _Data, _Child>()
 #else

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -118,10 +118,15 @@
 // macro name; nothing, otherwise.
 #if defined(__NVCC__)
 #  define STDEXEC_NVCC(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
-#elif defined(__NVCOMPILER)
-#  define STDEXEC_NVHPC(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
 #elif defined(__EDG__)
 #  define STDEXEC_EDG(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
+#  if defined(__NVCOMPILER)
+#    define STDEXEC_NVHPC(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
+#  endif
+#  if defined(__INTELLISENSE__)
+#    define STDEXEC_INTELLISENSE(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
+#    define STDEXEC_MSVC_HEADERS(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
+#  endif
 #elif defined(__clang__)
 #  define STDEXEC_CLANG(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
 #  if defined(_MSC_VER)
@@ -134,6 +139,7 @@
 #  define STDEXEC_GCC(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
 #elif defined(_MSC_VER)
 #  define STDEXEC_MSVC(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
+#  define STDEXEC_MSVC_HEADERS(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
 #endif
 
 #ifndef STDEXEC_NVCC
@@ -159,6 +165,12 @@
 #endif
 #ifndef STDEXEC_MSVC
 #  define STDEXEC_MSVC(...) STDEXEC_HEAD_OR_NULL(0, __VA_ARGS__)
+#endif
+#ifndef STDEXEC_MSVC_HEADERS
+#  define STDEXEC_MSVC_HEADERS(...) STDEXEC_HEAD_OR_NULL(0, __VA_ARGS__)
+#endif
+#ifndef STDEXEC_INTELLISENSE
+#  define STDEXEC_INTELLISENSE(...) STDEXEC_HEAD_OR_NULL(0, __VA_ARGS__)
 #endif
 
 #if STDEXEC_NVHPC()
@@ -255,7 +267,7 @@ namespace __coro = std::experimental;
 #  define STDEXEC_PRAGMA_PUSH()          _Pragma("nv_diagnostic push")
 #  define STDEXEC_PRAGMA_POP()           _Pragma("nv_diagnostic pop")
 #  define STDEXEC_PRAGMA_IGNORE_EDG(...) _Pragma(STDEXEC_STRINGIZE(nv_diag_suppress __VA_ARGS__))
-#elif STDEXEC_NVHPC() || STDEXEC_EDG()
+#elif STDEXEC_EDG()
 #  define STDEXEC_PRAGMA_PUSH()                                                                    \
     _Pragma("diagnostic push") STDEXEC_PRAGMA_IGNORE_EDG(invalid_error_number)
 #  define STDEXEC_PRAGMA_POP()           _Pragma("diagnostic pop")

--- a/include/stdexec/__detail/__connect_awaitable.hpp
+++ b/include/stdexec/__detail/__connect_awaitable.hpp
@@ -104,9 +104,15 @@ namespace stdexec {
       struct __t : __promise_base {
         using __id = __promise;
 
+#if STDEXEC_EDG()
+        __t(auto&&, _Receiver&& __rcvr) noexcept
+          : __rcvr_(__rcvr) {
+        }
+#else
         explicit __t(auto&, _Receiver& __rcvr) noexcept
           : __rcvr_(__rcvr) {
         }
+#endif
 
         auto unhandled_stopped() noexcept -> __coro::coroutine_handle<> {
           stdexec::set_stopped(static_cast<_Receiver&&>(__rcvr_));

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -133,7 +133,7 @@ namespace stdexec {
     template <__mstring _Where, __mstring _What>
     struct _FUNCTION_MUST_RETURN_A_VALID_SENDER_IN_THE_CURRENT_ENVIRONMENT_ { };
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
     template <class _Sender, class _Set, class... _Env>
     struct __bad_result_sender_ {
       using __t = __mexception<

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -83,7 +83,7 @@ namespace stdexec {
   enum class __muchar : unsigned char {
   };
 
-#if STDEXEC_NVCC() || STDEXEC_NVHPC()
+#if STDEXEC_NVCC() || STDEXEC_EDG()
   template <std::size_t _Np>
   using __msize_t = std::integral_constant<std::size_t, _Np>;
 #elif STDEXEC_MSVC()
@@ -205,7 +205,7 @@ namespace stdexec {
 
   template <std::size_t _Len>
   struct __mstring {
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
     template <std::size_t _Ny, std::size_t... _Is>
     constexpr __mstring(const char (&__str)[_Ny], __indices<_Is...>) noexcept
       : __what_{(_Is < _Ny ? __str[_Is] : '\0')...} {
@@ -236,7 +236,7 @@ namespace stdexec {
       return false;
     }
 
-#if !STDEXEC_NVHPC()
+#if !STDEXEC_EDG()
     constexpr auto operator<=>(const __mstring &) const noexcept -> std::strong_ordering = default;
 #endif
 
@@ -341,7 +341,7 @@ namespace stdexec {
   template <bool _ArgsOK, bool _FnOK = true>
   struct __i;
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
   // Most compilers memoize alias template specializations, but
   // nvc++ does not. So we memoize the type computations by
   // indirecting through a class template specialization.
@@ -892,7 +892,7 @@ namespace stdexec {
   template <class _From, class _To = __decay_t<_From>>
   using __cvref_id = __copy_cvref_t<_From, __id<_To>>;
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
   // nvc++ doesn't cache the results of alias template specializations.
   // To avoid repeated computation of the same function return type,
   // cache the result ourselves in a class template specialization.
@@ -906,7 +906,7 @@ namespace stdexec {
 #endif
 
 // BUGBUG TODO file this bug with nvc++
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
   template <const auto &_Fun, class... _As>
   using __result_of = __call_result_t<decltype(_Fun), _As...>;
 #else
@@ -1015,7 +1015,7 @@ namespace stdexec {
   template <class _Boolean>
   using __mnot = __meval<__mnot_t, _Boolean>;
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
   template <class... _Ints>
   struct __mplus_t : __mconstant<(__v<_Ints> + ...)> { };
 #else

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -1043,7 +1043,8 @@ namespace stdexec {
     using __f = __mor<__minvoke<_Fn, _Args>...>;
   };
 
-#if defined(__cpp_pack_indexing)
+// test_transfer_when_all.cpp fails on clang-19 with pack indexing.
+#if defined(__cpp_pack_indexing) && !STDEXEC_CLANG()
   template <class _Np, class... _Ts>
   using __m_at = _Ts...[__v<_Np>];
 

--- a/include/stdexec/__detail/__receivers.hpp
+++ b/include/stdexec/__detail/__receivers.hpp
@@ -137,7 +137,7 @@ namespace stdexec {
   namespace __detail {
     template <class _Receiver>
     concept __enable_receiver =                                            //
-      (STDEXEC_NVHPC(requires { typename _Receiver::receiver_concept; }&&) //
+      (STDEXEC_EDG(requires { typename _Receiver::receiver_concept; }&&) //
        derived_from<typename _Receiver::receiver_concept, receiver_t>)
       || requires { typename _Receiver::is_receiver; } // back-compat, NOT TO SPEC
       || STDEXEC_IS_BASE_OF(receiver_t, _Receiver);    // NOT TO SPEC, for receiver_adaptor

--- a/include/stdexec/__detail/__sender_adaptor_closure.hpp
+++ b/include/stdexec/__detail/__sender_adaptor_closure.hpp
@@ -97,10 +97,13 @@ namespace stdexec {
       template <sender _Sender>
         requires __callable<_Fun, _Sender, _As...>
       STDEXEC_ATTRIBUTE((host, device, always_inline))
-      __call_result_t<_Fun, _Sender, _As...>
-        operator()(_Sender&& __sndr) && noexcept(__nothrow_callable<_Fun, _Sender, _As...>) {
+      auto
+        operator()(_Sender&& __sndr) && //
+        noexcept(__nothrow_callable<_Fun, _Sender, _As...>)
+          -> __call_result_t<_Fun, _Sender, _As...> {
         return this->apply(
-          [&__sndr, this](_As&... __as) noexcept(__nothrow_callable<_Fun, _Sender, _As...>)
+          [&__sndr, this](_As&... __as) //
+          noexcept(__nothrow_callable<_Fun, _Sender, _As...>)
             -> __call_result_t<_Fun, _Sender, _As...> {
             return static_cast<_Fun&&>(__fun_)(
               static_cast<_Sender&&>(__sndr), static_cast<_As&&>(__as)...);
@@ -116,8 +119,8 @@ namespace stdexec {
         noexcept(__nothrow_callable<const _Fun&, _Sender, const _As&...>)
           -> __call_result_t<const _Fun&, _Sender, const _As&...> {
         return this->apply(
-          [&__sndr,
-           this](const _As&... __as) noexcept(__nothrow_callable<_Fun, _Sender, const _As&...>)
+          [&__sndr, this](const _As&... __as) //
+          noexcept(__nothrow_callable<const _Fun&, _Sender, const _As&...>)
             -> __call_result_t<const _Fun&, _Sender, const _As&...> {
             return __fun_(static_cast<_Sender&&>(__sndr), __as...);
           },

--- a/include/stdexec/__detail/__sender_adaptor_closure.hpp
+++ b/include/stdexec/__detail/__sender_adaptor_closure.hpp
@@ -94,6 +94,39 @@ namespace stdexec {
       STDEXEC_ATTRIBUTE((no_unique_address))
       _Fun __fun_{};
 
+#if STDEXEC_INTELLISENSE()
+      // MSVCBUG https://developercommunity.visualstudio.com/t/rejects-valid-EDG-invocation-of-lambda/10786020
+
+      template <class _Sender>
+      struct __lambda_rvalue {
+        __binder_back& __self_;
+        _Sender& __sndr_;
+
+        STDEXEC_ATTRIBUTE((host, device, always_inline))
+        auto
+          operator()(_As&... __as) const //
+          noexcept(__nothrow_callable<_Fun, _Sender, _As...>)
+            -> __call_result_t<_Fun, _Sender, _As...> {
+          return static_cast<_Fun&&>(__self_.__fun_)(
+            static_cast<_Sender&&>(__sndr_), static_cast<_As&&>(__as)...);
+        }
+      };
+
+      template <class _Sender>
+      struct __lambda_lvalue {
+        __binder_back const& __self_;
+        _Sender& __sndr_;
+
+        STDEXEC_ATTRIBUTE((host, device, always_inline))
+        auto
+          operator()(const _As&... __as) const //
+          noexcept(__nothrow_callable<const _Fun&, _Sender, const _As&...>)
+            -> __call_result_t<const _Fun&, _Sender, const _As&...> {
+          return __self_.__fun_(static_cast<_Sender&&>(__sndr_), __as...);
+        }
+      };
+#endif
+
       template <sender _Sender>
         requires __callable<_Fun, _Sender, _As...>
       STDEXEC_ATTRIBUTE((host, device, always_inline))
@@ -101,6 +134,9 @@ namespace stdexec {
         operator()(_Sender&& __sndr) && //
         noexcept(__nothrow_callable<_Fun, _Sender, _As...>)
           -> __call_result_t<_Fun, _Sender, _As...> {
+#if STDEXEC_INTELLISENSE()
+        return this->apply(__lambda_rvalue<_Sender>{*this, __sndr}, *this);
+#else
         return this->apply(
           [&__sndr, this](_As&... __as) //
           noexcept(__nothrow_callable<_Fun, _Sender, _As...>)
@@ -109,6 +145,7 @@ namespace stdexec {
               static_cast<_Sender&&>(__sndr), static_cast<_As&&>(__as)...);
           },
           *this);
+#endif
       }
 
       template <sender _Sender>
@@ -118,6 +155,9 @@ namespace stdexec {
         operator()(_Sender&& __sndr) const & //
         noexcept(__nothrow_callable<const _Fun&, _Sender, const _As&...>)
           -> __call_result_t<const _Fun&, _Sender, const _As&...> {
+#if STDEXEC_INTELLISENSE()
+        return this->apply(__lambda_lvalue<_Sender>{*this, __sndr}, *this);
+#else
         return this->apply(
           [&__sndr, this](const _As&... __as) //
           noexcept(__nothrow_callable<const _Fun&, _Sender, const _As&...>)
@@ -125,6 +165,7 @@ namespace stdexec {
             return __fun_(static_cast<_Sender&&>(__sndr), __as...);
           },
           *this);
+#endif
       }
     };
   } // namespace __closure

--- a/include/stdexec/__detail/__senders.hpp
+++ b/include/stdexec/__detail/__senders.hpp
@@ -81,6 +81,7 @@ namespace stdexec {
 
     struct get_completion_signatures_t {
       template <class _Sender, class... _Env>
+        requires (sizeof...(_Env) <= 1)
       static auto __impl() {
         // Compute the type of the transformed sender:
         using __tfx_fn = __if_c<sizeof...(_Env) == 0, __mconst<_Sender>, __q<__tfx_sender>>;

--- a/include/stdexec/__detail/__spin_loop_pause.hpp
+++ b/include/stdexec/__detail/__spin_loop_pause.hpp
@@ -22,14 +22,14 @@
 // Copyright (c) 2019 Maxim Egorushkin. MIT License.
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
-#  if STDEXEC_MSVC()
+#  if STDEXEC_MSVC_HEADERS()
 #    include <intrin.h>
 #  endif
 namespace stdexec {
   STDEXEC_ATTRIBUTE((always_inline))
   static void
     __spin_loop_pause() noexcept {
-#  if STDEXEC_MSVC()
+#  if STDEXEC_MSVC_HEADERS()
     _mm_pause();
 #  else
     __builtin_ia32_pause();

--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -173,7 +173,7 @@ namespace stdexec {
       _Sender,
       __env>>;
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
     // It requires some hoop-jumping to get the NVHPC compiler to report a meaningful
     // diagnostic for SFINAE failures.
     template <class _Sender>
@@ -215,7 +215,7 @@ namespace stdexec {
         return stdexec::apply_sender(__domain, *this, static_cast<_Sender&&>(__sndr));
       }
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
       // This is needed to get sensible diagnostics from nvc++
       template <class _Sender, class _Error = __error_description_t<_Sender>>
       auto operator()(_Sender&&, [[maybe_unused]] _Error __diagnostic = {}) const
@@ -303,7 +303,7 @@ namespace stdexec {
         return stdexec::apply_sender(__domain, *this, static_cast<_Sender&&>(__sndr));
       }
 
-#if STDEXEC_NVHPC()
+#if STDEXEC_EDG()
       template <
         class _Sender,
         class _Error = __error_description_t<__result_of<into_variant, _Sender>>>

--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -33,7 +33,7 @@ namespace stdexec {
   template <class _Ty>
   using __decay_t = __decay(_Ty);
 
-#elif STDEXEC_NVHPC()
+#elif STDEXEC_EDG()
 
   template <class _Ty>
   using __decay_t = std::decay_t<_Ty>;


### PR DESCRIPTION
* Add missing const in `sender_adaptor_closure`.
* Detect NVHPC as EDG first, add separate detection of NVHPC.
* Convert most NVHPC workaround conditions to check for EDG instead.
* Add detection of Visual Studio Intellisense (EDG).
* Add separate detection of the MSVC headers for Intellisense.
* Add workaround for Intellisense issue in `sender_adaptor_closure`.
* Add workarounds for EDG bugs that cropped up related to coroutines.
  It seems that currently the coroutine tests are not built in CI with EDG, because NVC++ is the only EDG based compiler and does not have coroutine support.

There is still an issue in `test_task.cpp` that I haven't been able to figure out. Once that's sorted as well, it would be nice to have another EDG-based compiler in CI, especially one with coroutine support.