### PR TITLE
squash new warnings from the nvhpc compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,11 +279,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
     # Unset these if using nvc++
     disable_compiler(LANG CUDA)
 
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 24.5.0)
-        set(_nvhpc_seperate_memory_flags "-gpu=mem:separate")
-    else()
-        set(_nvhpc_seperate_memory_flags "-gpu=nomanaged")
-    endif()
+    set(_nvhpc_seperate_memory_flags "-gpu=nomanaged")
+    # if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 24.5.0)
+    #     set(_nvhpc_seperate_memory_flags "-gpu=mem:separate")
+    # endif()
 endif()
 
 # Support target for examples and tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,9 +275,9 @@ target_compile_definitions(
 add_library(nvexec_executable_flags INTERFACE)
 
 target_compile_options(nvexec_executable_flags INTERFACE
-                       $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-gpu=nomanaged>)
+                       $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-gpu=mem:separate>)
 target_link_options(nvexec_executable_flags INTERFACE
-                    $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-gpu=nomanaged>)
+                    $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-gpu=mem:separate>)
 
 # Set up nvexec library
 option(STDEXEC_ENABLE_CUDA "Enable CUDA targets for non-nvc++ compilers" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,21 +271,28 @@ target_compile_definitions(
   stdexec_executable_flags INTERFACE
   $<$<NOT:$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>>:STDEXEC_ENABLE_EXTRA_TYPE_CHECKING>)
 
-# Support target for examples and tests
-add_library(nvexec_executable_flags INTERFACE)
-
-target_compile_options(nvexec_executable_flags INTERFACE
-                       $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-gpu=mem:separate>)
-target_link_options(nvexec_executable_flags INTERFACE
-                    $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-gpu=mem:separate>)
-
 # Set up nvexec library
 option(STDEXEC_ENABLE_CUDA "Enable CUDA targets for non-nvc++ compilers" OFF)
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
     set(STDEXEC_ENABLE_CUDA ON)
     # Unset these if using nvc++
     disable_compiler(LANG CUDA)
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 24.5.0)
+        set(_nvhpc_seperate_memory_flags "-gpu=mem:separate")
+    else()
+        set(_nvhpc_seperate_memory_flags "-gpu=nomanaged")
+    endif()
 endif()
