### PR TITLE
give `env<>` a deleted `query` member function

### DIFF
--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -438,6 +438,8 @@ namespace stdexec {
     struct env<> {
       using __t = env;
       using __id = env;
+
+      auto query() const = delete;
     };
 
     template <class... _Envs>


### PR DESCRIPTION
this is so that code that does:

```c++
template <class Env>
struct my_env : Env {
  using Env::query;
  auto query(my_query) const;
};
```

does not hard-error when `Env` is `stdexec::env<>`.