### PR TITLE
make `__continuation_handle` inherit from `std::coroutine_handle`

### DIFF
--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -119,8 +119,8 @@ namespace exec {
     inline constexpr __die_on_stop_t __die_on_stop;
 
     template <class _Promise>
-    concept __has_continuation = requires(_Promise& __promise, __continuation_handle<> __c) {
-      { __promise.continuation() } -> convertible_to<__continuation_handle<>>;
+    concept __has_continuation = requires(_Promise& __promise, __coroutine_handle<> __c) {
+      { __promise.continuation() } -> convertible_to<__coroutine_handle<>>;
       { __promise.set_continuation(__c) };
     };
 

--- a/include/exec/on_coro_disposition.hpp
+++ b/include/exec/on_coro_disposition.hpp
@@ -21,7 +21,7 @@
 #include "../stdexec/execution.hpp"
 #include "../stdexec/coroutine.hpp"
 #include "task.hpp"
-#include "inline_scheduler.hpp"
+#include "inline_scheduler.hpp" // IWYU pragma: keep
 #include "any_sender_of.hpp"
 
 #include <exception>

--- a/test/exec/test_task.cpp
+++ b/test/exec/test_task.cpp
@@ -259,7 +259,7 @@ namespace {
 
   struct test_domain {
     template <sender_expr_for<then_t> _Sender>
-    static constexpr auto transform_sender(_Sender&& __sndr) noexcept {
+    static constexpr auto transform_sender(_Sender&&) noexcept {
       return just("goodbye"s);
     }
   };


### PR DESCRIPTION
also, rename `__continuation_handle` to `__coroutine_handle`.

fixes #1610