### PR TITLE
advertise that `exec::task` is scheduler-affine via its attributes

### DIFF
--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -145,7 +145,7 @@ namespace exec {
       }
 
       [[nodiscard]]
-      auto await_ready() const noexcept -> bool {
+      static constexpr auto await_ready() noexcept -> bool {
         return false;
       }
 

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -118,6 +118,15 @@ namespace exec {
       }
 
       [[nodiscard]]
+      constexpr auto query(get_completion_behavior_t<set_value_t>) const noexcept {
+        if constexpr (__with_scheduler) {
+          return completion_behavior::asynchronous_affine;
+        } else {
+          return completion_behavior::unknown;
+        }
+      }
+
+      [[nodiscard]]
       auto stop_requested() const noexcept -> bool {
         return __stop_token_.stop_requested();
       }
@@ -405,7 +414,7 @@ namespace exec {
             auto __cleanup_task = at_coroutine_exit(schedule, std::move(__sched));
             // Insert the cleanup action into the head of the continuation chain by making
             // direct calls to the cleanup task's awaiter member functions. See type
-            // _cleanup_task in at_coroutine_exit.hpp:
+            // __at_coro_exit::__task in at_coroutine_exit.hpp:
             __cleanup_task.await_suspend(__coro::coroutine_handle<__promise>::from_promise(*this));
             (void) __cleanup_task.await_resume();
           }

--- a/include/stdexec/__detail/__completion_behavior.hpp
+++ b/include/stdexec/__detail/__completion_behavior.hpp
@@ -33,7 +33,7 @@ namespace stdexec {
   namespace __completion_behavior {
     enum class completion_behavior : int {
       unknown, ///< The completion behavior is unknown.
-      asynchronous, ///< The operation's completion will not happen on the calling thread before `start()`
+      asynchronous, ///< The operation's completion will not always happen on the calling thread before `start()`
                     ///< returns.
       asynchronous_affine, ///< Like asynchronous, but completes where it starts.
       inline_completion ///< The operation completes synchronously within `start()` on the same thread that called


### PR DESCRIPTION
fixes #1634