### PR TITLE
Silencing clang-tidy warnings

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -445,7 +445,7 @@ namespace exec {
       }
 
       __t(const __t& __other)
-        requires(_Copyable)
+        requires(_Copyable) : __vtable_(__other.__vtable_)
       {
         (*__other.__vtable_)(__copy_construct, this, __other);
       }
@@ -460,7 +460,7 @@ namespace exec {
         return *this;
       }
 
-      __t(__t&& __other) noexcept {
+      __t(__t&& __other) noexcept : __vtable_(__other.__vtable_) {
         (*__other.__vtable_)(__move_construct, this, static_cast<__t&&>(__other));
       }
 

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -320,16 +320,16 @@ namespace exec {
 
      private:
       struct __final_awaitable {
-        static constexpr auto await_ready() noexcept -> bool {
+        constexpr auto await_ready() noexcept -> bool {
           return false;
         }
 
-        static auto await_suspend(__coro::coroutine_handle<__promise> __h) noexcept
+        auto await_suspend(__coro::coroutine_handle<__promise> __h) noexcept
           -> __coro::coroutine_handle<> {
           return __h.promise().continuation().handle();
         }
 
-        static void await_resume() noexcept {
+        void await_resume() noexcept {
         }
       };
 
@@ -369,6 +369,7 @@ namespace exec {
           this->__data_.template emplace<1>(std::current_exception());
         }
 
+#ifndef __clang_analyzer__
         template <sender _Awaitable>
           requires __scheduler_provider<_Context>
         auto await_transform(_Awaitable&& __awaitable) noexcept -> decltype(auto) {
@@ -396,6 +397,7 @@ namespace exec {
           __context_->set_scheduler(__box.__sched_);
           return as_awaitable(schedule(__box.__sched_), *this);
         }
+#endif
 
         template <class _Awaitable>
         auto await_transform(_Awaitable&& __awaitable) noexcept -> decltype(auto) {

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -320,16 +320,16 @@ namespace exec {
 
      private:
       struct __final_awaitable {
-        constexpr auto await_ready() noexcept -> bool {
+        static constexpr auto await_ready() noexcept -> bool {
           return false;
         }
 
-        auto await_suspend(__coro::coroutine_handle<__promise> __h) noexcept
+        static auto await_suspend(__coro::coroutine_handle<__promise> __h) noexcept
           -> __coro::coroutine_handle<> {
           return __h.promise().continuation().handle();
         }
 
-        void await_resume() noexcept {
+        static void await_resume() noexcept {
         }
       };
 


### PR DESCRIPTION
 - Silencing `readability-static-accessed-through-instance` by removing static from function declaration
 - Silencing "Assigned value is garbage or undefined":
   - Properly initialize vtable
   - Disabling some code when run under clang-tidy