### PR TITLE
Allow just to Throw on Connect

### DIFF
--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -228,7 +228,7 @@ namespace stdexec {
 
       __op_base(_Sexpr&& __sndr, _Receiver&& __rcvr) noexcept(
         __nothrow_decay_copyable<_Receiver>
-        && __noexcept_of<__sexpr_impl<__tag_t>::get_state, _Sexpr, _Receiver&>)
+        && noexcept(__state_t(__sexpr_impl<__tag_t>::get_state(static_cast<_Sexpr&&>(__sndr), __rcvr_))))
         : __rcvr_(static_cast<_Receiver&&>(__rcvr))
         , __state_(__sexpr_impl<__tag_t>::get_state(static_cast<_Sexpr&&>(__sndr), __rcvr_)) {
       }

--- a/test/test_common/receivers.hpp
+++ b/test/test_common/receivers.hpp
@@ -487,7 +487,7 @@ namespace {
     F f_;
 
     template <class... Ts>
-    void set_value(Ts... vals) noexcept {
+    void set_value(Ts&&... vals) noexcept {
       STDEXEC_TRY {
         std::move(f_)(static_cast<Ts&&>(vals)...);
       }


### PR DESCRIPTION
Previously if connecting a just sender with a receiver threw due to a throwing move operation terminate was called due to an exception passing through noexcept.