### PR TITLE
Remove relative includes across components

### DIFF
--- a/include/exec/__detail/__atomic_intrusive_queue.hpp
+++ b/include/exec/__detail/__atomic_intrusive_queue.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__intrusive_queue.hpp"
+#include "stdexec/__detail/__intrusive_queue.hpp"
 
 #include <atomic>
 

--- a/include/exec/__detail/__basic_sequence.hpp
+++ b/include/exec/__detail/__basic_sequence.hpp
@@ -16,9 +16,9 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
-#include "../../stdexec/__detail/__meta.hpp"
-#include "../../stdexec/__detail/__basic_sender.hpp"
+#include "stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__basic_sender.hpp"
 
 #include "../sequence_senders.hpp"
 

--- a/include/exec/__detail/__bit_cast.hpp
+++ b/include/exec/__detail/__bit_cast.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__config.hpp"
 
 #if __has_include(<bit>)
 #  include <bit>

--- a/include/exec/__detail/__bwos_lifo_queue.hpp
+++ b/include/exec/__detail/__bwos_lifo_queue.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
-#include "../../stdexec/__detail/__spin_loop_pause.hpp"
+#include "stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__spin_loop_pause.hpp"
 
 #include <atomic>
 #include <bit>

--- a/include/exec/__detail/__numa.hpp
+++ b/include/exec/__detail/__numa.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__config.hpp"
 #include "../scope.hpp"
 
 #include <algorithm>

--- a/include/exec/__detail/intrusive_heap.hpp
+++ b/include/exec/__detail/intrusive_heap.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__config.hpp"
 
 #include <cstddef>
 #include <bit>

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/execution.hpp"
-#include "../stdexec/functional.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/functional.hpp"
 
 #include "./sequence_senders.hpp"
 

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -15,10 +15,10 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/stop_token.hpp"
-#include "../stdexec/__detail/__intrusive_queue.hpp"
-#include "../stdexec/__detail/__optional.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/stop_token.hpp"
+#include "stdexec/__detail/__intrusive_queue.hpp"
+#include "stdexec/__detail/__optional.hpp"
 #include "env.hpp"
 
 #include <mutex>

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -21,7 +21,7 @@
 #include <exception>
 #include <type_traits>
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include "inline_scheduler.hpp"
 #include "any_sender_of.hpp"
 

