### PR TITLE
give `stdexec::on` the standard-conforming there-and-back-again behavior

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -77,6 +77,7 @@ CompileFlags:
     - -Xtemplight
     - -profiler
     - -ignore-system
+    - "-fconcepts-diagnostics-depth=*"
 Diagnostics:
   Suppress:
     - "variadic_device_fn"

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -20,8 +20,6 @@
 
 #include "common.cuh"
 #include "stdexec/execution.hpp"
-#include "exec/on.hpp"
-
 
 #if defined(_NVHPC_CUDA) || defined(__CUDACC__)
 #  include "nvexec/detail/throw_on_cuda_error.cuh"
@@ -30,11 +28,11 @@
 #else
 namespace nvexec {
   struct stream_receiver_base {
-    using receiver_concept = stdexec::receiver_t;
+    using receiver_concept = ex::receiver_t;
   };
 
   struct stream_sender_base {
-    using sender_concept = stdexec::sender_t;
+    using sender_concept = ex::sender_t;
   };
 
   namespace detail {
@@ -73,13 +71,13 @@ namespace nvexec::_strm::repeat_n {
       op_state_.i_++;
 
       if (op_state_.i_ == op_state_.n_) {
-        op_state_.propagate_completion_signal(stdexec::set_value);
+        op_state_.propagate_completion_signal(ex::set_value);
         return;
       }
 
-      auto sch = stdexec::get_scheduler(stdexec::get_env(op_state_.rcvr_));
+      auto sch = ex::get_scheduler(ex::get_env(op_state_.rcvr_));
       inner_op_state_t& inner_op_state = op_state_.inner_op_state_.emplace(
-        stdexec::__emplace_from{[&]() noexcept {
+        ex::__emplace_from{[&]() noexcept {
           return ex::connect(ex::schedule(sch) | op_state_.closure_, receiver_2_t<OpT>{op_state_});
         }});
 
@@ -115,9 +113,9 @@ namespace nvexec::_strm::repeat_n {
       using inner_op_state_t = typename OpT::inner_op_state_t;
 
       if (op_state_.n_) {
-        auto sch = stdexec::get_scheduler(stdexec::get_env(op_state_.rcvr_));
+        auto sch = ex::get_scheduler(ex::get_env(op_state_.rcvr_));
         inner_op_state_t& inner_op_state = op_state_.inner_op_state_.emplace(
-          stdexec::__emplace_from{[&]() noexcept {
+          ex::__emplace_from{[&]() noexcept {
             return ex::connect(
               ex::schedule(sch) | op_state_.closure_, receiver_2_t<OpT>{op_state_});
           }});
@@ -148,10 +146,10 @@ namespace nvexec::_strm::repeat_n {
 
   template <class PredecessorSenderId, class Closure, class ReceiverId>
   struct operation_state_t : operation_state_base_t<ReceiverId> {
-    using PredSender = stdexec::__t<PredecessorSenderId>;
-    using Receiver = stdexec::__t<ReceiverId>;
-    using Scheduler = std::invoke_result_t<stdexec::get_scheduler_t, stdexec::env_of_t<Receiver>>;
-    using InnerSender = std::invoke_result_t<Closure, stdexec::schedule_result_t<Scheduler>>;
+    using PredSender = ex::__t<PredecessorSenderId>;
+    using Receiver = ex::__t<ReceiverId>;
+    using Scheduler = std::invoke_result_t<ex::get_scheduler_t, ex::env_of_t<Receiver>>;
+    using InnerSender = std::invoke_result_t<Closure, ex::schedule_result_t<Scheduler>>;
 
     using predecessor_op_state_t =
       ex::connect_result_t<PredSender, receiver_1_t<operation_state_t>>;
@@ -168,12 +166,12 @@ namespace nvexec::_strm::repeat_n {
       if (this->stream_provider_.status_ != cudaSuccess) {
         // Couldn't allocate memory for operation state, complete with error
         this->propagate_completion_signal(
-          stdexec::set_error, std::move(this->stream_provider_.status_));
+          ex::set_error, std::move(this->stream_provider_.status_));
       } else {
         if (n_) {
-          stdexec::start(*pred_op_state_);
+          ex::start(*pred_op_state_);
         } else {
-          this->propagate_completion_signal(stdexec::set_value);
+          this->propagate_completion_signal(ex::set_value);
         }
       }
     }
@@ -181,12 +179,12 @@ namespace nvexec::_strm::repeat_n {
     operation_state_t(PredSender&& pred_sender, Closure closure, Receiver&& rcvr, std::size_t n)
       : operation_state_base_t<ReceiverId>(
           static_cast<Receiver&&>(rcvr),
-          stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(pred_sender))
+          ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(pred_sender))
             .context_state_)
       , pred_sender_{static_cast<PredSender&&>(pred_sender)}
       , closure_(closure)
       , n_(n) {
-      pred_op_state_.emplace(stdexec::__emplace_from{[&]() noexcept {
+      pred_op_state_.emplace(ex::__emplace_from{[&]() noexcept {
         return ex::connect(static_cast<PredSender&&>(pred_sender_), receiver_1_t{*this});
       }});
     }
@@ -204,7 +202,7 @@ namespace repeat_n_detail {
     OpT& op_state_;
 
    public:
-    using receiver_concept = stdexec::receiver_t;
+    using receiver_concept = ex::receiver_t;
 
     void set_value() noexcept {
       using inner_op_state_t = typename OpT::inner_op_state_t;
@@ -212,13 +210,13 @@ namespace repeat_n_detail {
       op_state_.i_++;
 
       if (op_state_.i_ == op_state_.n_) {
-        stdexec::set_value(std::move(op_state_.rcvr_));
+        ex::set_value(std::move(op_state_.rcvr_));
         return;
       }
 
-      auto sch = stdexec::get_scheduler(stdexec::get_env(op_state_.rcvr_));
+      auto sch = ex::get_scheduler(ex::get_env(op_state_.rcvr_));
       inner_op_state_t& inner_op_state = op_state_.inner_op_state_.emplace(
-        stdexec::__emplace_from{[&]() noexcept {
+        ex::__emplace_from{[&]() noexcept {
           return ex::connect(ex::schedule(sch) | op_state_.closure_, receiver_2_t<OpT>{op_state_});
         }});
 
@@ -227,16 +225,16 @@ namespace repeat_n_detail {
 
     template <class Error>
     void set_error(Error&& err) noexcept {
-      stdexec::set_error(std::move(op_state_.rcvr_), static_cast<Error&&>(err));
+      ex::set_error(std::move(op_state_.rcvr_), static_cast<Error&&>(err));
     }
 
     void set_stopped() noexcept {
-      stdexec::set_stopped(std::move(op_state_.rcvr_));
+      ex::set_stopped(std::move(op_state_.rcvr_));
     }
 
     [[nodiscard]]
-    auto get_env() const noexcept -> stdexec::env_of_t<Receiver> {
-      return stdexec::get_env(op_state_.rcvr_);
+    auto get_env() const noexcept -> ex::env_of_t<Receiver> {
+      return ex::get_env(op_state_.rcvr_);
     }
 
     explicit receiver_2_t(OpT& op_state)
@@ -251,37 +249,37 @@ namespace repeat_n_detail {
     OpT& op_state_;
 
    public:
-    using receiver_concept = stdexec::receiver_t;
+    using receiver_concept = ex::receiver_t;
 
     void set_value() noexcept {
       using inner_op_state_t = typename OpT::inner_op_state_t;
 
       if (op_state_.n_) {
-        auto sch = stdexec::get_scheduler(stdexec::get_env(op_state_.rcvr_));
+        auto sch = ex::get_scheduler(ex::get_env(op_state_.rcvr_));
         inner_op_state_t& inner_op_state = op_state_.inner_op_state_.emplace(
-          stdexec::__emplace_from{[&]() noexcept {
+          ex::__emplace_from{[&]() noexcept {
             return ex::connect(
               ex::schedule(sch) | op_state_.closure_, receiver_2_t<OpT>{op_state_});
           }});
 
         ex::start(inner_op_state);
       } else {
-        stdexec::set_value(std::move(op_state_.rcvr_));
+        ex::set_value(std::move(op_state_.rcvr_));
       }
     }
 
     template <class Error>
     void set_error(Error&& err) noexcept {
-      stdexec::set_error(std::move(op_state_.rcvr_), static_cast<Error&&>(err));
+      ex::set_error(std::move(op_state_.rcvr_), static_cast<Error&&>(err));
     }
 
     void set_stopped() noexcept {
-      stdexec::set_stopped(std::move(op_state_.rcvr_));
+      ex::set_stopped(std::move(op_state_.rcvr_));
     }
 
     [[nodiscard]]
-    auto get_env() const noexcept -> stdexec::env_of_t<Receiver> {
-      return stdexec::get_env(op_state_.rcvr_);
+    auto get_env() const noexcept -> ex::env_of_t<Receiver> {
+      return ex::get_env(op_state_.rcvr_);
     }
 
     explicit receiver_1_t(OpT& op_state)
@@ -291,10 +289,10 @@ namespace repeat_n_detail {
 
   template <class PredecessorSenderId, class Closure, class ReceiverId>
   struct operation_state_t {
-    using PredSender = stdexec::__t<PredecessorSenderId>;
-    using Receiver = stdexec::__t<ReceiverId>;
-    using Scheduler = std::invoke_result_t<stdexec::get_scheduler_t, stdexec::env_of_t<Receiver>>;
-    using InnerSender = std::invoke_result_t<Closure, stdexec::schedule_result_t<Scheduler>>;
+    using PredSender = ex::__t<PredecessorSenderId>;
+    using Receiver = ex::__t<ReceiverId>;
+    using Scheduler = std::invoke_result_t<ex::get_scheduler_t, ex::env_of_t<Receiver>>;
+    using InnerSender = std::invoke_result_t<Closure, ex::schedule_result_t<Scheduler>>;
 
     using predecessor_op_state_t =
       ex::connect_result_t<PredSender, receiver_1_t<operation_state_t>>;
@@ -310,9 +308,9 @@ namespace repeat_n_detail {
 
     void start() & noexcept {
       if (n_) {
-        stdexec::start(*pred_op_state_);
+        ex::start(*pred_op_state_);
       } else {
-        stdexec::set_value(std::move(rcvr_));
+        ex::set_value(std::move(rcvr_));
       }
     }
 
@@ -321,7 +319,7 @@ namespace repeat_n_detail {
       , closure_(closure)
       , rcvr_(rcvr)
       , n_(n) {
-      pred_op_state_.emplace(stdexec::__emplace_from{[&]() noexcept {
+      pred_op_state_.emplace(ex::__emplace_from{[&]() noexcept {
         return ex::connect(static_cast<PredSender&&>(pred_sender_), receiver_1_t{*this});
       }});
     }
@@ -331,16 +329,16 @@ namespace repeat_n_detail {
   struct repeat_n_sender_t {
     using __t = repeat_n_sender_t;
     using __id = repeat_n_sender_t;
-    using Sender = stdexec::__t<SenderId>;
-    using sender_concept = stdexec::sender_t;
+    using Sender = ex::__t<SenderId>;
+    using sender_concept = ex::sender_t;
 
-    using completion_signatures = stdexec::completion_signatures<
-      stdexec::set_value_t(),
-      stdexec::set_stopped_t(),
-      stdexec::set_error_t(std::exception_ptr)
+    using completion_signatures = ex::completion_signatures<
+      ex::set_value_t(),
+      ex::set_stopped_t(),
+      ex::set_error_t(std::exception_ptr)
 #if defined(_NVHPC_CUDA) || defined(__CUDACC__)
         ,
-      stdexec::set_error_t(cudaError_t)
+      ex::set_error_t(cudaError_t)
 #endif
     >;
 
@@ -349,50 +347,50 @@ namespace repeat_n_detail {
     std::size_t n_{};
 
 #if defined(_NVHPC_CUDA) || defined(__CUDACC__)
-    template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
-      requires(stdexec::sender_to<Sender, Receiver>)
+    template <ex::__decays_to<repeat_n_sender_t> Self, ex::receiver Receiver>
+      requires(ex::sender_to<Sender, Receiver>)
            && (!nvexec::_strm::receiver_with_stream_env<Receiver>)
-    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver r)
-      -> repeat_n_detail::operation_state_t<SenderId, Closure, stdexec::__id<Receiver>> {
-      return repeat_n_detail::operation_state_t<SenderId, Closure, stdexec::__id<Receiver>>(
+    friend auto tag_invoke(ex::connect_t, Self&& self, Receiver r)
+      -> repeat_n_detail::operation_state_t<SenderId, Closure, ex::__id<Receiver>> {
+      return repeat_n_detail::operation_state_t<SenderId, Closure, ex::__id<Receiver>>(
         static_cast<Sender&&>(self.sender_), self.closure_, static_cast<Receiver&&>(r), self.n_);
     }
 
-    template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
-      requires(stdexec::sender_to<Sender, Receiver>)
+    template <ex::__decays_to<repeat_n_sender_t> Self, ex::receiver Receiver>
+      requires(ex::sender_to<Sender, Receiver>)
            && (nvexec::_strm::receiver_with_stream_env<Receiver>)
-    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver r)
-      -> nvexec::_strm::repeat_n::operation_state_t<SenderId, Closure, stdexec::__id<Receiver>> {
-      return nvexec::_strm::repeat_n::operation_state_t<SenderId, Closure, stdexec::__id<Receiver>>(
+    friend auto tag_invoke(ex::connect_t, Self&& self, Receiver r)
+      -> nvexec::_strm::repeat_n::operation_state_t<SenderId, Closure, ex::__id<Receiver>> {
+      return nvexec::_strm::repeat_n::operation_state_t<SenderId, Closure, ex::__id<Receiver>>(
         static_cast<Sender&&>(self.sender_), self.closure_, static_cast<Receiver&&>(r), self.n_);
     }
 #else
-    template <stdexec::__decays_to<repeat_n_sender_t> Self, stdexec::receiver Receiver>
-      requires stdexec::sender_to<Sender, Receiver>
-    friend auto tag_invoke(stdexec::connect_t, Self&& self, Receiver r)
-      -> repeat_n_detail::operation_state_t<SenderId, Closure, stdexec::__id<Receiver>> {
-      return repeat_n_detail::operation_state_t<SenderId, Closure, stdexec::__id<Receiver>>(
+    template <ex::__decays_to<repeat_n_sender_t> Self, ex::receiver Receiver>
+      requires ex::sender_to<Sender, Receiver>
+    friend auto tag_invoke(ex::connect_t, Self&& self, Receiver r)
+      -> repeat_n_detail::operation_state_t<SenderId, Closure, ex::__id<Receiver>> {
+      return repeat_n_detail::operation_state_t<SenderId, Closure, ex::__id<Receiver>>(
         static_cast<Sender&&>(self.sender_), self.closure_, static_cast<Receiver&&>(r), self.n_);
     }
 #endif
 
-    auto get_env() const noexcept -> stdexec::env_of_t<const Sender&> {
-      return stdexec::get_env(sender_);
+    auto get_env() const noexcept -> ex::env_of_t<const Sender&> {
+      return ex::get_env(sender_);
     }
   };
 } // namespace repeat_n_detail
 
 struct repeat_n_t {
-  template <stdexec::sender Sender, stdexec::__sender_adaptor_closure Closure>
+  template <ex::sender Sender, ex::__sender_adaptor_closure Closure>
   auto operator()(Sender&& __sndr, std::size_t n, Closure closure) const noexcept
-    -> repeat_n_detail::repeat_n_sender_t<stdexec::__id<Sender>, Closure> {
-    return repeat_n_detail::repeat_n_sender_t<stdexec::__id<Sender>, Closure>{
+    -> repeat_n_detail::repeat_n_sender_t<ex::__id<Sender>, Closure> {
+    return repeat_n_detail::repeat_n_sender_t<ex::__id<Sender>, Closure>{
       std::forward<Sender>(__sndr), closure, n};
   }
 
-  template <stdexec::__sender_adaptor_closure Closure>
+  template <ex::__sender_adaptor_closure Closure>
   auto operator()(std::size_t n, Closure closure) const
-    -> stdexec::__binder_back<repeat_n_t, std::size_t, Closure> {
+    -> ex::__binder_back<repeat_n_t, std::size_t, Closure> {
     return {
       {n, static_cast<Closure&&>(closure)},
       {},
@@ -406,8 +404,8 @@ inline constexpr repeat_n_t repeat_n{};
 template <class SchedulerT>
 [[nodiscard]]
 auto is_gpu_scheduler(SchedulerT&& scheduler) -> bool {
-  auto snd = ex::just() | exec::on(scheduler, ex::then([] { return nvexec::is_on_gpu(); }));
-  auto [on_gpu] = stdexec::sync_wait(std::move(snd)).value();
+  auto snd = ex::just() | ex::on(scheduler, ex::then([] { return nvexec::is_on_gpu(); }));
+  auto [on_gpu] = ex::sync_wait(std::move(snd)).value();
   return on_gpu;
 }
 
@@ -417,9 +415,9 @@ auto maxwell_eqs_snr(
   bool write_results,
   std::size_t n_iterations,
   fields_accessor accessor,
-  stdexec::scheduler auto&& computer) {
+  ex::scheduler auto&& computer) {
   return ex::just()
-       | exec::on(
+       | ex::on(
            computer,
            repeat_n(
              n_iterations,
@@ -434,18 +432,18 @@ void run_snr(
   std::size_t n_iterations,
   grid_t& grid,
   std::string_view scheduler_name,
-  stdexec::scheduler auto&& computer) {
+  ex::scheduler auto&& computer) {
   time_storage_t time{is_gpu_scheduler(computer)};
   fields_accessor accessor = grid.accessor();
 
   auto init = ex::just()
-            | exec::on(computer, ex::bulk(ex::par, grid.cells, grid_initializer(dt, accessor)));
-  stdexec::sync_wait(init);
+            | ex::on(computer, ex::bulk(ex::par, grid.cells, grid_initializer(dt, accessor)));
+  ex::sync_wait(init);
 
   auto snd = maxwell_eqs_snr(dt, time.get(), write_vtk, n_iterations, accessor, computer);
 
   report_performance(grid.cells, n_iterations, scheduler_name, [&snd] {
-    stdexec::sync_wait(std::move(snd));
+    ex::sync_wait(std::move(snd));
   });
 }
 

--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -21,6 +21,8 @@
 #include "common.cuh"
 #include "stdexec/execution.hpp"
 
+namespace ex = stdexec;
+
 #if defined(_NVHPC_CUDA) || defined(__CUDACC__)
 #  include "nvexec/detail/throw_on_cuda_error.cuh"
 #  include <nvexec/stream_context.cuh>
@@ -39,7 +41,7 @@ namespace nvexec {
     struct stream_op_state_base { };
   } // namespace detail
 
-  inline bool is_on_gpu() {
+  inline auto is_on_gpu() -> bool {
     return false;
   }
 } // namespace nvexec

--- a/examples/nvexec/maxwell_distributed.cpp
+++ b/examples/nvexec/maxwell_distributed.cpp
@@ -428,7 +428,7 @@ auto main(int argc, char *argv[]) -> int {
     };
   };
 
-  stdexec::sync_wait(
+  ex::sync_wait(
     ex::schedule(gpu)
     | ex::bulk(ex::par, accessor.own_cells(), distributed::grid_initializer(dt, accessor)));
 
@@ -485,17 +485,17 @@ auto main(int argc, char *argv[]) -> int {
 
   for (std::size_t compute_step = 0; compute_step < n_iterations; compute_step++) {
     auto compute_h = ex::when_all(
-      ex::just() | exec::on(gpu, ex::bulk(ex::par, bulk_cells, bulk_h_update)),
-      ex::just() | exec::on(gpu_with_priority, ex::bulk(ex::par, border_cells, border_h_update))
+      ex::just() | ex::on(gpu, ex::bulk(ex::par, bulk_cells, bulk_h_update)),
+      ex::just() | ex::on(gpu_with_priority, ex::bulk(ex::par, border_cells, border_h_update))
         | ex::then(exchange_hx));
 
     auto compute_e = ex::when_all(
-      ex::just() | exec::on(gpu, ex::bulk(ex::par, bulk_cells, bulk_e_update)),
-      ex::just() | exec::on(gpu_with_priority, ex::bulk(ex::par, border_cells, border_e_update))
+      ex::just() | ex::on(gpu, ex::bulk(ex::par, bulk_cells, bulk_e_update)),
+      ex::just() | ex::on(gpu_with_priority, ex::bulk(ex::par, border_cells, border_e_update))
         | ex::then(exchange_ez));
 
-    stdexec::sync_wait(std::move(compute_h));
-    stdexec::sync_wait(std::move(compute_e));
+    ex::sync_wait(std::move(compute_h));
+    ex::sync_wait(std::move(compute_e));
   }
 
   write();
@@ -503,18 +503,18 @@ auto main(int argc, char *argv[]) -> int {
   for (std::size_t compute_step = 0; compute_step < n_iterations; compute_step++) {
     auto compute_h =
       ex::just()
-      | exec::on(gpu, ex::bulk(ex::par, accessor.own_cells(), distributed::update_h(accessor)))
+      | ex::on(gpu, ex::bulk(ex::par, accessor.own_cells(), distributed::update_h(accessor)))
       | ex::then(exchange_hx);
 
     auto compute_e =
       ex::just()
-      | exec::on(
+      | ex::on(
         gpu,
         ex::bulk(ex::par, accessor.own_cells(), distributed::update_e(time.get(), dt, accessor)))
       | ex::then(exchange_ez);
 
-    stdexec::sync_wait(std::move(compute_h));
-    stdexec::sync_wait(std::move(compute_e));
+    ex::sync_wait(std::move(compute_h));
+    ex::sync_wait(std::move(compute_e));
   }
 
   write();

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -15,11 +15,13 @@
  */
 #pragma once
 
-#include "../stdexec/execution.hpp"
+#include "../stdexec/execution.hpp" // IWYU pragma: keep
 
 namespace exec {
   /////////////////////////////////////////////////////////////////////////////
   // A scoped version of [execution.senders.adaptors.on]
-  using stdexec::v2::on_t;
-  using stdexec::v2::on;
+  using on_t [[deprecated("on_t has been moved to the stdexec:: namespace")]] = stdexec::on_t;
+
+  [[deprecated("on has been moved to the stdexec:: namespace")]]
+  inline constexpr on_t const& on = stdexec::on;
 } // namespace exec

--- a/include/stdexec/__detail/__continues_on.hpp
+++ b/include/stdexec/__detail/__continues_on.hpp
@@ -86,11 +86,18 @@ namespace stdexec {
   using __continues_on::continues_on_t;
   inline constexpr continues_on_t continues_on{};
 
+  // Backward compatibility:
   using transfer_t = continues_on_t;
   inline constexpr continues_on_t transfer{};
 
   using continue_on_t = continues_on_t;
   inline constexpr continues_on_t continue_on{};
+
+  namespace v2 {
+    using continue_on_t [[deprecated("use stdexec::continues_on_t instead")]] = stdexec::continues_on_t;
+    [[deprecated("use stdexec::continues_on instead")]]
+    inline constexpr stdexec::continues_on_t const& continue_on = stdexec::continues_on;
+  } // namespace v2
 
   template <>
   struct __sexpr_impl<continues_on_t> : __continues_on::__continues_on_impl { };

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -212,10 +212,6 @@ namespace stdexec {
   using __starts_on_ns::starts_on_t;
   extern const starts_on_t starts_on;
 
-  using on_t [[deprecated("on_t has been renamed starts_on_t")]] = starts_on_t;
-  [[deprecated("on has been renamed starts_on")]]
-  extern const starts_on_t on;
-
   using start_on_t [[deprecated("start_on_t has been renamed starts_on_t")]] = starts_on_t;
   [[deprecated("start_on has been renamed starts_on")]]
   extern const starts_on_t start_on;
@@ -284,13 +280,12 @@ namespace stdexec {
   extern const ensure_started_t ensure_started;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
-  namespace __on_v2 {
+  namespace __on {
     struct on_t;
-  } // namespace __on_v2
+  } // namespace __on
 
-  namespace v2 {
-    using __on_v2::on_t;
-  } // namespace v2
+  using __on::on_t;
+  extern const on_t on;
 
   namespace __detail {
     struct __sexpr_apply_t;

--- a/include/stdexec/__detail/__on.hpp
+++ b/include/stdexec/__detail/__on.hpp
@@ -38,7 +38,7 @@
 namespace stdexec {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.senders.adaptors.on]
-  namespace __on_v2 {
+  namespace __on {
     inline constexpr __mstring __on_context = "In stdexec::on(Scheduler, Sender)..."_mstr;
     inline constexpr __mstring __no_scheduler_diag =
       "stdexec::on() requires a scheduler to transition back to."_mstr;
@@ -200,18 +200,19 @@ namespace stdexec {
         }
       }
     };
-  } // namespace __on_v2
+  } // namespace __on
+
+  using __on::on_t;
+  inline constexpr on_t on{};
 
   namespace v2 {
-    using __on_v2::on_t;
-    inline constexpr on_t on{};
-
-    using continue_on_t = v2::on_t;
-    inline constexpr continue_on_t continue_on{}; // for back-compat
+    using on_t [[deprecated("use stdexec::on_t instead")]] = stdexec::on_t;
+    [[deprecated("use stdexec::on instead")]]
+    inline constexpr stdexec::on_t const& on = stdexec::on;
   } // namespace v2
 
   template <>
-  struct __sexpr_impl<v2::on_t> : __sexpr_defaults {
+  struct __sexpr_impl<on_t> : __sexpr_defaults {
     static constexpr auto get_completion_signatures = []<class _Sender>(_Sender&&) noexcept
       -> __merror_or_t<
         __completion_signatures_of_t<transform_sender_result_t<default_domain, _Sender, env<>>>,

--- a/include/stdexec/__detail/__starts_on.hpp
+++ b/include/stdexec/__detail/__starts_on.hpp
@@ -76,7 +76,7 @@ namespace stdexec {
       static auto transform_sender(_Sender&& __sndr, const _Env&) {
         return __sexpr_apply(
           static_cast<_Sender&&>(__sndr),
-          []<class _Data, class _Child>(__ignore, _Data&& __data, _Child&& __child) {
+          []<class _Data, class _Child>(__ignore, _Data&& __data, _Child&& __child) -> auto {
             // This is the heart of starts_on: It uses `let_value` to schedule `__child` on the given scheduler:
             return let_value(schedule(__data), __detail::__always{static_cast<_Child&&>(__child)});
           });
@@ -86,9 +86,6 @@ namespace stdexec {
 
   using __starts_on_ns::starts_on_t;
   inline constexpr starts_on_t starts_on{};
-
-  using on_t = starts_on_t;
-  inline constexpr starts_on_t on{};
 
   using start_on_t = starts_on_t;
   inline constexpr starts_on_t start_on{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,9 @@ set(stdexec_test_sources
     stdexec/algos/factories/test_just_stopped.cpp
     stdexec/algos/factories/test_read.cpp
     stdexec/algos/adaptors/test_starts_on.cpp
+    stdexec/algos/adaptors/test_on.cpp
+    stdexec/algos/adaptors/test_on2.cpp
+    stdexec/algos/adaptors/test_on3.cpp
     stdexec/algos/adaptors/test_continues_on.cpp
     stdexec/algos/adaptors/test_schedule_from.cpp
     stdexec/algos/adaptors/test_then.cpp

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -26,9 +26,6 @@ set(exec_test_sources
     test_env.cpp
     test_finally.cpp
     test_into_tuple.cpp
-    test_on.cpp
-    test_on2.cpp
-    test_on3.cpp
     test_repeat_effect_until.cpp
     test_repeat_n.cpp
     async_scope/test_dtor.cpp

--- a/test/exec/test_repeat_n.cpp
+++ b/test/exec/test_repeat_n.cpp
@@ -124,7 +124,7 @@ namespace {
   TEST_CASE("repeat_n works when changing threads", "[adaptors][repeat_n]") {
     exec::static_thread_pool pool{2};
     bool called{false};
-    sender auto snd = exec::on(pool.get_scheduler(), ex::just() | ex::then([&] {
+    sender auto snd = stdexec::on(pool.get_scheduler(), ex::just() | ex::then([&] {
                                                        called = true;
                                                      }) | exec::repeat_n(10));
     stdexec::sync_wait(std::move(snd));

--- a/test/execpools/test_asio_thread_pool.cpp
+++ b/test/execpools/test_asio_thread_pool.cpp
@@ -85,7 +85,7 @@ namespace {
   } // namespace
 
   TEST_CASE(
-    "exec::on works when changing threads with execpools::asio_thread_pool",
+    "stdexec::on works when changing threads with execpools::asio_thread_pool",
     "[adaptors][exec::starts_on]") {
     execpools::asio_thread_pool pool;
     auto pool_sched = pool.get_scheduler();

--- a/test/execpools/test_taskflow_thread_pool.cpp
+++ b/test/execpools/test_taskflow_thread_pool.cpp
@@ -82,7 +82,7 @@ namespace {
   } // namespace
 
   TEST_CASE(
-    "exec::on works when changing threads with execpools::taskflow_thread_pool",
+    "stdexec::on works when changing threads with execpools::taskflow_thread_pool",
     "[adaptors][exec::starts_on]") {
     execpools::taskflow_thread_pool pool;
     auto pool_sched = pool.get_scheduler();

--- a/test/execpools/test_tbb_thread_pool.cpp
+++ b/test/execpools/test_tbb_thread_pool.cpp
@@ -82,7 +82,7 @@ namespace {
   } // namespace
 
   TEST_CASE(
-    "exec::on works when changing threads with execpools::tbb_thread_pool",
+    "stdexec::on works when changing threads with execpools::tbb_thread_pool",
     "[adaptors][exec::starts_on]") {
     execpools::tbb_thread_pool pool;
     auto pool_sched = pool.get_scheduler();

--- a/test/stdexec/algos/adaptors/test_let_error.cpp
+++ b/test/stdexec/algos/adaptors/test_let_error.cpp
@@ -306,7 +306,7 @@ namespace {
       | ex::let_error([](std::exception_ptr) { return ex::just_error(std::string{"err"}); }));
     check_err_types<ex::__mset<std::exception_ptr, std::string>>(
       ex::transfer_just(sched3)
-      | ex::let_error([](stdexec::__one_of<int, std::exception_ptr> auto) {
+      | ex::let_error([](ex::__one_of<int, std::exception_ptr> auto) {
           return ex::just_error(std::string{"err"});
         }));
 
@@ -317,7 +317,7 @@ namespace {
       ex::transfer_just(sched2) | ex::let_error([](std::exception_ptr) { return ex::just(); }));
     check_err_types<ex::__mset<std::exception_ptr>>(
       ex::transfer_just(sched3)
-      | ex::let_error([](stdexec::__one_of<int, std::exception_ptr> auto) { return ex::just(); }));
+      | ex::let_error([](ex::__one_of<int, std::exception_ptr> auto) { return ex::just(); }));
   }
 
   TEST_CASE("let_error keeps sends_stopped from input sender", "[adaptors][let_error]") {

--- a/test/stdexec/algos/adaptors/test_on.cpp
+++ b/test/stdexec/algos/adaptors/test_on.cpp
@@ -39,31 +39,31 @@ namespace {
 
   using _env_with_sched_t = decltype(_make_env_with_sched());
 
-  TEST_CASE("exec::on returns a sender", "[adaptors][exec::on]") {
-    auto snd = exec::on(inline_scheduler{}, ex::just(13));
+  TEST_CASE("stdexec::on returns a sender", "[adaptors][stdexec::on]") {
+    auto snd = ex::on(inline_scheduler{}, ex::just(13));
     static_assert(ex::sender<decltype(snd)>);
     (void) snd;
   }
 
-  TEST_CASE("exec::on with environment returns a sender", "[adaptors][exec::on]") {
-    auto snd = exec::on(inline_scheduler{}, ex::just(13));
+  TEST_CASE("stdexec::on with environment returns a sender", "[adaptors][stdexec::on]") {
+    auto snd = ex::on(inline_scheduler{}, ex::just(13));
     static_assert(ex::sender_in<decltype(snd), _env_with_sched_t>);
     (void) snd;
   }
 
-  TEST_CASE("exec::on simple example", "[adaptors][exec::on]") {
-    auto snd = exec::on(inline_scheduler{}, ex::just(13));
+  TEST_CASE("stdexec::on simple example", "[adaptors][stdexec::on]") {
+    auto snd = ex::on(inline_scheduler{}, ex::just(13));
     auto op =
       ex::connect(std::move(snd), expect_value_receiver{env_tag{}, _make_env_with_sched(), 13});
     ex::start(op);
     // The receiver checks if we receive the right value
   }
 
-  TEST_CASE("exec::on calls the receiver when the scheduler dictates", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on calls the receiver when the scheduler dictates", "[adaptors][stdexec::on]") {
     int recv_value{0};
     impulse_scheduler sched;
     auto env = _make_env_with_sched();
-    auto snd = exec::on(sched, ex::just(13));
+    auto snd = ex::on(sched, ex::just(13));
     auto op = ex::connect(std::move(snd), expect_value_receiver_ex{env, recv_value});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task; no effect expected
@@ -74,7 +74,7 @@ namespace {
     CHECK(recv_value == 13);
   }
 
-  TEST_CASE("exec::on calls the given sender when the scheduler dictates", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on calls the given sender when the scheduler dictates", "[adaptors][stdexec::on]") {
     bool called{false};
     auto snd_base = ex::just() | ex::then([&]() -> int {
                       called = true;
@@ -84,7 +84,7 @@ namespace {
     int recv_value{0};
     impulse_scheduler sched;
     auto env = _make_env_with_sched();
-    auto snd = exec::on(sched, std::move(snd_base));
+    auto snd = ex::on(sched, std::move(snd_base));
     auto op = ex::connect(std::move(snd), expect_value_receiver_ex{env, recv_value});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task
@@ -99,100 +99,100 @@ namespace {
     CHECK(recv_value == 19);
   }
 
-  TEST_CASE("exec::on works when changing threads", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on works when changing threads", "[adaptors][stdexec::on]") {
     exec::static_thread_pool pool{2};
     bool called{false};
     // launch some work on the thread pool
-    ex::sender auto snd = exec::on(pool.get_scheduler(), ex::just())
+    ex::sender auto snd = ex::on(pool.get_scheduler(), ex::just())
                         | ex::then([&] { called = true; }) | _with_scheduler();
     stdexec::sync_wait(std::move(snd));
     // the work should be executed
     REQUIRE(called);
   }
 
-  TEST_CASE("exec::on can be called with rvalue ref scheduler", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on can be called with rvalue ref scheduler", "[adaptors][stdexec::on]") {
     auto env = _make_env_with_sched();
-    auto snd = exec::on(inline_scheduler{}, ex::just(13));
+    auto snd = ex::on(inline_scheduler{}, ex::just(13));
     auto op = ex::connect(std::move(snd), expect_value_receiver{env_tag{}, env, 13});
     ex::start(op);
     // The receiver checks if we receive the right value
   }
 
-  TEST_CASE("exec::on can be called with const ref scheduler", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on can be called with const ref scheduler", "[adaptors][stdexec::on]") {
     auto env = _make_env_with_sched();
     const inline_scheduler sched;
-    auto snd = exec::on(sched, ex::just(13));
+    auto snd = ex::on(sched, ex::just(13));
     auto op = ex::connect(std::move(snd), expect_value_receiver{env_tag{}, env, 13});
     ex::start(op);
     // The receiver checks if we receive the right value
   }
 
-  TEST_CASE("exec::on can be called with ref scheduler", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on can be called with ref scheduler", "[adaptors][stdexec::on]") {
     auto env = _make_env_with_sched();
     inline_scheduler sched;
-    auto snd = exec::on(sched, ex::just(13));
+    auto snd = ex::on(sched, ex::just(13));
     auto op = ex::connect(std::move(snd), expect_value_receiver{env_tag{}, env, 13});
     ex::start(op);
     // The receiver checks if we receive the right value
   }
 
-  TEST_CASE("exec::on forwards set_error calls", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on forwards set_error calls", "[adaptors][stdexec::on]") {
     auto env = _make_env_with_sched();
     error_scheduler<std::exception_ptr> sched{std::exception_ptr{}};
-    auto snd = exec::on(sched, ex::just(13));
+    auto snd = ex::on(sched, ex::just(13));
     auto op = ex::connect(std::move(snd), expect_error_receiver{env, std::exception_ptr{}});
     ex::start(op);
     // The receiver checks if we receive an error
   }
 
-  TEST_CASE("exec::on forwards set_error calls of other types", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on forwards set_error calls of other types", "[adaptors][stdexec::on]") {
     auto env = _make_env_with_sched();
     error_scheduler<std::string> sched{std::string{"error"}};
-    auto snd = exec::on(sched, ex::just(13));
+    auto snd = ex::on(sched, ex::just(13));
     auto op = ex::connect(std::move(snd), expect_error_receiver{env, std::string{"error"}});
     ex::start(op);
     // The receiver checks if we receive an error
   }
 
-  TEST_CASE("exec::on forwards set_stopped calls", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on forwards set_stopped calls", "[adaptors][stdexec::on]") {
     auto env = _make_env_with_sched();
     stopped_scheduler sched{};
-    auto snd = exec::on(sched, ex::just(13));
+    auto snd = ex::on(sched, ex::just(13));
     auto op = ex::connect(std::move(snd), expect_stopped_receiver{env});
     ex::start(op);
     // The receiver checks if we receive the stopped signal
   }
 
   TEST_CASE(
-    "exec::on has the values_type corresponding to the given values",
-    "[adaptors][exec::on]") {
+    "stdexec::on has the values_type corresponding to the given values",
+    "[adaptors][stdexec::on]") {
     inline_scheduler sched{};
 
-    check_val_types<ex::__mset<pack<int>>>(exec::on(sched, ex::just(1)) | _with_scheduler());
+    check_val_types<ex::__mset<pack<int>>>(ex::on(sched, ex::just(1)) | _with_scheduler());
     check_val_types<ex::__mset<pack<int, double>>>(
-      exec::on(sched, ex::just(3, 0.14)) | _with_scheduler());
+      ex::on(sched, ex::just(3, 0.14)) | _with_scheduler());
     check_val_types<ex::__mset<pack<int, double, std::string>>>(
-      exec::on(sched, ex::just(3, 0.14, std::string{"pi"})) | _with_scheduler());
+      ex::on(sched, ex::just(3, 0.14, std::string{"pi"})) | _with_scheduler());
   }
 
-  TEST_CASE("exec::on keeps error_types from scheduler's sender", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on keeps error_types from scheduler's sender", "[adaptors][stdexec::on]") {
     inline_scheduler sched1{};
     error_scheduler sched2{};
     error_scheduler<int> sched3{43};
 
-    check_err_types<ex::__mset<>>(exec::on(sched1, ex::just(1)) | _with_scheduler());
+    check_err_types<ex::__mset<>>(ex::on(sched1, ex::just(1)) | _with_scheduler());
     check_err_types<ex::__mset<std::exception_ptr>>(
-      exec::on(sched2, ex::just(2)) | _with_scheduler());
-    check_err_types<ex::__mset<int>>(exec::on(sched3, ex::just(3)) | _with_scheduler());
+      ex::on(sched2, ex::just(2)) | _with_scheduler());
+    check_err_types<ex::__mset<int>>(ex::on(sched3, ex::just(3)) | _with_scheduler());
   }
 
-  TEST_CASE("exec::on keeps sends_stopped from scheduler's sender", "[adaptors][exec::on]") {
+  TEST_CASE("stdexec::on keeps sends_stopped from scheduler's sender", "[adaptors][stdexec::on]") {
     inline_scheduler sched1{};
     error_scheduler sched2{};
     stopped_scheduler sched3{};
 
-    check_sends_stopped<false>(exec::on(sched1, ex::just(1)) | _with_scheduler());
-    check_sends_stopped<true>(exec::on(sched2, ex::just(2)) | _with_scheduler());
-    check_sends_stopped<true>(exec::on(sched3, ex::just(3)) | _with_scheduler());
+    check_sends_stopped<false>(ex::on(sched1, ex::just(1)) | _with_scheduler());
+    check_sends_stopped<true>(ex::on(sched2, ex::just(2)) | _with_scheduler());
+    check_sends_stopped<true>(ex::on(sched3, ex::just(3)) | _with_scheduler());
   }
 } // namespace

--- a/test/stdexec/algos/adaptors/test_on2.cpp
+++ b/test/stdexec/algos/adaptors/test_on2.cpp
@@ -28,12 +28,12 @@ namespace {
 
   template <ex::scheduler Sched = inline_scheduler>
   inline auto _with_scheduler(Sched sched = {}) {
-    return exec::write_env(stdexec::prop{ex::get_scheduler, std::move(sched)});
+    return exec::write_env(ex::prop{ex::get_scheduler, std::move(sched)});
   }
 
   TEST_CASE(
-    "exec::on transitions back to the receiver's scheduler when completing with a value",
-    "[adaptors][exec::on]") {
+    "stdexec::on transitions back to the receiver's scheduler when completing with a value",
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto snd_base = ex::just() | ex::then([&]() -> int {
                       called = true;
@@ -43,7 +43,7 @@ namespace {
     int recv_value{0};
     impulse_scheduler sched1;
     impulse_scheduler sched2;
-    auto snd = exec::on(sched1, std::move(snd_base)) | _with_scheduler(sched2);
+    auto snd = ex::on(sched1, std::move(snd_base)) | _with_scheduler(sched2);
     auto op = ex::connect(std::move(snd), expect_value_receiver_ex{recv_value});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task
@@ -65,8 +65,8 @@ namespace {
   }
 
   TEST_CASE(
-    "exec::on transitions back to the receiver's scheduler when completing with an error",
-    "[adaptors][exec::on]") {
+    "stdexec::on transitions back to the receiver's scheduler when completing with an error",
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto snd_base = ex::just() | ex::let_value([&]() {
                       called = true;
@@ -76,7 +76,7 @@ namespace {
     int recv_error{0};
     impulse_scheduler sched1;
     impulse_scheduler sched2;
-    auto snd = exec::on(sched1, std::move(snd_base)) | _with_scheduler(sched2);
+    auto snd = ex::on(sched1, std::move(snd_base)) | _with_scheduler(sched2);
     auto op = ex::connect(std::move(snd), expect_error_receiver_ex{recv_error});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task
@@ -99,7 +99,7 @@ namespace {
 
   TEST_CASE(
     "inner on transitions back to outer on's scheduler when completing with a value",
-    "[adaptors][exec::on]") {
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto snd_base = ex::just() | ex::then([&]() -> int {
                       called = true;
@@ -110,7 +110,7 @@ namespace {
     impulse_scheduler sched1;
     impulse_scheduler sched2;
     impulse_scheduler sched3;
-    auto snd = exec::on(sched1, exec::on(sched2, std::move(snd_base))) | _with_scheduler(sched3);
+    auto snd = ex::on(sched1, ex::on(sched2, std::move(snd_base))) | _with_scheduler(sched3);
     auto op = ex::connect(std::move(snd), expect_value_receiver_ex{recv_value});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task
@@ -150,7 +150,7 @@ namespace {
 
   TEST_CASE(
     "inner on transitions back to outer on's scheduler when completing with an error",
-    "[adaptors][exec::on]") {
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto snd_base = ex::just() | ex::let_value([&]() {
                       called = true;
@@ -161,7 +161,7 @@ namespace {
     impulse_scheduler sched1;
     impulse_scheduler sched2;
     impulse_scheduler sched3;
-    auto snd = exec::on(sched1, exec::on(sched2, std::move(snd_base))) | _with_scheduler(sched3);
+    auto snd = ex::on(sched1, ex::on(sched2, std::move(snd_base))) | _with_scheduler(sched3);
     auto op = ex::connect(std::move(snd), expect_error_receiver_ex{recv_error});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task
@@ -200,8 +200,8 @@ namespace {
   }
 
   TEST_CASE(
-    "exec::on(closure) transitions onto and back off of the scheduler when completing with a value",
-    "[adaptors][exec::on]") {
+    "ex::on(closure) transitions onto and back off of the scheduler when completing with a value",
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto closure = ex::then([&]() -> int {
       called = true;
@@ -211,7 +211,7 @@ namespace {
     int recv_value{0};
     impulse_scheduler sched1;
     impulse_scheduler sched2;
-    auto snd = ex::just() | exec::on(sched1, std::move(closure)) | _with_scheduler(sched2);
+    auto snd = ex::just() | ex::on(sched1, std::move(closure)) | _with_scheduler(sched2);
     auto op = ex::connect(std::move(snd), expect_value_receiver_ex{recv_value});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task
@@ -233,9 +233,9 @@ namespace {
   }
 
   TEST_CASE(
-    "exec::on(closure) transitions onto and back off of the scheduler when completing with "
+    "ex::on(closure) transitions onto and back off of the scheduler when completing with "
     "an error",
-    "[adaptors][exec::on]") {
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto closure = ex::let_value([&]() {
       called = true;
@@ -245,7 +245,7 @@ namespace {
     int recv_error{0};
     impulse_scheduler sched1;
     impulse_scheduler sched2;
-    auto snd = ex::just() | exec::on(sched1, std::move(closure)) | _with_scheduler(sched2);
+    auto snd = ex::just() | ex::on(sched1, std::move(closure)) | _with_scheduler(sched2);
     auto op = ex::connect(std::move(snd), expect_error_receiver_ex{recv_error});
     ex::start(op);
     // Up until this point, the scheduler didn't start any task
@@ -268,7 +268,7 @@ namespace {
 
   TEST_CASE(
     "inner on(closure) transitions back to outer on's scheduler when completing with a value",
-    "[adaptors][exec::on]") {
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto closure = ex::then([&](int i) -> int {
       called = true;
@@ -279,7 +279,7 @@ namespace {
     impulse_scheduler sched1;
     impulse_scheduler sched2;
     impulse_scheduler sched3;
-    auto snd = exec::on(sched1, ex::just(19)) | exec::on(sched2, std::move(closure))
+    auto snd = ex::on(sched1, ex::just(19)) | ex::on(sched2, std::move(closure))
              | _with_scheduler(sched3);
     auto op = ex::connect(std::move(snd), expect_value_receiver_ex{recv_value});
     ex::start(op);
@@ -320,7 +320,7 @@ namespace {
 
   TEST_CASE(
     "inner on(closure) transitions back to outer on's scheduler when completing with an error",
-    "[adaptors][exec::on]") {
+    "[adaptors][stdexec::on]") {
     bool called{false};
     auto closure = ex::let_value([&](int i) {
       called = true;
@@ -331,7 +331,7 @@ namespace {
     impulse_scheduler sched1;
     impulse_scheduler sched2;
     impulse_scheduler sched3;
-    auto snd = exec::on(sched1, ex::just(19)) | exec::on(sched2, std::move(closure))
+    auto snd = ex::on(sched1, ex::just(19)) | ex::on(sched2, std::move(closure))
              | _with_scheduler(sched3);
     auto op = ex::connect(std::move(snd), expect_error_receiver_ex{recv_error});
     ex::start(op);

--- a/test/stdexec/algos/adaptors/test_on3.cpp
+++ b/test/stdexec/algos/adaptors/test_on3.cpp
@@ -86,42 +86,42 @@ namespace {
 
   static const auto probe_env = probe_env_t{};
 
-  static const auto env = exec::make_env(stdexec::prop{ex::get_scheduler, inline_scheduler{}});
+  static const auto env = exec::make_env(ex::prop{ex::get_scheduler, inline_scheduler{}});
 
-  TEST_CASE("Can pass exec::on sender to start_detached", "[adaptors][exec::on]") {
-    ex::start_detached(exec::on(inline_scheduler{}, ex::just()), env);
+  TEST_CASE("Can pass stdexec::on sender to start_detached", "[adaptors][stdexec::on]") {
+    ex::start_detached(ex::on(inline_scheduler{}, ex::just()), env);
   }
 
-  TEST_CASE("Can pass exec::on sender to split", "[adaptors][exec::on]") {
-    auto snd = ex::split(exec::on(inline_scheduler{}, ex::just()), env);
+  TEST_CASE("Can pass stdexec::on sender to split", "[adaptors][stdexec::on]") {
+    auto snd = ex::split(ex::on(inline_scheduler{}, ex::just()), env);
     (void) snd;
   }
 
-  TEST_CASE("Can pass exec::on sender to ensure_started", "[adaptors][exec::on]") {
-    auto snd = ex::ensure_started(exec::on(inline_scheduler{}, ex::just()), env);
+  TEST_CASE("Can pass stdexec::on sender to ensure_started", "[adaptors][stdexec::on]") {
+    auto snd = ex::ensure_started(ex::on(inline_scheduler{}, ex::just()), env);
     (void) snd;
   }
 
-  TEST_CASE("Can pass exec::on sender to async_scope::spawn", "[adaptors][exec::on]") {
+  TEST_CASE("Can pass stdexec::on sender to async_scope::spawn", "[adaptors][stdexec::on]") {
     exec::async_scope scope;
     impulse_scheduler sched;
-    scope.spawn(exec::on(sched, ex::just()), env);
+    scope.spawn(ex::on(sched, ex::just()), env);
     sched.start_next();
     ex::sync_wait(scope.on_empty());
   }
 
-  TEST_CASE("Can pass exec::on sender to async_scope::spawn_future", "[adaptors][exec::on]") {
+  TEST_CASE("Can pass stdexec::on sender to async_scope::spawn_future", "[adaptors][stdexec::on]") {
     exec::async_scope scope;
     impulse_scheduler sched;
-    auto fut = scope.spawn_future(exec::on(sched, ex::just(42)), env);
+    auto fut = scope.spawn_future(ex::on(sched, ex::just(42)), env);
     sched.start_next();
     auto [i] = ex::sync_wait(std::move(fut)).value();
     CHECK(i == 42);
     ex::sync_wait(scope.on_empty());
   }
 
-  TEST_CASE("exec::on updates the current scheduler in the receiver", "[adaptors][exec::on]") {
-    auto snd = ex::get_scheduler() | exec::on(inline_scheduler{}, probe_env())
+  TEST_CASE("stdexec::on updates the current scheduler in the receiver", "[adaptors][stdexec::on]") {
+    auto snd = ex::get_scheduler() | ex::on(inline_scheduler{}, probe_env())
              | ex::then([]<class Env>(Env) noexcept {
                  using Sched = ex::__call_result_t<ex::get_scheduler_t, Env>;
                  static_assert(ex::same_as<Sched, inline_scheduler>);

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -190,7 +190,7 @@ namespace {
     // The customization will return a different value
     basic_inline_scheduler<then_test_domain> sched;
     auto snd = ex::just(std::string{"hello"})
-             | exec::on(sched, ex::then([](std::string x) { return x + ", world"; }))
+             | ex::on(sched, ex::then([](std::string x) { return x + ", world"; }))
              | exec::write_env(stdexec::prop{ex::get_scheduler, inline_scheduler()});
     wait_for_value(std::move(snd), std::string{"ciao"});
   }

--- a/test/stdexec/algos/consumers/test_start_detached.cpp
+++ b/test/stdexec/algos/consumers/test_start_detached.cpp
@@ -93,7 +93,7 @@ namespace {
   }
 
   struct custom_sender {
-    using sender_concept = stdexec::sender_t;
+    using sender_concept = ex::sender_t;
     using __t = custom_sender;
     using __id = custom_sender;
     using completion_signatures = ex::completion_signatures<ex::set_value_t()>;
@@ -180,7 +180,7 @@ namespace {
   // NOT TO SPEC
   TEST_CASE("start_detached can be customized on scheduler", "[consumers][start_detached]") {
     bool called = false;
-    ex::start_detached(ex::just(), stdexec::prop{ex::get_scheduler, custom_scheduler{&called}});
+    ex::start_detached(ex::just(), ex::prop{ex::get_scheduler, custom_scheduler{&called}});
     CHECK(called);
   }
 
@@ -226,35 +226,35 @@ namespace {
     std::pmr::polymorphic_allocator<std::byte> alloc(&res);
     ex::start_detached(
       ex::just() | ex::then([&] { called = true; }),
-      exec::make_env(stdexec::prop{ex::get_allocator, alloc}));
+      exec::make_env(ex::prop{ex::get_allocator, alloc}));
     CHECK(called);
     CHECK(res.get_count() == 1);
     CHECK(res.get_alive() == 0);
   }
 #endif
 
-  TEST_CASE("exec::on can be passed to start_detached", "[adaptors][exec::on]") {
+  TEST_CASE("ex::on can be passed to start_detached", "[adaptors][ex::on]") {
     ex::run_loop loop;
     auto sch = loop.get_scheduler();
     auto snd = ex::get_scheduler() | ex::let_value([](auto sched) {
                  static_assert(ex::same_as<decltype(sched), ex::run_loop::__scheduler>);
                  return ex::starts_on(sched, ex::just());
                });
-    ex::start_detached(ex::v2::on(sch, std::move(snd)));
+    ex::start_detached(ex::on(sch, std::move(snd)));
     loop.finish();
     loop.run();
   }
 
   struct env { };
 
-  TEST_CASE("exec::on can be passed to start_detached with env", "[adaptors][exec::on]") {
+  TEST_CASE("ex::on can be passed to start_detached with env", "[adaptors][ex::on]") {
     ex::run_loop loop;
     auto sch = loop.get_scheduler();
     auto snd = ex::get_scheduler() | ex::let_value([](auto sched) {
                  static_assert(ex::same_as<decltype(sched), ex::run_loop::__scheduler>);
                  return ex::starts_on(sched, ex::just());
                });
-    ex::start_detached(ex::v2::on(sch, std::move(snd)), env{});
+    ex::start_detached(ex::on(sch, std::move(snd)), env{});
     loop.finish();
     loop.run();
   }


### PR DESCRIPTION
`stdexec::on` has been deprecated for a while because its behavior, which pre-dated [P3175](https://wg21.link/P3175), was akin to what is now `starts_on`; that is, it did not transition back to the starting execution context.

feeling that it was deprecated long enough, i have replaced its behavior with the standard-conforming one.