### PR TITLE
replace all the identical stop callback types with just one

### DIFF
--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -68,14 +68,6 @@ namespace exec {
       return __indirect_scheduler_provider<_ParentPromise>;
     }
 
-    struct __forward_stop_request {
-      inplace_stop_source& __stop_source_;
-
-      void operator()() noexcept {
-        __stop_source_.request_stop();
-      }
-    };
-
     template <class _ParentPromise>
     struct __default_awaiter_context;
 

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -28,14 +28,6 @@ namespace exec {
   namespace __when_any {
     using namespace stdexec;
 
-    struct __on_stop_requested {
-      inplace_stop_source& __stop_source_;
-
-      void operator()() noexcept {
-        __stop_source_.request_stop();
-      }
-    };
-
     template <class _Env>
     using __env_t = __join_env_t<prop<get_stop_token_t, inplace_stop_token>, _Env>;
 
@@ -101,7 +93,7 @@ namespace exec {
       }
 
       using __on_stop =
-        stop_callback_for_t<stop_token_of_t<env_of_t<_Receiver>&>, __on_stop_requested>;
+        stop_callback_for_t<stop_token_of_t<env_of_t<_Receiver>&>, __forward_stop_request>;
 
       inplace_stop_source __stop_source_{};
       std::optional<__on_stop> __on_stop_{};
@@ -216,7 +208,7 @@ namespace exec {
 
         void start() & noexcept {
           this->__on_stop_.emplace(
-            get_stop_token(get_env(this->__rcvr_)), __on_stop_requested{this->__stop_source_});
+            get_stop_token(get_env(this->__rcvr_)), __forward_stop_request{this->__stop_source_});
           if (this->__stop_source_.stop_requested()) {
             stdexec::set_stopped(static_cast<_Receiver&&>(this->__rcvr_));
           } else {

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -231,17 +231,9 @@ namespace nvexec::_strm {
         using Sender = stdexec::__t<SenderId>;
         using Receiver = stdexec::__t<ReceiverId>;
 
-        struct on_stop_requested {
-          inplace_stop_source& stop_source_;
-
-          void operator()() noexcept {
-            stop_source_.request_stop();
-          }
-        };
-
-        using on_stop = std::optional<
-          typename stop_token_of_t<env_of_t<Receiver>&>::template callback_type<on_stop_requested>
-        >;
+        using on_stop = std::optional<typename stop_token_of_t<
+          env_of_t<Receiver>&
+        >::template callback_type<__forward_stop_request>>;
 
         on_stop on_stop_{};
         std::shared_ptr<sh_state_t<Sender>> shared_state_;
@@ -293,7 +285,7 @@ namespace nvexec::_strm {
           if (old != completion_state) {
             on_stop_.emplace(
               get_stop_token(stdexec::get_env(this->rcvr_)),
-              on_stop_requested{shared_state->stop_source_});
+              __forward_stop_request{shared_state->stop_source_});
           }
 
           do {

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -45,14 +45,6 @@ namespace nvexec::_strm {
       stopped
     };
 
-    struct on_stop_requested {
-      inplace_stop_source& stop_source_;
-
-      void operator()() noexcept {
-        stop_source_.request_stop();
-      }
-    };
-
     template <class Env>
     using env_t = exec::make_env_t<Env, stdexec::prop<get_stop_token_t, inplace_stop_token>>;
 
@@ -367,7 +359,7 @@ namespace nvexec::_strm {
         void start() & noexcept {
           // register stop callback:
           auto tok = stdexec::get_stop_token(stdexec::get_env(rcvr_));
-          on_stop_.emplace(std::move(tok), _when_all::on_stop_requested{stop_source_});
+          on_stop_.emplace(std::move(tok), __forward_stop_request{stop_source_});
           if (stop_source_.stop_requested()) {
             // Stop has already been requested. Don't bother starting
             // the child operations.
@@ -476,7 +468,7 @@ namespace nvexec::_strm {
         inplace_stop_source stop_source_{};
 
         using stop_callback_t =
-          stop_callback_for_t<stop_token_of_t<env_of_t<Receiver>&>, _when_all::on_stop_requested>;
+          stop_callback_for_t<stop_token_of_t<env_of_t<Receiver>&>, __forward_stop_request>;
         std::optional<stop_callback_t> on_stop_{};
       };
 

--- a/include/stdexec/stop_token.hpp
+++ b/include/stdexec/stop_token.hpp
@@ -350,6 +350,14 @@ namespace stdexec {
     }
   }
 
+  struct __forward_stop_request {
+    void operator()() const noexcept {
+      __stop_source_.request_stop();
+    }
+
+    inplace_stop_source& __stop_source_;
+  };
+
   using in_place_stop_token
     [[deprecated("in_place_stop_token has been renamed inplace_stop_token")]] = inplace_stop_token;
 


### PR DESCRIPTION
this struct or ones like it appear many times:

```cpp
    struct __on_stop_t {
      stdexec::inplace_stop_source& __source_;

      void operator()() const noexcept {
        __source_.request_stop();
      }
    };
```

replace them all with `stdexec::__forward_stop_request` defined in `stop_token.hpp`.