### PR TITLE
Work around NVC++ bug with partial spec of var template

### DIFF
--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -121,8 +121,9 @@ namespace stdexec {
   template <class _Tp, _Tp _Ip>
   inline constexpr _Tp __v<std::integral_constant<_Tp, _Ip>> = _Ip;
 
+  // `decltype(_Np)` instead of `auto` to work around NVHPC/EDG bug.
   template <auto _Np>
-  inline constexpr auto __v<__mconstant<_Np>> = _Np;
+  inline constexpr decltype(_Np) __v<__mconstant<_Np>> = _Np;
 
   template <std::size_t _Np>
   inline constexpr std::size_t __v<__u8 (*)[_Np]> = _Np - 1; // see definition of __msize_t

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -123,7 +123,7 @@ namespace stdexec {
 
   // `decltype(_Np)` instead of `auto` to work around NVHPC/EDG bug.
   template <auto _Np>
-  inline constexpr decltype(_Np) __v<__mconstant<_Np>> = _Np;
+  inline constexpr __mtypeof<_Np> __v<__mconstant<_Np>> = _Np;
 
   template <std::size_t _Np>
   inline constexpr std::size_t __v<__u8 (*)[_Np]> = _Np - 1; // see definition of __msize_t

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -121,7 +121,7 @@ namespace stdexec {
   template <class _Tp, _Tp _Ip>
   inline constexpr _Tp __v<std::integral_constant<_Tp, _Ip>> = _Ip;
 
-  // `decltype(_Np)` instead of `auto` to work around NVHPC/EDG bug.
+  // `__mtypeof<_Np>` instead of `auto` to work around NVHPC/EDG bug.
   template <auto _Np>
   inline constexpr __mtypeof<_Np> __v<__mconstant<_Np>> = _Np;
 


### PR DESCRIPTION
The development branch of NVC++ currently has a regression where the compiler sometimes gets confused about the type of a partial specialization of a variable template with a deduced type.  Work around this bug by changing the type of `__v<__mconstant<_Np>>` from `auto` to the equivalent `decltype(_Np)`.