### PR TITLE
add missing include of `<utility>` for `std::unreachable`

### DIFF
--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -40,6 +40,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <type_traits> // IWYU pragma: keep
+#include <utility> // IWYU pragma: keep for std::unreachable
 
 // When used with no arguments, these macros expand to 1 if the current
 // compiler corresponds to the macro name; 0, otherwise. When used with arguments,


### PR DESCRIPTION
fixes #1557 