### PR TITLE
let_value, _error, & _stopped: Use After Move On Exception From Connect

### DIFF
--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -111,7 +111,7 @@ namespace stdexec {
           return __env::__join(__env_, stdexec::get_env(__rcvr_));
         }
 
-        _Receiver __rcvr_;
+        _Receiver& __rcvr_;
         const _Env2& __env_;
       };
     };
@@ -291,7 +291,7 @@ namespace stdexec {
 
       template <class _ResultSender, class _OpState>
       auto __get_result_receiver(const _ResultSender&, _OpState& __op_state) -> decltype(auto) {
-        return __rcvr_t{static_cast<_Receiver&&>(__op_state.__rcvr_), __env2_};
+        return __rcvr_t{__op_state.__rcvr_, __env2_};
       }
 
       STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS


### PR DESCRIPTION
When a completion signal is sent on the appropriate completion channel (i.e. set_value, set_error, or set_stopped) let_value, let_error, and let_stopped (respectively):

1. Store the values associated with the signal, if any,
2. Invoke their associated invocable with those stored values, and then
3. Connect the sender returned by that invocation

Prior to this commit the implementation of the operations enumerated above moved the final receiver into the connect operation in step 3 (more precisely those implementations moved the final receiver into a wrapper receiver which was in turn moved into that connect operation). This meant that if the connect operation:

1. Decay-copied the receiver (thereby moving from it), and then
2. Threw an exception

The resulting error completion signal would be sent to a receiver which had been moved from.

Reproduced in a unit test and fixed.