### PR TITLE
fix race condition in nvexec's `when_all` implementation

### DIFF
--- a/include/nvexec/detail/event.cuh
+++ b/include/nvexec/detail/event.cuh
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// clang-format Language: Cpp
+
+#pragma once
+
+#include "config.cuh"
+#include "cuda_fwd.cuh"
+#include "throw_on_cuda_error.cuh"
+
+#include <utility>
+
+namespace nvexec::detail {
+  struct cuda_event {
+    cuda_event() {
+      if (auto status =
+            STDEXEC_DBG_ERR(::cudaEventCreateWithFlags(&event_, cudaEventDisableTiming));
+          status != cudaSuccess) {
+        throw cuda_error(status, "cudaEventCreate");
+      }
+    }
+
+    cuda_event(cuda_event&& other) noexcept
+      : event_(std::exchange(other.event_, nullptr)) {
+    }
+
+    ~cuda_event() {
+      if (event_ != nullptr) {
+        STDEXEC_DBG_ERR(::cudaEventDestroy(event_));
+      }
+    }
+
+    auto operator=(cuda_event&& other) noexcept -> cuda_event& {
+      event_ = std::exchange(other.event_, nullptr);
+      return *this;
+    }
+
+    auto try_record(cudaStream_t stream) noexcept -> cudaError_t {
+      return STDEXEC_DBG_ERR(::cudaEventRecord(event_, stream));
+    }
+
+    auto try_wait(cudaStream_t stream) noexcept -> cudaError_t {
+      return STDEXEC_DBG_ERR(::cudaStreamWaitEvent(stream, event_, 0));
+    }
+
+   private:
+    cudaEvent_t event_{};
+  };
+} // namespace nvexec::detail

--- a/include/nvexec/detail/throw_on_cuda_error.cuh
+++ b/include/nvexec/detail/throw_on_cuda_error.cuh
@@ -18,18 +18,37 @@
 #include "config.cuh"
 
 #include <cstdio>
+#include <stdexcept>
 
 #include <cuda_runtime_api.h>
 
-namespace nvexec {
-  namespace detail {
-    inline cudaError_t debug_cuda_error(
-      cudaError_t error,
-      [[maybe_unused]] char const * file_name,
-      [[maybe_unused]] int line) {
-      // Clear the global CUDA error state which may have been set by the last
-      // call. Otherwise, errors may "leak" to unrelated calls.
-      cudaGetLastError();
+namespace nvexec::detail {
+  class cuda_error : public ::std::runtime_error {
+   private:
+    struct __msg_storage {
+      char __buffer[256]; // NOLINT
+    };
+
+    static auto
+      __format_cuda_error(const int __status, const char* __msg, char* __msg_buffer) noexcept
+      -> char* {
+      ::snprintf(__msg_buffer, 256, "cudaError %d: %s", __status, __msg);
+      return __msg_buffer;
+    }
+
+   public:
+    cuda_error(const int __status, const char* __msg, __msg_storage __msg_buffer = {0}) noexcept
+      : ::std::runtime_error(__format_cuda_error(__status, __msg, __msg_buffer.__buffer)) {
+    }
+  };
+
+  inline auto debug_cuda_error(
+    cudaError_t error,
+    [[maybe_unused]] char const * file_name,
+    [[maybe_unused]] int line) -> cudaError_t {
+    // Clear the global CUDA error state which may have been set by the last
+    // call. Otherwise, errors may "leak" to unrelated calls.
+    cudaGetLastError();
 
 #if defined(STDEXEC_STDERR)
       if (error != cudaSuccess) {
@@ -43,8 +62,7 @@ namespace nvexec {
 #endif
 
       return error;
-    }
-  } // namespace detail
+  }
+} // namespace nvexec::detail
 
 #define STDEXEC_DBG_ERR(E) ::nvexec::detail::debug_cuda_error(E, __FILE__, __LINE__) /**/
-} // namespace nvexec

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -169,18 +169,15 @@ namespace nvexec::STDEXEC_STREAM_DETAIL_NS {
           template <class Error>
           void _set_error_impl(Error&& err) noexcept {
             // TODO: What memory orderings are actually needed here?
-            auto old_state = op_state_->__state_.exchange(_when_all::error);
-            // If the previous state was __error or __stopped, then we have already requested
+            auto old_state = op_state_->state_.exchange(_when_all::error);
+            // If the previous state was error or stopped, then we have already requested
             // stop on the stop source. Otherwise, request stop.
             if (old_state == _when_all::started) {
-              op_state_->__stop_source_.request_stop();
+              op_state_->stop_source_.request_stop();
             }
             // If we are the first child to complete with an error, we must save the error.
             // (Any subsequent errors are ignores.)
             if (old_state != _when_all::error) {
-              op_state_->stop_source_.request_stop();
-              // We won the race, free to write the error into the operation
-              // state without worry.
               op_state_->errors_.template emplace<__decay_t<Error>>(static_cast<Error&&>(err));
             }
             op_state_->arrive();


### PR DESCRIPTION
this also fixes a bug in the cuda version of `when_all` where a child's error completion was getting dropped if a different child stopped early.

finally, it fixes a bug in the default implementation of `when_all` where a stop request gets sent twice if one child finishes with "stopped" and then another child finishes with an error.