### PR TITLE
Use `get_completion_signatures` in `any_sender`.

### DIFF
--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -1060,10 +1060,6 @@ namespace exec {
             __storage_.__get_object_pointer(), static_cast<__receiver_ref_t&&>(__receiver));
         }
 
-        explicit operator bool() const noexcept {
-          return __get_object_pointer(__storage_) != nullptr;
-        }
-
         auto get_env() const noexcept -> __env_t {
           return {__storage_.__get_vtable(), __storage_.__get_object_pointer()};
         }


### PR DESCRIPTION
Ensures that `any_sender` implements `get_completion_signatures`
rather than `completion_signatures`.

`get_completion_signatures` is constrained to only exist if the
passed environment satisfies any non-`never_stop_token` stop-token
receiver-queries. This avoids hard compilation errors when a
non-`never_stop_token` receiver-query is present and the sender
is probed for completion signatures in an empty environment.

Also renames `is_never_stop_token_query` to
`is_never_stop_token_query_v` to be consistent with the naming
used for `__is_not_stop_token_query_v`, where `_v` is a `__mbool`
and non-`_v` is a concept.

Solves issue in https://godbolt.org/z/bq3nGhdzr.
