### PR TITLE
Change _CUDA_VSTD to ::cuda::std

### DIFF
--- a/test/nvexec/reduce.cpp
+++ b/test/nvexec/reduce.cpp
@@ -17,7 +17,7 @@ namespace {
   struct minimum {
     template <class T1, class T2>
     constexpr auto
-      operator()(const T1& lhs, const T2& rhs) const -> _CUDA_VSTD::common_type_t<T1, T2> {
+      operator()(const T1& lhs, const T2& rhs) const -> ::cuda::std::common_type_t<T1, T2> {
       return (lhs < rhs) ? lhs : rhs;
     }
   };


### PR DESCRIPTION
A few days ago CCCL got rid of the macro `_CUDA_VSTD`.  CCCL code now uses `::cuda::std` instead of a macro.  Make the same change in the one place in stdexec that uses `_CUDA_VSTD`, which is in test/nvexec/reduce.cpp.