### PR TITLE
allow using __optional with -fno-exceptions

### DIFF
--- a/include/stdexec/__detail/__optional.hpp
+++ b/include/stdexec/__detail/__optional.hpp
@@ -119,21 +119,21 @@ namespace stdexec {
 
       auto value() & -> _Tp& {
         if (!__has_value_) {
-          throw __bad_optional_access();
+          STDEXEC_THROW(__bad_optional_access());
         }
         return __value_;
       }
 
       auto value() const & -> const _Tp& {
         if (!__has_value_) {
-          throw __bad_optional_access();
+          STDEXEC_THROW(__bad_optional_access());
         }
         return __value_;
       }
 
       auto value() && -> _Tp&& {
         if (!__has_value_) {
-          throw __bad_optional_access();
+          STDEXEC_THROW(__bad_optional_access());
         }
         return static_cast<_Tp&&>(__value_);
       }


### PR DESCRIPTION
Currently, including `<exec/async_scope.hpp>` will err:

```c++
include/stdexec/__detail/__optional.hpp:122:11: error: cannot use 'throw' with exceptions disabled
          throw __bad_optional_access();
```