### PR TITLE
Fix: stack-use-after-free after recent run_loop changes

### DIFF
--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -100,10 +100,7 @@ namespace stdexec {
       }
 
       void wait() noexcept {
-        // Account for spurios wakeups
-        while (!__done_.load(stdexec::__std::memory_order_acquire)) {
-          __done_.wait(false, stdexec::__std::memory_order_acquire);
-        }
+        __done_.wait(false, stdexec::__std::memory_order_acquire);
       }
     };
 


### PR DESCRIPTION
The changes introduced to #1683 (changing run_loop from a condition variable to atomics) introduced a stack-use-after-free when the task completion is happening on a different thread: `run_loop::finish` might cause
 `sync_wait_t::apply_sender` to return before scheduling the noop task, ending
the lifetime of the queue before the noop task push could be finalized:
 - Thread 1 sets __finishing_ to true
 - Thread 2 observed __finishing is true, __noop_task hasn't been pushed yet and finishes successfully returns.
 - Thread 1 tries to push __noop_task to the queue, which now is out of scope.

To avoid this situation, the sync_wait state is additionally synchronized on the `finish` being returning successfully (avoiding the aforementioned race condition).