--- a/include/exec/create.hpp
+++ b/include/exec/create.hpp
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/execution.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
 
 namespace exec {
   namespace __create {

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(1302)

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -16,9 +16,9 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/__detail/__manual_lifetime.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/__detail/__manual_lifetime.hpp"
 
 namespace exec {
   namespace __final {

--- a/include/exec/inline_scheduler.hpp
+++ b/include/exec/inline_scheduler.hpp
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 #include <exception>
 

--- a/include/exec/into_tuple.hpp
+++ b/include/exec/into_tuple.hpp
@@ -15,11 +15,11 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/functional.hpp"
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/__detail/__basic_sender.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/functional.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__basic_sender.hpp"
 
 namespace exec {
   namespace __into_tuple {

--- a/include/exec/just_from.hpp
+++ b/include/exec/just_from.hpp
@@ -15,9 +15,9 @@
  */
 #pragma once
 
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/execution.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
 
 namespace exec {
   struct AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT;

--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
 
 namespace exec {
   namespace __materialize {

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 namespace exec {
   /////////////////////////////////////////////////////////////////////////////

--- a/include/exec/on_coro_disposition.hpp
+++ b/include/exec/on_coro_disposition.hpp
@@ -18,8 +18,8 @@
 
 // The original idea is taken from libunifex and adapted to stdexec.
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/coroutine.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/coroutine.hpp"
 #include "task.hpp"
 #include "inline_scheduler.hpp"
 #include "any_sender_of.hpp"

--- a/include/exec/repeat_effect_until.hpp
+++ b/include/exec/repeat_effect_until.hpp
@@ -16,12 +16,12 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/functional.hpp"
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/__detail/__basic_sender.hpp"
-#include "../stdexec/__detail/__manual_lifetime.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/functional.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__basic_sender.hpp"
+#include "stdexec/__detail/__manual_lifetime.hpp"
 
 #include "on.hpp"
 #include "trampoline_scheduler.hpp"

--- a/include/exec/repeat_n.hpp
+++ b/include/exec/repeat_n.hpp
@@ -16,12 +16,12 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/functional.hpp"
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/__detail/__basic_sender.hpp"
-#include "../stdexec/__detail/__manual_lifetime.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/functional.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__basic_sender.hpp"
+#include "stdexec/__detail/__manual_lifetime.hpp"
 
 #include "on.hpp"
 #include "trampoline_scheduler.hpp"

--- a/include/exec/reschedule.hpp
+++ b/include/exec/reschedule.hpp
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 namespace exec {
   namespace __resched {

--- a/include/exec/scope.hpp
+++ b/include/exec/scope.hpp
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../stdexec/__detail/__scope.hpp"
+#include "stdexec/__detail/__scope.hpp"
 
 namespace exec {
 

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../../stdexec/concepts.hpp"
-#include "../../stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
 #include "../sequence_senders.hpp"
 #include "../any_sender_of.hpp"
 

--- a/include/exec/sequence/empty_sequence.hpp
+++ b/include/exec/sequence/empty_sequence.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../../stdexec/concepts.hpp"
-#include "../../stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
 #include "../sequence_senders.hpp"
 
 namespace exec {

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../../stdexec/concepts.hpp"
-#include "../../stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
 #include "../sequence_senders.hpp"
 
 #include <atomic>

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__config.hpp"
 
 #if STDEXEC_HAS_STD_RANGES()
 

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../../stdexec/concepts.hpp"
-#include "../../stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
 #include "../sequence_senders.hpp"
 
 #include "../__detail/__basic_sequence.hpp"

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 namespace exec {
   struct sequence_sender_t : stdexec::sender_t { };

--- a/include/exec/single_thread_context.hpp
+++ b/include/exec/single_thread_context.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 #include <thread>
 

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -17,11 +17,11 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/__detail/__config.hpp"
-#include "../stdexec/__detail/__intrusive_queue.hpp"
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/__detail/__manual_lifetime.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__intrusive_queue.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__manual_lifetime.hpp"
 #include "__detail/__atomic_intrusive_queue.hpp"
 #include "__detail/__bwos_lifo_queue.hpp"
 #include "__detail/__xorshift.hpp"

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -20,11 +20,11 @@
 #include <exception>
 #include <utility>
 
-#include "../stdexec/coroutine.hpp"
-#include "../stdexec/execution.hpp"
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/__detail/__optional.hpp"
-#include "../stdexec/__detail/__variant.hpp"
+#include "stdexec/coroutine.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__optional.hpp"
+#include "stdexec/__detail/__variant.hpp"
 
 #include "any_sender_of.hpp"
 #include "at_coroutine_exit.hpp"

--- a/include/exec/timed_scheduler.hpp
+++ b/include/exec/timed_scheduler.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/functional.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/functional.hpp"
 
 namespace exec {
   namespace __now {

--- a/include/exec/timed_thread_scheduler.hpp
+++ b/include/exec/timed_thread_scheduler.hpp
@@ -20,8 +20,8 @@
 #include "./timed_scheduler.hpp"
 #include "./__detail/intrusive_heap.hpp"
 
-#include "../stdexec/__detail/__intrusive_mpsc_queue.hpp"
-#include "../stdexec/__detail/__spin_loop_pause.hpp"
+#include "stdexec/__detail/__intrusive_mpsc_queue.hpp"
+#include "stdexec/__detail/__spin_loop_pause.hpp"
 
 #include <bit>
 

--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
-#include "../stdexec/stop_token.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/stop_token.hpp"
 
 #include <cstddef>
 #include <type_traits>

--- a/include/exec/variant_sender.hpp
+++ b/include/exec/variant_sender.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 #include <variant>
 #include <type_traits>

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -16,9 +16,9 @@
  */
 #pragma once
 
-#include "../stdexec/concepts.hpp"
-#include "../stdexec/execution.hpp"
-#include "../stdexec/stop_token.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/stop_token.hpp"
 
 #include <type_traits>
 #include <exception>

--- a/include/nvexec/detail/config.cuh
+++ b/include/nvexec/detail/config.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__config.hpp"
 
 #if !defined(_NVHPC_CUDA) && !defined(__CUDACC__)
 #  error The NVIDIA schedulers and utilities require CUDA support

--- a/include/nvexec/detail/memory.cuh
+++ b/include/nvexec/detail/memory.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 #include <cuda/std/bit>
 

--- a/include/nvexec/detail/queue.cuh
+++ b/include/nvexec/detail/queue.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 #include <memory_resource>
 #include <type_traits>

--- a/include/nvexec/detail/throw_on_cuda_error.cuh
+++ b/include/nvexec/detail/throw_on_cuda_error.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 #include "config.cuh"
 

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -17,8 +17,8 @@
 
 #include <algorithm>
 #include <type_traits>
-#include "../../stdexec/concepts.hpp"
-#include "../../stdexec/execution.hpp"
+#include "stdexec/concepts.hpp"
+#include "stdexec/execution.hpp"
 
 #include "config.cuh"
 

--- a/include/nvexec/multi_gpu_context.cuh
+++ b/include/nvexec/multi_gpu_context.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "stream_context.cuh"

--- a/include/nvexec/nvtx.cuh
+++ b/include/nvexec/nvtx.cuh
@@ -17,7 +17,7 @@
 
 #include <nvtx3/nvToolsExt.h>
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "stream/common.cuh"

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
-#include "../../stdexec/__detail/__ranges.hpp"
+#include "stdexec/execution.hpp"
+#include "stdexec/__detail/__ranges.hpp"
 #include <type_traits>
 
 #include <cuda/std/type_traits>

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -18,7 +18,7 @@
 #include <stack>
 #include <atomic>
 #include <memory_resource>
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 
 #include <cuda/std/type_traits>
 #include <cuda/std/tuple>

--- a/include/nvexec/stream/continues_on.cuh
+++ b/include/nvexec/stream/continues_on.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "../detail/throw_on_cuda_error.cuh"

--- a/include/nvexec/stream/launch.cuh
+++ b/include/nvexec/stream/launch.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 #include <ranges>
 

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <atomic>
-#include "../../stdexec/execution.hpp"
-#include "../../exec/env.hpp"
+#include "stdexec/execution.hpp"
+#include "exec/env.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/start_detached.cuh
+++ b/include/nvexec/stream/start_detached.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/submit.cuh
+++ b/include/nvexec/stream/submit.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include "../../exec/env.hpp"
-#include "../../stdexec/execution.hpp"
+#include "exec/env.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 
 #include "common.cuh"

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "stdexec/execution.hpp"
 #include <type_traits>
 #include <memory_resource>
 

--- a/include/stdexec/__detail/__spin_loop_pause.hpp
+++ b/include/stdexec/__detail/__spin_loop_pause.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__config.hpp"
+#include "stdexec/__detail/__config.hpp"
 
 // The below code for spin_loop_pause is taken from https://github.com/max0x7ba/atomic_queue/blob/master/include/atomic_queue/defs.h
 // Copyright (c) 2019 Maxim Egorushkin. MIT License.


### PR DESCRIPTION
Includes of the form `"../stdexec/execution.hpp"` are converted to `"stdexec/execution.hpp"`. This allows packaging the component headers separately.

If the headers are packaged separately, the packages break due to the relative includes. Personally I think relative includes should always be avoided, but in this PR I only changed those that go across components (`stdexec`, `exec`, `nvexec`, ...).