### PR TITLE
build: add lightweight meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,26 @@
+project('stdexec', 'cpp', version: '0.11.0', license: 'Apache2')
+
+stdexec_dep = declare_dependency(
+    include_directories: include_directories('include'),
+)
+
+if not meson.is_subproject()
+
+    install_subdir(
+        'include/exec',
+        install_dir: 'include',
+        strip_directory: false,
+    )
+    install_subdir(
+        'include/stdexec',
+        install_dir: 'include',
+        strip_directory: false,
+    )
+
+    pkgc = import('pkgconfig')
+    pkgc.generate(
+        name: 'stdexec',
+        version: meson.project_version(),
+        description: 'stdexec: experimental P2300 implementation',
+    )
+endif


### PR DESCRIPTION
Add a simple meson.build file, which allows:

   - meson repositories to use stdexec as a subproject[1,2].
   - a simple way to install stdexec for Yocto-based distributions[3].

Meson only easily supports meson or cmake dependencies.  The current
CMakeLists.txt doesn't work as a Meson subproject due to the use of
downloaded pieces, such as rapids-cmake.  Similarly, Yocto does not
allow unmanaged downloads, but instead requires all downloads to be
able to be cached.

The meson.build file proposed here is very simple and only exposes
the headers that would be installed by the default CMake invocation.
It also generates a pkgconfig file so that the package can be found
as a dependency when installed into a Linux distribution.

OpenBMC currently leverages stdexec for performing asynchronous
dbus operations.  Currently, we are vendoring portions of stdexec
directly into the dbus library ("sdbusplus").  This work allows
separation of the two.

[1]: https://mesonbuild.com/Subprojects.html
[2]: https://gerrit.openbmc.org/c/openbmc/sdbusplus/+/85062
[3]: https://gerrit.openbmc.org/c/openbmc/openbmc/+/85064

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
