### PR TITLE
Customize `bulk_chunked` and `bulk_unchunked` for `parallel_scheduler`

### DIFF
--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "member-function-customization"
       - "pull-request/[0-9]+"
+      - "parallel-scheduler-backend-api"
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}

--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -6,7 +6,6 @@ on:
       - main
       - "member-function-customization"
       - "pull-request/[0-9]+"
-      - "parallel-scheduler-backend-api"
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}

--- a/include/exec/__detail/__system_context_replaceability_api.hpp
+++ b/include/exec/__detail/__system_context_replaceability_api.hpp
@@ -113,7 +113,7 @@ namespace exec::system_context_replaceability {
   /// Receiver for bulk sheduling operations.
   struct bulk_item_receiver : receiver {
     /// Called for each item of a bulk operation, possible on different threads.
-    virtual void execute(std::uint32_t) noexcept = 0;
+    virtual void execute(std::uint32_t, std::uint32_t) noexcept = 0;
   };
 
   /// Interface for the parallel scheduler backend.
@@ -125,9 +125,15 @@ namespace exec::system_context_replaceability {
     /// Schedule work on parallel scheduler, calling `__r` when done and using `__s` for preallocated
     /// memory.
     virtual void schedule(std::span<std::byte> __s, receiver& __r) noexcept = 0;
-    /// Schedule bulk work of size `__n` on parallel scheduler, calling `__r` for each item and then
-    /// when done, and using `__s` for preallocated memory.
-    virtual void bulk_schedule(
+    /// Schedule bulk work of size `__n` on parallel scheduler, calling `__r` for different
+    /// subranges of [0, __n), and using `__s` for preallocated memory.
+    virtual void schedule_bulk_chunked(
+      std::uint32_t __n,
+      std::span<std::byte> __s,
+      bulk_item_receiver& __r) noexcept = 0;
+    /// Schedule bulk work of size `__n` on parallel scheduler, calling `__r` for each item, and
+    /// using `__s` for preallocated memory.
+    virtual void schedule_bulk_unchunked(
       std::uint32_t __n,
       std::span<std::byte> __s,
       bulk_item_receiver& __r) noexcept = 0;

--- a/test/exec/test_system_context.cpp
+++ b/test/exec/test_system_context.cpp
@@ -236,7 +236,7 @@ TEST_CASE("simple bulk_unchunked task on system context", "[types][system_schedu
 }
 
 TEST_CASE("bulk_chunked on parallel_scheduler performs chunking", "[types][system_scheduler]") {
-  bool has_chunking = false;
+  std::atomic<bool> has_chunking = false;
 
   exec::parallel_scheduler sched = exec::get_parallel_scheduler();
   auto bulk_snd =
@@ -247,7 +247,7 @@ TEST_CASE("bulk_chunked on parallel_scheduler performs chunking", "[types][syste
     });
   ex::sync_wait(std::move(bulk_snd));
 
-  REQUIRE(has_chunking);
+  REQUIRE(has_chunking.load());
 }
 
 TEST_CASE(


### PR DESCRIPTION
Doing this, we will align with the intent of P2079R7.
- the backend supports `shedule_bulk_chunked` and `schedule_bulk_unchunked` instead of `bulk_schedule`
- update replaceability API to match P2079R7
- add chunking logic
- if execution policy of bulk_chunked doesn't require parallelization, call only one chunk
- add more tests