### PR TITLE
address continues_on/schedule_from lazy customization snafu

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -74,6 +74,7 @@ CompileFlags:
     - "--expt-relaxed-constexpr"
     - "-forward-unknown-to-host-compiler"
     - "-Werror=cross-execution-space-call"
+    - "-e1000"
 Diagnostics:
   Suppress:
     - "variadic_device_fn"

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -65,7 +65,7 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
             // a kernel and construct the temporary storage on the device to avoid managed
             // memory movements. Otherwise, we construct the temporary storage on the host
             // and prefetch it to the device.
-            storage_t* storage = static_cast<storage_t*>(operation_state_.temp_storage_);
+            auto* storage = static_cast<storage_t*>(operation_state_.temp_storage_);
             constexpr bool construct_on_device = trivially_copyable<__decay_t<As>...>;
 
             if constexpr (!construct_on_device) {

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -37,13 +37,6 @@ namespace stdexec {
   namespace __detail {
     template <class _Sender>
     using __impl_of = decltype((__declval<_Sender>().__impl_));
-
-    struct __get_data {
-      template <class _Data>
-      STDEXEC_ATTRIBUTE((always_inline)) _Data&& operator()(__ignore, _Data&& __data, auto&&...) const noexcept {
-        return static_cast<_Data&&>(__data);
-      }
-    };
   } // namespace __detail
 
   namespace {

--- a/include/stdexec/__detail/__connect_awaitable.hpp
+++ b/include/stdexec/__detail/__connect_awaitable.hpp
@@ -187,8 +187,7 @@ namespace stdexec {
 #  if STDEXEC_GCC() && (__GNUC__ > 11)
       __attribute__((__used__))
 #  endif
-      static auto
-        __co_impl(_Awaitable __awaitable, _Receiver __rcvr) -> __operation_t<_Receiver> {
+      static auto __co_impl(_Awaitable __awaitable, _Receiver __rcvr) -> __operation_t<_Receiver> {
         using __result_t = __await_result_t<_Awaitable, __promise_t<_Receiver>>;
         std::exception_ptr __eptr;
         try {

--- a/include/stdexec/__detail/__continues_on.hpp
+++ b/include/stdexec/__detail/__continues_on.hpp
@@ -29,16 +29,11 @@
 #include "__senders_core.hpp"
 #include "__tag_invoke.hpp"
 #include "__transform_sender.hpp"
-#include "__type_traits.hpp"
-
-#include <utility>
 
 namespace stdexec {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.senders.adaptors.continues_on]
   namespace __continues_on {
-    using __schfr::__environ;
-
     template <class _Env>
     using __scheduler_t = __result_of<get_completion_scheduler<set_value_t>, _Env>;
 
@@ -48,23 +43,22 @@ namespace stdexec {
 
     struct continues_on_t {
       template <sender _Sender, scheduler _Scheduler>
-      auto operator()(_Sender&& __sndr, _Scheduler&& __sched) const -> __well_formed_sender auto {
+      auto operator()(_Sender&& __sndr, _Scheduler __sched) const -> __well_formed_sender auto {
         auto __domain = __get_early_domain(__sndr);
-        using _Env = __t<__environ<__id<__decay_t<_Scheduler>>>>;
         return stdexec::transform_sender(
           __domain,
           __make_sexpr<continues_on_t>(
-            _Env{{static_cast<_Scheduler&&>(__sched)}}, static_cast<_Sender&&>(__sndr)));
+            static_cast<_Scheduler&&>(__sched), static_cast<_Sender&&>(__sndr)));
       }
 
       template <scheduler _Scheduler>
-      STDEXEC_ATTRIBUTE((always_inline)) auto operator()(_Scheduler&& __sched) const
-        -> __binder_back<continues_on_t, __decay_t<_Scheduler>> {
+      STDEXEC_ATTRIBUTE((always_inline)) auto operator()(_Scheduler __sched) const //
+        -> __binder_back<continues_on_t, _Scheduler> {
         return {{static_cast<_Scheduler&&>(__sched)}, {}, {}};
       }
 
       //////////////////////////////////////////////////////////////////////////////////////////////
-      using _Env = __0;
+      using _Sched = __0;
       using _Sender = __1;
       using __legacy_customizations_t = //
         __types<
@@ -72,20 +66,18 @@ namespace stdexec {
             continues_on_t,
             get_completion_scheduler_t<set_value_t>(get_env_t(const _Sender&)),
             _Sender,
-            get_completion_scheduler_t<set_value_t>(_Env)),
-          tag_invoke_t(continues_on_t, _Sender, get_completion_scheduler_t<set_value_t>(_Env))>;
+            _Sched),
+          tag_invoke_t(continues_on_t, _Sender, _Sched)>;
 
-      template <class _Env>
-      static auto __transform_sender_fn(const _Env&) {
+      static auto __transform_sender_fn() {
         return [&]<class _Data, class _Child>(__ignore, _Data&& __data, _Child&& __child) {
-          auto __sched = get_completion_scheduler<set_value_t>(__data);
-          return schedule_from(std::move(__sched), static_cast<_Child&&>(__child));
+          return schedule_from(static_cast<_Data&&>(__data), static_cast<_Child&&>(__child));
         };
       }
 
       template <class _Sender, class _Env>
       static auto transform_sender(_Sender&& __sndr, const _Env& __env) {
-        return __sexpr_apply(static_cast<_Sender&&>(__sndr), __transform_sender_fn(__env));
+        return __sexpr_apply(static_cast<_Sender&&>(__sndr), __transform_sender_fn());
       }
     };
 
@@ -93,13 +85,14 @@ namespace stdexec {
       static constexpr auto get_attrs = //
         []<class _Data, class _Child>(const _Data& __data, const _Child& __child) noexcept
         -> decltype(auto) {
-        return __env::__join(__data, stdexec::get_env(__child));
+        return __env::__join(__sched_attrs{std::cref(__data)}, stdexec::get_env(__child));
       };
 
       static constexpr auto get_completion_signatures = //
         []<class _Sender>(_Sender&&) noexcept           //
         -> __completion_signatures_of_t<                //
-          transform_sender_result_t<default_domain, _Sender, empty_env>> {
+          transform_sender_result_t<default_domain, _Sender, env<>>> {
+        return {};
       };
     };
   } // namespace __continues_on

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -332,9 +332,6 @@ namespace stdexec {
 
   inline constexpr get_domain_t get_domain{};
 
-  template <class _Env>
-  using __domain_of_t = __decay_t<__call_result_t<get_domain_t, _Env>>;
-
   template <class _Tag, class _Queryable, class _Default>
   using __query_result_or_t = __call_result_t<query_or_t, _Tag, _Queryable, _Default>;
 
@@ -658,6 +655,31 @@ namespace stdexec {
     requires(_EnvProvider& __ep) {
       { get_env(std::as_const(__ep)) } -> queryable;
     };
+
+  template <class _Scheduler>
+  struct __sched_attrs {
+    using __t = __sched_attrs;
+    using __id = __sched_attrs;
+
+    using __scheduler_t = __decay_t<_Scheduler>;
+    _Scheduler __sched_;
+
+    auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> __scheduler_t {
+      return __sched_;
+    }
+
+    auto query(get_completion_scheduler_t<set_stopped_t>) const noexcept -> __scheduler_t {
+      return __sched_;
+    }
+
+    template <class _Sched = _Scheduler>
+    auto query(get_domain_t) const noexcept -> __domain_of_t<_Sched> {
+      return get_domain(__sched_);
+    }
+  };
+
+  template <class _Scheduler>
+  __sched_attrs(_Scheduler) -> __sched_attrs<std::unwrap_reference_t<_Scheduler>>;
 
   using __env::__as_root_env_t;
   using __env::__as_root_env;

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -91,6 +91,7 @@ namespace stdexec {
     struct get_stop_token_t;
     template <__completion_tag _CPO>
     struct get_completion_scheduler_t;
+    struct get_domain_t;
   } // namespace __queries
 
   using __queries::forwarding_query_t;
@@ -102,6 +103,7 @@ namespace stdexec {
   using __queries::get_delegation_scheduler_t;
   using __queries::get_stop_token_t;
   using __queries::get_completion_scheduler_t;
+  using __queries::get_domain_t;
 
   extern const forwarding_query_t forwarding_query;
   extern const execute_may_block_caller_t execute_may_block_caller;
@@ -113,6 +115,7 @@ namespace stdexec {
   extern const get_stop_token_t get_stop_token;
   template <__completion_tag _CPO>
   extern const get_completion_scheduler_t<_CPO> get_completion_scheduler;
+  extern const get_domain_t get_domain;
 
   struct never_stop_token;
   class inplace_stop_source;
@@ -130,6 +133,9 @@ namespace stdexec {
   template <class _Sender, class _CPO>
   using __completion_scheduler_for =
     __call_result_t<get_completion_scheduler_t<_CPO>, env_of_t<const _Sender&>>;
+
+  template <class _Env>
+  using __domain_of_t = __decay_t<__call_result_t<get_domain_t, _Env>>;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   namespace __sigs {
@@ -209,6 +215,13 @@ namespace stdexec {
   extern const starts_on_t start_on;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
+  namespace __schfr {
+    struct schedule_from_t;
+  } // namespace __schfr
+
+  using __schfr::schedule_from_t;
+  extern const schedule_from_t schedule_from;
+
   namespace __continues_on {
     struct continues_on_t;
   } // namespace __continues_on

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -341,6 +341,7 @@ namespace stdexec {
     //! the sender factory function, `_Fun`, and passing its result to a receiver.
     template <class _Receiver, class _Fun, class _Set, class _Sched>
     struct __op_state_for {
+      static_assert(!std::is_reference_v<_Sched>);
       template <class... _Args>
       using __f = __op_state_t<
         __mcall<__result_sender_fn<_Set, _Fun, _Sched, env_of_t<_Receiver>>, _Args...>,
@@ -458,7 +459,7 @@ namespace stdexec {
           static_assert(sender_expr_for<_Sender, __let_t<_Set, _Domain>>);
           using _Fun = __data_of<_Sender>;
           using _Child = __child_of<_Sender>;
-          using _Sched = __completion_sched<_Child, _Set>;
+          using _Sched = __decay_t<__completion_sched<_Child, _Set>>;
           using __mk_let_state = __mbind_front_q<__let_state, _Receiver, _Fun, _Set, _Sched>;
 
           using __let_state_t = __gather_completions_of<

--- a/include/stdexec/__detail/__sender_introspection.hpp
+++ b/include/stdexec/__detail/__sender_introspection.hpp
@@ -19,6 +19,14 @@
 
 namespace stdexec {
   namespace __detail {
+    // Accessor for the "data" field of a sender
+    struct __get_data {
+      template <class _Data>
+      STDEXEC_ATTRIBUTE((always_inline)) auto operator()(__ignore, _Data&& __data, auto&&...) const noexcept -> _Data&& {
+        return static_cast<_Data&&>(__data);
+      }
+    };
+
     // A function object that is to senders what std::apply is to tuples:
     struct __sexpr_apply_t {
       template <class _Sender, class _ApplyFn>

--- a/include/stdexec/__detail/__tag_invoke.hpp
+++ b/include/stdexec/__detail/__tag_invoke.hpp
@@ -42,7 +42,8 @@ namespace stdexec {
     // For handling queryables with a static constexpr query member function:
     template <class _Tag, class _Env>
       requires true // so this overload is preferred over the one below
-    STDEXEC_ATTRIBUTE((always_inline)) constexpr auto tag_invoke(_Tag, const _Env&) noexcept -> __mconstant<_Env::query(_Tag())> {
+    STDEXEC_ATTRIBUTE((
+      always_inline)) constexpr auto tag_invoke(_Tag, const _Env&) noexcept -> __mconstant<_Env::query(_Tag())> {
       return {};
     }
 

--- a/include/stdexec/__detail/__transfer_just.hpp
+++ b/include/stdexec/__detail/__transfer_just.hpp
@@ -92,8 +92,7 @@ namespace stdexec {
 
     inline auto __make_env_fn() noexcept {
       return []<class _Scheduler>(const _Scheduler& __sched, const auto&...) noexcept {
-        using _Env = __t<__schfr::__environ<__id<_Scheduler>>>;
-        return _Env{__sched};
+        return __sched_attrs{std::cref(__sched)};
       };
     }
 

--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -429,24 +429,20 @@ namespace stdexec {
     };
 
     struct transfer_when_all_t {
-      using _Env = __0;
+      using _Sched = __0;
       using _Sender = __1;
       using __legacy_customizations_t = //
-        __types<tag_invoke_t(
-          transfer_when_all_t,
-          get_completion_scheduler_t<set_value_t>(const _Env&),
-          _Sender...)>;
+        __types<tag_invoke_t(transfer_when_all_t, _Sched, _Sender...)>;
 
       template <scheduler _Scheduler, sender... _Senders>
         requires __domain::__has_common_domain<_Senders...>
       auto
-        operator()(_Scheduler&& __sched, _Senders&&... __sndrs) const -> __well_formed_sender auto {
-        using _Env = __t<__schfr::__environ<__id<__decay_t<_Scheduler>>>>;
+        operator()(_Scheduler __sched, _Senders&&... __sndrs) const -> __well_formed_sender auto {
         auto __domain = query_or(get_domain, __sched, default_domain());
         return stdexec::transform_sender(
           __domain,
           __make_sexpr<transfer_when_all_t>(
-            _Env{static_cast<_Scheduler&&>(__sched)}, static_cast<_Senders&&>(__sndrs)...));
+            static_cast<_Scheduler&&>(__sched), static_cast<_Senders&&>(__sndrs)...));
       }
 
       template <class _Sender, class _Env>
@@ -458,45 +454,40 @@ namespace stdexec {
           static_cast<_Sender&&>(__sndr),
           [&]<class _Data, class... _Child>(__ignore, _Data&& __data, _Child&&... __child) {
             return continues_on(
-              when_all_t()(static_cast<_Child&&>(__child)...),
-              get_completion_scheduler<set_value_t>(__data));
+              when_all_t()(static_cast<_Child&&>(__child)...), static_cast<_Data&&>(__data));
           });
       }
     };
 
     struct __transfer_when_all_impl : __sexpr_defaults {
       static constexpr auto get_attrs = //
-        []<class _Data>(const _Data& __data, const auto&...) noexcept -> const _Data& {
-        return __data; // NOLINT(bugprone-return-const-ref-from-parameter)
-      };
+        []<class _Data>(const _Data& __data, const auto&...) noexcept {
+          return __sched_attrs{std::cref(__data)};
+        };
 
       static constexpr auto get_completion_signatures = //
-        []<class _Sender>(_Sender&&) noexcept           //
-        -> __completion_signatures_of_t<                //
+        []<class _Sender>(_Sender&&) noexcept
+        -> __completion_signatures_of_t<
           transform_sender_result_t<default_domain, _Sender, empty_env>> {
         return {};
       };
     };
 
     struct transfer_when_all_with_variant_t {
-      using _Env = __0;
+      using _Sched = __0;
       using _Sender = __1;
       using __legacy_customizations_t = //
-        __types<tag_invoke_t(
-          transfer_when_all_with_variant_t,
-          get_completion_scheduler_t<set_value_t>(const _Env&),
-          _Sender...)>;
+        __types<tag_invoke_t(transfer_when_all_with_variant_t, _Sched, _Sender...)>;
 
       template <scheduler _Scheduler, sender... _Senders>
         requires __domain::__has_common_domain<_Senders...>
       auto
         operator()(_Scheduler&& __sched, _Senders&&... __sndrs) const -> __well_formed_sender auto {
-        using _Env = __t<__schfr::__environ<__id<__decay_t<_Scheduler>>>>;
         auto __domain = query_or(get_domain, __sched, default_domain());
         return stdexec::transform_sender(
           __domain,
           __make_sexpr<transfer_when_all_with_variant_t>(
-            _Env{{static_cast<_Scheduler&&>(__sched)}}, static_cast<_Senders&&>(__sndrs)...));
+            static_cast<_Scheduler&&>(__sched), static_cast<_Senders&&>(__sndrs)...));
       }
 
       template <class _Sender, class _Env>
@@ -508,17 +499,16 @@ namespace stdexec {
           static_cast<_Sender&&>(__sndr),
           [&]<class _Data, class... _Child>(__ignore, _Data&& __data, _Child&&... __child) {
             return transfer_when_all_t()(
-              get_completion_scheduler<set_value_t>(static_cast<_Data&&>(__data)),
-              into_variant(static_cast<_Child&&>(__child))...);
+              static_cast<_Data&&>(__data), into_variant(static_cast<_Child&&>(__child))...);
           });
       }
     };
 
     struct __transfer_when_all_with_variant_impl : __sexpr_defaults {
       static constexpr auto get_attrs = //
-        []<class _Data>(const _Data& __data, const auto&...) noexcept -> const _Data& {
-        return __data; // NOLINT(bugprone-return-const-ref-from-parameter)
-      };
+        []<class _Data>(const _Data& __data, const auto&...) noexcept {
+          return __sched_attrs{std::cref(__data)};
+        };
 
       static constexpr auto get_completion_signatures = //
         []<class _Sender>(_Sender&&) noexcept           //

--- a/test/stdexec/algos/adaptors/test_let_value.cpp
+++ b/test/stdexec/algos/adaptors/test_let_value.cpp
@@ -21,8 +21,6 @@
 #include <test_common/type_helpers.hpp>
 #include <exec/static_thread_pool.hpp>
 
-#include <chrono>
-
 namespace ex = stdexec;
 
 using namespace std::chrono_literals;

--- a/test/stdexec/algos/adaptors/test_schedule_from.cpp
+++ b/test/stdexec/algos/adaptors/test_schedule_from.cpp
@@ -23,8 +23,6 @@
 #include <exec/any_sender_of.hpp>
 #include <exec/static_thread_pool.hpp>
 
-#include <chrono>
-
 namespace ex = stdexec;
 
 using namespace std::chrono_literals;


### PR DESCRIPTION
also address some conformance issues with the "Data" type of the continues_on and schedule_from senders, and similar changes to transfer_when_all and transfer_when_all_with_variant.