### PR TITLE
stdexec::when_all: Nothrow Connect

### DIFF
--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -310,7 +310,7 @@ namespace stdexec {
     template <class _Receiver>
     static auto __mk_state_fn(const _Receiver&) noexcept {
       using __env_of_t = env_of_t<_Receiver>;
-      return []<__max1_sender<__env_t<__env_of_t>>... _Child>(__ignore, __ignore, _Child&&...) {
+      return []<__max1_sender<__env_t<__env_of_t>>... _Child>(__ignore, __ignore, _Child&&...) noexcept {
         using _Traits = __traits<__env_of_t, _Child...>;
         using _ErrorsVariant = _Traits::__errors_variant;
         using _ValuesTuple = _Traits::__values_tuple;
@@ -368,7 +368,7 @@ namespace stdexec {
       };
 
       static constexpr auto get_state =
-        []<class _Self, class _Receiver>(_Self&& __self, _Receiver& __rcvr)
+        []<class _Self, class _Receiver>(_Self&& __self, _Receiver& __rcvr) noexcept
         -> __sexpr_apply_result_t<_Self, __mk_state_fn_t<_Receiver>> {
         return __sexpr_apply(static_cast<_Self&&>(__self), __when_all::__mk_state_fn(__rcvr));
       };

--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -33,6 +33,7 @@ namespace {
   TEST_CASE("when_all returns a sender", "[adaptors][when_all]") {
     auto snd = ex::when_all(ex::just(3), ex::just(0.1415));
     static_assert(ex::sender<decltype(snd)>);
+    static_assert(noexcept(ex::connect(snd, expect_error_receiver{})));
     (void) snd;
   }
 


### PR DESCRIPTION
get_state was missing noexcept and therefore stdexec::when_all senders were never nothrow connectable.

This defect is present in std::execution and addressing it is LWG4502.