### PR TITLE
Add workaround for Clang/Catch2/libstdc++ issue

### DIFF
--- a/test/exec/test_just_from.cpp
+++ b/test/exec/test_just_from.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "exec/just_from.hpp"
+#include "test_common/tuple.hpp"
 #include "test_common/type_helpers.hpp"
 
 #include <catch2/catch.hpp>
@@ -75,7 +76,7 @@ TEST_CASE("just_from with multiple completions", "[just_from]") {
       constexpr auto N = std::tuple_size_v<Tupl>;
       CHECK(N == 2);
       if constexpr (N == 2) {
-        CHECK(tupl == std::tuple{43, 44});
+        CHECK_TUPLE(tupl == std::tuple{43, 44});
       }
     },
     var);

--- a/test/stdexec/algos/consumers/test_sync_wait.cpp
+++ b/test/stdexec/algos/consumers/test_sync_wait.cpp
@@ -19,6 +19,7 @@
 #include <test_common/schedulers.hpp>
 #include <test_common/senders.hpp>
 #include <test_common/receivers.hpp>
+#include <test_common/tuple.hpp>
 #include <test_common/type_helpers.hpp>
 #include <exec/static_thread_pool.hpp>
 
@@ -134,7 +135,7 @@ namespace {
       sync_wait_with_variant(snd);
 
     CHECK(res.has_value());
-    CHECK(std::get<0>(std::get<0>(res.value())) == std::make_tuple(13));
+    CHECK_TUPLE(std::get<0>(std::get<0>(res.value())) == std::make_tuple(13));
   }
 
   TEST_CASE(
@@ -147,7 +148,7 @@ namespace {
     std::optional<std::tuple<std::variant<std::tuple<int>>>> res = sync_wait_with_variant(snd);
 
     CHECK(res.has_value());
-    CHECK(std::get<0>(std::get<0>(res.value())) == std::make_tuple(13));
+    CHECK_TUPLE(std::get<0>(std::get<0>(res.value())) == std::make_tuple(13));
   }
 
   TEST_CASE("sync_wait works if signaled from a different thread", "[consumers][sync_wait]") {

--- a/test/test_common/receivers.hpp
+++ b/test/test_common/receivers.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <catch2/catch.hpp>
+#include <test_common/tuple.hpp>
 #include <test_common/type_helpers.hpp>
 #include <stdexec/execution.hpp>
 
@@ -187,7 +188,7 @@ namespace {
     }
 
     void set_value(const Ts&... vals) noexcept {
-      CHECK(values_ == std::tie(vals...));
+      CHECK_TUPLE(values_ == std::tie(vals...));
       this->set_called();
     }
 
@@ -524,8 +525,8 @@ namespace {
     CHECK(res.has_value());
     std::tuple<Ts...> expected(static_cast<Ts&&>(val)...);
     if constexpr (std::tuple_size_v<std::tuple<Ts...>> == 1)
-      CHECK(std::get<0>(res.value()) == std::get<0>(expected));
+      CHECK_TUPLE(std::get<0>(res.value()) == std::get<0>(expected));
     else
-      CHECK(res.value() == expected);
+      CHECK_TUPLE(res.value() == expected);
   }
 } // namespace

--- a/test/test_common/tuple.hpp
+++ b/test/test_common/tuple.hpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Lauri Vasama
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <catch2/catch.hpp>
+
+#include <tuple>
+
+// Workaround for https://github.com/llvm/llvm-project/issues/113087
+#if defined(__clang__) && defined(__cpp_lib_tuple_like)
+#define CHECK_TUPLE(...) CHECK((__VA_ARGS__))
+#else
+#define CHECK_TUPLE CHECK
+#endif


### PR DESCRIPTION
Catch2 `CHECK`s involving tuples fail on Clang with libstdc++ when using C++23 mode, which enables new tuple comparisons operators.

See this Clang issue: https://github.com/llvm/llvm-project/issues/113087