### PR TITLE
implement proposed resolution of P3718

### DIFF
--- a/include/nvexec/nvtx.cuh
+++ b/include/nvexec/nvtx.cuh
@@ -121,8 +121,8 @@ namespace nvexec {
           return {};
         }
 
-        auto get_env() const noexcept -> env_of_t<const Sender&> {
-          return stdexec::get_env(sndr_);
+        auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+          return {&sndr_};
         }
       };
     };

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -147,8 +147,8 @@ namespace nvexec::_strm {
         return {};
       }
 
-      auto get_env() const noexcept -> env_of_t<const Sender&> {
-        return stdexec::get_env(sndr_);
+      auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+        return {&sndr_};
       }
     };
   };
@@ -383,8 +383,8 @@ namespace nvexec::_strm {
         return {};
       }
 
-      auto get_env() const noexcept -> env_of_t<const Sender&> {
-        return stdexec::get_env(sndr_);
+      auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+        return {&sndr_};
       }
     };
   };

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -45,9 +45,7 @@ namespace nvexec::_strm {
       const inplace_stop_source& stop_source,
       stream_provider_t* stream_provider) noexcept {
       return make_stream_env(
-        __env::__from{[&](get_stop_token_t) noexcept {
-          return stop_source.get_token();
-        }},
+        __env::__from{[&](get_stop_token_t) noexcept { return stop_source.get_token(); }},
         stream_provider);
     }
 
@@ -355,8 +353,8 @@ namespace nvexec::_strm {
         return operation_t<Receiver>{static_cast<Receiver&&>(rcvr), std::move(shared_state_)};
       }
 
-      auto get_env() const noexcept -> env_of_t<const Sender&> {
-        return stdexec::get_env(sndr_);
+      auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+        return {&sndr_};
       }
 
       template <class... Tys>
@@ -398,7 +396,7 @@ namespace nvexec::_strm {
     using _sender_t = __t<ensure_started_sender_t<__id<__decay_t<Sender>>>>;
 
     template <class Env, stream_completing_sender Sender>
-    auto operator()(__ignore, Env&& /*env*/, Sender&& sndr) const -> _sender_t<Sender> {
+    auto operator()(__ignore, Env&&, Sender&& sndr) const -> _sender_t<Sender> {
       auto sched = get_completion_scheduler<set_value_t>(get_env(sndr));
       return _sender_t<Sender>{sched.context_state_, static_cast<Sender&&>(sndr)};
     }

--- a/include/nvexec/stream/launch.cuh
+++ b/include/nvexec/stream/launch.cuh
@@ -151,8 +151,8 @@ namespace nvexec {
           return {};
         }
 
-        auto get_env() const noexcept -> env_of_t<const Sender&> {
-          return stdexec::get_env(sndr_);
+        auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+          return {&sndr_};
         }
       };
     };

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -40,9 +40,7 @@ namespace nvexec::_strm {
       const inplace_stop_source& stop_source,
       stream_provider_t* stream_provider) noexcept {
       return make_stream_env(
-        __env::__from{[&](get_stop_token_t) noexcept {
-          return stop_source.get_token();
-        }},
+        __env::__from{[&](get_stop_token_t) noexcept { return stop_source.get_token(); }},
         stream_provider);
     }
 
@@ -358,9 +356,8 @@ namespace nvexec::_strm {
         return operation_t<Receiver>{static_cast<Receiver&&>(rcvr), shared_state_};
       }
 
-      [[nodiscard]]
-      auto get_env() const noexcept -> env_of_t<const Sender&> {
-        return stdexec::get_env(sndr_);
+      auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+        return {&sndr_};
       }
 
       explicit __t(context_state_t context_state, Sender sndr)

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -207,8 +207,8 @@ namespace nvexec::_strm {
         return {};
       }
 
-      auto get_env() const noexcept -> env_of_t<const Sender&> {
-        return stdexec::get_env(sndr_);
+      auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+        return {&sndr_};
       }
     };
   };

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -189,8 +189,8 @@ namespace nvexec::_strm {
         return {};
       }
 
-      auto get_env() const noexcept -> env_of_t<const Sender&> {
-        return stdexec::get_env(sndr_);
+      auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+        return {&sndr_};
       }
     };
   };

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -159,8 +159,8 @@ namespace nvexec::_strm {
         return {};
       }
 
-      auto get_env() const noexcept -> env_of_t<const Sender&> {
-        return stdexec::get_env(sndr_);
+      auto get_env() const noexcept -> stream_sender_attrs<Sender> {
+        return {&sndr_};
       }
     };
   };

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -106,7 +106,7 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-#ifdef __CUDACC__
+#if defined(__CUDACC__) || STDEXEC_NVHPC()
 #  define STDEXEC_CUDA(...) STDEXEC_HEAD_OR_TAIL(1, __VA_ARGS__)
 #else
 #  define STDEXEC_CUDA(...) STDEXEC_HEAD_OR_NULL(0, __VA_ARGS__)
