### PR TITLE
sequence: relax iterate to support ranges::input_range

### DIFF
--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -53,7 +53,8 @@ namespace exec {
         __operation_base<_Iterator, _Sentinel>* __parent_;
 
         void start() & noexcept {
-          stdexec::set_value(static_cast<_ItemRcvr&&>(__rcvr_), *__parent_->__iterator_++);
+          stdexec::set_value(static_cast<_ItemRcvr&&>(__rcvr_), *__parent_->__iterator_);
+          ++__parent_->__iterator_;
         }
       };
     };
@@ -125,7 +126,6 @@ namespace exec {
         if (this->__iterator_ == this->__sentinel_) {
           stdexec::set_value(static_cast<_Receiver&&>(__rcvr_));
         } else {
-
           try {
             stdexec::start(__op_.emplace(__emplace_from{[&] {
               return stdexec::connect(

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -162,7 +162,7 @@ namespace exec {
     };
 
     struct iterate_t {
-      template <std::ranges::forward_range _Range>
+      template <std::ranges::input_range _Range>
         requires __decay_copyable<_Range>
       auto operator()(_Range&& __range) const {
         return make_sequence_expr<iterate_t>(__decay_t<_Range>{static_cast<_Range&&>(__range)});

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -53,8 +53,9 @@ namespace exec {
         __operation_base<_Iterator, _Sentinel>* __parent_;
 
         void start() & noexcept {
-          stdexec::set_value(static_cast<_ItemRcvr&&>(__rcvr_), *__parent_->__iterator_);
-          ++__parent_->__iterator_;
+          auto& __iter = __parent_->__iterator_;
+          stdexec::set_value(static_cast<_ItemRcvr&&>(__rcvr_), *__iter);
+          ++__iter;
         }
       };
     };


### PR DESCRIPTION
Relaxes requirement on iterate from `forward_range` to `input_range` in order to support single-pass ranges.