+
+# Support target for examples and tests
+add_library(nvexec_executable_flags INTERFACE)
+
+target_compile_options(nvexec_executable_flags INTERFACE
+                       $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:${_nvhpc_seperate_memory_flags}>)
+target_link_options(nvexec_executable_flags INTERFACE
+                    $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:${_nvhpc_seperate_memory_flags}>)
 
 if(STDEXEC_ENABLE_CUDA)
     file(GLOB_RECURSE nvexec_headers CONFIGURE_DEPENDS include/nvexec/*.cuh)

--- a/examples/nvexec/maxwell/cuda.cuh
+++ b/examples/nvexec/maxwell/cuda.cuh
@@ -18,6 +18,9 @@
 #include "common.cuh"
 #include "nvexec/detail/throw_on_cuda_error.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 template <int BlockThreads, class Action>
 __launch_bounds__(BlockThreads) __global__ void kernel(std::size_t cells, Action action) {
   std::size_t cell_id = threadIdx.x + blockIdx.x * BlockThreads;
@@ -62,3 +65,5 @@ void run_cuda(
 
   cudaStreamDestroy(stream);
 }
+
+STDEXEC_PRAGMA_POP()

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -1150,27 +1150,21 @@ namespace exec {
     }
 
     template <class... _As>
-      requires stdexec::tag_invocable<stdexec::set_value_t, __receiver_base, _As...>
+      requires stdexec::__callable<stdexec::set_value_t, __receiver_base, _As...>
     void set_value(_As&&... __as) noexcept {
-      stdexec::tag_invoke(
-        stdexec::set_value,
-        static_cast<__receiver_base&&>(__receiver_),
-        static_cast<_As&&>(__as)...);
+      stdexec::set_value(static_cast<__receiver_base&&>(__receiver_), static_cast<_As&&>(__as)...);
     }
 
     template <class _Error>
-      requires stdexec::tag_invocable<stdexec::set_error_t, __receiver_base, _Error>
+      requires stdexec::__callable<stdexec::set_error_t, __receiver_base, _Error>
     void set_error(_Error&& __err) noexcept {
-      stdexec::tag_invoke(
-        stdexec::set_error,
-        static_cast<__receiver_base&&>(__receiver_),
-        static_cast<_Error&&>(__err));
+      stdexec::set_error(static_cast<__receiver_base&&>(__receiver_), static_cast<_Error&&>(__err));
     }
 
     void set_stopped() noexcept
-      requires stdexec::tag_invocable<stdexec::set_stopped_t, __receiver_base>
+      requires stdexec::__callable<stdexec::set_stopped_t, __receiver_base>
     {
-      stdexec::tag_invoke(stdexec::set_stopped, static_cast<__receiver_base&&>(__receiver_));
+      stdexec::set_stopped(static_cast<__receiver_base&&>(__receiver_));
     }
 
     auto get_env() const noexcept -> stdexec::env_of_t<__receiver_base> {

--- a/include/nvexec/multi_gpu_context.cuh
+++ b/include/nvexec/multi_gpu_context.cuh
@@ -20,6 +20,9 @@
 
 #include "stream_context.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec {
   namespace STDEXEC_STREAM_DETAIL_NS {
     template <sender Sender, std::integral Shape, class Fun>
@@ -275,3 +278,5 @@ namespace nvexec {
     }
   };
 } // namespace nvexec
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -20,6 +20,9 @@
 
 #include "common.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace _bulk {
@@ -384,3 +387,5 @@ namespace stdexec::__detail {
     nvexec::STDEXEC_STREAM_DETAIL_NS::multi_gpu_bulk_sender_t<__name_of<__t<SenderId>>, Shape, Fun>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::multi_gpu_bulk_sender_t<SenderId, Shape, Fun>>{};
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -30,6 +30,10 @@
 #include "../detail/throw_on_cuda_error.cuh"
 #include "../detail/queue.cuh"
 #include "../detail/variant.cuh"
+#include "stdexec/__detail/__config.hpp"
+
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
 namespace nvexec {
   using stdexec::operator""_mstr;
@@ -813,3 +817,5 @@ namespace nvexec {
 
   inline constexpr STDEXEC_STREAM_DETAIL_NS::get_stream_t get_stream{};
 } // namespace nvexec
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -21,6 +21,9 @@
 #include "../detail/throw_on_cuda_error.cuh"
 #include "common.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace _ensure_started {
     template <class Tag, class... As, class Variant>
@@ -386,3 +389,5 @@ namespace stdexec::__detail {
     nvexec::STDEXEC_STREAM_DETAIL_NS::ensure_started_sender_t<__name_of<__t<SenderId>>>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::ensure_started_sender_t<SenderId>>{};
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/launch.cuh
+++ b/include/nvexec/stream/launch.cuh
@@ -22,6 +22,7 @@
 
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
 namespace nvexec {
   namespace STDEXEC_STREAM_DETAIL_NS {

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -20,6 +20,9 @@
 
 #include "common.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace let_xxx {
     template <class... As, class Fun, class ResultSenderT>
@@ -270,3 +273,5 @@ namespace stdexec::__detail {
     nvexec::STDEXEC_STREAM_DETAIL_NS::let_sender_t<__name_of<__t<SenderId>>, Fun, Set>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::let_sender_t<SenderId, Fun, Set>>{};
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -133,13 +133,13 @@ namespace nvexec {
       using __sender =
         stdexec::__t<reduce_::sender_t<stdexec::__id<__decay_t<Sender>>, InitT, Fun>>;
 
-      template <sender Sender, __movable_value InitT, __movable_value Fun = cub::Sum>
+      template <sender Sender, __movable_value InitT, __movable_value Fun = cuda::std::plus<>>
       __sender<Sender, InitT, Fun> operator()(Sender&& sndr, InitT init, Fun fun) const {
         return __sender<Sender, InitT, Fun>{
           {}, static_cast<Sender&&>(sndr), static_cast<InitT&&>(init), static_cast<Fun&&>(fun)};
       }
 
-      template <class InitT, class Fun = cub::Sum>
+      template <class InitT, class Fun = cuda::std::plus<>>
       STDEXEC_ATTRIBUTE((always_inline)) auto operator()(InitT init, Fun fun = {}) const -> __binder_back<reduce_t, InitT, Fun> {
         return {
           {static_cast<InitT&&>(init), static_cast<Fun&&>(fun)},

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -21,6 +21,9 @@
 #include "common.cuh"
 #include "../detail/variant.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace _sched_from {
@@ -239,3 +242,5 @@ namespace stdexec::__detail {
     nvexec::STDEXEC_STREAM_DETAIL_NS::schedule_from_sender_t<_Scheduler, __name_of<__t<_SenderId>>>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::schedule_from_sender_t<_Scheduler, _SenderId>>;
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -23,6 +23,9 @@
 #include "common.cuh"
 #include "../detail/throw_on_cuda_error.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
   namespace _split {
     inline auto __make_env(
@@ -362,3 +365,5 @@ namespace stdexec::__detail {
   extern __mconst<nvexec::STDEXEC_STREAM_DETAIL_NS::split_sender_t<__name_of<__t<SenderId>>>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::split_sender_t<SenderId>>;
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -20,6 +20,9 @@
 
 #include "common.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace _then {
@@ -207,3 +210,5 @@ namespace stdexec::__detail {
     nvexec::STDEXEC_STREAM_DETAIL_NS::then_sender_t<__name_of<__t<SenderId>>, Fun>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::then_sender_t<SenderId, Fun>>{};
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -20,6 +20,9 @@
 
 #include "common.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace _upon_error {
@@ -189,3 +192,5 @@ namespace stdexec::__detail {
     nvexec::STDEXEC_STREAM_DETAIL_NS::upon_error_sender_t<__name_of<__t<SenderId>>, Fun>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::upon_error_sender_t<SenderId, Fun>>{};
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -20,6 +20,9 @@
 
 #include "common.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace _upon_stopped {
@@ -161,3 +164,5 @@ namespace stdexec::__detail {
     nvexec::STDEXEC_STREAM_DETAIL_NS::upon_stopped_sender_t<__name_of<__t<SenderId>>, Fun>>
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::upon_stopped_sender_t<SenderId, Fun>>{};
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -23,6 +23,9 @@
 #include "../detail/queue.cuh"
 #include "../detail/throw_on_cuda_error.cuh"
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
+
 namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
 
   namespace _when_all {
@@ -447,3 +450,5 @@ namespace stdexec::__detail {
     __name_of_v<nvexec::STDEXEC_STREAM_DETAIL_NS::
                   when_all_sender_t<WithCompletionScheduler, Scheduler, SenderIds...>>{};
 } // namespace stdexec::__detail
+
+STDEXEC_PRAGMA_POP()

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -269,7 +269,8 @@ namespace __coro = std::experimental;
 #  define STDEXEC_PRAGMA_IGNORE_EDG(...) _Pragma(STDEXEC_STRINGIZE(nv_diag_suppress __VA_ARGS__))
 #elif STDEXEC_EDG()
 #  define STDEXEC_PRAGMA_PUSH()                                                                    \
-    _Pragma("diagnostic push") STDEXEC_PRAGMA_IGNORE_EDG(invalid_error_number)
+    _Pragma("diagnostic push") STDEXEC_PRAGMA_IGNORE_EDG(invalid_error_number)                     \
+      STDEXEC_PRAGMA_IGNORE_EDG(invalid_error_tag)
 #  define STDEXEC_PRAGMA_POP()           _Pragma("diagnostic pop")
 #  define STDEXEC_PRAGMA_IGNORE_EDG(...) _Pragma(STDEXEC_STRINGIZE(diag_suppress __VA_ARGS__))
 #elif STDEXEC_CLANG() || STDEXEC_GCC()

--- a/include/stdexec/__detail/__debug.hpp
+++ b/include/stdexec/__detail/__debug.hpp
@@ -21,6 +21,7 @@
 #include "__diagnostics.hpp"
 #include "__env.hpp"
 #include "__meta.hpp"
+#include "__senders_core.hpp"
 #include "__tag_invoke.hpp"
 
 #include <exception> // IWYU pragma: keep for std::terminate

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -159,9 +159,6 @@ namespace stdexec {
   extern const connect_t connect;
 
   template <class _Sender, class _Receiver>
-  using connect_result_t = __call_result_t<connect_t, _Sender, _Receiver>;
-
-  template <class _Sender, class _Receiver>
   concept __nothrow_connectable = __nothrow_callable<connect_t, _Sender, _Receiver>;
 
   struct sender_t;

--- a/include/stdexec/__detail/__receivers.hpp
+++ b/include/stdexec/__detail/__receivers.hpp
@@ -30,13 +30,18 @@ namespace stdexec {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.receivers]
   namespace __rcvrs {
-    struct set_value_t {
-      template <class _Fn, class... _Args>
-      using __f = __minvoke<_Fn, _Args...>;
+    template <class _Receiver, class... _As>
+    concept __set_value_member = requires(_Receiver&& __rcvr, _As&&... __args) {
+      static_cast<_Receiver &&>(__rcvr).set_value(static_cast<_As &&>(__args)...);
+    };
 
-      template <__same_as<set_value_t> _Self, class _Receiver, class... _As>
-      STDEXEC_ATTRIBUTE((host, device, always_inline)) friend auto tag_invoke(_Self, _Receiver&& __rcvr, _As&&... __as) noexcept
-        -> decltype(static_cast<_Receiver&&>(__rcvr).set_value(static_cast<_As&&>(__as)...)) {
+    struct set_value_t {
+      template <class _Fn, class... _As>
+      using __f = __minvoke<_Fn, _As...>;
+
+      template <class _Receiver, class... _As>
+        requires __set_value_member<_Receiver, _As...>
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) friend void tag_invoke(set_value_t, _Receiver&& __rcvr, _As&&... __as) noexcept {
         static_assert(
           noexcept(static_cast<_Receiver&&>(__rcvr).set_value(static_cast<_As&&>(__as)...)),
           "set_value member functions must be noexcept");
@@ -57,14 +62,19 @@ namespace stdexec {
       }
     };
 
+    template <class _Receiver, class _Error>
+    concept __set_error_member = requires(_Receiver&& __rcvr, _Error&& __err) {
+      static_cast<_Receiver &&>(__rcvr).set_error(static_cast<_Error &&>(__err));
+    };
+
     struct set_error_t {
       template <class _Fn, class... _Args>
         requires(sizeof...(_Args) == 1)
       using __f = __minvoke<_Fn, _Args...>;
 
-      template <__same_as<set_error_t> _Self, class _Receiver, class _Error>
-      STDEXEC_ATTRIBUTE((host, device, always_inline)) friend auto tag_invoke(_Self, _Receiver&& __rcvr, _Error&& __err) noexcept
-        -> decltype(static_cast<_Receiver&&>(__rcvr).set_error(static_cast<_Error&&>(__err))) {
+      template <class _Receiver, class _Error>
+        requires __set_error_member<_Receiver, _Error>
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) friend void tag_invoke(set_error_t, _Receiver&& __rcvr, _Error&& __err) noexcept {
         static_assert(
           noexcept(static_cast<_Receiver&&>(__rcvr).set_error(static_cast<_Error&&>(__err))),
           "set_error member functions must be noexcept");
@@ -85,14 +95,19 @@ namespace stdexec {
       }
     };
 
+    template <class _Receiver>
+    concept __set_stopped_member = requires(_Receiver&& __rcvr) { //
+      static_cast<_Receiver &&>(__rcvr).set_stopped();
+    };
+
     struct set_stopped_t {
       template <class _Fn, class... _Args>
         requires(sizeof...(_Args) == 0)
       using __f = __minvoke<_Fn, _Args...>;
 
-      template <__same_as<set_stopped_t> _Self, class _Receiver>
-      STDEXEC_ATTRIBUTE((host, device, always_inline)) friend auto tag_invoke(_Self, _Receiver&& __rcvr) noexcept
-        -> decltype(static_cast<_Receiver&&>(__rcvr).set_stopped()) {
+      template <class _Receiver>
+        requires __set_stopped_member<_Receiver>
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) friend void tag_invoke(set_stopped_t, _Receiver&& __rcvr) noexcept {
         static_assert(
           noexcept(static_cast<_Receiver&&>(__rcvr).set_stopped()),
           "set_stopped member functions must be noexcept");
@@ -147,7 +162,7 @@ namespace stdexec {
       -> __mexception<_MISSING_COMPLETION_SIGNAL_<_Tag(_Args...)>, _WITH_RECEIVER_<_Receiver>>;
 
     template <class _Receiver, class _Tag, class... _Args>
-      requires nothrow_tag_invocable<_Tag, _Receiver, _Args...>
+      requires __callable<_Tag, _Receiver, _Args...>
     auto __try_completion(_Tag (*)(_Args...)) -> __msuccess;
 
     template <class _Receiver, class... _Sigs>

--- a/include/stdexec/__detail/__senders_core.hpp
+++ b/include/stdexec/__detail/__senders_core.hpp
@@ -74,6 +74,5 @@ namespace stdexec {
        };
 
   template <class _Sender, class _Receiver>
-    requires sender_to<_Sender, _Receiver>
   using connect_result_t = __call_result_t<connect_t, _Sender, _Receiver>;
 } // namespace stdexec

--- a/include/stdexec/__detail/__senders_core.hpp
+++ b/include/stdexec/__detail/__senders_core.hpp
@@ -23,6 +23,7 @@
 #include "__concepts.hpp"
 #include "__domain.hpp"
 #include "__env.hpp"
+#include "__receivers.hpp"
 #include "__type_traits.hpp"
 
 namespace stdexec {
@@ -60,4 +61,19 @@ namespace stdexec {
            get_completion_signatures(static_cast<_Sender&&>(__sndr), static_cast<_Env&&>(__env)...)
          } -> __valid_completion_signatures;
        };
+
+  /////////////////////////////////////////////////////////////////////////////
+  // [exec.snd]
+  template <class _Sender, class _Receiver>
+  concept sender_to =                          //
+    receiver<_Receiver>                        //
+    && sender_in<_Sender, env_of_t<_Receiver>> //
+    && __receiver_from<_Receiver, _Sender>     //
+    && requires(_Sender&& __sndr, _Receiver&& __rcvr) {
+         connect(static_cast<_Sender &&>(__sndr), static_cast<_Receiver &&>(__rcvr));
+       };
+
+  template <class _Sender, class _Receiver>
+    requires sender_to<_Sender, _Receiver>
+  using connect_result_t = __call_result_t<connect_t, _Sender, _Receiver>;
 } // namespace stdexec

--- a/include/stdexec/__detail/__transform_completion_signatures.hpp
+++ b/include/stdexec/__detail/__transform_completion_signatures.hpp
@@ -476,10 +476,8 @@ namespace stdexec {
     sender_in<_Sender, _Env...> && __sends<set_stopped_t, _Sender, _Env...>;
 
   template <class _Sender, class... _Env>
-  using __single_sender_value_t = __value_types_t<
-    __completion_signatures_of_t<_Sender, _Env...>,
-    __msingle_or<void>,
-    __q<__msingle>>;
+  using __single_sender_value_t =
+    __value_types_t<__completion_signatures_of_t<_Sender, _Env...>, __q<__msingle>, __q<__msingle>>;
 
   template <class _Sender, class... _Env>
   concept __single_value_sender =  //

--- a/test/nvexec/reduce.cpp
+++ b/test/nvexec/reduce.cpp
@@ -35,7 +35,7 @@ namespace {
 
     nvexec::stream_context stream{};
     auto snd = ex::transfer_just(stream.get_scheduler(), std::span{input})
-             | nvexec::reduce(0, cub::Sum{});
+             | nvexec::reduce(0, cuda::std::plus{});
 
     STATIC_REQUIRE(ex::sender_of<decltype(snd), ex::set_value_t(int&)>);
 
@@ -69,7 +69,7 @@ namespace {
 
     nvexec::stream_context stream{};
     auto snd = ex::transfer_just(stream.get_scheduler(), std::span{first, last})
-             | nvexec::reduce(init, cub::Min{});
+             | nvexec::reduce(init, cuda::minimum{});
 
     auto [result] = ex::sync_wait(std::move(snd)).value();
 

--- a/test/nvexec/reduce.cpp
+++ b/test/nvexec/reduce.cpp
@@ -7,6 +7,7 @@
 
 #include <thrust/device_vector.h>
 #include <cub/thread/thread_operators.cuh>
+#include <cuda/functional>
 
 #include <algorithm>
 #include <span>

--- a/test/stdexec/algos/adaptors/test_stopped_as_optional.cpp
+++ b/test/stdexec/algos/adaptors/test_stopped_as_optional.cpp
@@ -55,7 +55,7 @@ namespace {
     "stopped_as_optional shall not work with multi-value senders",
     "[adaptors][stopped_as_optional]") {
     auto snd = ex::just(3, 0.1415) | ex::stopped_as_optional();
-    static_assert(!std::invocable<ex::connect_t, decltype(snd), expect_error_receiver<>>);
+    static_assert(!ex::sender_to<decltype(snd), expect_error_receiver<>>);
   }
 
   TEST_CASE(
@@ -66,7 +66,7 @@ namespace {
       | ex::let_error([](std::exception_ptr) { return ex::just(std::string{"err"}); });
     check_val_types<ex::__mset<pack<int>, pack<std::string>>>(in_snd);
     auto snd = std::move(in_snd) | ex::stopped_as_optional();
-    static_assert(!std::invocable<ex::connect_t, decltype(snd), expect_error_receiver<>>);
+    static_assert(!ex::sender_to<decltype(snd), expect_error_receiver<>>);
   }
 
   TEST_CASE("stopped_as_optional forwards errors", "[adaptors][stopped_as_optional]") {

--- a/test/stdexec/cpos/test_cpo_connect.cpp
+++ b/test/stdexec/cpos/test_cpo_connect.cpp
@@ -69,7 +69,7 @@ namespace {
 
   TEST_CASE("cannot connect sender with invalid receiver", "[cpo][cpo_connect]") {
     static_assert(ex::sender<my_sender_unconstrained>);
-    REQUIRE_FALSE(std::invocable<ex::connect_t, my_sender_unconstrained, int>);
+    REQUIRE_FALSE(ex::sender_to<my_sender_unconstrained, int>);
   }
 
   struct strange_receiver {


### PR DESCRIPTION
~~as per cplusplus/sender-receiver#320~~ rolled back that change because of potential constraint recursion. i like the other changes in this PR tho.

also tagging along are some warning suppressions in `nvexec/`