### PR TITLE
remove needless hops through `tag_invoke`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.graphviz",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -23,5 +23,5 @@ namespace exec {
   using on_t [[deprecated("on_t has been moved to the stdexec:: namespace")]] = stdexec::on_t;
 
   [[deprecated("on has been moved to the stdexec:: namespace")]]
-  inline constexpr on_t const& on = stdexec::on;
+  inline constexpr stdexec::on_t const & on = stdexec::on;
 } // namespace exec

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -335,7 +335,8 @@ namespace exec {
     using __sender_base = stdexec::__t<__any::__sequence_sender<
       _Completions,
       queries<_SenderQueries...>,
-      queries<_ReceiverQueries...>>>;
+      queries<_ReceiverQueries...>
+    >>;
     __sender_base __sender_;
 
    public:
@@ -352,11 +353,9 @@ namespace exec {
       : __sender_(static_cast<_Sender&&>(__sender)) {
     }
 
-    template <stdexec::same_as<__t> _Self, sequence_receiver_of<item_types> _Rcvr>
-    friend auto tag_invoke(exec::subscribe_t, _Self&& __self, _Rcvr __rcvr)
-      -> subscribe_result_t<__sender_base, _Rcvr> {
-      return exec::subscribe(
-        static_cast<__sender_base&&>(__self.__sender_), static_cast<_Rcvr&&>(__rcvr));
+    template <sequence_receiver_of<item_types> _Rcvr>
+    auto subscribe(_Rcvr __rcvr) && -> subscribe_result_t<__sender_base, _Rcvr> {
+      return exec::subscribe(static_cast<__sender_base&&>(__sender_), static_cast<_Rcvr&&>(__rcvr));
     }
 
     auto get_env() const noexcept -> stdexec::env_of_t<__sender_base> {

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -41,15 +41,15 @@ namespace exec {
         using __id = __receiver;
         __operation_base<_Receiver, _Adaptor>* __op_;
 
-        template <same_as<set_next_t> _SetNext, same_as<__t> _Self, class _Item>
+        template <class _Item>
           requires __callable<_Adaptor&, _Item>
                 && __callable<exec::set_next_t, _Receiver&, __call_result_t<_Adaptor&, _Item>>
-        friend auto tag_invoke(_SetNext, _Self& __self, _Item&& __item) noexcept(
-          __nothrow_callable<_SetNext, _Receiver&, __call_result_t<_Adaptor&, _Item>>
+        auto set_next(_Item&& __item) & noexcept(
+          __nothrow_callable<set_next_t, _Receiver&, __call_result_t<_Adaptor&, _Item>>
           && __nothrow_callable<_Adaptor&, _Item>)
           -> next_sender_of_t<_Receiver, __call_result_t<_Adaptor&, _Item>> {
           return exec::set_next(
-            __self.__op_->__receiver_, __self.__op_->__adaptor_(static_cast<_Item&&>(__item)));
+            __op_->__receiver_, __op_->__adaptor_(static_cast<_Item&&>(__item)));
         }
 
         void set_value() noexcept {

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1456,7 +1456,7 @@ namespace exec {
         __intrusive_queue<&task_base::next> tasks_{};
         std::size_t tasks_size_{};
         std::atomic<std::size_t> countdown_{std::ranges::size(range_)};
-      }; // namespace schedule_all_
+      };
 
       template <class Range, class ItemReceiverId>
       struct item_operation {
@@ -1645,8 +1645,6 @@ namespace exec {
 
       template <class Range>
       class sequence<Range>::__t {
-        using item_sender_t = stdexec::__t<item_sender<Range>>;
-
         Range range_;
         static_thread_pool_* pool_;
 
@@ -1668,11 +1666,17 @@ namespace exec {
           , pool_(&pool) {
         }
 
-       private:
-        template <__decays_to<__t> Self, exec::sequence_receiver_of<item_types> Receiver>
-        friend auto tag_invoke(exec::subscribe_t, Self&& self, Receiver rcvr) noexcept
+        template <exec::sequence_receiver_of<item_types> Receiver>
+        auto subscribe(Receiver rcvr) && noexcept
           -> stdexec::__t<operation<Range, stdexec::__id<Receiver>>> {
-          return {static_cast<Range&&>(self.range_), *self.pool_, static_cast<Receiver&&>(rcvr)};
+          return {static_cast<Range&&>(range_), *pool_, static_cast<Receiver&&>(rcvr)};
+        }
+
+        template <exec::sequence_receiver_of<item_types> Receiver>
+          requires __decay_copyable<Range const&>
+        auto subscribe(Receiver rcvr) const & noexcept
+          -> stdexec::__t<operation<Range, stdexec::__id<Receiver>>> {
+          return {range_, *pool_, static_cast<Receiver&&>(rcvr)};
         }
       };
     } // namespace schedule_all_

--- a/include/exec/timed_scheduler.hpp
+++ b/include/exec/timed_scheduler.hpp
@@ -33,16 +33,20 @@ namespace exec {
                            { __tp -= __dur } -> same_as<_Tp&>;
                          };
 
+    template <class _Scheduler>
+    concept __has_now = requires(const _Scheduler& __sched) { __sched.now(); };
+
     struct now_t {
-      template <__same_as<now_t> _Self, class _Scheduler>
-      STDEXEC_ATTRIBUTE(always_inline)
-      friend auto tag_invoke(_Self, _Scheduler&& __sched) noexcept(noexcept(__sched.now()))
-        -> decltype(__sched.now()) {
+      template <class _Scheduler>
+        requires __has_now<_Scheduler>
+      auto operator()(const _Scheduler& __sched) const noexcept(noexcept(__sched.now()))
+        -> __decay_t<decltype(__sched.now())> {
+        static_assert(time_point<__decay_t<decltype(__sched.now())>>);
         return __sched.now();
       }
 
       template <class _Scheduler>
-        requires tag_invocable<now_t, const _Scheduler&>
+        requires(!__has_now<_Scheduler>) && tag_invocable<now_t, const _Scheduler&>
       auto operator()(const _Scheduler& __sched) const
         noexcept(nothrow_tag_invocable<now_t, const _Scheduler&>)
           -> __decay_t<tag_invoke_result_t<now_t, const _Scheduler&>> {
@@ -68,86 +72,74 @@ namespace exec {
   using duration_of_t = typename stdexec::__decay_t<time_point_of_t<_TimedScheduler>>::duration;
 
   namespace __schedule_after {
+    struct __schedule_after_base_t;
     struct schedule_after_t;
   } // namespace __schedule_after
 
+  using __schedule_after::__schedule_after_base_t;
   using __schedule_after::schedule_after_t;
   extern const schedule_after_t schedule_after;
 
   namespace __schedule_at {
+    struct __schedule_at_base_t;
     struct schedule_at_t;
   } // namespace __schedule_at
 
+  using __schedule_at::__schedule_at_base_t;
   using __schedule_at::schedule_at_t;
   extern const schedule_at_t schedule_at;
-
-  template <class _TimedScheduler>
-  concept __has_custom_schedule_after = __timed_scheduler<_TimedScheduler>
-                                     && stdexec::tag_invocable<
-                                          schedule_after_t,
-                                          _TimedScheduler,
-                                          const duration_of_t<_TimedScheduler>&>;
-
-  template <__has_custom_schedule_after _TimedScheduler>
-  using __custom_schedule_after_sender_t = stdexec::tag_invoke_result_t<
-    schedule_after_t,
-    _TimedScheduler,
-    const duration_of_t<_TimedScheduler>&>;
-
-  template <class _TimedScheduler>
-  concept __has_custom_schedule_at = __timed_scheduler<_TimedScheduler>
-                                  && stdexec::tag_invocable<
-                                       schedule_at_t,
-                                       _TimedScheduler,
-                                       const time_point_of_t<_TimedScheduler>&>;
-
-  template <__has_custom_schedule_at _TimedScheduler>
-  using __custom_schedule_at_sender_t = stdexec::tag_invoke_result_t<
-    schedule_at_t,
-    _TimedScheduler,
-    const time_point_of_t<_TimedScheduler>&>;
 
   namespace __schedule_after {
     using namespace stdexec;
 
-    struct schedule_after_t {
-      template <__same_as<schedule_after_t> _Self, class _Scheduler>
+    template <class _Scheduler>
+    concept __has_schedule_after_member =
+      requires(_Scheduler&& __sched, const duration_of_t<_Scheduler>& __duration) {
+        __sched.schedule_after(__duration);
+      };
+
+    struct __schedule_after_base_t {
+      template <class _Scheduler>
+        requires __has_schedule_after_member<_Scheduler>
       STDEXEC_ATTRIBUTE(always_inline)
-      friend auto tag_invoke(
-        _Self,
-        _Scheduler&& __sched,
-        const duration_of_t<_Scheduler>& __duration)
+      auto operator()(_Scheduler&& __sched, const duration_of_t<_Scheduler>& __duration) const
         noexcept(noexcept(__sched.schedule_after(__duration)))
           -> decltype(__sched.schedule_after(__duration)) {
+        static_assert(sender<decltype(__sched.schedule_after(__duration))>);
         return __sched.schedule_after(__duration);
       }
 
       template <class _Scheduler>
-        requires __has_custom_schedule_after<_Scheduler>
+        requires(!__has_schedule_after_member<_Scheduler>)
+             && tag_invocable<schedule_after_t, _Scheduler, const duration_of_t<_Scheduler>&>
+      STDEXEC_ATTRIBUTE(always_inline)
       auto operator()(_Scheduler&& __sched, const duration_of_t<_Scheduler>& __duration) const
-        noexcept(stdexec::nothrow_tag_invocable<
-                 schedule_after_t,
-                 _Scheduler,
-                 const duration_of_t<_Scheduler>&>)
-          -> __custom_schedule_after_sender_t<_Scheduler> {
-        static_assert(sender<__custom_schedule_after_sender_t<_Scheduler>>);
+        noexcept(
+          nothrow_tag_invocable<schedule_after_t, _Scheduler, const duration_of_t<_Scheduler>&>)
+          -> tag_invoke_result_t<schedule_after_t, _Scheduler, const duration_of_t<_Scheduler>&> {
+        static_assert(
+          sender<
+            tag_invoke_result_t<schedule_after_t, _Scheduler, const duration_of_t<_Scheduler>&>
+          >);
         return tag_invoke(schedule_after, static_cast<_Scheduler&&>(__sched), __duration);
       }
+    };
+
+    struct schedule_after_t : __schedule_after_base_t {
+      using __schedule_after_base_t::operator();
 
       template <class _Scheduler>
-        requires(!__has_custom_schedule_after<_Scheduler>) && __has_custom_schedule_at<_Scheduler>
+        requires(!__callable<__schedule_after_base_t, _Scheduler, const duration_of_t<_Scheduler>&>)
+             && __callable<__schedule_at_base_t, _Scheduler, const time_point_of_t<_Scheduler>&>
+      STDEXEC_ATTRIBUTE(always_inline)
       auto operator()(_Scheduler&& __sched, const duration_of_t<_Scheduler>& __duration)
         const noexcept {
-        static_assert(sender<__custom_schedule_at_sender_t<_Scheduler>>);
         // TODO get_completion_scheduler<set_value_t>
-        return stdexec::let_value(
-          stdexec::just(),
+        return let_value(
+          just(),
           [__sched, __duration]() noexcept(
-            stdexec::__nothrow_callable<
-              schedule_at_t,
-              _Scheduler,
-              const time_point_of_t<_Scheduler>&>&&
-              stdexec::__nothrow_callable<now_t, const _Scheduler&>) {
+            __nothrow_callable<schedule_at_t, _Scheduler, const time_point_of_t<_Scheduler>&>&&
+              __nothrow_callable<now_t, const _Scheduler&>) {
             return schedule_at(__sched, now(__sched) + __duration);
           });
       }
@@ -159,43 +151,52 @@ namespace exec {
   namespace __schedule_at {
     using namespace stdexec;
 
-    struct schedule_at_t {
-      template <__same_as<schedule_at_t> _Self, class _Scheduler>
+    template <class _Scheduler>
+    concept __has_schedule_at_member =
+      requires(_Scheduler&& __sched, const time_point_of_t<_Scheduler>& __time_point) {
+        __sched.schedule_at(__time_point);
+      };
+
+    struct __schedule_at_base_t {
+      template <class _Scheduler>
+        requires __has_schedule_at_member<_Scheduler>
       STDEXEC_ATTRIBUTE(always_inline)
-      friend auto tag_invoke(
-        _Self,
-        _Scheduler&& __sched,
-        const time_point_of_t<_Scheduler>& __time_point)
+      auto operator()(_Scheduler&& __sched, const time_point_of_t<_Scheduler>& __time_point) const
         noexcept(noexcept(__sched.schedule_at(__time_point)))
           -> decltype(__sched.schedule_at(__time_point)) {
+        static_assert(sender<decltype(__sched.schedule_at(__time_point))>);
         return __sched.schedule_at(__time_point);
       }
 
       template <class _Scheduler>
-        requires __has_custom_schedule_at<_Scheduler>
+        requires(!__has_schedule_at_member<_Scheduler>)
+             && tag_invocable<schedule_at_t, _Scheduler, const time_point_of_t<_Scheduler>&>
+      STDEXEC_ATTRIBUTE(always_inline)
       auto operator()(_Scheduler&& __sched, const time_point_of_t<_Scheduler>& __time_point) const
-        noexcept(stdexec::nothrow_tag_invocable<
-                 schedule_at_t,
-                 _Scheduler,
-                 const time_point_of_t<_Scheduler>&>) -> __custom_schedule_at_sender_t<_Scheduler> {
-        static_assert(sender<__custom_schedule_at_sender_t<_Scheduler>>);
+        noexcept(
+          nothrow_tag_invocable<schedule_at_t, _Scheduler, const time_point_of_t<_Scheduler>&>)
+          -> tag_invoke_result_t<schedule_at_t, _Scheduler, const time_point_of_t<_Scheduler>&> {
+        static_assert(
+          sender<
+            tag_invoke_result_t<schedule_at_t, _Scheduler, const time_point_of_t<_Scheduler>&>
+          >);
         return tag_invoke(schedule_at, static_cast<_Scheduler&&>(__sched), __time_point);
       }
+    };
+
+    struct schedule_at_t : __schedule_at_base_t {
+      using __schedule_at_base_t::operator();
 
       template <class _Scheduler>
-        requires(!__has_custom_schedule_at<_Scheduler>) && __has_custom_schedule_after<_Scheduler>
-      auto operator()(_Scheduler&& __sched, const time_point_of_t<_Scheduler>& __time_point)
-        const noexcept {
-        static_assert(sender<__custom_schedule_after_sender_t<_Scheduler>>);
+        requires(!__callable<__schedule_at_base_t, _Scheduler, const time_point_of_t<_Scheduler>&>)
+             && __callable<__schedule_after_base_t, _Scheduler, const duration_of_t<_Scheduler>&>
+      auto operator()(_Scheduler&& __sched, const time_point_of_t<_Scheduler>& __time_point) const
+        noexcept(noexcept(schedule_after(__sched, __time_point - now(__sched)))) {
         // TODO get_completion_scheduler<set_value_t>
-        return stdexec::let_value(
-          stdexec::just(),
+        return let_value(
+          just(),
           [__sched, __time_point]() noexcept(
-            stdexec::__nothrow_callable<
-              schedule_after_t,
-              _Scheduler,
-              const duration_of_t<_Scheduler>&>&&
-              stdexec::__nothrow_callable<now_t, const _Scheduler&>) {
+            noexcept(schedule_after(__sched, __time_point - now(__sched)))) {
             return schedule_after(__sched, __time_point - now(__sched));
           });
       }

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -189,6 +189,8 @@ namespace stdexec {
   using __sched::schedule_t;
   extern const schedule_t schedule;
 
+  struct scheduler_t;
+
   //////////////////////////////////////////////////////////////////////////////////////////////////
   namespace __as_awaitable {
     struct as_awaitable_t;

--- a/include/stdexec/__detail/__receivers.hpp
+++ b/include/stdexec/__detail/__receivers.hpp
@@ -31,7 +31,7 @@ namespace stdexec {
   // [execution.receivers]
   namespace __rcvrs {
     template <class _Receiver, class... _As>
-    concept __set_value_member = requires(_Receiver&& __rcvr, _As&&... __args) {
+    concept __set_value_member = requires(_Receiver &&__rcvr, _As &&...__args) {
       static_cast<_Receiver &&>(__rcvr).set_value(static_cast<_As &&>(__args)...);
     };
 
@@ -42,31 +42,31 @@ namespace stdexec {
       template <class _Receiver, class... _As>
         requires __set_value_member<_Receiver, _As...>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      friend void tag_invoke(set_value_t, _Receiver&& __rcvr, _As&&... __as) noexcept {
+      void operator()(_Receiver &&__rcvr, _As &&...__as) const noexcept {
         static_assert(
-          noexcept(static_cast<_Receiver&&>(__rcvr).set_value(static_cast<_As&&>(__as)...)),
+          noexcept(static_cast<_Receiver &&>(__rcvr).set_value(static_cast<_As &&>(__as)...)),
           "set_value member functions must be noexcept");
         static_assert(
           __same_as<
-            decltype(static_cast<_Receiver&&>(__rcvr).set_value(static_cast<_As&&>(__as)...)),
+            decltype(static_cast<_Receiver &&>(__rcvr).set_value(static_cast<_As &&>(__as)...)),
             void
           >,
           "set_value member functions must return void");
-        static_cast<_Receiver&&>(__rcvr).set_value(static_cast<_As&&>(__as)...);
+        static_cast<_Receiver &&>(__rcvr).set_value(static_cast<_As &&>(__as)...);
       }
 
       template <class _Receiver, class... _As>
-        requires tag_invocable<set_value_t, _Receiver, _As...>
+        requires(!__set_value_member<_Receiver, _As...>)
+             && tag_invocable<set_value_t, _Receiver, _As...>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      void operator()(_Receiver&& __rcvr, _As&&... __as) const noexcept {
+      void operator()(_Receiver &&__rcvr, _As &&...__as) const noexcept {
         static_assert(nothrow_tag_invocable<set_value_t, _Receiver, _As...>);
-        (void) tag_invoke(
-          stdexec::set_value_t{}, static_cast<_Receiver&&>(__rcvr), static_cast<_As&&>(__as)...);
+        (void) tag_invoke(*this, static_cast<_Receiver &&>(__rcvr), static_cast<_As &&>(__as)...);
       }
     };
 
     template <class _Receiver, class _Error>
-    concept __set_error_member = requires(_Receiver&& __rcvr, _Error&& __err) {
+    concept __set_error_member = requires(_Receiver &&__rcvr, _Error &&__err) {
       static_cast<_Receiver &&>(__rcvr).set_error(static_cast<_Error &&>(__err));
     };
 
@@ -78,31 +78,31 @@ namespace stdexec {
       template <class _Receiver, class _Error>
         requires __set_error_member<_Receiver, _Error>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      friend void tag_invoke(set_error_t, _Receiver&& __rcvr, _Error&& __err) noexcept {
+      void operator()(_Receiver &&__rcvr, _Error &&__err) const noexcept {
         static_assert(
-          noexcept(static_cast<_Receiver&&>(__rcvr).set_error(static_cast<_Error&&>(__err))),
+          noexcept(static_cast<_Receiver &&>(__rcvr).set_error(static_cast<_Error &&>(__err))),
           "set_error member functions must be noexcept");
         static_assert(
           __same_as<
-            decltype(static_cast<_Receiver&&>(__rcvr).set_error(static_cast<_Error&&>(__err))),
+            decltype(static_cast<_Receiver &&>(__rcvr).set_error(static_cast<_Error &&>(__err))),
             void
           >,
           "set_error member functions must return void");
-        static_cast<_Receiver&&>(__rcvr).set_error(static_cast<_Error&&>(__err));
+        static_cast<_Receiver &&>(__rcvr).set_error(static_cast<_Error &&>(__err));
       }
 
       template <class _Receiver, class _Error>
-        requires tag_invocable<set_error_t, _Receiver, _Error>
+        requires(!__set_error_member<_Receiver, _Error>)
+             && tag_invocable<set_error_t, _Receiver, _Error>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      void operator()(_Receiver&& __rcvr, _Error&& __err) const noexcept {
+      void operator()(_Receiver &&__rcvr, _Error &&__err) const noexcept {
         static_assert(nothrow_tag_invocable<set_error_t, _Receiver, _Error>);
-        (void) tag_invoke(
-          stdexec::set_error_t{}, static_cast<_Receiver&&>(__rcvr), static_cast<_Error&&>(__err));
+        (void) tag_invoke(*this, static_cast<_Receiver &&>(__rcvr), static_cast<_Error &&>(__err));
       }
     };
 
     template <class _Receiver>
-    concept __set_stopped_member = requires(_Receiver&& __rcvr) {
+    concept __set_stopped_member = requires(_Receiver &&__rcvr) {
       static_cast<_Receiver &&>(__rcvr).set_stopped();
     };
 
@@ -114,22 +114,22 @@ namespace stdexec {
       template <class _Receiver>
         requires __set_stopped_member<_Receiver>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      friend void tag_invoke(set_stopped_t, _Receiver&& __rcvr) noexcept {
+      void operator()(_Receiver &&__rcvr) const noexcept {
         static_assert(
-          noexcept(static_cast<_Receiver&&>(__rcvr).set_stopped()),
+          noexcept(static_cast<_Receiver &&>(__rcvr).set_stopped()),
           "set_stopped member functions must be noexcept");
         static_assert(
-          __same_as<decltype(static_cast<_Receiver&&>(__rcvr).set_stopped()), void>,
+          __same_as<decltype(static_cast<_Receiver &&>(__rcvr).set_stopped()), void>,
           "set_stopped member functions must return void");
-        static_cast<_Receiver&&>(__rcvr).set_stopped();
+        static_cast<_Receiver &&>(__rcvr).set_stopped();
       }
 
       template <class _Receiver>
-        requires tag_invocable<set_stopped_t, _Receiver>
+        requires(!__set_stopped_member<_Receiver>) && tag_invocable<set_stopped_t, _Receiver>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      void operator()(_Receiver&& __rcvr) const noexcept {
+      void operator()(_Receiver &&__rcvr) const noexcept {
         static_assert(nothrow_tag_invocable<set_stopped_t, _Receiver>);
-        (void) tag_invoke(stdexec::set_stopped_t{}, static_cast<_Receiver&&>(__rcvr));
+        (void) tag_invoke(*this, static_cast<_Receiver &&>(__rcvr));
       }
     };
   } // namespace __rcvrs
@@ -148,7 +148,7 @@ namespace stdexec {
   namespace __detail {
     template <class _Receiver>
     concept __enable_receiver =
-      (STDEXEC_EDG(requires { typename _Receiver::receiver_concept; }&&)
+      (STDEXEC_EDG(requires { typename _Receiver::receiver_concept; } &&)
          derived_from<typename _Receiver::receiver_concept, receiver_t>)
       || requires { typename _Receiver::is_receiver; } // back-compat, NOT TO SPEC
       || STDEXEC_IS_BASE_OF(receiver_t, _Receiver);    // NOT TO SPEC, for receiver_adaptor
@@ -173,14 +173,14 @@ namespace stdexec {
     auto __try_completion(_Tag (*)(_Args...)) -> __msuccess;
 
     template <class _Receiver, class... _Sigs>
-    auto __try_completions(completion_signatures<_Sigs...>*) -> decltype((
+    auto __try_completions(completion_signatures<_Sigs...> *) -> decltype((
       __msuccess(),
       ...,
-      __detail::__try_completion<_Receiver>(static_cast<_Sigs*>(nullptr))));
+      __detail::__try_completion<_Receiver>(static_cast<_Sigs *>(nullptr))));
   } // namespace __detail
 
   template <class _Receiver, class _Completions>
-  concept receiver_of = receiver<_Receiver> && requires(_Completions* __completions) {
+  concept receiver_of = receiver<_Receiver> && requires(_Completions *__completions) {
     { __detail::__try_completions<__decay_t<_Receiver>>(__completions) } -> __ok;
   };
 
@@ -191,28 +191,28 @@ namespace stdexec {
   /// A utility for calling set_value with the result of a function invocation:
   template <class _Receiver, class _Fun, class... _As>
   STDEXEC_ATTRIBUTE(host, device)
-  void __set_value_invoke(_Receiver&& __rcvr, _Fun&& __fun, _As&&... __as) noexcept {
+  void __set_value_invoke(_Receiver &&__rcvr, _Fun &&__fun, _As &&...__as) noexcept {
     STDEXEC_TRY {
       if constexpr (same_as<void, __invoke_result_t<_Fun, _As...>>) {
-        __invoke(static_cast<_Fun&&>(__fun), static_cast<_As&&>(__as)...);
-        stdexec::set_value(static_cast<_Receiver&&>(__rcvr));
+        __invoke(static_cast<_Fun &&>(__fun), static_cast<_As &&>(__as)...);
+        stdexec::set_value(static_cast<_Receiver &&>(__rcvr));
       } else {
         stdexec::set_value(
-          static_cast<_Receiver&&>(__rcvr),
-          __invoke(static_cast<_Fun&&>(__fun), static_cast<_As&&>(__as)...));
+          static_cast<_Receiver &&>(__rcvr),
+          __invoke(static_cast<_Fun &&>(__fun), static_cast<_As &&>(__as)...));
       }
     }
     STDEXEC_CATCH_ALL {
       if constexpr (!__nothrow_invocable<_Fun, _As...>) {
-        stdexec::set_error(static_cast<_Receiver&&>(__rcvr), std::current_exception());
+        stdexec::set_error(static_cast<_Receiver &&>(__rcvr), std::current_exception());
       }
     }
   }
 
   template <class _Tag, class _Receiver>
-  auto __mk_completion_fn(_Tag, _Receiver& __rcvr) noexcept {
-    return [&]<class... _Args>(_Args&&... __args) noexcept {
-      _Tag()(static_cast<_Receiver&&>(__rcvr), static_cast<_Args&&>(__args)...);
+  auto __mk_completion_fn(_Tag, _Receiver &__rcvr) noexcept {
+    return [&]<class... _Args>(_Args &&...__args) noexcept {
+      _Tag()(static_cast<_Receiver &&>(__rcvr), static_cast<_Args &&>(__args)...);
     };
   }
 } // namespace stdexec

--- a/include/stdexec/__detail/__senders.hpp
+++ b/include/stdexec/__detail/__senders.hpp
@@ -120,7 +120,8 @@ namespace stdexec {
             // set_value_t() or set_value_t(T)
             __minvoke<__mremove<void, __qf<set_value_t>>, _AwaitResult>,
             set_error_t(std::exception_ptr),
-            set_stopped_t()>;
+            set_stopped_t()
+          >;
           return static_cast<_Result (*)()>(nullptr);
         } else if constexpr (sizeof...(_Env) == 0) {
           // It's possible this is a dependent sender.
@@ -135,7 +136,8 @@ namespace stdexec {
           using _Result = __mexception<
             _UNRECOGNIZED_SENDER_TYPE_<>,
             _WITH_SENDER_<_Sender>,
-            _WITH_ENVIRONMENT_<_Env>...>;
+            _WITH_ENVIRONMENT_<_Env>...
+          >;
           return static_cast<_Result (*)()>(nullptr);
         }
       }
@@ -162,7 +164,8 @@ namespace stdexec {
       transform_sender_result_t,
       __late_domain_of_t<_Sender, env_of_t<_Receiver>>,
       _Sender,
-      env_of_t<_Receiver>>;
+      env_of_t<_Receiver>
+    >;
 
     template <class _Sender, class _Receiver>
     using __member_result_t = decltype(__declval<_Sender>().connect(__declval<_Receiver>()));
@@ -195,7 +198,8 @@ namespace stdexec {
         if constexpr (sender_in<_Sender, env_of_t<_Receiver>>) {
           // Instantiate __debug_sender via completion_signatures_of_t to check that the actual
           // completions match the expected completions.
-          using __checked_signatures [[maybe_unused]] = completion_signatures_of_t<_Sender, env_of_t<_Receiver>>;
+          using __checked_signatures
+            [[maybe_unused]] = completion_signatures_of_t<_Sender, env_of_t<_Receiver>>;
         } else {
           __diagnose_sender_concept_failure<_Sender, env_of_t<_Receiver>>();
         }
@@ -276,7 +280,7 @@ namespace stdexec {
           auto&& __tfx_sndr = transform_sender(__domain, static_cast<_Sender&&>(__sndr), __env);
           return __tfx_sndr
             .connect(static_cast<_TfxSender&&>(__tfx_sndr), static_cast<_Receiver&&>(__rcvr));
-        } else if constexpr (__with_member<_TfxSender, _Receiver>) {
+        } else if constexpr (__with_member<_TfxSender, _Receiver>) { // NOLINT(bugprone-branch-clone)
           return transform_sender(__domain, static_cast<_Sender&&>(__sndr), __env)
             .connect(static_cast<_Receiver&&>(__rcvr));
         } else if constexpr (__with_tag_invoke<_TfxSender, _Receiver>) {
@@ -291,8 +295,8 @@ namespace stdexec {
         } else {
           // This should generate an instantiation backtrace that contains useful
           // debugging information.
-          return transform_sender(__domain, static_cast<_Sender&&>(__sndr), __env).connect(
-            static_cast<_Receiver&&>(__rcvr));
+          return transform_sender(__domain, static_cast<_Sender&&>(__sndr), __env)
+            .connect(static_cast<_Receiver&&>(__rcvr));
         }
       }
 
@@ -321,7 +325,9 @@ namespace stdexec {
                           _Sender,
                           _Env,
                           __mcompose_q<__types, __qf<__tag_of_sig_t<_SetSig>>::template __f>,
-                          __mconcat<__qq<__types>>>>;
+                          __mconcat<__qq<__types>>
+                        >
+                   >;
 
   template <class _Error>
     requires false
@@ -334,12 +340,14 @@ namespace stdexec {
       set_error_t,
       __nofail_t,
       __sigs::__default_completion,
-      __types>;
+      __types
+    >;
   };
 
   /////////////////////////////////////////////////////////////////////////////
   // early sender type-checking
   template <class _Sender>
   concept __well_formed_sender = __detail::__well_formed_completions<
-    __minvoke<__with_default_q<__completion_signatures_of_t, dependent_completions>, _Sender>>;
+    __minvoke<__with_default_q<__completion_signatures_of_t, dependent_completions>, _Sender>
+  >;
 } // namespace stdexec

--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -64,9 +64,9 @@ namespace stdexec {
         return true;
       }
 
-      // static constexpr auto query(__debug::__is_debug_env_t) noexcept -> bool {
-      //   return true;
-      // }
+      static constexpr auto query(__debug::__is_debug_env_t) noexcept -> bool {
+        return true;
+      }
     };
 
     // What should sync_wait(just_stopped()) return?

--- a/test/exec/sequence/test_transform_each.cpp
+++ b/test/exec/sequence/test_transform_each.cpp
@@ -17,13 +17,11 @@
 
 #include "exec/sequence/transform_each.hpp"
 
-#include "exec/sequence/any_sequence_of.hpp"
 #include "exec/sequence/empty_sequence.hpp"
 #include "exec/sequence/iterate.hpp"
 #include "exec/sequence/ignore_all_values.hpp"
 #include <catch2/catch.hpp>
 
-#include <exec/on.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
 #include <test_common/senders.hpp>

--- a/test/exec/test_task.cpp
+++ b/test/exec/test_task.cpp
@@ -24,8 +24,6 @@
 
 #  include <catch2/catch.hpp>
 
-#  include <thread>
-
 using namespace exec;
 using namespace stdexec;
 

--- a/test/execpools/test_asio_thread_pool.cpp
+++ b/test/execpools/test_asio_thread_pool.cpp
@@ -23,7 +23,6 @@
 #include <stdexec/execution.hpp>
 
 #include <test_common/schedulers.hpp>
-#include <exec/on.hpp>
 #include <exec/inline_scheduler.hpp>
 
 #include <execpools/asio/asio_thread_pool.hpp>
@@ -92,7 +91,7 @@ namespace {
       ex::get_forward_progress_guarantee(pool_sched) == ex::forward_progress_guarantee::parallel);
     bool called{false};
     // launch some work on the thread pool
-    ex::sender auto snd = ex::starts_on(pool_sched, ex::just()) | ex::then([&] { called = true; })
+    ex::sender auto snd = ex::on(pool_sched, ex::just()) | ex::then([&] { called = true; })
                         | _with_scheduler();
     ex::sync_wait(std::move(snd));
     // the work should be executed

--- a/test/execpools/test_taskflow_thread_pool.cpp
+++ b/test/execpools/test_taskflow_thread_pool.cpp
@@ -17,12 +17,9 @@
 
 #include <catch2/catch.hpp>
 
-#include <span>
-
 #include <stdexec/execution.hpp>
 
 #include <test_common/schedulers.hpp>
-#include <exec/on.hpp>
 #include <exec/inline_scheduler.hpp>
 
 #include <execpools/taskflow/taskflow_thread_pool.hpp>

--- a/test/execpools/test_tbb_thread_pool.cpp
+++ b/test/execpools/test_tbb_thread_pool.cpp
@@ -22,7 +22,6 @@
 #include <stdexec/execution.hpp>
 
 #include <test_common/schedulers.hpp>
-#include <exec/on.hpp>
 #include <exec/inline_scheduler.hpp>
 
 #include <execpools/tbb/tbb_thread_pool.hpp>
@@ -89,7 +88,7 @@ namespace {
       ex::get_forward_progress_guarantee(pool_sched) == ex::forward_progress_guarantee::parallel);
     bool called{false};
     // launch some work on the thread pool
-    ex::sender auto snd = ex::starts_on(pool_sched, ex::just()) | ex::then([&] { called = true; })
+    ex::sender auto snd = ex::on(pool_sched, ex::just()) | ex::then([&] { called = true; })
                         | _with_scheduler();
     ex::sync_wait(std::move(snd));
     // the work should be executed

--- a/test/stdexec/algos/adaptors/test_on.cpp
+++ b/test/stdexec/algos/adaptors/test_on.cpp
@@ -19,7 +19,6 @@
 #include <stdexec/execution.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
-#include <exec/on.hpp>
 #include <exec/static_thread_pool.hpp>
 
 namespace ex = stdexec;

--- a/test/stdexec/algos/adaptors/test_on2.cpp
+++ b/test/stdexec/algos/adaptors/test_on2.cpp
@@ -19,7 +19,6 @@
 #include <stdexec/execution.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
-#include <exec/on.hpp>
 
 namespace ex = stdexec;
 

--- a/test/stdexec/algos/adaptors/test_on3.cpp
+++ b/test/stdexec/algos/adaptors/test_on3.cpp
@@ -18,7 +18,6 @@
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>
 #include <test_common/schedulers.hpp>
-#include <exec/on.hpp>
 #include <exec/async_scope.hpp>
 
 namespace ex = stdexec;

--- a/test/stdexec/algos/adaptors/test_then.cpp
+++ b/test/stdexec/algos/adaptors/test_then.cpp
@@ -16,7 +16,6 @@
 
 #include <catch2/catch.hpp>
 #include <stdexec/execution.hpp>
-#include <exec/on.hpp>
 #include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
 #include <test_common/senders.hpp>

--- a/test/stdexec/cpos/test_cpo_receiver.cpp
+++ b/test/stdexec/cpos/test_cpo_receiver.cpp
@@ -221,24 +221,6 @@ namespace {
     REQUIRE(val == INT_MAX);
   }
 
-  TEST_CASE("set_value can be called through tag_invoke", "[cpo][cpo_receiver]") {
-    int val = 0;
-    tag_invoke(stdexec::set_value, recv_value{&val}, 10);
-    REQUIRE(val == 10);
-  }
-
-  TEST_CASE("set_error can be called through tag_invoke", "[cpo][cpo_receiver]") {
-    int val = 0;
-    tag_invoke(stdexec::set_error, recv_value{&val}, 10);
-    REQUIRE(val == -10);
-  }
-
-  TEST_CASE("set_stopped can be called through tag_invoke", "[cpo][cpo_receiver]") {
-    int val = 0;
-    tag_invoke(stdexec::set_stopped, recv_value{&val});
-    REQUIRE(val == INT_MAX);
-  }
-
   TEST_CASE(
     "tag types can be deduced from set_value, set_error and set_stopped",
     "[cpo][cpo_receiver]") {


### PR DESCRIPTION
prior to this PR, many of stdexec's customization points were expressed exclusively in terms of `tag_invoke`. For example, the `get_env(obj)` CPO accepted arguments for which `tag_invoke(get_env, obj)` was well-formed. to accommodate those objects that implemented `get_env` as a member function, an overload of `tag_invoke` was added to the CPO, like:

```c++
struct get_env_t {
  template <class T>
    requires tag_invocable<get_env_t, T const&>
  auto operator()(T const& t) const noexcept -> decltype(auto) {
    return tag_invoke(*this, t);
  }

  // tag_invoke overload that dispatches to named member:
  template <class T>
  friend auto tag_invoke(get_env_t, T const& t) noexcept -> decltype(auto)
    requires requires { t.get_env(); } {
      return t.get_env()
  }
};
```

this meant that calls to stdexec CPOs would always route through `tag_invoke`, even when it is not strictly necessary.

this PR removes all of those extra hops through `tag_invoke`.