### PR TITLE
hides the scary files in examples/nvexec from clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -15,7 +15,7 @@ If:
 CompileFlags:
   Add:
     # Allow variadic CUDA functions
-    - "-fcuda-allow-variadic-functions"
+    - "-Xclang=-fcuda-allow-variadic-functions"
 
 ---
 

--- a/.clangd
+++ b/.clangd
@@ -46,6 +46,7 @@ CompileFlags:
 CompileFlags:
   CompilationDatabase: .
   Add:
+    - "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
     # report all errors
     - "-ferror-limit=0"
     - "-fmacro-backtrace-limit=0"

--- a/.clangd
+++ b/.clangd
@@ -1,11 +1,5 @@
 # https://clangd.llvm.org/config
 
-# Apply a config conditionally to all C files
-If:
-  PathMatch: .*\.(c|h)$
-
----
-
 # Apply a config conditionally to all C++ files except those in the
 # include/execpools directory which need platform-dependent headers
 If:
@@ -17,10 +11,11 @@ If:
 # Apply a config conditionally to all CUDA files
 If:
   PathMatch: .*\.cuh?$
+  PathExclude: examples/nvexec/.*
 CompileFlags:
   Add:
     # Allow variadic CUDA functions
-    - "-Xclang=-fcuda-allow-variadic-functions"
+    - "-fcuda-allow-variadic-functions"
 
 ---
 
@@ -35,7 +30,7 @@ CompileFlags:
 
 # Use clang++ in CUDA mode to provide intellisense for files with `nvexec` in their path
 If:
-  PathMatch: (include|examples|test)/nvexec.*
+  PathMatch: [include/nvexec/.*, test/nvexec/.*]
 CompileFlags:
   Compiler: clang++
   Add:
@@ -43,6 +38,7 @@ CompileFlags:
     - "cuda"
     - "-std=gnu++20"
     - "-Wno-unknown-cuda-version"
+    - "--cuda-host-only"
 
 ---
 


### PR DESCRIPTION
clangd is crashy when processing the maxwell files in examples/nvexec, so tell clangd to skip them.