### PR TITLE
Relax `__enable_sequence_sender` concept.

### DIFF
--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -134,7 +134,7 @@ namespace exec {
   template <class _Sender>
   concept __enable_sequence_sender = requires {
     typename _Sender::sender_concept;
-  } && stdexec::same_as<typename _Sender::sender_concept, sequence_sender_t>;
+  } && stdexec::derived_from<typename _Sender::sender_concept, sequence_sender_t>;
 
   template <class _Sender>
   inline constexpr bool enable_sequence_sender = __enable_sequence_sender<_Sender>;


### PR DESCRIPTION
Relaxes the sequence-sender concept to use `derived_from` rather than `same_as` in the same vein as the `__enable_sender` concept, to make it possible to create specialized sequence-sender concepts that are interopable with exec sequence-senders.