### PR TITLE
Relax overload resolution of any receivers completion functions

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -439,9 +439,7 @@ namespace exec {
         (*__other.__vtable_)(__copy_construct, this, __other);
       }
 
-      auto operator=(const __t& __other) -> __t&
-        requires(_Copyable)
-      {
+      auto operator=(const __t& __other) -> __t& requires(_Copyable) {
         if (&__other != this) {
           __t tmp(__other);
           *this = std::move(tmp);
@@ -615,6 +613,7 @@ namespace exec {
           , public __query_vfun<_Queries>... {
          public:
           using __query_vfun<_Queries>::operator()...;
+          using __any_::__rcvr_vfun<_Sigs>::operator()...;
 
          private:
           template <class _Rcvr>
@@ -674,24 +673,21 @@ namespace exec {
         }
 
         template <class... _As>
-          requires __one_of<set_value_t(_As...), _Sigs...>
+          requires __callable<__vtable_t, void*, set_value_t, _As...>
         void set_value(_As&&... __as) noexcept {
-          const __any_::__rcvr_vfun<set_value_t(_As...)>* __vfun = __env_.__vtable_;
-          (*__vfun->__complete_)(__env_.__rcvr_, static_cast<_As&&>(__as)...);
+          (*__env_.__vtable_)(__env_.__rcvr_, set_value_t(), static_cast<_As&&>(__as)...);
         }
 
         template <class _Error>
-          requires __one_of<set_error_t(_Error), _Sigs...>
+          requires __callable<__vtable_t, void*, set_error_t, _Error>
         void set_error(_Error&& __err) noexcept {
-          const __any_::__rcvr_vfun<set_error_t(_Error)>* __vfun = __env_.__vtable_;
-          (*__vfun->__complete_)(__env_.__rcvr_, static_cast<_Error&&>(__err));
+          (*__env_.__vtable_)(__env_.__rcvr_, set_error_t(), static_cast<_Error&&>(__err));
         }
 
         void set_stopped() noexcept
-          requires __one_of<set_stopped_t(), _Sigs...>
+          requires __callable<__vtable_t, void*, set_stopped_t>
         {
-          const __any_::__rcvr_vfun<set_stopped_t()>* __vfun = __env_.__vtable_;
-          (*__vfun->__complete_)(__env_.__rcvr_);
+          (*__env_.__vtable_)(__env_.__rcvr_, set_stopped_t());
         }
 
         auto get_env() const noexcept -> const __env_t& {

--- a/include/stdexec/__detail/__receiver_ref.hpp
+++ b/include/stdexec/__detail/__receiver_ref.hpp
@@ -30,16 +30,16 @@ namespace stdexec { namespace __any_ {
 
   template <class _Tag, class... _Args>
   struct __rcvr_vfun<_Tag(_Args...)> {
-    void (*__complete_)(void*, _Args&&...) noexcept;
+    void (*__complete_)(void*, _Args...) noexcept;
 
-    void operator()(void* __obj, _Tag, _Args&&... __args) const noexcept {
+    void operator()(void* __obj, _Tag, _Args... __args) const noexcept {
       __complete_(__obj, static_cast<_Args&&>(__args)...);
     }
   };
 
   template <class _GetReceiver = std::identity, class _Obj, class _Tag, class... _Args>
   constexpr auto __rcvr_vfun_fn(_Obj*, _Tag (*)(_Args...)) noexcept {
-    return +[](void* __ptr, _Args&&... __args) noexcept {
+    return +[](void* __ptr, _Args... __args) noexcept {
       _Obj* __obj = static_cast<_Obj*>(__ptr);
       _Tag()(std::move(_GetReceiver()(*__obj)), static_cast<_Args&&>(__args)...);
     };
@@ -95,16 +95,20 @@ namespace stdexec { namespace __any_ {
     }
 
     template <class... _As>
+      requires __callable<__receiver_vtable_for<_Sigs, _Env>, void*, set_value_t, _As...>
     void set_value(_As&&... __as) noexcept {
       (*__vtable_)(__op_state_, set_value_t(), static_cast<_As&&>(__as)...);
     }
 
     template <class _Error>
+      requires __callable<__receiver_vtable_for<_Sigs, _Env>, void*, set_error_t, _Error>
     void set_error(_Error&& __err) noexcept {
       (*__vtable_)(__op_state_, set_error_t(), static_cast<_Error&&>(__err));
     }
 
-    void set_stopped() noexcept {
+    void set_stopped() noexcept
+      requires __callable<__receiver_vtable_for<_Sigs, _Env>, void*, set_stopped_t>
+    {
       (*__vtable_)(__op_state_, set_stopped_t());
     }
 


### PR DESCRIPTION
The completion functions of the any_receiver type are currently more strictly constrained than necessary. This PR relaxes them by obeying the rules of overload resolution. 

That change enables an `any_receiver<set_value_t(int), set_error_t(std::exception_ptr)>::any_sender<>` to be assigned from a sender that has `completion_signatures<set_value_t(const int&), set_error_t(const std::exception_ptr&)>` such as resulting senders from the split algorithm.