### PR TITLE
stricter type checking in `connect`, and fixes for the problems exposed

### DIFF
--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -131,31 +131,31 @@ namespace exec {
             : __env_{__create_vtable(__mtype<__vtable_t>{}, __mtype<_Rcvr>{}), &__rcvr} {
           }
 
-          template <same_as<set_next_t> _SetNext, same_as<__t> _Self, class _Sender>
+          template <same_as<__t> _Self, class _Sender>
             requires constructible_from<__item_sender, _Sender>
-          friend auto tag_invoke(_SetNext, _Self& __self, _Sender&& __sndr) -> __void_sender {
-            return (*static_cast<const __rcvr_next_vfun<__next_sigs>*>(__self.__env_.__vtable_)
-                       ->__fn_)(__self.__env_.__rcvr_, static_cast<_Sender&&>(__sndr));
+          STDEXEC_MEMFN_DECL(auto set_next)(this _Self& __self, _Sender&& __sndr) -> __void_sender {
+            const __rcvr_next_vfun<__next_sigs>* __vfun = __self.__env_.__vtable_;
+            return __vfun->__fn_(__self.__env_.__rcvr_, static_cast<_Sender&&>(__sndr));
           }
 
           // set_value_t() is always valid for a sequence
           void set_value() noexcept {
-            (*static_cast<const __vfun<set_value_t()>*>(__env_.__vtable_)->__complete_)(__env_
-                                                                                          .__rcvr_);
+            const __vfun<set_value_t()>& __vfun = *__env_.__vtable_;
+            __vfun(__env_.__rcvr_, set_value_t());
           }
 
           template <class Error>
             requires __v<__mapply<__mcontains<set_error_t(Error)>, __sigs>>
           void set_error(Error&& __error) noexcept {
-            (*static_cast<const __vfun<set_error_t(Error)>*>(__env_.__vtable_)
-                ->__complete_)(__env_.__rcvr_, static_cast<Error&&>(__error));
+            const __vfun<set_error_t(Error)>& __vfun = *__env_.__vtable_;
+            __vfun(__env_.__rcvr_, set_error_t(), static_cast<Error&&>(__error));
           }
 
           void set_stopped() noexcept
             requires __v<__mapply<__mcontains<set_stopped_t()>, __sigs>>
           {
-            (*static_cast<const __vfun<set_stopped_t()>*>(__env_.__vtable_)
-                ->__complete_)(__env_.__rcvr_);
+            const __vfun<set_stopped_t()>& __vfun = *__env_.__vtable_;
+            __vfun(__env_.__rcvr_, set_stopped_t());
           }
 
           auto get_env() const noexcept -> const __env_t& {

--- a/include/stdexec/__detail/__any_receiver_ref.hpp
+++ b/include/stdexec/__detail/__any_receiver_ref.hpp
@@ -62,7 +62,12 @@ namespace stdexec::__any_ {
       , __do_get_env{&__s_get_env<_OpState, _GetEnv>} {
     }
 
-    using __rcvr_vfun<_Sigs>::operator()...;
+    template <class _Tag, class... _Args>
+      requires __one_of<_Tag(_Args...), _Sigs...>
+    void operator()(void* __obj, _Tag, _Args&&... __args) const noexcept {
+      const __rcvr_vfun<_Tag(_Args...)>& __vfun = *this;
+      __vfun(__obj, _Tag{}, static_cast<_Args&&>(__args)...);
+    }
 
     auto __get_env(const void* __op_state) const noexcept -> _Env {
       return __do_get_env(__op_state);

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -172,6 +172,8 @@ namespace stdexec {
   extern const bool enable_sender;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
+  struct operation_state_t;
+
   namespace __start {
     struct start_t;
   } // namespace __start
@@ -194,6 +196,13 @@ namespace stdexec {
 
   using __as_awaitable::as_awaitable_t;
   extern const as_awaitable_t as_awaitable;
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  struct transform_sender_t;
+  extern const transform_sender_t transform_sender;
+
+  template <class _Domain, class _Sender, class... _Env>
+  using transform_sender_result_t = __call_result_t<transform_sender_t, _Domain, _Sender, _Env...>;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   namespace __starts_on_ns {

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -283,6 +283,7 @@ namespace stdexec {
 
   template <class _What, class... _With>
   struct _ERROR_ {
+    using __what_t = _What;
     auto operator,(__msuccess) const noexcept -> _ERROR_;
   };
 

--- a/include/stdexec/__detail/__optional.hpp
+++ b/include/stdexec/__detail/__optional.hpp
@@ -105,6 +105,17 @@ namespace stdexec {
         return *std::launder(__p);
       }
 
+      template <class _Fn, class... _Args>
+        requires same_as<_Tp, __call_result_t<_Fn>>
+      auto __emplace_from(_Fn&& __f, _Args&&... __args) noexcept(__nothrow_callable<_Fn, _Args...>) -> _Tp& {
+        reset();
+        auto __sg = __mk_has_value_guard(__has_value_);
+        auto* __p = ::new (static_cast<void*>(std::addressof(__value_)))
+          _Tp(static_cast<_Fn&&>(__f)(static_cast<_Args&&>(__args)...));
+        __sg.__dismiss();
+        return *std::launder(__p);
+      }
+
       auto value() & -> _Tp& {
         if (!__has_value_) {
           throw __bad_optional_access();

--- a/include/stdexec/__detail/__read_env.hpp
+++ b/include/stdexec/__detail/__read_env.hpp
@@ -110,9 +110,9 @@ namespace stdexec {
         } else {
           constexpr bool _Nothrow = __nothrow_callable<__query, env_of_t<_Receiver>>;
           auto __query_fn = [&]() noexcept(_Nothrow) -> __result&& {
-            __state.__result_.emplace(__emplace_from{[&]() noexcept(_Nothrow) {
+            __state.__result_.__emplace_from([&]() noexcept(_Nothrow) {
               return __query()(stdexec::get_env(__rcvr));
-            }});
+            });
             return static_cast<__result&&>(*__state.__result_);
           };
           stdexec::__set_value_invoke(static_cast<_Receiver&&>(__rcvr), __query_fn);

--- a/include/stdexec/__detail/__shared.hpp
+++ b/include/stdexec/__detail/__shared.hpp
@@ -64,13 +64,19 @@ namespace stdexec::__shared {
   >; // BUGBUG NOT TO SPEC
 
   template <class _Receiver>
+  struct __notify_fn {
+    template <class _Tag, class... _Args>
+    void operator()(_Tag __tag, _Args&&... __args) const noexcept {
+      __tag(static_cast<_Receiver&&>(__rcvr_), static_cast<_Args&&>(__args)...);
+    }
+
+    _Receiver& __rcvr_;
+  };
+
+  template <class _Receiver>
   auto __make_notify_visitor(_Receiver& __rcvr) noexcept {
     return [&]<class _Tuple>(_Tuple&& __tupl) noexcept -> void {
-      __tupl.apply(
-        [&](auto __tag, auto&&... __args) noexcept -> void {
-          __tag(static_cast<_Receiver&&>(__rcvr), __forward_like<_Tuple>(__args)...);
-        },
-        __tupl);
+      __tupl.apply(__notify_fn<_Receiver>{__rcvr}, static_cast<_Tuple&&>(__tupl));
     };
   }
 

--- a/include/stdexec/__detail/__transform_sender.hpp
+++ b/include/stdexec/__detail/__transform_sender.hpp
@@ -124,9 +124,6 @@ namespace stdexec {
     using __detail::__transform_dependent_sender::operator();
   } transform_sender{};
 
-  template <class _Domain, class _Sender, class... _Env>
-  using transform_sender_result_t = __call_result_t<transform_sender_t, _Domain, _Sender, _Env...>;
-
   inline constexpr __detail::__transform_env transform_env{};
 
   struct _CHILD_SENDERS_WITH_DIFFERENT_DOMAINS_ { };

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -74,6 +74,14 @@ namespace stdexec {
     auto operator=(const __move_only&) -> __move_only& = delete;
   };
 
+  template <class... _Fns>
+  struct __overload : _Fns... {
+    using _Fns::operator()...;
+  };
+
+  template <class... _Fns>
+  __overload(_Fns...) -> __overload<_Fns...>;
+
   inline constexpr auto __umax(std::initializer_list<std::size_t> __il) noexcept -> std::size_t {
     std::size_t __m = 0;
     for (std::size_t __i: __il) {

--- a/test/stdexec/concepts/test_awaitables.cpp
+++ b/test/stdexec/concepts/test_awaitables.cpp
@@ -19,8 +19,6 @@
 
 #include <exec/static_thread_pool.hpp>
 #include <stdexec/coroutine.hpp>
-#include <tuple>
-#include <variant>
 
 #include <test_common/type_helpers.hpp>
 


### PR DESCRIPTION
the `connect(Sndr, Rcvr)` CPO now mandates `sender_in<Sndr, env_of_t<Rcvr>>` and `receiver_of<Rcvr, completion_signatures_of_t<Sndr, env_of_t<Rcvr>>>`. this exposed problems in `read_env` and in the type-erasing sender wrapper, which this PR fixes.