@@ -481,6 +481,63 @@ namespace stdexec {
 #  undef STDEXEC_ENABLE_EXTRA_TYPE_CHECKING
 #  define STDEXEC_ENABLE_EXTRA_TYPE_CHECKING() 1
 #endif
+
+#if STDEXEC_MSVC()
+#  define STDEXEC_NO_EXCEPTIONS() (_HAS_EXCEPTIONS == 0) || (_CPPUNWIND == 0)
+#else
+#  define STDEXEC_NO_EXCEPTIONS() (__EXCEPTIONS == 0)
+#endif
+
+// We need to treat host and device separately
+#if STDEXEC_CUDA() && defined(__CUDA_ARCH__) && !STDEXEC_NVHPC()
+#  define STDEXEC_GLOBAL_CONSTANT STDEXEC_ATTRIBUTE((device)) constexpr
+#else
+#  define STDEXEC_GLOBAL_CONSTANT inline constexpr
+#endif
+
+#if defined(__CUDACC__) || STDEXEC_NVHPC()
+#  define STDEXEC_CUDA_COMPILATION() 1
+#else
+#  define STDEXEC_CUDA_COMPILATION() 0
+#endif
+
+#if STDEXEC_CUDA_COMPILATION() || __has_include(<cuda_runtime_api.h>)
+#  define STDEXEC_HAS_CTK() 1
+#else
+#  define STDEXEC_HAS_CTK() 0
+#endif
+
+// clang-format off
+#if STDEXEC_HAS_CTK() && __has_include(<nv/target>)
+#  include <nv/target>
+#  define STDEXEC_IF_HOST(...)     NV_IF_TARGET(NV_IS_HOST, (__VA_ARGS__;))
+#  define STDEXEC_IF_DEVICE(...)   NV_IF_TARGET(NV_IS_DEVICE, (__VA_ARGS__;))
+#else
+#  define STDEXEC_IF_HOST(...)     {__VA_ARGS__;}
+#  define STDEXEC_IF_DEVICE(...)
+#endif
+// clang-format on
+
+// CUDA compilers preinclude cuda_runtime.h, so we need to include it here to get the CUDART_VERSION macro
+#if STDEXEC_HAS_CTK() && !STDEXEC_CUDA_COMPILATION()
+#  include <cuda_runtime_api.h>
+#endif
+
+// clang-format off
+#if STDEXEC_NO_EXCEPTIONS() || (STDEXEC_CUDA_COMPILATION() && defined(__CUDA_ARCH__))
+#  define STDEXEC_TRY
+#  define STDEXEC_CATCH(...) STDEXEC_CATCH_I
+#  define STDEXEC_CATCH_I(...)
+#elif STDEXEC_CUDA_COMPILATION() && STDEXEC_NVHPC()
+#  define STDEXEC_TRY if target (nv::target::is_host) { try
+#  define STDEXEC_CATCH(...) catch(__VA_ARGS__) STDEXEC_CATCH_I
+#  define STDEXEC_CATCH_I(...) { __VA_ARGS__ } } else { __VA_ARGS__ }
+#else
+#  define STDEXEC_TRY try
+#  define STDEXEC_CATCH(...) catch(__VA_ARGS__) STDEXEC_CATCH_I
+#  define STDEXEC_CATCH_I(...) { __VA_ARGS__ }
+#endif
+// clang-format on
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // clang-tidy struggles with the CUDA function annotations

--- a/include/stdexec/__detail/__continues_on.hpp
+++ b/include/stdexec/__detail/__continues_on.hpp
@@ -71,7 +71,9 @@ namespace stdexec {
       static constexpr auto get_attrs = //
         []<class _Data, class _Child>(const _Data& __data, const _Child& __child) noexcept
         -> decltype(auto) {
-        return __env::__join(__sched_attrs{std::cref(__data)}, stdexec::get_env(__child));
+        using __domain_t = __detail::__early_domain_of_t<_Child, __none_such>;
+        return __env::__join(
+          __sched_attrs{std::cref(__data), __domain_t{}}, stdexec::get_env(__child));
       };
 
       static constexpr auto get_completion_signatures = //

--- a/include/stdexec/__detail/__ensure_started.hpp
+++ b/include/stdexec/__detail/__ensure_started.hpp
@@ -43,7 +43,8 @@ namespace stdexec {
         if constexpr (sender_expr_for<_Sender, __ensure_started_t>) {
           return static_cast<_Sender&&>(__sndr);
         } else {
-          auto __domain = __get_late_domain(__sndr, __env);
+          auto __early_domain = __get_early_domain(__sndr);
+          auto __domain = __get_late_domain(__sndr, __env, __early_domain);
           return stdexec::transform_sender(
             __domain,
             __make_sexpr<ensure_started_t>(

--- a/include/stdexec/__detail/__schedule_from.hpp
+++ b/include/stdexec/__detail/__schedule_from.hpp
@@ -164,7 +164,9 @@ namespace stdexec {
 
       static constexpr auto get_attrs = //
         []<class _Data, class _Child>(const _Data& __data, const _Child& __child) noexcept {
-          return __env::__join(__sched_attrs{std::cref(__data)}, stdexec::get_env(__child));
+          auto __domain = query_or(get_domain, __data, default_domain{});
+          return __env::__join(
+            __sched_attrs{std::cref(__data), __domain}, stdexec::get_env(__child));
         };
 
       static constexpr auto get_completion_signatures = //

--- a/include/stdexec/__detail/__split.hpp
+++ b/include/stdexec/__detail/__split.hpp
@@ -39,7 +39,7 @@ namespace stdexec {
       template <sender _Sender, class _Env = env<>>
         requires sender_in<_Sender, _Env> && __decay_copyable<env_of_t<_Sender>>
       auto operator()(_Sender&& __sndr, _Env&& __env = {}) const -> __well_formed_sender auto {
-        auto __domain = __get_late_domain(__sndr, __env);
+        auto __domain = __get_late_domain(__sndr, __env, __get_early_domain(__sndr));
         return stdexec::transform_sender(
           __domain,
           __make_sexpr<split_t>(static_cast<_Env&&>(__env), static_cast<_Sender&&>(__sndr)));

--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -27,7 +27,6 @@
 #include "__meta.hpp"
 #include "__senders.hpp"
 #include "__receivers.hpp"
-#include "__submit.hpp"
 #include "__transform_completion_signatures.hpp"
 #include "__transform_sender.hpp"
 #include "__run_loop.hpp"
@@ -187,7 +186,8 @@ namespace stdexec {
         if constexpr (!sender_in<_Sender, __env>) {
           stdexec::__diagnose_sender_concept_failure<_Sender, __env>();
         } else {
-          using __domain_t = __late_domain_of_t<_Sender, __env>;
+          using __early_domain_t = __early_domain_of_t<_Sender>;
+          using __domain_t = __late_domain_of_t<_Sender, __env, __early_domain_t>;
           constexpr auto __success_completion_count =
             __v<value_types_of_t<_Sender, __env, __types, __msize::__f>>;
           static_assert(

--- a/include/stdexec/__detail/__then.hpp
+++ b/include/stdexec/__detail/__then.hpp
@@ -73,22 +73,22 @@ namespace stdexec {
         return {};
       };
 
-      static constexpr auto complete = //
-        []<class _Tag, class _State, class _Receiver, class... _Args>(
-          __ignore,
-          _State& __state,
-          _Receiver& __rcvr,
-          _Tag,
-          _Args&&... __args) noexcept -> void {
-        if constexpr (__same_as<_Tag, set_value_t>) {
-          stdexec::__set_value_invoke(
-            static_cast<_Receiver&&>(__rcvr),
-            static_cast<_State&&>(__state),
-            static_cast<_Args&&>(__args)...);
-        } else {
-          _Tag()(static_cast<_Receiver&&>(__rcvr), static_cast<_Args&&>(__args)...);
+      struct __complete_fn {
+        template <class _Tag, class _State, class _Receiver, class... _Args>
+        STDEXEC_ATTRIBUTE((host, device)) void operator()(__ignore, _State& __state, _Receiver& __rcvr, _Tag, _Args&&... __args)
+          const noexcept {
+          if constexpr (__same_as<_Tag, set_value_t>) {
+            stdexec::__set_value_invoke(
+              static_cast<_Receiver&&>(__rcvr),
+              static_cast<_State&&>(__state),
+              static_cast<_Args&&>(__args)...);
+          } else {
+            _Tag()(static_cast<_Receiver&&>(__rcvr), static_cast<_Args&&>(__args)...);
+          }
         }
       };
+
+      static constexpr auto complete = __complete_fn{};
     };
   } // namespace __then
 

--- a/include/stdexec/__detail/__transfer_just.hpp
+++ b/include/stdexec/__detail/__transfer_just.hpp
@@ -69,8 +69,9 @@ namespace stdexec {
       }
     };
 
-    inline auto __make_env_fn() noexcept {
+    inline auto __make_attrs_fn() noexcept {
       return []<class _Scheduler>(const _Scheduler& __sched, const auto&...) noexcept {
+        static_assert(scheduler<_Scheduler>, "transfer_just requires a scheduler");
         return __sched_attrs{std::cref(__sched)};
       };
     }
@@ -78,7 +79,7 @@ namespace stdexec {
     struct __transfer_just_impl : __sexpr_defaults {
       static constexpr auto get_attrs = //
         []<class _Data>(const _Data& __data) noexcept {
-          return __data.apply(__make_env_fn(), __data);
+          return __data.apply(__make_attrs_fn(), __data);
         };
 
       static constexpr auto get_completion_signatures = //

--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -36,16 +36,20 @@ STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 
 namespace stdexec {
-  inline constexpr std::size_t __variant_npos = ~0UL;
+#if STDEXEC_NVHPC()
+  enum __variant_npos_t : std::size_t {
+    __variant_npos = ~0UL
+  };
+#else
+  STDEXEC_GLOBAL_CONSTANT std::size_t __variant_npos = ~0UL;
+#endif
 
   struct __monostate { };
 
   namespace __var {
     STDEXEC_ATTRIBUTE((host, device)) inline auto __mk_index_guard(std::size_t &__index, std::size_t __new) noexcept {
       __index = __new;
-      return __scope_guard{[&__index]() noexcept {
-        __index = __variant_npos;
-      }};
+      return __scope_guard{[&__index]() noexcept { __index = __variant_npos; }};
     }
 
     template <auto _Idx, class... _Ts>

--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -451,8 +451,10 @@ namespace stdexec {
 
     struct __transfer_when_all_impl : __sexpr_defaults {
       static constexpr auto get_attrs = //
-        []<class _Data>(const _Data& __data, const auto&...) noexcept {
-          return __sched_attrs{std::cref(__data)};
+        []<class _Scheduler, class... _Child>(const _Scheduler& __sched, const _Child&...) noexcept {
+          using __sndr_t = __call_result_t<when_all_t, _Child...>;
+          using __domain_t = __detail::__early_domain_of_t<__sndr_t, __none_such>;
+          return __sched_attrs{std::cref(__sched), __domain_t{}};
         };
 
       static constexpr auto get_completion_signatures = //
@@ -490,8 +492,10 @@ namespace stdexec {
 
     struct __transfer_when_all_with_variant_impl : __sexpr_defaults {
       static constexpr auto get_attrs = //
-        []<class _Data>(const _Data& __data, const auto&...) noexcept {
-          return __sched_attrs{std::cref(__data)};
+        []<class _Scheduler, class... _Child>(const _Scheduler& __sched, const _Child&...) noexcept {
+          using __sndr_t = __call_result_t<when_all_with_variant_t, _Child...>;
+          using __domain_t = __detail::__early_domain_of_t<__sndr_t, __none_such>;
+          return __sched_attrs{std::cref(__sched), __domain_t{}};
         };
 
       static constexpr auto get_completion_signatures = //

--- a/include/stdexec/functional.hpp
+++ b/include/stdexec/functional.hpp
@@ -33,7 +33,7 @@ namespace stdexec {
 
     template <class... _Ts>
       requires __callable<_Fun1, _Ts...> && __callable<_Fun0, __call_result_t<_Fun1, _Ts...>>
-    STDEXEC_ATTRIBUTE((always_inline)) auto
+    STDEXEC_ATTRIBUTE((host, device, always_inline)) auto
       operator()(_Ts&&... __ts) && -> __call_result_t<_Fun0, __call_result_t<_Fun1, _Ts...>> {
       return static_cast<_Fun0&&>(__t0_)(static_cast<_Fun1&&>(__t1_)(static_cast<_Ts&&>(__ts)...));
     }
@@ -41,7 +41,7 @@ namespace stdexec {
     template <class... _Ts>
       requires __callable<const _Fun1&, _Ts...>
             && __callable<const _Fun0&, __call_result_t<const _Fun1&, _Ts...>>
-    STDEXEC_ATTRIBUTE((always_inline)) auto
+    STDEXEC_ATTRIBUTE((host, device, always_inline)) auto
       operator()(_Ts&&... __ts) const & -> __call_result_t<_Fun0, __call_result_t<_Fun1, _Ts...>> {
       return __t0_(__t1_(static_cast<_Ts&&>(__ts)...));
     }
@@ -49,7 +49,7 @@ namespace stdexec {
 
   inline constexpr struct __compose_t {
     template <class _Fun0, class _Fun1>
-    STDEXEC_ATTRIBUTE((always_inline)) auto operator()(_Fun0 __fun0, _Fun1 __fun1) const -> __composed<_Fun0, _Fun1> {
+    STDEXEC_ATTRIBUTE((host, device, always_inline)) auto operator()(_Fun0 __fun0, _Fun1 __fun1) const -> __composed<_Fun0, _Fun1> {
       return {static_cast<_Fun0&&>(__fun0), static_cast<_Fun1&&>(__fun1)};
     }
   } __compose{};
@@ -62,7 +62,7 @@ namespace stdexec {
 
     struct __funobj {
       template <class _Fun, class... _Args>
-      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Fun&& __fun, _Args&&... __args) const
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Fun&& __fun, _Args&&... __args) const
         noexcept(noexcept((static_cast<_Fun&&>(__fun))(static_cast<_Args&&>(__args)...)))
           -> decltype((static_cast<_Fun&&>(__fun))(static_cast<_Args&&>(__args)...)) {
         return static_cast<_Fun&&>(__fun)(static_cast<_Args&&>(__args)...);
@@ -71,7 +71,7 @@ namespace stdexec {
 
     struct __memfn {
       template <class _Memptr, class _Ty, class... _Args>
-    STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Memptr __mem_ptr, _Ty&& __ty, _Args&&... __args) const
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Memptr __mem_ptr, _Ty&& __ty, _Args&&... __args) const
         noexcept(noexcept(((static_cast<_Ty&&>(__ty)).*__mem_ptr)(static_cast<_Args&&>(__args)...)))
           -> decltype(((static_cast<_Ty&&>(__ty)).*__mem_ptr)(static_cast<_Args&&>(__args)...)) {
         return ((static_cast<_Ty&&>(__ty)).*__mem_ptr)(static_cast<_Args&&>(__args)...);
@@ -80,7 +80,7 @@ namespace stdexec {
 
     struct __memfn_refwrap {
       template <class _Memptr, class _Ty, class... _Args>
-    STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Memptr __mem_ptr, _Ty __ty, _Args&&... __args) const
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Memptr __mem_ptr, _Ty __ty, _Args&&... __args) const
         noexcept(noexcept((__ty.get().*__mem_ptr)(static_cast<_Args&&>(__args)...)))
           -> decltype((__ty.get().*__mem_ptr)(static_cast<_Args&&>(__args)...)) {
         return (__ty.get().*__mem_ptr)(static_cast<_Args&&>(__args)...);
@@ -89,7 +89,7 @@ namespace stdexec {
 
     struct __memfn_smartptr {
       template <class _Memptr, class _Ty, class... _Args>
-      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Memptr __mem_ptr, _Ty&& __ty, _Args&&... __args) const
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Memptr __mem_ptr, _Ty&& __ty, _Args&&... __args) const
         noexcept(noexcept(((*static_cast<_Ty&&>(__ty)).*__mem_ptr)(static_cast<_Args&&>(__args)...)))
           -> decltype(((*static_cast<_Ty&&>(__ty)).*__mem_ptr)(static_cast<_Args&&>(__args)...)) {
         return ((*static_cast<_Ty&&>(__ty)).*__mem_ptr)(static_cast<_Args&&>(__args)...);
@@ -98,7 +98,7 @@ namespace stdexec {
 
     struct __memobj {
       template <class _Mbr, class _Class, class _Ty>
-      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Mbr _Class::* __mem_ptr, _Ty&& __ty) const noexcept
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Mbr _Class::* __mem_ptr, _Ty&& __ty) const noexcept
         -> decltype(((static_cast<_Ty&&>(__ty)).*__mem_ptr)) {
         return ((static_cast<_Ty&&>(__ty)).*__mem_ptr);
       }
@@ -106,7 +106,7 @@ namespace stdexec {
 
     struct __memobj_refwrap {
       template <class _Mbr, class _Class, class _Ty>
-      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Mbr _Class::* __mem_ptr, _Ty __ty) const noexcept
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Mbr _Class::* __mem_ptr, _Ty __ty) const noexcept
         -> decltype((__ty.get().*__mem_ptr)) {
         return (__ty.get().*__mem_ptr);
       }
@@ -114,16 +114,16 @@ namespace stdexec {
 
     struct __memobj_smartptr {
       template <class _Mbr, class _Class, class _Ty>
-      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Mbr _Class::* __mem_ptr, _Ty&& __ty) const noexcept
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Mbr _Class::* __mem_ptr, _Ty&& __ty) const noexcept
         -> decltype(((*static_cast<_Ty&&>(__ty)).*__mem_ptr)) {
         return ((*static_cast<_Ty&&>(__ty)).*__mem_ptr);
       }
     };
 
-    auto __invoke_selector(__ignore, __ignore) noexcept -> __funobj;
+    STDEXEC_ATTRIBUTE((host, device)) auto __invoke_selector(__ignore, __ignore) noexcept -> __funobj;
 
     template <class _Mbr, class _Class, class _Ty>
-    auto __invoke_selector(_Mbr _Class::*, const _Ty&) noexcept {
+    STDEXEC_ATTRIBUTE((host, device)) auto __invoke_selector(_Mbr _Class::*, const _Ty&) noexcept {
       if constexpr (STDEXEC_IS_FUNCTION(_Mbr)) {
         // member function ptr case
         if constexpr (STDEXEC_IS_BASE_OF(_Class, _Ty)) {
@@ -147,13 +147,13 @@ namespace stdexec {
 
     struct __invoke_t {
       template <class _Fun>
-      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Fun&& __fun) const
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Fun&& __fun) const
         noexcept(noexcept(static_cast<_Fun&&>(__fun)())) -> decltype(static_cast<_Fun&&>(__fun)()) {
         return static_cast<_Fun&&>(__fun)();
       }
 
       template <class _Fun, class _Ty, class... _Args>
-      STDEXEC_ATTRIBUTE((always_inline)) constexpr auto operator()(_Fun&& __fun, _Ty&& __ty, _Args&&... __args) const
+      STDEXEC_ATTRIBUTE((host, device, always_inline)) constexpr auto operator()(_Fun&& __fun, _Ty&& __ty, _Args&&... __args) const
         noexcept(noexcept(__invoke_::__invoke_selector(__fun, __ty)(
           static_cast<_Fun&&>(__fun),
           static_cast<_Ty&&>(__ty),

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -186,8 +186,8 @@ namespace {
           return {};
         }
 
-        auto get_env() const noexcept -> stdexec::env_of_t<const Sender&> {
-          return stdexec::get_env(sndr_);
+        auto get_env() const noexcept -> stdexec::__fwd_env_t<stdexec::env_of_t<Sender>> {
+          return stdexec::__env::__fwd_fn{}(stdexec::get_env(sndr_));
         }
       };
     };
@@ -252,8 +252,8 @@ namespace {
           return {};
         }
 
-        auto get_env() const noexcept -> stdexec::env_of_t<const Sender&> {
-          return stdexec::get_env(sndr_);
+        auto get_env() const noexcept -> stdexec::__fwd_env_t<stdexec::env_of_t<Sender>> {
+          return stdexec::__env::__fwd_fn{}(stdexec::get_env(sndr_));
         }
       };
     };

--- a/test/stdexec/algos/adaptors/test_continues_on.cpp
+++ b/test/stdexec/algos/adaptors/test_continues_on.cpp
@@ -255,7 +255,7 @@ namespace {
   };
 
   TEST_CASE(
-    "continues_on late customization is passed on the destination scheduler",
+    "continues_on late customization is passed on the receiver's scheduler",
     "[adaptors][continues_on]") {
     // The customization will return a different value
     ex::scheduler auto sched_A = basic_inline_scheduler<test_domain_A>{};
@@ -264,6 +264,6 @@ namespace {
     std::string res;
     auto op = ex::connect(std::move(snd), expect_value_receiver_ex{res});
     ex::start(op);
-    REQUIRE(res == "goodbye");
+    REQUIRE(res == "hello");
   }
 } // namespace

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -126,10 +126,6 @@ namespace {
       ex::sender auto snd = ex::schedule(sched) | ex::then([] { });
       REQUIRE(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(snd)) == sched);
     }
-    SECTION("for stop channel") {
-      ex::sender auto snd = ex::just_stopped() | ex::continues_on(sched) | ex::then([] { });
-      REQUIRE(ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(snd)) == sched);
-    }
   }
 
   TEST_CASE("then forwards env", "[adaptors][then]") {

--- a/test/stdexec/algos/adaptors/test_transfer_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_transfer_when_all.cpp
@@ -164,9 +164,9 @@ namespace {
       using scheduler = basic_inline_scheduler<domain>;
 
       auto snd = ex::starts_on(
-        inline_scheduler(),
+        scheduler(),
         ex::transfer_when_all( //
-          scheduler(),         //
+          inline_scheduler(),  //
           ex::just(3),         //
           ex::just(0.1415)     //
           ));
@@ -213,9 +213,9 @@ namespace {
       using scheduler = basic_inline_scheduler<domain>;
 
       auto snd = ex::starts_on(
-        inline_scheduler(),
+        scheduler(),                        //
         ex::transfer_when_all_with_variant( //
-          scheduler(),                      //
+        inline_scheduler(),                 //
           ex::just(3),                      //
           ex::just(0.1415)                  //
           ));
@@ -262,9 +262,9 @@ namespace {
       using scheduler = basic_inline_scheduler<domain>;
 
       auto snd = ex::starts_on(
-        inline_scheduler(),
+        scheduler(),                        //
         ex::transfer_when_all_with_variant( //
-          scheduler(),                      //
+          inline_scheduler(),               //
           ex::just(3),                      //
           ex::just(0.1415)                  //
           ));

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -381,11 +381,11 @@ namespace {
       using scheduler = basic_inline_scheduler<domain>;
 
       auto snd = ex::starts_on(
-        scheduler(),
-        ex::when_all(      //
-          ex::just(3),     //
-          ex::just(0.1415) //
-          ));
+          scheduler(),
+          ex::when_all(      //
+            ex::just(3),     //
+            ex::just(0.1415) //
+            ));
       wait_for_value(std::move(snd), std::string{"hello world"});
     }
   }

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -94,6 +94,8 @@ namespace {
 
   struct custom_sender {
     using sender_concept = stdexec::sender_t;
+    using __t = custom_sender;
+    using __id = custom_sender;
     using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
     bool* called;
 
@@ -111,7 +113,7 @@ namespace {
 
     [[nodiscard]]
     auto get_env() const noexcept {
-      return ex::prop{ex::get_domain, domain{}};
+      return ex::prop{ex::get_domain_late, domain{}};
     }
 
     template <class Receiver>

--- a/test/stdexec/algos/consumers/test_sync_wait.cpp
+++ b/test/stdexec/algos/consumers/test_sync_wait.cpp
@@ -220,47 +220,21 @@ namespace {
     }
   };
 
-  TEST_CASE("sync_wait can be customized with scheduler", "[consumers][sync_wait]") {
-    // The customization will return a different value
-    basic_inline_scheduler<sync_wait_test_domain> sched;
-    auto snd = ex::just(std::string{"hello"}) | ex::continues_on(sched);
-    auto res = ex::sync_wait(std::move(snd));
-    STATIC_REQUIRE(std::same_as<decltype(res), sync_wait_test_domain::single_result_t>);
-    CHECK(res.has_value());
-    CHECK(std::get<0>(res.value()) == "ciao");
-  }
-
-  TEST_CASE("sync_wait can be customized without scheduler", "[consumers][sync_wait]") {
+  TEST_CASE("sync_wait can be customized", "[consumers][sync_wait]") {
     // The customization will return a different value
     auto snd = ex::just(std::string{"hello"})
-             | exec::write_attrs(ex::prop{ex::get_domain, sync_wait_test_domain{}});
+             | exec::write_attrs(ex::prop{ex::get_domain_late, sync_wait_test_domain{}});
     auto res = ex::sync_wait(std::move(snd));
     STATIC_REQUIRE(std::same_as<decltype(res), sync_wait_test_domain::single_result_t>);
     CHECK(res.has_value());
     CHECK(std::get<0>(res.value()) == "ciao");
   }
 
-  TEST_CASE(
-    "sync_wait_with_variant can be customized with scheduler",
-    "[consumers][sync_wait_with_variant]") {
-    // The customization will return a different value
-    basic_inline_scheduler<sync_wait_test_domain> sched;
-    auto snd1 = fallible_just(std::string{"hello_multi"}) //
-              | ex::let_error(always(ex::just(42)));
-    auto snd2 = ex::continues_on(std::move(snd1), sched);
-    auto res = ex::sync_wait_with_variant(std::move(snd2));
-    STATIC_REQUIRE(std::same_as<decltype(res), sync_wait_test_domain::multi_result_t>);
-    CHECK(res.has_value());
-    CHECK(std::get<0>(std::get<1>(res.value())) == std::string{"ciao_multi"});
-  }
-
-  TEST_CASE(
-    "sync_wait_with_variant can be customized without scheduler",
-    "[consumers][sync_wait_with_variant]") {
+  TEST_CASE("sync_wait_with_variant can be customized", "[consumers][sync_wait_with_variant]") {
     // The customization will return a different value
     auto snd = fallible_just(std::string{"hello_multi"}) //
              | ex::let_error(always(ex::just(42)))       //
-             | exec::write_attrs(ex::prop{ex::get_domain, sync_wait_test_domain{}});
+             | exec::write_attrs(ex::prop{ex::get_domain_late, sync_wait_test_domain{}});
     auto res = ex::sync_wait_with_variant(std::move(snd));
     STATIC_REQUIRE(std::same_as<decltype(res), sync_wait_test_domain::multi_result_t>);
     CHECK(res.has_value());

--- a/test/stdexec/algos/factories/test_transfer_just.cpp
+++ b/test/stdexec/algos/factories/test_transfer_just.cpp
@@ -165,22 +165,13 @@ namespace {
     REQUIRE(
       ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(ex::transfer_just(sched1, 1)))
       == sched1);
-    REQUIRE(
-      ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(ex::transfer_just(sched1, 1)))
-      == sched1);
 
     REQUIRE(
       ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(ex::transfer_just(sched2, 2)))
       == sched2);
-    REQUIRE(
-      ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(ex::transfer_just(sched2, 2)))
-      == sched2);
 
     REQUIRE(
       ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(ex::transfer_just(sched3, 3)))
-      == sched3);
-    REQUIRE(
-      ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(ex::transfer_just(sched3, 3)))
       == sched3);
   }
 

--- a/test/stdexec/cpos/cpo_helpers.cuh
+++ b/test/stdexec/cpos/cpo_helpers.cuh
@@ -48,6 +48,18 @@ namespace {
     }
   };
 
+  struct cpo_sender_attrs_t {
+    [[nodiscard]]
+    auto query(ex::get_domain_t) const noexcept {
+      return cpo_sender_domain{};
+    }
+
+    [[nodiscard]]
+    auto query(ex::get_domain_late_t) const noexcept {
+      return cpo_sender_domain{};
+    }
+  };
+
   template <class CPO>
   struct cpo_test_sender_t {
     using sender_concept = stdexec::sender_t;
@@ -59,7 +71,7 @@ namespace {
       ex::set_stopped_t()>;
 
     auto get_env() const noexcept {
-      return ex::prop{ex::get_domain, cpo_sender_domain{}};
+      return cpo_sender_attrs_t{};
     }
   };
 

--- a/test/stdexec/cpos/test_cpo_bulk.cpp
+++ b/test/stdexec/cpos/test_cpo_bulk.cpp
@@ -37,19 +37,5 @@ namespace {
         STATIC_REQUIRE(scope == scope_t::free_standing);
       }
     }
-
-    SECTION("by completion scheduler") {
-      cpo_test_scheduler_t<ex::bulk_t>::sender_t snd{};
-
-      {
-        constexpr scope_t scope = decltype(snd | ex::bulk(ex::par, n, f))::scope;
-        STATIC_REQUIRE(scope == scope_t::scheduler);
-      }
-
-      {
-        constexpr scope_t scope = decltype(ex::bulk(snd, ex::par, n, f))::scope;
-        STATIC_REQUIRE(scope == scope_t::scheduler);
-      }
-    }
   }
 } // namespace

--- a/test/stdexec/cpos/test_cpo_ensure_started.cpp
+++ b/test/stdexec/cpos/test_cpo_ensure_started.cpp
@@ -25,11 +25,5 @@ namespace {
       constexpr scope_t scope = decltype(ex::ensure_started(snd))::scope;
       STATIC_REQUIRE(scope == scope_t::free_standing);
     }
-
-    SECTION("by completion scheduler") {
-      cpo_test_scheduler_t<ex::ensure_started_t>::sender_t snd{};
-      constexpr scope_t scope = decltype(ex::ensure_started(snd))::scope;
-      STATIC_REQUIRE(scope == scope_t::scheduler);
-    }
   }
 } // namespace

--- a/test/stdexec/cpos/test_cpo_split.cpp
+++ b/test/stdexec/cpos/test_cpo_split.cpp
@@ -33,19 +33,5 @@ namespace {
         STATIC_REQUIRE(scope == scope_t::free_standing);
       }
     }
-
-    SECTION("by completion scheduler") {
-      cpo_test_scheduler_t<ex::split_t>::sender_t snd{};
-
-      {
-        constexpr scope_t scope = decltype(ex::split(snd))::scope;
-        STATIC_REQUIRE(scope == scope_t::scheduler);
-      }
-
-      {
-        constexpr scope_t scope = decltype(snd | ex::split())::scope;
-        STATIC_REQUIRE(scope == scope_t::scheduler);
-      }
-    }
   }
 } // namespace

--- a/test/stdexec/cpos/test_cpo_upon_stopped.cpp
+++ b/test/stdexec/cpos/test_cpo_upon_stopped.cpp
@@ -36,20 +36,5 @@ namespace {
         STATIC_REQUIRE(scope == scope_t::free_standing);
       }
     }
-
-    SECTION("by completion scheduler") {
-      cpo_test_scheduler_t<ex::upon_stopped_t, ex::set_stopped_t>::sender_t snd{};
-
-      {
-        constexpr scope_t scope = decltype(snd | ex::upon_stopped(f))::scope;
-        STATIC_REQUIRE(scope == scope_t::scheduler);
-      }
-
-      {
-        ex::get_completion_scheduler<ex::set_stopped_t>(ex::get_env(snd));
-        constexpr scope_t scope = decltype(ex::upon_stopped(snd, f))::scope;
-        STATIC_REQUIRE(scope == scope_t::scheduler);
-      }
-    }
   }
 } // namespace


### PR DESCRIPTION
[P3718](https://isocpp.org/files/papers/P3718R0.html) describes some issues with lazy sender algorithm customization. this pr implements the proposed resolution.

* add non-forwarding `get_domain_late` query
* `get_domain_late(get_env(continues_on(sndr, sch)))` returns the domain of `sndr`
* `get_domain_late(get_env(schedule_from(sch, sndr)))`
* `__get_late_domain(sndr, env, default)` returns:
  * `get_domain_late(get_env(sndr))` if that is well-formed,
  * otherwise, `get_domain(env)` if that is well-formed,
  * otherwise, `get_domain(get_scheduler(env))` if that is well-formed,
  * otherwise, `default`.
* algorithms that eagerly connect senders (`sync_wait[_with_variant]`, `ensure_started`, `start_detached`, and `split`) compute the domain as follows:
  ```c++
  __get_domain_late(sndr, env, __get_domain_early(sndr))
  ```
