### PR TITLE
Avoid "warning: unused variable"

### DIFF
--- a/test/exec/test_task.cpp
+++ b/test/exec/test_task.cpp
@@ -265,6 +265,7 @@ namespace {
           []() -> exec::task<void> {
             auto token = co_await stdexec::get_stop_token();
             assert(!token.stop_possible());
+            (void)token;
           }(),
           stdexec::prop{stdexec::get_stop_token, stdexec::never_stop_token{}});
     }());


### PR DESCRIPTION
Addresses:
```
stdexec/test/exec/test_task.cpp:266:18: warning: unused variable 'token' [-Wunused-variable]
  266 |             auto token = co_await stdexec::get_stop_token();
```
