### PR TITLE
Ensure `__decay` builtin is not part of function signatures.

### DIFF
--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -31,13 +31,14 @@ namespace stdexec {
 #if STDEXEC_HAS_BUILTIN(__decay)
 
   namespace __tt {
-    template <class _Ty>
-    struct __decay {
-      using type = __decay(_Ty);
+    template <bool>
+    struct __decay_ {
+      template <class _Ty>
+      using __f = __decay(_Ty);
     };
   } // namespace __tt
   template <class _Ty>
-  using __decay_t = typename __tt::__decay<_Ty>::type;
+  using __decay_t = typename __tt::__decay_<sizeof(_Ty) == ~0ul>::template __f<_Ty>;
 
 #elif STDEXEC_NVHPC()
 

--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -38,7 +38,7 @@ namespace stdexec {
     };
   } // namespace __tt
   template <class _Ty>
-  using __decay_t = typename __tt::__decay_<sizeof(_Ty) == ~0ul>::template __f<_Ty>;
+  using __decay_t = typename __tt::__decay_<sizeof(__declval<_Ty>) == ~0ul>::template __f<_Ty>;
 
 #elif STDEXEC_NVHPC()
 

--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -30,8 +30,14 @@ namespace stdexec {
   // __decay_t: An efficient implementation for std::decay
 #if STDEXEC_HAS_BUILTIN(__decay)
 
+  namespace __tt {
+    template <class _Ty>
+    struct __decay {
+      using type = __decay(_Ty);
+    };
+  } // namespace __tt
   template <class _Ty>
-  using __decay_t = __decay(_Ty);
+  using __decay_t = typename __tt::__decay<_Ty>::type;
 
 #elif STDEXEC_NVHPC()
 

--- a/include/stdexec/__detail/__type_traits.hpp
+++ b/include/stdexec/__detail/__type_traits.hpp
@@ -31,6 +31,9 @@ namespace stdexec {
 #if STDEXEC_HAS_BUILTIN(__decay)
 
   namespace __tt {
+    template <class>
+    struct __wrap;
+
     template <bool>
     struct __decay_ {
       template <class _Ty>
@@ -38,7 +41,7 @@ namespace stdexec {
     };
   } // namespace __tt
   template <class _Ty>
-  using __decay_t = typename __tt::__decay_<sizeof(__declval<_Ty>) == ~0ul>::template __f<_Ty>;
+  using __decay_t = typename __tt::__decay_<sizeof(__tt::__wrap<_Ty>*) == ~0ul>::template __f<_Ty>;
 
 #elif STDEXEC_NVHPC()
 


### PR DESCRIPTION
Example in readme fails to compile with at least gcc 14.2.1 and trunk: https://godbolt.org/z/xr536qvEo

Wrap call to `__decay` builtin in class template, same as #1124.