### PR TITLE
Remove hard-coded dependency on tbb

### DIFF
--- a/examples/nvexec/CMakeLists.txt
+++ b/examples/nvexec/CMakeLists.txt
@@ -91,7 +91,7 @@ function(def_cpu_example example)
     )
     set_source_files_properties(${source} PROPERTIES LANGUAGE ${_lang_cxx})
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        target_link_options(${target} PRIVATE -lc++abi -ltbb)
+        target_link_options(${target} PRIVATE -lc++abi)
     endif()
 endfunction()
 


### PR DESCRIPTION
Fixes build error when `CMAKE_CXX_COMPILER_ID` is `Clang` and `STDEXEC_BUILD_TESTS=On` and `STDEXEC_ENABLE_TBB=Off`.
Error:
```
[ 68%] Linking CXX executable maxwell_cpu_mt
/local-projects/spack-install/linux-skylake_avx512/binutils-2.44-3qirehrhw34fnoedc55vbztqquoezltr/bin/ld: cannot find -ltbb: No such file or directory
```