### PR TITLE
Bug:  static_thread_pool::get_scheduler_on_thread causes SegFault

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -407,7 +407,7 @@ namespace exec {
 
         static_thread_pool_* pool_;
         remote_queue* queue_;
-        const nodemask* nodemask_;
+        const nodemask* nodemask_ = &nodemask::any();
         std::size_t thread_idx_{std::numeric_limits<std::size_t>::max()};
 
        public:

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -44,6 +44,7 @@ set(exec_test_sources
     test_trampoline_scheduler.cpp
     test_sequence_senders.cpp
     test_sequence.cpp
+    test_static_thread_pool.cpp
     test_just_from.cpp
     sequence/test_any_sequence_of.cpp
     sequence/test_empty_sequence.cpp

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -1,0 +1,22 @@
+#include "catch2/catch.hpp"
+#include <exec/static_thread_pool.hpp>
+#include <stdexec/execution.hpp>
+
+#include <thread>
+#include <unordered_set>
+namespace ex = stdexec;
+
+TEST_CASE("static_thread_pool::get_scheduler_on_thread Test start on a specific thread", "[types][static_thread_pool]")
+{
+  constexpr const size_t num_of_threads = 5;
+  exec::static_thread_pool pool {num_of_threads};
+
+  std::unordered_set<std::thread::id> thread_ids;
+  for(size_t i = 0; i < num_of_threads; ++i)
+  {
+    auto sender = ex::schedule(pool.get_scheduler_on_thread(i))
+     | ex::then([&]{thread_ids.insert(std::this_thread::get_id());});
+    ex::sync_wait(std::move(sender));
+  }
+  REQUIRE(thread_ids.size() == num_of_threads);
+}

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -6,16 +6,16 @@
 #include <unordered_set>
 namespace ex = stdexec;
 
-TEST_CASE("static_thread_pool::get_scheduler_on_thread Test start on a specific thread", "[types][static_thread_pool]")
-{
+TEST_CASE(
+  "static_thread_pool::get_scheduler_on_thread Test start on a specific thread",
+  "[types][static_thread_pool]") {
   constexpr const size_t num_of_threads = 5;
-  exec::static_thread_pool pool {num_of_threads};
+  exec::static_thread_pool pool{num_of_threads};
 
   std::unordered_set<std::thread::id> thread_ids;
-  for(size_t i = 0; i < num_of_threads; ++i)
-  {
+  for (size_t i = 0; i < num_of_threads; ++i) {
     auto sender = ex::schedule(pool.get_scheduler_on_thread(i))
-     | ex::then([&]{thread_ids.insert(std::this_thread::get_id());});
+                | ex::then([&] { thread_ids.insert(std::this_thread::get_id()); });
     ex::sync_wait(std::move(sender));
   }
   REQUIRE(thread_ids.size() == num_of_threads);


### PR DESCRIPTION
### Issue
`nodemask_` is not initialized when `get_scheduler_on_thread` is called on a `static_thread_pool`

### Details

A new test is added. I haven't find existing tests for the `static_thread_pool`, thought starting one can be handy for later.

The test case creates a new pool and try to start tasks on different thread indexes. It fails with segmentation fault without the fix because the member pointer is not initialized.

With the fix we can observe that the pool scheduled tasks on different threads.