### PR TITLE
improve the `STDEXEC_TRY` and `STDEXEC_CATCH` portability macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,7 +90,9 @@ Macros: [
   'STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS=[[no_unique_address]]',
   'STDEXEC_MISSING_MEMBER(X,Y)=true',
   'STDEXEC_DEFINE_MEMBER(X)=void foo() {}',
-  'STDEXEC_AUTO_RETURN(...)=->decltype(auto){ return __VA_ARGS__; }'
+  'STDEXEC_AUTO_RETURN(...)=->decltype(auto){ return __VA_ARGS__; }',
+  'STDEXEC_TRY(...)=try { __VA_ARGS__ }',
+  'STDEXEC_CATCH(...)=catch __VA_ARGS__',
 ]
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: All

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -530,24 +530,27 @@ namespace stdexec {
 //
 // Usage:
 //   STDEXEC_TRY({
-//     ...                            // Code that may throw an exception
+//     ...                                     // Code that may throw an exception
 //   })
-//   STDEXEC_CATCH((cuda_error& e) {  // Handle CUDA exceptions
+//   STDEXEC_CATCH_FALLTHRU((cuda_error& e) {  // Handle CUDA exceptions
 //     ...
 //   })
-//   STDEXEC_CATCH((...) {            // Handle any other exceptions
+//   STDEXEC_CATCH((...) {                     // Handle any other exceptions
 //     ...
 //   })
 // clang-format off
 #if STDEXEC_NO_EXCEPTIONS() || (STDEXEC_CUDA_COMPILATION() && defined(__CUDA_ARCH__))
 #  define STDEXEC_TRY(...) { __VA_ARGS__ }
 #  define STDEXEC_CATCH(...)
+#  define STDEXEC_CATCH_FALLTHRU(...)
 #elif STDEXEC_CUDA_COMPILATION() && STDEXEC_NVHPC()
-#  define STDEXEC_TRY(...) if target (nv::target::is_device) { __VA_ARGS__ } else try { __VA_ARGS__ }
-#  define STDEXEC_CATCH(...) catch __VA_ARGS__
+#  define STDEXEC_TRY(...) if target (nv::target::is_device) { __VA_ARGS__ } else { try { __VA_ARGS__ }
+#  define STDEXEC_CATCH(...) catch __VA_ARGS__ }
+#  define STDEXEC_CATCH_FALLTHRU(...) catch __VA_ARGS__
 #else
 #  define STDEXEC_TRY(...) try { __VA_ARGS__ }
 #  define STDEXEC_CATCH(...) catch __VA_ARGS__
+#  define STDEXEC_CATCH_FALLTHRU(...) catch __VA_ARGS__
 #endif
 // clang-format on
 

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -530,27 +530,27 @@ namespace stdexec {
 //
 // Usage:
 //   STDEXEC_TRY({
-//     ...                                     // Code that may throw an exception
+//     ...                               // Code that may throw an exception
 //   })
-//   STDEXEC_CATCH_FALLTHRU((cuda_error& e) {  // Handle CUDA exceptions
+//   STDEXEC_CATCH_OR((cuda_error& e) {  // Handle CUDA exceptions
 //     ...
 //   })
-//   STDEXEC_CATCH((...) {                     // Handle any other exceptions
+//   STDEXEC_CATCH((...) {               // Handle any other exceptions
 //     ...
 //   })
 // clang-format off
 #if STDEXEC_NO_EXCEPTIONS() || (STDEXEC_CUDA_COMPILATION() && defined(__CUDA_ARCH__))
 #  define STDEXEC_TRY(...) { __VA_ARGS__ }
 #  define STDEXEC_CATCH(...)
-#  define STDEXEC_CATCH_FALLTHRU(...)
+#  define STDEXEC_CATCH_OR(...)
 #elif STDEXEC_CUDA_COMPILATION() && STDEXEC_NVHPC()
 #  define STDEXEC_TRY(...) if target (nv::target::is_device) { __VA_ARGS__ } else { try { __VA_ARGS__ }
 #  define STDEXEC_CATCH(...) catch __VA_ARGS__ }
-#  define STDEXEC_CATCH_FALLTHRU(...) catch __VA_ARGS__
+#  define STDEXEC_CATCH_OR(...) catch __VA_ARGS__
 #else
 #  define STDEXEC_TRY(...) try { __VA_ARGS__ }
 #  define STDEXEC_CATCH(...) catch __VA_ARGS__
-#  define STDEXEC_CATCH_FALLTHRU(...) catch __VA_ARGS__
+#  define STDEXEC_CATCH_OR(...) catch __VA_ARGS__
 #endif
 // clang-format on
 

--- a/include/stdexec/__detail/__receivers.hpp
+++ b/include/stdexec/__detail/__receivers.hpp
@@ -192,18 +192,20 @@ namespace stdexec {
   template <class _Receiver, class _Fun, class... _As>
   STDEXEC_ATTRIBUTE(host, device)
   void __set_value_invoke(_Receiver&& __rcvr, _Fun&& __fun, _As&&... __as) noexcept {
-    STDEXEC_TRY {
+    STDEXEC_TRY({
       if constexpr (same_as<void, __invoke_result_t<_Fun, _As...>>) {
         __invoke(static_cast<_Fun&&>(__fun), static_cast<_As&&>(__as)...);
         stdexec::set_value(static_cast<_Receiver&&>(__rcvr));
       } else {
-        set_value(
+        stdexec::set_value(
           static_cast<_Receiver&&>(__rcvr),
           __invoke(static_cast<_Fun&&>(__fun), static_cast<_As&&>(__as)...));
       }
-    }
-    STDEXEC_CATCH(...)(if constexpr (!__nothrow_invocable<_Fun, _As...>) {
-      stdexec::set_error(static_cast<_Receiver&&>(__rcvr), std::current_exception());
+    })
+    STDEXEC_CATCH((...) { //
+      if constexpr (!__nothrow_invocable<_Fun, _As...>) {
+        stdexec::set_error(static_cast<_Receiver&&>(__rcvr), std::current_exception());
+      }
     })
   }
 

--- a/test/nvexec/let_stopped.cpp
+++ b/test/nvexec/let_stopped.cpp
@@ -39,7 +39,7 @@ namespace {
   }
 
   TEST_CASE(
-    "let_stopped can preceed a sender without values",
+    "nvexec let_stopped can preceed a sender without values",
     "[cuda][stream][adaptors][let_stopped]") {
     nvexec::stream_context stream_ctx{};
 

--- a/test/nvexec/upon_error.cpp
+++ b/test/nvexec/upon_error.cpp
@@ -38,7 +38,7 @@ namespace {
   }
 
   TEST_CASE(
-    "upon_error can preceed a sender without values",
+    "nvexec upon_error can preceed a sender without values",
     "[cuda][stream][adaptors][upon_error]") {
     nvexec::stream_context stream_ctx{};
 
@@ -62,7 +62,7 @@ namespace {
   }
 
   TEST_CASE(
-    "upon_error can succeed a sender without values",
+    "nvexec upon_error can succeed a sender without values",
     "[cuda][stream][adaptors][upon_error]") {
     nvexec::stream_context stream_ctx{};
 


### PR DESCRIPTION
the current `try`/`catch` macros can be made simpler which also adding support for multiple `catch` blocks. the new macros are also easier for formatting tools like clang-format.