### PR TITLE
fix a bad test for `async_scope::spawn_future`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,47 +5,34 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "C++ Tests (lldb)",
-            "type": "lldb",
+            "name": "C++ Current Target (lldb-dap)",
+            "type": "lldb-dap",
             "request": "launch",
-            "stdio": null,
             "stopOnEntry": false,
-            "terminal": "console",
-            "console": "internalConsole",
-            "sourceLanguages": ["cpp", "cuda"],
-            "internalConsoleOptions": "neverOpen",
-            "cwd": "${command:cmake.buildDirectory}",
-            "relativePathBase": "${command:cmake.buildDirectory}",
-            "program": "${command:cmake.buildDirectory}/${input:CXX_TEST_SUITE}",
-            "initCommands": ["settings set target.disable-aslr false"],
-            "args": ["-v", "normal", "${input:CXX_TEST_TAGS}"],
-        },
-        {
-            "name": "CUDA Tests (cuda-gdb)",
-            "type": "cuda-gdb",
-            "request": "launch",
-            "stopAtEntry": false,
-            "breakOnLaunch": false,
-            "internalConsoleOptions": "neverOpen",
-            "program": "${command:cmake.buildDirectory}/${input:CUDA_TEST_SUITE}",
-            "cwd": "${command:cmake.buildDirectory}",
-            "args": "-v normal ${input:CUDA_TEST_TAGS}",
-        },
-        {
-            "name": "C++ Current Target (lldb)",
-            "type": "lldb",
-            "request": "launch",
-            "stdio": null,
-            "stopOnEntry": false,
-            "terminal": "console",
-            "console": "internalConsole",
-            "sourceLanguages": ["cpp", "cuda"],
-            "internalConsoleOptions": "neverOpen",
+            "internalConsoleOptions": "openOnFirstSessionStart",
             "cwd": "${command:cmake.launchTargetDirectory}",
-            "relativePathBase": "${command:cmake.launchTargetDirectory}",
             "program": "${command:cmake.launchTargetPath}",
-            "initCommands": ["settings set target.disable-aslr false"],
+            "initCommands": [
+                "settings set target.disable-aslr false"
+            ],
             "args": "${input:CXX_PROGRAM_ARGS}",
+        },
+        {
+            "name": "C++ Tests (lldb-dap)",
+            "type": "lldb-dap",
+            "request": "launch",
+            "stopOnEntry": false,
+            "internalConsoleOptions": "openOnFirstSessionStart",
+            "cwd": "${command:cmake.buildDirectory}",
+            "program": "${command:cmake.buildDirectory}/${input:CXX_TEST_SUITE}",
+            "initCommands": [
+                "settings set target.disable-aslr false"
+            ],
+            "args": [
+                "-v",
+                "normal",
+                "${input:CXX_TEST_TAGS}"
+            ],
         },
         {
             "name": "CUDA Current Target (cuda-gdb)",
@@ -53,13 +40,26 @@
             "request": "launch",
             "stopAtEntry": false,
             "breakOnLaunch": false,
-            "internalConsoleOptions": "neverOpen",
+            "internalConsoleOptions": "openOnFirstSessionStart",
             "program": "${command:cmake.launchTargetPath}",
             "cwd": "${command:cmake.launchTargetDirectory}",
             "args": "${input:CXX_PROGRAM_ARGS}",
         },
+        {
+            "name": "CUDA Tests (cuda-gdb)",
+            "type": "cuda-gdb",
+            "request": "launch",
+            "stopAtEntry": false,
+            "breakOnLaunch": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "program": "${command:cmake.buildDirectory}/${input:CUDA_TEST_SUITE}",
+            "cwd": "${command:cmake.buildDirectory}",
+            "args": "-v normal ${input:CUDA_TEST_TAGS}",
+        },
     ],
     "inputs": [
+        // These require the Tasks Shell Input extension:
+        // https://marketplace.visualstudio.com/items?itemName=augustocdias.tasks-shell-input
         {
             "id": "CXX_PROGRAM_ARGS",
             "type": "promptString",

--- a/include/exec/just_from.hpp
+++ b/include/exec/just_from.hpp
@@ -59,7 +59,9 @@ namespace exec {
       template <class... Ts>
         requires stdexec::__sigs::__is_compl_sig<_set_tag_t(Ts...)>
       auto operator()(Ts&&... ts) const noexcept //
-        -> stdexec::completion_signatures<_set_tag_t(Ts...)>;
+        -> stdexec::completion_signatures<_set_tag_t(Ts...)> {
+        return {};
+      }
     };
 
     template <class Rcvr>

--- a/include/stdexec/__detail/__starts_on.hpp
+++ b/include/stdexec/__detail/__starts_on.hpp
@@ -37,7 +37,7 @@ namespace stdexec {
     struct __always {
       _Ty __val_;
 
-      auto operator()() noexcept -> _Ty {
+      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()() noexcept(__nothrow_constructible_from<_Ty, _Ty>) -> _Ty {
         return static_cast<_Ty&&>(__val_);
       }
     };

--- a/include/stdexec/__detail/__tuple.hpp
+++ b/include/stdexec/__detail/__tuple.hpp
@@ -46,7 +46,8 @@ namespace stdexec {
 
     template <class _Ty>
     concept __empty = //
-      STDEXEC_IS_EMPTY(_Ty) && STDEXEC_IS_TRIVIALLY_CONSTRUCTIBLE(_Ty);
+      STDEXEC_IS_EMPTY(_Ty) && STDEXEC_IS_TRIVIALLY_CONSTRUCTIBLE(_Ty)
+      && STDEXEC_IS_TRIVIALLY_COPYABLE(_Ty);
 
     template <__empty _Ty>
     inline _Ty __value{};

--- a/test/exec/async_scope/test_spawn_future.cpp
+++ b/test/exec/async_scope/test_spawn_future.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch.hpp>
 #include <exec/async_scope.hpp>
 #include <exec/env.hpp>
+#include <exec/just_from.hpp>
 #include <exec/static_thread_pool.hpp>
 #include "test_common/schedulers.hpp"
 #include "test_common/receivers.hpp"
@@ -148,7 +149,9 @@ namespace {
     };
 
     ex::sender auto snd =
-      scope.spawn_future(ex::starts_on(pool.get_scheduler(), ex::just(throwing_copy())));
+      scope.spawn_future(ex::starts_on(pool.get_scheduler(), exec::just_from([](auto sink) {
+                                         return sink(throwing_copy());
+                                       })));
     try {
       sync_wait(std::move(snd));
       FAIL("Exceptions should have been thrown");


### PR DESCRIPTION
the test was relying on a bug in the implementation of `__tuple`, which this commit also fixes. finally, it fixes a bug in the implementation of `starts_on` that causes `terminate` to be called if moving the sender throws.