### PR TITLE
Use `get_system_scheduler()` to obtain the system scheduler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build*/
+.build*/
 .cache
 .vscode/*
 !.vscode/launch.json

--- a/test/exec/test_system_context.cpp
+++ b/test/exec/test_system_context.cpp
@@ -33,70 +33,41 @@
 
 namespace ex = stdexec;
 
-TEST_CASE("system_context has default ctor and dtor", "[types][system_scheduler]") {
-  STATIC_REQUIRE(std::is_default_constructible_v<exec::system_context>);
-  STATIC_REQUIRE(std::is_destructible_v<exec::system_context>);
-}
-
-TEST_CASE("system_context is not copyable nor movable", "[types][system_scheduler]") {
-  STATIC_REQUIRE_FALSE(std::is_copy_constructible_v<exec::system_context>);
-  STATIC_REQUIRE_FALSE(std::is_move_constructible_v<exec::system_context>);
-}
-
 TEST_CASE("system_context can return a scheduler", "[types][system_scheduler]") {
-  auto sched = exec::system_context{}.get_scheduler();
+  auto sched = exec::get_system_scheduler();
   STATIC_REQUIRE(ex::scheduler<decltype(sched)>);
 }
 
-TEST_CASE("can query max concurrency from system_context", "[types][system_scheduler]") {
-  exec::system_context ctx;
-  size_t max_concurrency = ctx.max_concurrency();
-  REQUIRE(max_concurrency >= 1);
-}
-
 TEST_CASE("system scheduler is not default constructible", "[types][system_scheduler]") {
-  auto sched = exec::system_context{}.get_scheduler();
+  auto sched = exec::get_system_scheduler();
   using sched_t = decltype(sched);
   STATIC_REQUIRE(!std::is_default_constructible_v<sched_t>);
   STATIC_REQUIRE(std::is_destructible_v<sched_t>);
 }
 
 TEST_CASE("system scheduler is copyable and movable", "[types][system_scheduler]") {
-  auto sched = exec::system_context{}.get_scheduler();
+  auto sched = exec::get_system_scheduler();
   using sched_t = decltype(sched);
   STATIC_REQUIRE(std::is_copy_constructible_v<sched_t>);
   STATIC_REQUIRE(std::is_move_constructible_v<sched_t>);
 }
 
 TEST_CASE("a copied scheduler is equal to the original", "[types][system_scheduler]") {
-  exec::system_context ctx;
-  auto sched1 = ctx.get_scheduler();
+  auto sched1 = exec::get_system_scheduler();
   auto sched2 = sched1;
   REQUIRE(sched1 == sched2);
 }
 
 TEST_CASE(
-  "two schedulers obtained from the same system_context are equal",
+  "two schedulers obtained from get_system_scheduler() are equal",
   "[types][system_scheduler]") {
-  exec::system_context ctx;
-  auto sched1 = ctx.get_scheduler();
-  auto sched2 = ctx.get_scheduler();
-  REQUIRE(sched1 == sched2);
-}
-
-TEST_CASE(
-  "compare two schedulers obtained from different system_context objects",
-  "[types][system_scheduler]") {
-  exec::system_context ctx1;
-  auto sched1 = ctx1.get_scheduler();
-  exec::system_context ctx2;
-  auto sched2 = ctx2.get_scheduler();
-  // TODO: clarify the result of this in the paper
+  auto sched1 = exec::get_system_scheduler();
+  auto sched2 = exec::get_system_scheduler();
   REQUIRE(sched1 == sched2);
 }
 
 TEST_CASE("system scheduler can produce a sender", "[types][system_scheduler]") {
-  auto snd = ex::schedule(exec::system_context{}.get_scheduler());
+  auto snd = ex::schedule(exec::get_system_scheduler());
   using sender_t = decltype(snd);
 
   STATIC_REQUIRE(ex::sender<sender_t>);
@@ -105,8 +76,7 @@ TEST_CASE("system scheduler can produce a sender", "[types][system_scheduler]") 
 }
 
 TEST_CASE("trivial schedule task on system context", "[types][system_scheduler]") {
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
 
   ex::sync_wait(ex::schedule(sched));
 }
@@ -114,8 +84,7 @@ TEST_CASE("trivial schedule task on system context", "[types][system_scheduler]"
 TEST_CASE("simple schedule task on system context", "[types][system_scheduler]") {
   std::thread::id this_id = std::this_thread::get_id();
   std::thread::id pool_id{};
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
 
   auto snd = ex::then(ex::schedule(sched), [&] { pool_id = std::this_thread::get_id(); });
 
@@ -127,14 +96,12 @@ TEST_CASE("simple schedule task on system context", "[types][system_scheduler]")
 }
 
 TEST_CASE("simple schedule forward progress guarantee", "[types][system_scheduler]") {
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
   REQUIRE(ex::get_forward_progress_guarantee(sched) == ex::forward_progress_guarantee::parallel);
 }
 
 TEST_CASE("get_completion_scheduler", "[types][system_scheduler]") {
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
   REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(ex::schedule(sched))) == sched);
   REQUIRE(
     ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(ex::schedule(sched))) == sched);
@@ -144,8 +111,7 @@ TEST_CASE("simple chain task on system context", "[types][system_scheduler]") {
   std::thread::id this_id = std::this_thread::get_id();
   std::thread::id pool_id{};
   std::thread::id pool_id2{};
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
 
   auto snd = ex::then(ex::schedule(sched), [&] { pool_id = std::this_thread::get_id(); });
   auto snd2 = ex::then(std::move(snd), [&] { pool_id2 = std::this_thread::get_id(); });
@@ -161,8 +127,7 @@ TEST_CASE("simple chain task on system context", "[types][system_scheduler]") {
 
 // TODO: fix this test. This also makes tsan and asan unhappy.
 // TEST_CASE("checks stop_token before starting the work", "[types][system_scheduler]") {
-//   exec::system_context ctx;
-//   exec::system_scheduler sched = ctx.get_scheduler();
+//   exec::system_scheduler sched = exec::get_system_scheduler();
 
 //   exec::async_scope scope;
 //   scope.request_stop();
@@ -185,8 +150,7 @@ TEST_CASE("simple bulk task on system context", "[types][system_scheduler]") {
   std::thread::id this_id = std::this_thread::get_id();
   constexpr size_t num_tasks = 16;
   std::thread::id pool_ids[num_tasks];
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
 
   auto bulk_snd = ex::bulk(ex::schedule(sched), num_tasks, [&](unsigned long id) {
     pool_ids[id] = std::this_thread::get_id();
@@ -207,8 +171,7 @@ TEST_CASE("simple bulk chaining on system context", "[types][system_scheduler]")
   std::thread::id pool_id{};
   std::thread::id propagated_pool_ids[num_tasks];
   std::thread::id pool_ids[num_tasks];
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
 
   auto snd = ex::then(ex::schedule(sched), [&] {
     pool_id = std::this_thread::get_id();
@@ -268,8 +231,7 @@ TEST_CASE("can change the implementation of system context", "[types][system_sch
 
   std::thread::id this_id = std::this_thread::get_id();
   std::thread::id pool_id{};
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
 
   auto snd = ex::then(ex::schedule(sched), [&] { pool_id = std::this_thread::get_id(); });
 

--- a/test/exec/test_system_context_replaceability.cpp
+++ b/test/exec/test_system_context_replaceability.cpp
@@ -58,8 +58,7 @@ TEST_CASE(
   "[system_scheduler][replaceability]") {
   std::thread::id this_id = std::this_thread::get_id();
   std::thread::id pool_id{};
-  exec::system_context ctx;
-  exec::system_scheduler sched = ctx.get_scheduler();
+  exec::system_scheduler sched = exec::get_system_scheduler();
 
   auto snd = ex::then(ex::schedule(sched), [&] { pool_id = std::this_thread::get_id(); });
 


### PR DESCRIPTION
The `system_context` class is not needed anymore.
This aligns it with the direction of the P2079 paper.