### PR TITLE
Fix constraint on `__optional::__emplace_from`.

### DIFF
--- a/include/stdexec/__detail/__optional.hpp
+++ b/include/stdexec/__detail/__optional.hpp
@@ -106,7 +106,7 @@ namespace stdexec {
       }
 
       template <class _Fn, class... _Args>
-        requires same_as<_Tp, __call_result_t<_Fn>>
+        requires same_as<_Tp, __call_result_t<_Fn, _Args...>>
       auto __emplace_from(_Fn&& __f, _Args&&... __args) noexcept(__nothrow_callable<_Fn, _Args...>)
         -> _Tp& {
         reset();


### PR DESCRIPTION
The `_Args` template parameter pack is currently not passed to the `__optional<_Tp>::__emplace_from` constraint that checks that the return-type of invoking `_Fn` with `_Args...` is `_Tp`.