### PR TITLE
cmake: reuse existing asio target if present

### DIFF
--- a/cmake/import_standalone_asio.cmake
+++ b/cmake/import_standalone_asio.cmake
@@ -8,6 +8,10 @@
 #       import_standalone_asio([TAG github-tag] VERSION [version-stirng])
 #
 function(import_standalone_asio)
+    if(TARGET asio)
+      message(STATUS "stdexec: reusing existing asio target")
+      return()
+    endif()
     set(options "")
     set(args TAG VERSION)
     set(multi_args "")


### PR DESCRIPTION
I’m using standalone Asio via vcpkg in an existing project, with CMake configured like this:

```cmake
find_package(asio CONFIG REQUIRED)
```

When I tried to integrate `stdexec` and `asioexec` into the same project using CPM:

```cmake
CPMAddPackage(
    NAME stdexec
    GITHUB_REPOSITORY NVIDIA/stdexec
    GIT_TAG main
    OPTIONS
        "STDEXEC_ENABLE_ASIO ON"
        "STDEXEC_ASIO_IMPLEMENTATION standalone"
)
```

CMake failed with the following error:

```text
CMake Error at /home/kkkzbh/vcpkg/scripts/buildsystems/vcpkg.cmake:649 (_add_library):
  _add_library cannot create target "asio" because an alias with the same
  name already exists.
Call Stack (most recent call first):
  cmake-build-debug/_deps/stdexec-src/cmake/import_standalone_asio.cmake:29 (add_library)
  cmake-build-debug/_deps/stdexec-src/CMakeLists.txt:524 (import_standalone_asio)
```

This happens because `vcpkg` already provides an `asio` target, and `stdexec`’s CMake code tries to create another `asio` target in `import_standalone_asio.cmake`, which CMake rejects.

There are a few ways to work around this in user code:

* Switch to the Boost.Asio backend for `stdexec`, or
* Remove the `find_package(asio CONFIG REQUIRED)` + vcpkg-provided Asio and only use the `asio` target created by `stdexec`.

However, it is more convenient and less surprising if `stdexec` can reuse an existing `asio` target instead of failing.

To avoid the conflict, I changed the `import_standalone_asio` function to detect an existing `asio` target and reuse it:

```cmake
function(import_standalone_asio)
    if (TARGET asio)
        message(STATUS "stdexec: reusing existing asio target")
        return()
    endif()

    set(options "")
    # ...
endfunction()
```

With this change:

* If a project (for example, via vcpkg) already defines an `asio` target, `stdexec` will reuse it and skip creating its own target.
* If no `asio` target exists, `stdexec` behaves as before and imports standalone Asio normally.

This makes it easier to integrate `stdexec` into existing CMake projects that already depend on standalone Asio.
