### PR TITLE
fix dependent sender computation in `write_env`'s completion signatures

### DIFF
--- a/include/stdexec/__detail/__write_env.hpp
+++ b/include/stdexec/__detail/__write_env.hpp
@@ -67,11 +67,11 @@ namespace stdexec {
         };
 
       static constexpr auto get_completion_signatures =
-        []<class _Self, class... _Env>(_Self&&, _Env&&...) noexcept
-        -> __completion_signatures_of_t<
-          __child_of<_Self>,
-          __meval<__join_env_t, const __decay_t<__data_of<_Self>>&, _Env...>
-        > {
+          []<class _Self, class... _Env>(_Self &&, _Env &&...) noexcept
+          -> __completion_signatures_of_t<
+              __child_of<_Self>,
+              __meval<__join_env_t, const __decay_t<__data_of<_Self>> &,
+                      _Env>...> {
         static_assert(sender_expr_for<_Self, write_env_t>);
         return {};
       };


### PR DESCRIPTION
fixes #1612