### PR TITLE
the trampoline needs to be fifo to properly interleave sequences

### DIFF
--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -29,7 +29,9 @@ namespace exec {
     struct __trampoline_state {
       static thread_local __trampoline_state* __current_;
 
-      __trampoline_state() noexcept {
+      __trampoline_state(std::size_t __max_recursion_depth, std::size_t __max_recursion_size) noexcept
+        : __max_recursion_size_(__max_recursion_size)
+        , __max_recursion_depth_(__max_recursion_depth) {
         __current_ = this;
       }
 
@@ -39,28 +41,45 @@ namespace exec {
 
       void __drain() noexcept;
 
+      // these origin schedule frame limits will apply to all
+      // nested trampoline instances on this thread
+      const std::size_t __max_recursion_size_;
+      const std::size_t __max_recursion_depth_;
+
+      // track state of origin schedule frame
+      std::intptr_t __recursion_origin_ = 0;
       std::size_t __recursion_depth_ = 1;
       _Operation* __head_ = nullptr;
+      _Operation* __tail_ = nullptr;
     };
 
     class __scheduler {
-      std::size_t __max_recursion_depth_;
+      const std::size_t __max_recursion_size_;
+      const std::size_t __max_recursion_depth_;
 
      public:
       __scheduler() noexcept
-        : __max_recursion_depth_(16) {
+        : __max_recursion_size_(4096)
+        , __max_recursion_depth_(16) {
       }
 
       explicit __scheduler(std::size_t __max_recursion_depth) noexcept
-        : __max_recursion_depth_(__max_recursion_depth) {
+        : __max_recursion_size_(4096)
+        , __max_recursion_depth_(__max_recursion_depth) {
+      }
+
+      explicit __scheduler(std::size_t __max_recursion_depth, std::size_t __max_recursion_size) noexcept
+        : __max_recursion_size_(__max_recursion_size)
+        , __max_recursion_depth_(__max_recursion_depth) {
       }
 
      private:
       struct __operation_base {
         using __execute_fn = void(__operation_base*) noexcept;
 
-        explicit __operation_base(__execute_fn* __execute, std::size_t __max_depth) noexcept
+        explicit __operation_base(__execute_fn* __execute, std::size_t __max_size, std::size_t __max_depth) noexcept
           : __execute_(__execute)
+          , __max_recursion_size_(__max_size)
           , __max_recursion_depth_(__max_depth) {
         }
 
@@ -70,22 +89,45 @@ namespace exec {
 
         void start() & noexcept {
           auto* __current_state = __trampoline_state<__operation_base>::__current_;
+
           if (__current_state == nullptr) {
-            __trampoline_state<__operation_base> __state;
+            // origin schedule frame on this thread
+            __trampoline_state<__operation_base> __state{__max_recursion_depth_, __max_recursion_size_};
             __execute();
             __state.__drain();
-          } else if (__current_state->__recursion_depth_ < __max_recursion_depth_) {
-            ++__current_state->__recursion_depth_;
-            __execute();
           } else {
-            // Exceeded recursion limit.
-            __next_ = std::exchange(__current_state->__head_, static_cast<__operation_base*>(this));
+            // recursive schedule frame on this thread
+
+            // calculate stack consumption for this schedule
+            std::size_t __current_size = std::abs(reinterpret_cast<std::intptr_t>(&__current_state)
+                                            - __current_state->__recursion_origin_);
+
+            if (__current_size < __current_state->__max_recursion_size_
+              && __current_state->__recursion_depth_ < __current_state->__max_recursion_depth_) {
+              // inline this recursive schedule
+              ++__current_state->__recursion_depth_;
+              __execute();
+            } else {
+              // Exceeded recursion limit.
+
+              // push this recursive schedule to list tail
+              __prev_ = std::exchange(__current_state->__tail_, static_cast<__operation_base*>(this));
+              if (__prev_ != nullptr) {
+                // was not empty
+                std::exchange(__prev_->__next_, static_cast<__operation_base*>(this));
+              } else {
+                // was empty
+                std::exchange(__current_state->__head_, static_cast<__operation_base*>(this));
+              }
+            }
           }
         }
 
+        __operation_base* __prev_ = nullptr;
         __operation_base* __next_ = nullptr;
         __execute_fn* __execute_;
-        std::size_t __max_recursion_depth_;
+        const std::size_t __max_recursion_size_;
+        const std::size_t __max_recursion_depth_;
       };
 
       template <class _ReceiverId>
@@ -96,9 +138,9 @@ namespace exec {
           using __id = __operation;
           STDEXEC_ATTRIBUTE(no_unique_address) _Receiver __receiver_;
 
-          explicit __t(_Receiver __rcvr, std::size_t __max_depth)
+          explicit __t(_Receiver __rcvr, std::size_t __max_size, std::size_t __max_depth)
             noexcept(__nothrow_move_constructible<_Receiver>)
-            : __operation_base(&__t::__execute_impl, __max_depth)
+            : __operation_base(&__t::__execute_impl, __max_size, __max_depth)
             , __receiver_(static_cast<_Receiver&&>(__rcvr)) {
           }
 
@@ -128,14 +170,15 @@ namespace exec {
         using completion_signatures =
           stdexec::completion_signatures<set_value_t(), set_stopped_t()>;
 
-        explicit __schedule_sender(std::size_t __max_depth) noexcept
-          : __max_recursion_depth_(__max_depth) {
+        explicit __schedule_sender(std::size_t __max_size, std::size_t __max_depth) noexcept
+          : __max_recursion_size_(__max_size)
+          , __max_recursion_depth_(__max_depth) {
         }
 
         template <receiver_of<completion_signatures> _Receiver>
         auto connect(_Receiver __rcvr) const noexcept(__nothrow_move_constructible<_Receiver>)
           -> __operation_t<_Receiver> {
-          return __operation_t<_Receiver>{static_cast<_Receiver&&>(__rcvr), __max_recursion_depth_};
+          return __operation_t<_Receiver>{static_cast<_Receiver&&>(__rcvr), __max_recursion_size_, __max_recursion_depth_};
         }
 
         [[nodiscard]]
@@ -148,13 +191,14 @@ namespace exec {
           return *this;
         }
 
-        std::size_t __max_recursion_depth_;
+        const std::size_t __max_recursion_size_;
+        const std::size_t __max_recursion_depth_;
       };
 
      public:
       [[nodiscard]]
       auto schedule() const noexcept -> __schedule_sender {
-        return __schedule_sender{__max_recursion_depth_};
+        return __schedule_sender{__max_recursion_size_, __max_recursion_depth_};
       }
 
       auto operator==(const __scheduler&) const noexcept -> bool = default;
@@ -167,8 +211,22 @@ namespace exec {
     template <class _Operation>
     void __trampoline_state<_Operation>::__drain() noexcept {
       while (__head_ != nullptr) {
+        // pop the head of the list
         _Operation* __op = std::exchange(__head_, __head_->__next_);
+        __op->__next_ = nullptr;
+        __op->__prev_ = nullptr;
+        if (__head_ != nullptr) {
+          // is not empty
+          __head_->__prev_ = nullptr;
+        } else {
+          // is empty
+          __tail_ = nullptr;
+        }
+
+        // reset the origin schedule frame state
+        __recursion_origin_ = reinterpret_cast<std::intptr_t>(&__op);
         __recursion_depth_ = 1;
+
         __op->__execute();
       }
     }


### PR DESCRIPTION
also:
- added a stack size limit
- fixed the limits so that the origin trampoline limits apply to all nested trampolines