### PR TITLE
[execpools,asio] add executor getter to be able to schedule asio functions

### DIFF
--- a/include/execpools/asio/asio_thread_pool.hpp
+++ b/include/execpools/asio/asio_thread_pool.hpp
@@ -32,7 +32,7 @@ namespace execpools {
     }
 
     [[nodiscard]]
-    auto executor() const {
+    auto get_executor() const {
       return executor_;
     }
 

--- a/include/execpools/asio/asio_thread_pool.hpp
+++ b/include/execpools/asio/asio_thread_pool.hpp
@@ -30,6 +30,12 @@ namespace execpools {
       return static_cast<std::uint32_t>(
         asio_impl::query(executor_, asio_impl::execution::occupancy));
     }
+
+    [[nodiscard]]
+    auto executor() const {
+      return executor_;
+    }
+
    private:
     [[nodiscard]]
     static constexpr auto forward_progress_guarantee() -> stdexec::forward_progress_guarantee {

--- a/test/execpools/test_asio_thread_pool.cpp
+++ b/test/execpools/test_asio_thread_pool.cpp
@@ -175,7 +175,7 @@ namespace {
     const auto current_thread_id = std::this_thread::get_id();
 
     execpools::asio_thread_pool pool{1ul};
-    asioexec::asio_impl::system_timer timer{pool.executor()};
+    asioexec::asio_impl::system_timer timer{pool.get_executor()};
     const auto [other_thread_id] =
       stdexec::sync_wait(timer.async_wait(asioexec::use_sender) | stdexec::then([](auto&&...) {
                            return std::this_thread::get_id();
@@ -184,6 +184,6 @@ namespace {
     REQUIRE(current_thread_id != other_thread_id);
 
     // demo to access underlying execution context
-    asioexec::asio_impl::query(pool.executor(), asioexec::asio_impl::execution::context_t{}).stop();
+    asioexec::asio_impl::query(pool.get_executor(), asioexec::asio_impl::execution::context_t{}).stop();
   }
 } // namespace

--- a/test/execpools/test_asio_thread_pool.cpp
+++ b/test/execpools/test_asio_thread_pool.cpp
@@ -29,6 +29,8 @@
 
 #include <execpools/asio/asio_thread_pool.hpp>
 
+#include <asioexec/use_sender.hpp>
+
 namespace ex = stdexec;
 
 namespace {
@@ -167,5 +169,21 @@ namespace {
     STATIC_REQUIRE(std::is_same_v<decltype(value), std::span<double>>);
     REQUIRE(value.data() == output.data());
     CHECK(output == std::array{1.0, 3.0, 2.0, 0.0});
+  }
+
+  TEST_CASE("asiothreadpool with asioexec interoperability") {
+    const auto current_thread_id = std::this_thread::get_id();
+
+    execpools::asio_thread_pool pool{1ul};
+    asioexec::asio_impl::system_timer timer{pool.executor()};
+    const auto [other_thread_id] =
+      stdexec::sync_wait(timer.async_wait(asioexec::use_sender) | stdexec::then([](auto&&...) {
+                           return std::this_thread::get_id();
+                         }))
+        .value();
+    REQUIRE(current_thread_id != other_thread_id);
+
+    // demo to access underlying execution context
+    asioexec::asio_impl::query(pool.executor(), asioexec::asio_impl::execution::context_t{}).stop();
   }
 } // namespace


### PR DESCRIPTION
Currently the asiothread pool can be only used with the senders. However e.g. an asio timer always needs some execution context. 
By adding a getter for the executor of the thread pool, one can use both APIs together as the example test shows