### PR TITLE
let_value, _error, & _stopped: Check Invocation Noexceptness With Cor…

### DIFF
--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -551,7 +551,7 @@ namespace stdexec {
         _Receiver& __rcvr = __op_state.__rcvr_;
 
         if constexpr (
-          (__nothrow_decay_copyable<_As> && ...) && __nothrow_callable<_Fun, _As...>
+          (__nothrow_decay_copyable<_As> && ...) && __nothrow_callable<_Fun, __decay_t<_As>&...>
           && __nothrow_connectable<_ResultSender, __result_receiver_t<_Receiver, _Env2>>) {
           __bind_(__state, __op_state, static_cast<_As&&>(__as)...);
         } else {


### PR DESCRIPTION
…rect Value Category

After the delivery of a completion signal which ought to be intercepted let_value, let_error, and let_stopped perform a "bind" operation. The intercepted values (if any) are stored within the operation state and then the invocable used to parameterize the operation is invoked to obtain a new sender which is then connected and started. If it's the case that:

- Decay-copying the intercepted values does not throw,
- Invoking the invocable does not throw, and
- Connecting the obtained sender does not throw

Then the bind operation doesn't throw. In this case there's no need to wrap that operation in a try/catch and emit the emission of an error completion signal from the catch block.

Prior to this commit when checking the second bullet above the implementations of let_value, let_error, and let_stopped checked for invocability with the value category by which the values were provided by the predecessor operation. The invocation actually takes place with the stored, decay-copied versions of these values. This meant that if the provided invocable had multiple overloads of its function call operator with different noexcept specifications the implementation could proceed as if no exception could be thrown when this was not the case leading to an exception propagating into noexcept and std::terminate being called.

Reproduced in a unit test and fixed.