### PR TITLE
Make `__variant::__at` a public alias template.

### DIFF
--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -93,10 +93,11 @@ namespace stdexec {
         }
       }
 
+     public:
+
       template <std::size_t _Ny>
       using __at = __m_at_c<_Ny, _Ts...>;
 
-     public:
       // immovable:
       __variant(__variant &&) = delete;
 


### PR DESCRIPTION
Generally useful when using `__variant`, just as `variant_alternative_t` is for `std::variant`.