### PR TITLE
work around bug in nvc++ regarding lambdas with defaulted parameters

### DIFF
--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -140,7 +140,7 @@ namespace stdexec {
         };
 
       static constexpr auto get_completion_signatures = //
-        []<class _Sender>(_Sender&& __sndr, __ignore = {}) noexcept {
+        []<class _Sender>(_Sender&& __sndr, auto&&...) noexcept {
           static_assert(
             __mnever<tag_of_t<_Sender>>,
             "No customization of get_completion_signatures for this sender tag type.");


### PR DESCRIPTION
from @dkolsen-pgi : 

> The bug is that the front end incorrectly reports a compilation error for a constexpr static data member generic lambda with a default value for one of its function parameters.  Here is the minimal reproducer:
>
> ```c++
> struct A {
>   static constexpr auto f = [](auto, int = 42){};
> };
> ```

