### PR TITLE
Make `STDEXEC::system_context` respect `BUILD_SHARED_LIBS`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,7 @@ if (STDEXEC_ENABLE_NUMA)
 endif()
 
 set(SYSTEM_CONTEXT_SOURCES src/system_context/system_context.cpp)
-add_library(system_context STATIC ${SYSTEM_CONTEXT_SOURCES})
+add_library(system_context ${SYSTEM_CONTEXT_SOURCES})
 target_compile_features(system_context PUBLIC cxx_std_20)
 set_target_properties(system_context PROPERTIES
     CXX_STANDARD 20


### PR DESCRIPTION
Closes https://github.com/NVIDIA/stdexec/issues/1524 if you want.

Default decided by `BUILD_SHARED_LIBS` as per <https://cmake.org/cmake/help/latest/command/add_library.html>, so users already building static libs wont notice.