### PR TITLE
Add `merge` for sequence senders

### DIFF
--- a/include/exec/__detail/__basic_sequence.hpp
+++ b/include/exec/__detail/__basic_sequence.hpp
@@ -71,35 +71,36 @@ namespace exec {
       return {};
     }
 
-    template <stdexec::__decays_to<__seqexpr> _Self, class _Env>
-    STDEXEC_MEMFN_DECL(auto get_item_types)(this _Self&& __self, _Env&& __env)
-      -> decltype(__self.__tag()
-                    .get_item_types(static_cast<_Self&&>(__self), static_cast<_Env&&>(__env))) {
+    template <stdexec::__decays_to<__seqexpr> _Self, class... _Env>
+    static auto get_item_types(_Self&& __self, _Env&&... __env)
+      -> decltype(__self.__tag().get_item_types(
+        static_cast<_Self&&>(__self),
+        static_cast<_Env&&>(__env)...)) {
       return {};
     }
 
     template <stdexec::__decays_to<__seqexpr> _Self, stdexec::receiver _Receiver>
-    STDEXEC_MEMFN_DECL(auto subscribe)(this _Self&& __self, _Receiver&& __rcvr) noexcept(noexcept(
+    static auto subscribe(_Self&& __self, _Receiver&& __rcvr) noexcept(noexcept(
       __self.__tag().subscribe(static_cast<_Self&&>(__self), static_cast<_Receiver&&>(__rcvr))))
       -> decltype(__self.__tag()
                     .subscribe(static_cast<_Self&&>(__self), static_cast<_Receiver&&>(__rcvr))) {
       return __tag_t::subscribe(static_cast<_Self&&>(__self), static_cast<_Receiver&&>(__rcvr));
     }
 
-    template <class _Sender, class _ApplyFn>
+    template <class _Sequence, class _ApplyFn>
     static auto
-      apply(_Sender&& __sndr, _ApplyFn&& __fun) noexcept(stdexec::__nothrow_callable<
-                                                         stdexec::__detail::__impl_of<_Sender>,
-                                                         stdexec::__copy_cvref_fn<_Sender>,
+      apply(_Sequence&& __sequence, _ApplyFn&& __fun) noexcept(stdexec::__nothrow_callable<
+                                                         stdexec::__detail::__impl_of<_Sequence>,
+                                                         stdexec::__copy_cvref_fn<_Sequence>,
                                                          _ApplyFn
       >)
         -> stdexec::__call_result_t<
-          stdexec::__detail::__impl_of<_Sender>,
-          stdexec::__copy_cvref_fn<_Sender>,
+          stdexec::__detail::__impl_of<_Sequence>,
+          stdexec::__copy_cvref_fn<_Sequence>,
           _ApplyFn
         > {
-      return static_cast<_Sender&&>(__sndr)
-        .__impl_(stdexec::__copy_cvref_fn<_Sender>(), static_cast<_ApplyFn&&>(__fun));
+      return static_cast<_Sequence&&>(__sequence)
+        .__impl_(stdexec::__copy_cvref_fn<_Sequence>(), static_cast<_ApplyFn&&>(__fun));
     }
   };
 

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -276,8 +276,6 @@ namespace exec {
       using __completion_sigs = __sequence_completion_signatures_of_t<_Child, _Env>;
 
       template <class _Child>
-        requires receiver_of<_Receiver, __completion_sigs<_Child>>
-              && sequence_sender_to<_Child, __receiver_t<_Child>>
       auto operator()(__ignore, __ignore, _Child&& __child)
         noexcept(__nothrow_constructible_from<__operation_t<_Child>, _Child, _Receiver>)
           -> __operation_t<_Child> {
@@ -287,7 +285,7 @@ namespace exec {
 
     struct ignore_all_values_t {
       template <sender _Sender>
-      auto operator()(_Sender&& __sndr) const {
+      auto operator()(_Sender&& __sndr) const -> __well_formed_sender auto {
         auto __domain = __get_early_domain(static_cast<_Sender&&>(__sndr));
         return transform_sender(
           __domain, __make_sexpr<ignore_all_values_t>(__(), static_cast<_Sender&&>(__sndr)));
@@ -320,11 +318,6 @@ namespace exec {
         []<class _Sender, receiver _Receiver>(_Sender&& __sndr, _Receiver __rcvr) noexcept(
           __nothrow_callable<__sexpr_apply_t, _Sender, __connect_fn<_Receiver>>)
         -> __call_result_t<__sexpr_apply_t, _Sender, __connect_fn<_Receiver>>
-        requires receiver_of<_Receiver, __completion_sigs<__child_of<_Sender>, env_of_t<_Receiver>>>
-              && sequence_sender_to<
-                   __child_of<_Sender>,
-                   __receiver_t<__child_of<_Sender>, _Receiver>
-              >
       {
         static_assert(sender_expr_for<_Sender, ignore_all_values_t>);
         return __sexpr_apply(static_cast<_Sender&&>(__sndr), __connect_fn<_Receiver>{__rcvr});

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -167,7 +167,7 @@ namespace exec {
     struct iterate_t {
       template <std::ranges::forward_range _Range>
         requires __decay_copyable<_Range>
-      auto operator()(_Range&& __range) const {
+      auto operator()(_Range&& __range) const -> __well_formed_sequence_sender auto {
         return make_sequence_expr<iterate_t>(__decay_t<_Range>{static_cast<_Range&&>(__range)});
       }
 

--- a/include/exec/sequence/merge.hpp
+++ b/include/exec/sequence/merge.hpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../../stdexec/concepts.hpp"
+#include "../../stdexec/execution.hpp"
+#include "../sequence_senders.hpp"
+
+#include "../__detail/__basic_sequence.hpp"
+#include "./transform_each.hpp"
+#include "./ignore_all_values.hpp"
+#include "stdexec/__detail/__execution_fwd.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__senders_core.hpp"
+#include "stdexec/__detail/__transform_completion_signatures.hpp"
+
+namespace exec {
+  namespace __merge {
+    using namespace stdexec;
+
+    template <class _Receiver>
+    struct __operation_base {
+      _Receiver __receiver_;
+    };
+
+    template <class _ReceiverId>
+    struct __result_receiver {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      struct __t {
+        using receiver_concept = stdexec::receiver_t;
+        using __id = __result_receiver;
+
+        __operation_base<_Receiver>* __op_;
+
+        void set_value() noexcept {
+          stdexec::set_value(static_cast<_Receiver&&>(__op_->__receiver_));
+        }
+
+        template <class _Error>
+        void set_error(_Error&& __error) noexcept {
+          stdexec::set_error(
+            static_cast<_Receiver&&>(__op_->__receiver_), static_cast<_Error&&>(__error));
+        }
+
+        void set_stopped() noexcept
+        {
+          stdexec::set_stopped(static_cast<_Receiver&&>(__op_->__receiver_));
+        }
+
+        auto get_env() const noexcept -> env_of_t<_Receiver> {
+          return stdexec::get_env(__op_->__receiver_);
+        }
+      };
+    };
+
+    template <class _ReceiverId>
+    struct __merge_each_fn {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      template <sender _Item>
+      auto operator()(_Item&& __item, __operation_base<_Receiver>* __op) const noexcept(
+        __nothrow_callable<set_next_t, _Receiver&, _Item>)
+        -> next_sender_of_t<_Receiver, _Item> {
+        return exec::set_next(
+          __op->__receiver_, static_cast<_Item&&>(__item));
+      }
+    };
+
+    struct __combine {
+      template<class _ReceiverId>
+      using merge_each_fn_t = __binder_back<__merge_each_fn<_ReceiverId>, __operation_base<__t<_ReceiverId>>*>;
+
+      template<class _Sequence, class _ReceiverId>
+      using transform_sender_t = __call_result_t<exec::transform_each_t, _Sequence, merge_each_fn_t<_ReceiverId>>;
+      template<class _Sequence, class _ReceiverId>
+      using ignored_sender_t = __call_result_t<exec::ignore_all_values_t, transform_sender_t<_Sequence, _ReceiverId>>;
+
+      template<class _ReceiverId, class... _Sequences>
+      using result_sender_t = __call_result_t<when_all_t,
+                                                ignored_sender_t<_Sequences, _ReceiverId>...>;
+    };
+
+    template <class _ReceiverId, class... _Sequences>
+    struct __operation {
+      using _Receiver = stdexec::__t<_ReceiverId>;
+
+      using merge_each_fn_t = typename __combine::merge_each_fn_t<_ReceiverId>;
+
+      template<class _ReceiverIdDependent>
+      using result_sender_t = typename __combine::result_sender_t<_ReceiverIdDependent, _Sequences...>;
+
+      struct __t : __operation_base<_Receiver> {
+        using __id = __operation;
+
+        connect_result_t<result_sender_t<_ReceiverId>, stdexec::__t<__result_receiver<_ReceiverId>>> __op_result_;
+
+        __t(_Receiver __rcvr, _Sequences... __sequences)
+          : __operation_base<
+              _Receiver
+            >{static_cast<_Receiver&&>(__rcvr)}
+          , __op_result_{stdexec::connect(
+            stdexec::when_all(
+              exec::ignore_all_values(
+                exec::transform_each(static_cast<_Sequences&&>(__sequences), merge_each_fn_t{{this}, {}, {}}))...),
+            stdexec::__t<__result_receiver<_ReceiverId>>{this})} {
+        }
+
+        void start() & noexcept {
+          stdexec::start(__op_result_);
+        }
+      };
+    };
+
+    template <class _Receiver>
+    struct __subscribe_fn {
+      _Receiver& __rcvr_;
+
+      template <class... _Sequences>
+      auto operator()(__ignore, _Sequences... __sequences) noexcept(
+        (__nothrow_decay_copyable<_Sequences> && ...)
+        && __nothrow_move_constructible<_Receiver>)
+        -> __t<__operation<__id<_Receiver>, _Sequences...>> {
+        return {
+          static_cast<_Receiver&&>(__rcvr_),
+          static_cast<_Sequences&&>(__sequences)...};
+      }
+    };
+
+    struct merge_t {
+      template <class... _Sequences>
+      auto operator()(_Sequences&&... __sequences) const
+        noexcept((__nothrow_decay_copyable<_Sequences> && ...))
+        -> __well_formed_sequence_sender auto {
+        auto __domain = __common_domain_t<_Sequences...>();
+        return transform_sender(
+          __domain, make_sequence_expr<merge_t>(
+              static_cast<_Sequences&&>(__sequences)...));
+      }
+
+      template <class... _Args>
+      using __all_nothrow_decay_copyable = __mbool<(__nothrow_decay_copyable<_Args> && ...)>;
+
+      template <class _Error>
+      using __set_error_t = completion_signatures<set_error_t(__decay_t<_Error>)>;
+
+      struct _INVALID_ARGUMENTS_TO_MERGE_ { };
+
+      template <class _Self, class _Env>
+      using __error_t = __mexception<
+        _INVALID_ARGUMENTS_TO_MERGE_,
+        __children_of<_Self, __q<_WITH_SEQUENCES_>>,
+        _WITH_ENVIRONMENT_<_Env>
+      >;
+
+      template <class... _Env>
+      struct __completions_t {
+
+        template <class... _Sequences>
+        using __f = __meval<
+          __concat_completion_signatures,
+          completion_signatures<set_stopped_t()>,
+          __sequence_completion_signatures_of_t<_Sequences, _Env...>...
+        >;
+      };
+
+      template <class _Self, class... _Env>
+      using __completions = __children_of<_Self, __completions_t<_Env...>>;
+
+      template <sender_expr_for<merge_t> _Self, class... _Env>
+      static auto get_completion_signatures(_Self&&, _Env&&...) noexcept {
+          return __minvoke<__mtry_catch<__q<__completions>, __q<__error_t>>, _Self, _Env...>();
+      }
+
+      template <class... _Env>
+      struct __items_t {
+
+        template <class... _Sequences>
+        using __f = stdexec::__mapply<
+        stdexec::__munique<stdexec::__q<exec::item_types>>,
+          stdexec::__minvoke<
+            stdexec::__mconcat<stdexec::__qq<exec::item_types>>,
+              __item_types_of_t<_Sequences, _Env...>...>>;
+      };
+
+      template <class _Self, class... _Env>
+      using __items = __children_of<_Self, __items_t<_Env...>>;
+
+      template <sender_expr_for<merge_t> _Self, class... _Env>
+      static auto get_item_types(_Self&&, _Env&&...) noexcept {
+          return __minvoke<__mtry_catch<__q<__items>, __q<__error_t>>, _Self, _Env...>();
+      }
+
+      template <sender_expr_for<merge_t> _Self, receiver _Receiver>
+      static auto subscribe(_Self&& __self, _Receiver __rcvr)
+        noexcept(__nothrow_callable<__sexpr_apply_t, _Self, __subscribe_fn<_Receiver>>)
+          -> __sexpr_apply_result_t<_Self, __subscribe_fn<_Receiver>> {
+        return __sexpr_apply(static_cast<_Self&&>(__self), __subscribe_fn<_Receiver>{__rcvr});
+      }
+    };
+  } // namespace __merge
+
+  using __merge::merge_t;
+  inline constexpr merge_t merge{};
+} // namespace exec

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -192,7 +192,7 @@ namespace exec {
                  >)
         static auto get_item_types(_Self&&, _Env&&...) noexcept -> __mexception<
           _TRANSFORM_EACH_ADAPTOR_INVOCATION_FAILED_<_Self>,
-          __sequence_sndr::_WITH_SEQUENCE_<__child_of<_Self>>,
+          _WITH_SEQUENCE_<__child_of<_Self>>,
           _WITH_ENVIRONMENT_<_Env...>,
           _WITH_TYPE_<__try_adaptor_calls_result_t<
             __data_of<_Self>,
@@ -206,7 +206,7 @@ namespace exec {
               && (!__mvalid<__item_types_of_t, __child_of<_Self>, _Env...>)
       static auto get_item_types(_Self&&, _Env&&...) noexcept -> __mexception<
         _TRANSFORM_EACH_ITEM_TYPES_OF_THE_CHILD_ARE_INVALID_<_Self>,
-        __sequence_sndr::_WITH_SEQUENCE_<__child_of<_Self>>,
+        _WITH_SEQUENCE_<__child_of<_Self>>,
         _WITH_ENVIRONMENT_<_Env...>>;
 
       template<class _Transform>
@@ -221,7 +221,7 @@ namespace exec {
                 >
       static auto get_item_types(_Self&&, _Env&&...) noexcept -> __mexception<
         _TRANSFORM_EACH_ITEM_TYPES_CALCULATION_FAILED_<_Self>,
-        __sequence_sndr::_WITH_SEQUENCE_<__child_of<_Self>>,
+        _WITH_SEQUENCE_<__child_of<_Self>>,
         _WITH_ENVIRONMENT_<_Env...>>;
 
       template <sender_expr_for<transform_each_t> _Self, class... _Env>

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -21,6 +21,8 @@
 #include "../sequence_senders.hpp"
 
 #include "../__detail/__basic_sequence.hpp"
+#include "stdexec/__detail/__diagnostics.hpp"
+#include "stdexec/__detail/__meta.hpp"
 
 namespace exec {
   namespace __transform_each {
@@ -42,8 +44,6 @@ namespace exec {
         __operation_base<_Receiver, _Adaptor>* __op_;
 
         template <class _Item>
-          requires __callable<_Adaptor&, _Item>
-                && __callable<exec::set_next_t, _Receiver&, __call_result_t<_Adaptor&, _Item>>
         auto set_next(_Item&& __item) & noexcept(
           __nothrow_callable<set_next_t, _Receiver&, __call_result_t<_Adaptor&, _Item>>
           && __nothrow_callable<_Adaptor&, _Item>)
@@ -57,7 +57,6 @@ namespace exec {
         }
 
         template <class _Error>
-          requires __callable<set_error_t, _Receiver, _Error>
         void set_error(_Error&& __error) noexcept {
           stdexec::set_error(
             static_cast<_Receiver&&>(__op_->__receiver_), static_cast<_Error&&>(__error));
@@ -121,29 +120,37 @@ namespace exec {
     template <class _Item>
     struct _WITH_ITEM_SENDER_ { };
 
-    template <class _Adaptor, class _Item>
-    auto __try_call(_Item*) -> stdexec::__mexception<
-      _NOT_CALLABLE_ADAPTOR_<_Adaptor&>,
-      _WITH_ITEM_SENDER_<stdexec::__name_of<_Item>>
-    >;
+    template <class _Adaptor>
+    struct __try_adaptor_calls_t {
 
-    template <class _Adaptor, class _Item>
-      requires stdexec::__callable<_Adaptor&, _Item>
-    auto __try_call(_Item*) -> stdexec::__msuccess;
+      template <class _Item>
+      auto operator()(_Item*) -> stdexec::__mexception<
+        _NOT_CALLABLE_ADAPTOR_<_Adaptor&>,
+        _WITH_ITEM_SENDER_<stdexec::__name_of<_Item>>
+      >;
 
-    template <class _Adaptor, class... _Items>
-    auto __try_calls(item_types<_Items...>*) -> decltype((
-      stdexec::__msuccess() && ... && __try_call<_Adaptor>(static_cast<_Items*>(nullptr))));
+      template <class _Item>
+        requires stdexec::__callable<_Adaptor&, _Item>
+      auto operator()(_Item*) -> stdexec::__msuccess;
+
+      template <class... _Items>
+      auto operator()(item_types<_Items...>*) -> decltype((
+        stdexec::__msuccess(), ..., (*this)(static_cast<_Items*>(nullptr))));
+    };
 
     template <class _Adaptor, class _Items>
-    concept __callabale_adaptor_for = requires(_Items* __items) {
-      { __try_calls<stdexec::__decay_t<_Adaptor>>(__items) } -> stdexec::__ok;
+    using __try_adaptor_calls_result_t = __call_result_t<__try_adaptor_calls_t<stdexec::__decay_t<_Adaptor>>, _Items>;
+
+    template <class _Adaptor, class _Items>
+    concept __callable_adaptor_for = requires(_Items* __items) {
+      { __try_adaptor_calls_t<stdexec::__decay_t<_Adaptor>>{}(__items) } -> stdexec::__ok;
     };
 
     struct transform_each_t {
       template <sender _Sequence, __sender_adaptor_closure _Adaptor>
       auto operator()(_Sequence&& __sndr, _Adaptor&& __adaptor) const
-        noexcept(__nothrow_decay_copyable<_Sequence> && __nothrow_decay_copyable<_Adaptor>) {
+        noexcept(__nothrow_decay_copyable<_Sequence> && __nothrow_decay_copyable<_Adaptor>)
+        -> __well_formed_sequence_sender auto {
         return make_sequence_expr<transform_each_t>(
           static_cast<_Adaptor&&>(__adaptor), static_cast<_Sequence&&>(__sndr));
       }
@@ -155,12 +162,12 @@ namespace exec {
         return {{static_cast<_Adaptor&&>(__adaptor)}, {}, {}};
       }
 
-      template <class _Self, class _Env>
-      using __completion_sigs_t = __sequence_completion_signatures_of_t<__child_of<_Self>, _Env>;
+      template <class _Self, class... _Env>
+      using __completion_sigs_t = __sequence_completion_signatures_of_t<__child_of<_Self>, _Env...>;
 
-      template <sender_expr_for<transform_each_t> _Self, class _Env>
+      template <sender_expr_for<transform_each_t> _Self, class... _Env>
       static auto
-        get_completion_signatures(_Self&&, _Env&&) noexcept -> __completion_sigs_t<_Self, _Env> {
+        get_completion_signatures(_Self&&, _Env&&...) noexcept -> __completion_sigs_t<_Self, _Env...> {
         return {};
       }
 
@@ -170,11 +177,61 @@ namespace exec {
           stdexec::__mbind_front_q<__call_result_t, __data_of<_Self>&>,
           stdexec::__munique<stdexec::__q<item_types>>
         >,
-        item_types_of_t<__child_of<_Self>, _Env...>
+        __item_types_of_t<__child_of<_Self>, _Env...>
       >;
 
-      template <sender_expr_for<transform_each_t> _Self, class _Env>
-      static auto get_item_types(_Self&&, _Env&&) noexcept -> __item_types_t<_Self, _Env> {
+        template<class _Transform>
+        struct _TRANSFORM_EACH_ADAPTOR_INVOCATION_FAILED_ {};
+
+        template <sender_expr_for<transform_each_t> _Self, class... _Env>
+          requires (!__mvalid<__item_types_t, _Self, _Env...>)
+                && __mvalid<__item_types_of_t, __child_of<_Self>, _Env...>
+                && (!__callable_adaptor_for<
+                   __data_of<_Self>,
+                   __item_types_of_t<__child_of<_Self>, _Env...>
+                 >)
+        static auto get_item_types(_Self&&, _Env&&...) noexcept -> __mexception<
+          _TRANSFORM_EACH_ADAPTOR_INVOCATION_FAILED_<_Self>,
+          __sequence_sndr::_WITH_SEQUENCE_<__child_of<_Self>>,
+          _WITH_ENVIRONMENT_<_Env...>,
+          _WITH_TYPE_<__try_adaptor_calls_result_t<
+            __data_of<_Self>,
+            __item_types_of_t<__child_of<_Self>, _Env...>>>>;
+
+      template<class _Transform>
+      struct _TRANSFORM_EACH_ITEM_TYPES_OF_THE_CHILD_ARE_INVALID_ {};
+
+      template <sender_expr_for<transform_each_t> _Self, class... _Env>
+        requires (!__mvalid<__item_types_t, _Self, _Env...>)
+              && (!__mvalid<__item_types_of_t, __child_of<_Self>, _Env...>)
+      static auto get_item_types(_Self&&, _Env&&...) noexcept -> __mexception<
+        _TRANSFORM_EACH_ITEM_TYPES_OF_THE_CHILD_ARE_INVALID_<_Self>,
+        __sequence_sndr::_WITH_SEQUENCE_<__child_of<_Self>>,
+        _WITH_ENVIRONMENT_<_Env...>>;
+
+      template<class _Transform>
+      struct _TRANSFORM_EACH_ITEM_TYPES_CALCULATION_FAILED_ {};
+
+      template <sender_expr_for<transform_each_t> _Self, class... _Env>
+        requires (!__mvalid<__item_types_t, _Self, _Env...>)
+              && __mvalid<__item_types_of_t, __child_of<_Self>, _Env...>
+              && __callable_adaptor_for<
+                  __data_of<_Self>,
+                  __item_types_of_t<__child_of<_Self>, _Env...>
+                >
+      static auto get_item_types(_Self&&, _Env&&...) noexcept -> __mexception<
+        _TRANSFORM_EACH_ITEM_TYPES_CALCULATION_FAILED_<_Self>,
+        __sequence_sndr::_WITH_SEQUENCE_<__child_of<_Self>>,
+        _WITH_ENVIRONMENT_<_Env...>>;
+
+      template <sender_expr_for<transform_each_t> _Self, class... _Env>
+        requires __mvalid<__item_types_t, _Self, _Env...>
+              && __mvalid<__item_types_of_t, __child_of<_Self>, _Env...>
+              && __callable_adaptor_for<
+                  __data_of<_Self>,
+                  __item_types_of_t<__child_of<_Self>, _Env...>
+                >
+      static auto get_item_types(_Self&&, _Env&&...) noexcept -> __item_types_t<_Self, _Env...> {
         return {};
       }
 
@@ -185,12 +242,6 @@ namespace exec {
       using __operation_t = __t<__operation<__child_of<_Self>, __id<_Receiver>, __data_of<_Self>>>;
 
       template <sender_expr_for<transform_each_t> _Self, receiver _Receiver>
-        requires __callabale_adaptor_for<
-                   __data_of<_Self>,
-                   item_types_of_t<__child_of<_Self>, env_of_t<_Receiver>>
-                 >
-              && sequence_receiver_of<_Receiver, __item_types_t<_Self, env_of_t<_Receiver>>>
-              && sequence_sender_to<__child_of<_Self>, __receiver_t<_Self, _Receiver>>
       static auto subscribe(_Self&& __self, _Receiver __rcvr)
         noexcept(__nothrow_callable<__sexpr_apply_t, _Self, __subscribe_fn<_Receiver>>)
           -> __call_result_t<__sexpr_apply_t, _Self, __subscribe_fn<_Receiver>> {

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -155,6 +155,22 @@ namespace exec {
     struct __item_types { };
   } // namespace __debug
 
+  namespace __errs {
+    using namespace stdexec;
+    inline constexpr __mstring __unrecognized_sequence_type_diagnostic =
+      "The given type cannot be used as a sequence with the given environment "
+      "because the attempt to compute the item types failed."_mstr;
+  } // namespace __errs
+
+  template <class _Sequence>
+  struct _WITH_SEQUENCE_;
+
+  template <class... _Sequences>
+  struct _WITH_SEQUENCES_;
+
+  template <stdexec::__mstring _Diagnostic = __errs::__unrecognized_sequence_type_diagnostic>
+  struct _UNRECOGNIZED_SEQUENCE_TYPE_;
+
   /////////////////////////////////////////////////////////////////////////////
   // [execution.seqtraits]
   namespace __sequence_sndr {
@@ -163,18 +179,6 @@ namespace exec {
     template <class _Sequence, class... _Env>
     using __item_types_of_t =
       __call_result_t<get_item_types_t, _Sequence, _Env...>;
-
-    namespace __errs {
-      inline constexpr __mstring __unrecognized_sequence_type_diagnostic =
-        "The given type cannot be used as a sequence with the given environment "
-        "because the attempt to compute the item types failed."_mstr;
-    } // namespace __errs
-
-    template <class _Sequence>
-    struct _WITH_SEQUENCE_;
-
-    template <__mstring _Diagnostic = __errs::__unrecognized_sequence_type_diagnostic>
-    struct _UNRECOGNIZED_SEQUENCE_TYPE_;
 
     template <class _Sequence, class... _Env>
     using __unrecognized_sequence_error =
@@ -279,7 +283,7 @@ namespace exec {
   template <class _Sequence, class _Item>
   auto __check_item(_Item*) -> stdexec::__mexception<
     _SEQUENCE_ITEM_IS_NOT_A_WELL_FORMED_SENDER_<_Item>,
-    __sequence_sndr::_WITH_SEQUENCE_<_Sequence>
+    _WITH_SEQUENCE_<_Sequence>
   >;
 
   template <class _Sequence, class _Item>
@@ -297,7 +301,7 @@ namespace exec {
     requires (!stdexec::__merror<_Items>)
   auto __check_items(_Items*) -> stdexec::__mexception<
     _SEQUENCE_GET_ITEM_TYPES_RESULT_IS_NOT_WELL_FORMED_<_Items>,
-    __sequence_sndr::_WITH_SEQUENCE_<_Sequence>
+    _WITH_SEQUENCE_<_Sequence>
   >;
 
   template <class _Sequence, class... _Items>
@@ -317,7 +321,7 @@ namespace exec {
           && (!stdexec::__mvalid<__item_types_of_t, _Sequence>)
   auto __check_sequence(_Sequence*) -> stdexec::__mexception<
     _SEQUENCE_GET_ITEM_TYPES_IS_NOT_WELL_FORMED_,
-    __sequence_sndr::_WITH_SEQUENCE_<_Sequence>
+    _WITH_SEQUENCE_<_Sequence>
   >;
 
   template <class _Sequence>

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -50,6 +50,7 @@ set(exec_test_sources
     sequence/test_ignore_all_values.cpp
     sequence/test_iterate.cpp
     sequence/test_transform_each.cpp
+    sequence/test_merge.cpp
     $<$<BOOL:${STDEXEC_ENABLE_TBB}>:../execpools/test_tbb_thread_pool.cpp>
     $<$<BOOL:${STDEXEC_ENABLE_TASKFLOW}>:../execpools/test_taskflow_thread_pool.cpp>
     $<$<BOOL:${STDEXEC_ENABLE_ASIO}>:../execpools/test_asio_thread_pool.cpp>

--- a/test/exec/sequence/test_merge.cpp
+++ b/test/exec/sequence/test_merge.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2023 Maikel Nadolski
+ * Copyright (c) 2023 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "exec/sequence/merge.hpp"
+
+#include "exec/sequence/empty_sequence.hpp"
+#include "exec/sequence/iterate.hpp"
+#include "exec/sequence/ignore_all_values.hpp"
+#include "exec/sequence/transform_each.hpp"
+#include "exec/sequence.hpp"
+#include "exec/sequence_senders.hpp"
+#include "exec/trampoline_scheduler.hpp"
+#include "exec/static_thread_pool.hpp"
+#include "stdexec/__detail/__just.hpp"
+#include "stdexec/__detail/__meta.hpp"
+#include "stdexec/__detail/__continues_on.hpp"
+#include "stdexec/__detail/__upon_error.hpp"
+#include <atomic>
+#include <catch2/catch.hpp>
+
+#include <mutex>
+#include <test_common/schedulers.hpp>
+#include <test_common/receivers.hpp>
+#include <test_common/senders.hpp>
+#include <test_common/type_helpers.hpp>
+#include <thread>
+
+namespace {
+
+struct null_receiver {
+  using __id = null_receiver;
+  using __t = null_receiver;
+  using receiver_concept = ex::receiver_t;
+
+  void set_value() noexcept {
+  }
+
+  template <class _Error>
+  void set_error(_Error&& ) noexcept {
+  }
+
+  void set_stopped() noexcept {
+  }
+
+  [[nodiscard]]
+  auto get_env() const noexcept -> ex::env<> {
+    return {};
+  }
+
+  struct ignore_values_fn_t {
+    template<class... _Vs>
+    void operator()(_Vs&&...) const noexcept {}
+  };
+
+  template <ex::sender _Item>
+  [[nodiscard]]
+  auto set_next(_Item&& __item) & noexcept(ex::__nothrow_decay_copyable<_Item>)
+    -> stdexec::__call_result_t<stdexec::upon_error_t,
+          stdexec::__call_result_t<stdexec::then_t,
+            _Item, ignore_values_fn_t>,
+          ignore_values_fn_t> {
+    return stdexec::upon_error(stdexec::then(static_cast<_Item&&>(__item), ignore_values_fn_t{}), ignore_values_fn_t{});
+  }
+};
+
+  TEST_CASE(
+    "merge - merge two sequence senders of no elements",
+    "[sequence_senders][merge][empty_sequence]") {
+    int counter = 0;
+    auto merged = exec::merge(exec::empty_sequence(), exec::empty_sequence());
+    auto op = exec::subscribe(merged, null_receiver{});
+    ex::start(op);
+    CHECK(counter == 0);
+  }
+
+  TEST_CASE(
+    "merge - merge three sequence senders of no elements",
+    "[sequence_senders][merge][empty_sequence]") {
+    int counter = 0;
+    auto merged = exec::merge(exec::empty_sequence(), exec::empty_sequence(), exec::empty_sequence());
+    auto op = exec::subscribe(merged, null_receiver{});
+    ex::start(op);
+    CHECK(counter == 0);
+  }
+
+  TEST_CASE(
+    "merge - merge sender of 2 senders",
+    "[sequence_senders][merge]") {
+    int value = 0;
+    int count = 0;
+    auto merged = exec::merge(ex::just(84), ex::just(-42));
+    auto transformed = exec::transform_each(merged, ex::then([&value, &count](int x) noexcept {
+                                              value += x;
+                                              ++count;
+                                            }));
+    auto op = exec::subscribe(transformed, null_receiver{});
+    ex::start(op);
+    CHECK(value == 42);
+    CHECK(count == 2);
+  }
+
+  TEST_CASE(
+    "merge - merge sender of 2 senders and ignores all values",
+    "[sequence_senders][merge][ignore_all_values]") {
+    int value = 0;
+    int count = 0;
+    auto merged = exec::merge(ex::just(84), ex::just(-42));
+    auto transformed = exec::transform_each(merged, ex::then([&value, &count](int x) {
+                                              value += x;
+                                              ++count;
+                                              return value;
+                                            }))
+                     | exec::ignore_all_values();
+    ex::sync_wait(transformed);
+    CHECK(value == 42);
+    CHECK(count == 2);
+  }
+
+#if STDEXEC_HAS_STD_RANGES()
+  TEST_CASE(
+    "merge - merge sender merges all items",
+    "[sequence_senders][merge][iterate]") {
+    auto range = [](auto from, auto to) {
+      return exec::iterate(std::views::iota(from, to));
+    };
+    auto then_each = [](auto f) {
+      return exec::transform_each(ex::then(f));
+    };
+    // this trampoline is used to interleave the merged iterate() sequences
+    // the parameters set the max inline schedule recursion depth and max
+    // inline schedule stack size
+    exec::trampoline_scheduler sched{16, 512};
+    int total = 0;
+    int count = 0;
+    std::ptrdiff_t max = 0;
+    auto sum = exec::merge(range(100, 120), range(200, 220), range(300, 320))
+             | then_each([&total, &count, &max](int x) noexcept {
+                  std::ptrdiff_t current = 0;
+                  current = std::abs(reinterpret_cast<char*>(&current) - reinterpret_cast<char*>(&max));
+                  max = current > max ? current : max;
+                  UNSCOPED_INFO("item: " << x << ", stack size: " << current);
+                  total += x;
+                  ++count;
+                });
+    // this causes both iterate sequences to use the same trampoline.
+    ex::sync_wait(exec::sequence(
+          stdexec::schedule(sched),
+          exec::ignore_all_values(sum)));
+    UNSCOPED_INFO("max stack size: " << max);
+    CHECK(total == 12570);
+    CHECK(count == 60);
+  }
+
+  TEST_CASE(
+    "merge - merge sender merges all items from multiple threads",
+    "[sequence_senders][static_thread_pool][merge][iterate]") {
+
+    exec::static_thread_pool ctx0{1};
+    ex::scheduler auto sched0 = ctx0.get_scheduler();
+    exec::static_thread_pool ctx1{1};
+    ex::scheduler auto sched1 = ctx1.get_scheduler();
+    exec::static_thread_pool ctx2{1};
+    ex::scheduler auto sched2 = ctx2.get_scheduler();
+    exec::static_thread_pool ctx3{1};
+    ex::scheduler auto sched3 = ctx3.get_scheduler();
+
+    auto range = [](auto from, auto to) {
+      return exec::iterate(std::views::iota(from, to));
+    };
+    auto then_each = [](auto f) {
+      return exec::transform_each(ex::then(f));
+    };
+    auto continues_each_on = [](auto sched) {
+      return exec::transform_each(ex::continues_on(sched));
+    };
+    int total = 0;
+    int count = 0;
+    auto sum = exec::merge(
+                 range(100, 120) | continues_each_on(sched0),
+                 range(200, 220) | continues_each_on(sched1),
+                 range(300, 320) | continues_each_on(sched2))
+             | then_each([](int x) noexcept {
+                  // runs on sched0 and sched1 and sched2 in parallel.
+                  // access to shared data would need to be protected
+                  return std::make_tuple(x, std::this_thread::get_id());
+                })
+             | continues_each_on(sched3)
+             | then_each([&total, &count](auto v) {
+                  // runs only on sched3, which is a strand (a static
+                  // pool with one thread)
+                  // it is safe to use shared data here
+                  auto [x, id] = v;
+                  total += x;
+                  ++count;
+                  UNSCOPED_INFO("item: " << x
+                    << ", from thread id: " << id
+                    << ", on thread id: " << std::this_thread::get_id());
+                });
+    ex::sync_wait(exec::sequence(
+          ex::schedule(sched3),
+          exec::ignore_all_values(sum)));
+    CHECK(total == 12570);
+    CHECK(count == 60);
+  }
+#endif
+
+  struct my_domain {
+    template <ex::sender_expr_for<ex::then_t> Sender, class Env>
+    static auto transform_sender(Sender&&, const Env&) {
+      return ex::just(int{21});
+    }
+  };
+
+  TEST_CASE("merge - can be customized late", "[merge][ignore_all_values]") {
+    // The customization will return a different value
+    basic_inline_scheduler<my_domain> sched;
+    int result = 0;
+    int count = 0;
+    auto start = ex::just(std::string{"hello"});
+    auto with_scheduler = ex::write_env(ex::prop{ex::get_scheduler, inline_scheduler()});
+    auto adaptor = ex::on(sched, ex::then([](std::string x) { return x + ", world"; }))
+                 | with_scheduler;
+    auto snd = exec::merge(
+                       start | exec::transform_each(adaptor),
+                       start | exec::transform_each(adaptor))
+             | exec::transform_each(ex::then([&](int x) { result += x; ++count; }))
+             | exec::ignore_all_values();
+    ex::sync_wait(snd);
+    CHECK(result == 42);
+    CHECK(count == 2);
+  }
+
+} // namespace


### PR DESCRIPTION
`merge` takes multiple sequence-senders and forwards all the item-senders from each of the input sequences to the same `Receiver::set_next`  

The calls to `Receiver::set_next` are not synchronized. If each sequence-sender is emitting on a different scheduler in parallel, then the calls to `Receiver::set_next` will also be in parallel.

`merge` completes after all the sequence-senders complete.

The other commits were needed to debug the `merge` implementation.