### PR TITLE
remove vestigial get_completion_signatures on exec::task causing poor diagnostics

### DIFF
--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -494,22 +494,6 @@ namespace exec {
         return __task_awaitable<>{std::exchange(__coro_, {})};
       }
 
-      // From the list of types [_Ty], remove any types that are void, and send
-      //   the resulting list to __qf<set_value_t>, which uses the list of types
-      //   as arguments of a function type. In other words, set_value_t() if _Ty
-      //   is void, and set_value_t(_Ty) otherwise.
-      using __set_value_sig_t = __minvoke<__mremove<void, __qf<set_value_t>>, _Ty>;
-
-      // Specify basic_task's completion signatures
-      //   This is only necessary when basic_task is not generally awaitable
-      //   owing to constraints imposed by its _Context parameter.
-      using __task_traits_t =
-        completion_signatures<__set_value_sig_t, set_error_t(std::exception_ptr), set_stopped_t()>;
-
-      auto get_completion_signatures(__ignore = {}) const -> __task_traits_t {
-        return {};
-      }
-
       explicit basic_task(__coro::coroutine_handle<promise_type> __coro) noexcept
         : __coro_(__coro) {
       }


### PR DESCRIPTION
fixes #1604

`exec::task` has a `get_completion_signatures` member function that was no doubt added with the best of intentions. however, like the appendix, it has no use and only causes problems: namely, poor diagnostics. See #1604, #1594, and #1536 for examples.

this pr removes the problematic member function from `exec::task`. there is still room for improvement in the resulting diagnostics, but it's better than before.