### PR TITLE
remove the use of the `__v` variable template

### DIFF
--- a/examples/benchmark/static_thread_pool_old.hpp
+++ b/examples/benchmark/static_thread_pool_old.hpp
@@ -16,10 +16,10 @@
  */
 #pragma once
 
-#include "stdexec/execution.hpp"
 #include "stdexec/__detail/__config.hpp"
 #include "stdexec/__detail/__intrusive_queue.hpp"
 #include "stdexec/__detail/__meta.hpp"
+#include "stdexec/execution.hpp"
 
 #include <atomic>
 #include <condition_variable>
@@ -80,7 +80,7 @@ namespace exec_old {
     template <class... Args>
     struct __bulk_non_throwing {
       using __t = stdexec::__decayed_tuple<Args...>;
-      static constexpr bool __v = noexcept(__t(std::declval<Args>()...));
+      static constexpr bool value = noexcept(__t(std::declval<Args>()...));
     };
 #endif
 
@@ -91,7 +91,7 @@ namespace exec_old {
       stdexec::__nothrow_callable<Fun, Shape, Args&...> &&
     // and emplacing a tuple doesn't throw
 #if STDEXEC_MSVC()
-      __bulk_non_throwing<Args...>::__v
+      __bulk_non_throwing<Args...>::value
 #else
       noexcept(stdexec::__decayed_tuple<Args...>(std::declval<Args>()...))
 #endif
@@ -444,12 +444,12 @@ namespace exec_old {
 
     template <class Sender, class Env>
     using with_error_invoke_t = stdexec::__if_c<
-      stdexec::__v<stdexec::__value_types_of_t<
+      stdexec::__value_types_of_t<
         Sender,
         Env,
         stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
         stdexec::__q<stdexec::__mand>
-      >>,
+      >::value,
       stdexec::completion_signatures<>,
       stdexec::__eptr_completion
     >;
@@ -665,12 +665,12 @@ namespace exec_old {
     using CvrefSender = stdexec::__cvref_t<CvrefSenderId>;
     using Receiver = stdexec::__t<ReceiverId>;
 
-    static constexpr bool may_throw = !stdexec::__v<stdexec::__value_types_of_t<
+    static constexpr bool may_throw = !stdexec::__value_types_of_t<
       CvrefSender,
       stdexec::env_of_t<Receiver>,
       stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
       stdexec::__q<stdexec::__mand>
-    >>;
+    >::value;
 
     using bulk_rcvr = bulk_receiver<CvrefSenderId, ReceiverId, Shape, Fun, may_throw>;
     using shared_state = bulk_shared_state<CvrefSenderId, ReceiverId, Shape, Fun, may_throw>;

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -988,7 +988,7 @@ namespace exec {
     struct __sender {
       using __receiver_ref_t = __receiver_ref<_Sigs, _ReceiverQueries>;
       static constexpr bool __with_inplace_stop_token =
-        __v<__mapply<__mall_of<__q<__is_not_stop_token_query_t>>, _ReceiverQueries>>;
+        __mapply<__mall_of<__q<__is_not_stop_token_query_t>>, _ReceiverQueries>::value;
 
       class __vtable : public __query_vtable<_SenderQueries> {
        public:

--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -256,11 +256,11 @@ namespace exec {
 
     template <class Sender, class... Env>
     using with_error_invoke_t = stdexec::__if_c<
-      stdexec::__v<stdexec::__value_types_t<
+      stdexec::__value_types_t<
         stdexec::__completion_signatures_of_t<Sender, Env...>,
         stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
         stdexec::__q<stdexec::__mand>
-      >>,
+      >::value,
       stdexec::completion_signatures<>,
       stdexec::__eptr_completion
     >;
@@ -470,12 +470,12 @@ namespace exec {
   struct __libdispatch_bulk::bulk_op_state<CvrefSenderId, ReceiverId, Shape, Fun>::__t {
     using __id = bulk_op_state;
 
-    static constexpr bool may_throw = !stdexec::__v<stdexec::__value_types_of_t<
+    static constexpr bool may_throw = !stdexec::__value_types_of_t<
       CvrefSender,
       stdexec::env_of_t<Receiver>,
       stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
       stdexec::__q<stdexec::__mand>
-    >>;
+    >::value;
 
     using bulk_rcvr = bulk_receiver_t<CvrefSender, Receiver, Shape, Fun, may_throw>;
     using shared_state = bulk_shared_state<CvrefSender, Receiver, Shape, Fun, may_throw>;

--- a/include/exec/sequence.hpp
+++ b/include/exec/sequence.hpp
@@ -90,7 +90,7 @@ namespace exec {
       using _rcvr_t = _seq::_rcvr<Rcvr, stdexec::__id<_opstate>, stdexec::__msize_t<Idx>>;
 
       template <class Sender, class Idx>
-      using _child_opstate_t = stdexec::connect_result_t<Sender, _rcvr_t<stdexec::__v<Idx>>>;
+      using _child_opstate_t = stdexec::connect_result_t<Sender, _rcvr_t<Idx::value>>;
 
       using _mk_child_ops_variant_fn = stdexec::__mzip_with2<
         stdexec::__q2<_child_opstate_t>,
@@ -122,7 +122,7 @@ namespace exec {
       STDEXEC_ATTRIBUTE(host, device)
       void _set_value(Index, [[maybe_unused]] Args&&... args) noexcept {
         STDEXEC_TRY {
-          constexpr size_t Idx = stdexec::__v<Index> + 1;
+          constexpr size_t Idx = Index::value + 1;
           if constexpr (Idx == sizeof...(Senders) + 1) {
             stdexec::set_value(static_cast<Rcvr&&>(_rcvr), static_cast<Args&&>(args)...);
           } else {

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -144,14 +144,14 @@ namespace exec {
           }
 
           template <class Error>
-            requires __v<__mapply<__mcontains<set_error_t(Error)>, __sigs>>
+            requires __mapply<__mcontains<set_error_t(Error)>, __sigs>::value
           void set_error(Error&& __error) noexcept {
             const __vfun<set_error_t(Error)>& __vfun = *__env_.__vtable_;
             __vfun(__env_.__rcvr_, set_error_t(), static_cast<Error&&>(__error));
           }
 
           void set_stopped() noexcept
-            requires __v<__mapply<__mcontains<set_stopped_t()>, __sigs>>
+            requires __mapply<__mcontains<set_stopped_t()>, __sigs>::value
           {
             const __vfun<set_stopped_t()>& __vfun = *__env_.__vtable_;
             __vfun(__env_.__rcvr_, set_stopped_t());

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -24,13 +24,13 @@
 
 namespace exec {
   template <class _Variant, class _Type, class... _Args>
-  concept __variant_emplaceable = requires(_Variant& __v, _Args&&... __args) {
-    __v.template emplace<_Type>(static_cast<_Args&&>(__args)...);
+  concept __variant_emplaceable = requires(_Variant& __var, _Args&&... __args) {
+    __var.template emplace<_Type>(static_cast<_Args&&>(__args)...);
   };
 
   template <class _Variant, class _Type, class... _Args>
-  concept __nothrow_variant_emplaceable = requires(_Variant& __v, _Args&&... __args) {
-    { __v.template emplace<_Type>(static_cast<_Args&&>(__args)...) } noexcept;
+  concept __nothrow_variant_emplaceable = requires(_Variant& __var, _Args&&... __args) {
+    { __var.template emplace<_Type>(static_cast<_Args&&>(__args)...) } noexcept;
   };
 
   namespace __ignore_all_values {

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -100,7 +100,7 @@ namespace exec {
     using __mall_contained_in_t = __mapply<__mall_contained_in_impl<_Haystack>, _Needles>;
 
     template <class _Needles, class _Haystack>
-    concept __all_contained_in = __v<__mall_contained_in_t<_Needles, _Haystack>>;
+    concept __all_contained_in = __mall_contained_in_t<_Needles, _Haystack>::value;
   } // namespace __sequence_sndr
 
   // This concept checks if a given sender satisfies the requirements to be returned from `set_next`.

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1152,11 +1152,11 @@ namespace exec {
 
       template <class Sender, class... Env>
       using _with_error_invoke_t = __if_c<
-        __v<__value_types_t<
+        __value_types_t<
           __completion_signatures_of_t<Sender, Env...>,
           _is_nothrow_bulk_fn<Shape, Fun>,
           __q<__mand>
-        >>,
+        >::value,
         completion_signatures<>,
         __eptr_completion
       >;
@@ -1412,12 +1412,12 @@ namespace exec {
     >::__t {
       using __id = _bulk_opstate;
 
-      static constexpr bool may_throw = !__v<__value_types_of_t<
+      static constexpr bool may_throw = !__value_types_of_t<
         CvrefSender,
         env_of_t<Receiver>,
         _is_nothrow_bulk_fn<Shape, Fun>,
         __q<__mand>
-      >>;
+      >::value;
 
       using receiver_t =
         _bulk_receiver_t<Parallelize, Shape, Fun, may_throw, CvrefSender, Receiver>;

--- a/include/execpools/thread_pool_base.hpp
+++ b/include/execpools/thread_pool_base.hpp
@@ -297,12 +297,12 @@ namespace execpools {
 
         struct __t {
           using __id = bulk_op_state;
-          static constexpr bool may_throw = !stdexec::__v<stdexec::__value_types_of_t<
+          static constexpr bool may_throw = !stdexec::__value_types_of_t<
             CvrefSender,
             stdexec::env_of_t<Receiver>,
             stdexec::__mbind_front_q<bulk_non_throwing, Fun, Shape>,
             stdexec::__q<stdexec::__mand>
-          >>;
+          >::value;
 
           using bulk_rcvr =
             stdexec::__t<bulk_receiver<CvrefSenderId, ReceiverId, Shape, Fun, may_throw>>;

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -150,7 +150,7 @@ namespace nvexec {
     STDEXEC_ATTRIBUTE(host, device)
     void construct(As&&... as) {
       ::new (storage_.data_) T(static_cast<As&&>(as)...);
-      index_ = stdexec::__v<stdexec::__mcall<stdexec::__mfind_i<T>, Ts...>>;
+      index_ = stdexec::__mcall<stdexec::__mfind_i<T>, Ts...>::value;
     }
 
     STDEXEC_ATTRIBUTE(host, device)
@@ -161,7 +161,8 @@ namespace nvexec {
             using val_t = stdexec::__decay_t<decltype(val)>;
             if constexpr (std::is_same_v<
                             val_t,
-                            ::cuda::std::tuple<stdexec::set_error_t, std::exception_ptr>>) {
+                            ::cuda::std::tuple<stdexec::set_error_t, std::exception_ptr>
+                          >) {
               // TODO Not quite possible at the moment
             } else {
               val.~val_t();

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include "../../stdexec/execution.hpp"
 #include "../../stdexec/__detail/__ranges.hpp"
+#include "../../stdexec/execution.hpp"
 #include <algorithm>
 #include <cstddef>
 
@@ -48,20 +48,20 @@ namespace nvexec::_strm::__algo_range_init_fun {
 
       template <class... Sizes>
       struct max_in_pack {
-        static constexpr ::std::size_t value = ::std::max({::std::size_t{}, __v<Sizes>...});
+        static constexpr ::std::size_t value = ::std::max({::std::size_t{}, Sizes::value...});
       };
 
       struct max_result_size {
         template <class... _As>
         using result_size_for_t = stdexec::__t<result_size_for<_As...>>;
 
-        static constexpr ::std::size_t value = __v<__gather_completions_of_t<
+        static constexpr ::std::size_t value = __gather_completions_of_t<
           set_value_t,
           Sender,
           env_of_t<Receiver>,
           __q<result_size_for_t>,
           __q<max_in_pack>
-        >>;
+        >::value;
       };
 
       operation_state_base_t<ReceiverId>& op_state_;
@@ -138,10 +138,11 @@ namespace nvexec::_strm::__algo_range_init_fun {
       STDEXEC_EXPLICIT_THIS_END(connect)
 
       template <__decays_to<__t> Self, class... Env>
-      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this Self&&, Env&&...) -> completion_signatures<Self, Env...> {
+      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this Self&&, Env&&...)
+        -> completion_signatures<Self, Env...> {
         return {};
       }
-        STDEXEC_EXPLICIT_THIS_END(get_completion_signatures)
+      STDEXEC_EXPLICIT_THIS_END(get_completion_signatures)
 
       auto get_env() const noexcept -> env_of_t<const Sender&> {
         return stdexec::get_env(sndr_);

--- a/include/nvexec/stream/continues_on.cuh
+++ b/include/nvexec/stream/continues_on.cuh
@@ -20,8 +20,8 @@
 
 #include "../../stdexec/execution.hpp"
 
-#include "common.cuh"
 #include "../detail/variant.cuh"
+#include "common.cuh"
 
 #include <cuda/std/tuple>
 
@@ -117,7 +117,7 @@ namespace nvexec::_strm {
 
             operation_state_.defer_temp_storage_destruction(storage);
 
-            unsigned int index = __v<__mapply<__mfind_i<tuple_t>, storage_t>>;
+            unsigned int index = __mapply<__mfind_i<tuple_t>, storage_t>::value;
 
             nvexec::visit(
               [&](auto& tpl) noexcept {
@@ -232,12 +232,13 @@ namespace nvexec::_strm {
       STDEXEC_EXPLICIT_THIS_END(connect)
 
       template <__decays_to<__t> _Self, class... _Env>
-      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this _Self&&, _Env&&...) -> transform_completion_signatures<
-        __completion_signatures_of_t<__copy_cvref_t<_Self, Sender>, _Env...>,
-        completion_signatures<set_error_t(cudaError_t)>,
-        _trnsfr::value_completions_t,
-        _trnsfr::error_completions_t
-      > {
+      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this _Self&&, _Env&&...)
+        -> transform_completion_signatures<
+          __completion_signatures_of_t<__copy_cvref_t<_Self, Sender>, _Env...>,
+          completion_signatures<set_error_t(cudaError_t)>,
+          _trnsfr::value_completions_t,
+          _trnsfr::error_completions_t
+        > {
         return {};
       }
       STDEXEC_EXPLICIT_THIS_END(get_completion_signatures)

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -75,13 +75,13 @@ namespace nvexec::_strm {
 
           if constexpr (stream_sender<Sender, env_t>) {
             cudaStream_t stream = shared_state_->stream_provider_.own_stream_.value();
-            shared_state_->index_ = __v<__mapply<__mfind_i<tuple_t>, variant_t>>;
+            shared_state_->index_ = __mapply<__mfind_i<tuple_t>, variant_t>::value;
             copy_kernel<Tag, As&&...>
               <<<1, 1, 0, stream>>>(shared_state_->data_, static_cast<As&&>(as)...);
             shared_state_->stream_provider_
               .status_ = STDEXEC_LOG_CUDA_API(cudaEventRecord(shared_state_->event_, stream));
           } else {
-            shared_state_->index_ = __v<__mapply<__mfind_i<tuple_t>, variant_t>>;
+            shared_state_->index_ = __mapply<__mfind_i<tuple_t>, variant_t>::value;
           }
         }
 

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -48,7 +48,7 @@ namespace nvexec::_strm {
 
     template <class... Sizes>
     struct max_in_pack {
-      static constexpr std::size_t value = std::max({std::size_t{}, __v<Sizes>...});
+      static constexpr std::size_t value = std::max({std::size_t{}, Sizes::value...});
     };
 
     template <class Sender, class PropagateReceiver, class Fun, class SetTag>
@@ -61,13 +61,13 @@ namespace nvexec::_strm {
       template <class... As>
       using __sender_size_for_t = stdexec::__t<__sender_size_for_<As...>>;
 
-      static constexpr std::size_t value = __v<__gather_completions_of_t<
+      static constexpr std::size_t value = __gather_completions_of_t<
         SetTag,
         Sender,
         env_of_t<PropagateReceiver>,
         __q<__sender_size_for_t>,
         __q<max_in_pack>
-      >>;
+      >::value;
     };
 
     template <class Receiver, class Fun>
@@ -108,7 +108,7 @@ namespace nvexec::_strm {
         using __id = _receiver_;
 
         static constexpr std::size_t memory_allocation_size =
-          __v<__max_sender_size<Sender, PropagateReceiver, Fun, Let>>;
+          __max_sender_size<Sender, PropagateReceiver, Fun, Let>::value;
 
         template <__one_of<Let> Tag, class... As>
           requires __minvocable<__result_sender_fn<Fun>, As...>

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -27,9 +27,9 @@
 
 #include <cuda/std/tuple>
 
-#include "common.cuh"
 #include "../detail/cuda_atomic.cuh" // IWYU pragma: keep
 #include "../detail/throw_on_cuda_error.cuh"
+#include "common.cuh"
 
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
@@ -72,13 +72,13 @@ namespace nvexec::_strm {
 
           if constexpr (stream_sender<Sender, env_t>) {
             cudaStream_t stream = sh_state_.op_state2_.get_stream();
-            sh_state_.index_ = __v<__mapply<__mfind_i<tuple_t>, variant_t>>;
+            sh_state_.index_ = __mapply<__mfind_i<tuple_t>, variant_t>::value;
             copy_kernel<Tag, As&&...>
               <<<1, 1, 0, stream>>>(sh_state_.data_, static_cast<As&&>(as)...);
             sh_state_.stream_provider_
               .status_ = STDEXEC_LOG_CUDA_API(cudaEventRecord(sh_state_.event_, stream));
           } else {
-            sh_state_.index_ = __v<__mapply<__mfind_i<tuple_t>, variant_t>>;
+            sh_state_.index_ = __mapply<__mfind_i<tuple_t>, variant_t>::value;
           }
         }
 

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -143,7 +143,7 @@ namespace nvexec::_strm {
 
       template <class... Sizes>
       struct max_in_pack {
-        static constexpr std::size_t value = std::max({std::size_t{}, __v<Sizes>...});
+        static constexpr std::size_t value = std::max({std::size_t{}, Sizes::value...});
       };
 
       template <class Receiver>
@@ -152,13 +152,13 @@ namespace nvexec::_strm {
         template <class... _As>
         using result_size_for_t = stdexec::__t<result_size_for<_As...>>;
 
-        static constexpr std::size_t value = __v<__gather_completions_of_t<
+        static constexpr std::size_t value = __gather_completions_of_t<
           set_value_t,
           Sender,
           env_of_t<Receiver>,
           __q<result_size_for_t>,
           __q<max_in_pack>
-        >>;
+        >::value;
       };
 
       template <class Receiver>
@@ -206,7 +206,8 @@ namespace nvexec::_strm {
       STDEXEC_EXPLICIT_THIS_END(connect)
 
       template <__decays_to<__t> Self, class... Env>
-      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this Self&&, Env&&...) -> _completion_signatures_t<Self, Env...> {
+      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this Self&&, Env&&...)
+        -> _completion_signatures_t<Self, Env...> {
         return {};
       }
       STDEXEC_EXPLICIT_THIS_END(get_completion_signatures)

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -141,7 +141,7 @@ namespace nvexec::_strm {
 
       template <class... Sizes>
       struct max_in_pack {
-        static constexpr std::size_t value = std::max({std::size_t{}, __v<Sizes>...});
+        static constexpr std::size_t value = std::max({std::size_t{}, Sizes::value...});
       };
 
       template <class Receiver>
@@ -150,13 +150,13 @@ namespace nvexec::_strm {
         template <class... _As>
         using result_size_for_t = stdexec::__t<result_size_for<_As...>>;
 
-        static constexpr std::size_t value = __v<__gather_completions_of_t<
+        static constexpr std::size_t value = __gather_completions_of_t<
           set_error_t,
           Sender,
           env_of_t<Receiver>,
           __q<result_size_for_t>,
           __q<max_in_pack>
-        >>;
+        >::value;
       };
 
       template <class Receiver>
@@ -188,7 +188,8 @@ namespace nvexec::_strm {
       STDEXEC_EXPLICIT_THIS_END(connect)
 
       template <__decays_to<__t> Self, class... Env>
-      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this Self&&, Env&&...) -> completion_signatures<Self, Env...> {
+      STDEXEC_EXPLICIT_THIS_BEGIN(auto get_completion_signatures)(this Self&&, Env&&...)
+        -> completion_signatures<Self, Env...> {
         return {};
       }
       STDEXEC_EXPLICIT_THIS_END(get_completion_signatures)

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -154,7 +154,7 @@ namespace stdexec {
           _Receiver& __rcvr,
           _SetTag,
           _Args&&... __args) noexcept {
-          static_assert(__v<_Index> == 0, "I don't know how to complete this operation.");
+          static_assert(_Index::value == 0, "I don't know how to complete this operation.");
           _SetTag()(std::move(__rcvr), static_cast<_Args&&>(__args)...);
         };
 
@@ -496,8 +496,6 @@ namespace stdexec {
       using __tag_t = __desc_t::__tag;
       using __captures_t = __minvoke<__desc_t, __q<__detail::__captures_t>>;
 
-      mutable __captures_t __impl_;
-
       template <class _Tag, class _Data, class... _Child>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
       explicit __sexpr(_Tag, _Data&& __data, _Child&&... __child)
@@ -573,12 +571,14 @@ namespace stdexec {
           return __self.__impl_(__copy_cvref_fn<_Self>(), __nth_pack_element<_Idx>);
         }
       }
+
+      mutable __captures_t __impl_;
     };
 
     template <class _Tag, class _Data, class... _Child>
-    STDEXEC_ATTRIBUTE(host, device)
-    __sexpr(_Tag, _Data, _Child...) -> __sexpr<STDEXEC_SEXPR_DESCRIPTOR(_Tag, _Data, _Child...)>;
-  } // namespace
+    STDEXEC_HOST_DEVICE_DEDUCTION_GUIDE
+      __sexpr(_Tag, _Data, _Child...) -> __sexpr<STDEXEC_SEXPR_DESCRIPTOR(_Tag, _Data, _Child...)>;
+  } // anonymous namespace
 
   template <class _Tag, class _Data, class... _Child>
   using __sexpr_t = __sexpr<STDEXEC_SEXPR_DESCRIPTOR(_Tag, _Data, _Child...)>;
@@ -631,7 +631,7 @@ namespace stdexec {
     extern __basic_sender_name __demangle_v<__sexpr<_Descriptor>>;
 
     template <__has_id _Sender>
-      requires(!same_as<__id<_Sender>, _Sender>)
+      requires __not_same_as<__id<_Sender>, _Sender>
     extern __id_name __demangle_v<_Sender>;
   } // namespace __detail
 } // namespace stdexec
@@ -641,7 +641,7 @@ namespace std {
   struct tuple_size<stdexec::__sexpr<_Descriptor>>
     : integral_constant<
         size_t,
-        stdexec::__v<stdexec::__minvoke<stdexec::__result_of<_Descriptor>, stdexec::__msize>>
+        stdexec::__minvoke<stdexec::__result_of<_Descriptor>, stdexec::__msize>::value
       > { };
 
   template <size_t _Idx, auto _Descriptor>

--- a/include/stdexec/__detail/__completion_signatures.hpp
+++ b/include/stdexec/__detail/__completion_signatures.hpp
@@ -180,7 +180,7 @@ namespace stdexec {
 
   template <__valid_completion_signatures _Sigs>
   inline constexpr bool __sends_stopped =
-    __v<typename __cmplsigs::__partitions_of_t<_Sigs>::__count_stopped> != 0;
+    __cmplsigs::__partitions_of_t<_Sigs>::__count_stopped::value != 0;
 
   template <class... _Sigs>
   using __concat_completion_signatures =
@@ -243,11 +243,11 @@ namespace stdexec {
     [[nodiscard]]
     static consteval auto __count(_Tag) noexcept -> std::size_t {
       if constexpr (_Tag{} == set_value) {
-        return __v<typename __partitioned::__t::__count_values>;
+        return __partitioned::__t::__count_values::value;
       } else if constexpr (_Tag{} == set_error) {
-        return __v<typename __partitioned::__t::__count_errors>;
+        return __partitioned::__t::__count_errors::value;
       } else {
-        return __v<typename __partitioned::__t::__count_stopped>;
+        return __partitioned::__t::__count_stopped::value;
       }
     }
 
@@ -364,15 +364,14 @@ namespace stdexec {
 
     template <class _Sigs>
     inline constexpr std::size_t __count_of<set_value_t, _Sigs> =
-      __v<typename __cmplsigs::__partitions_of_t<_Sigs>::__count_values>;
+      __cmplsigs::__partitions_of_t<_Sigs>::__count_values::value;
 
     template <class _Sigs>
     inline constexpr std::size_t __count_of<set_error_t, _Sigs> =
-      __v<typename __cmplsigs::__partitions_of_t<_Sigs>::__count_errors>;
-
+      __cmplsigs::__partitions_of_t<_Sigs>::__count_errors::value;
     template <class _Sigs>
     inline constexpr std::size_t __count_of<set_stopped_t, _Sigs> =
-      __v<typename __cmplsigs::__partitions_of_t<_Sigs>::__count_stopped>;
+      __cmplsigs::__partitions_of_t<_Sigs>::__count_stopped::value;
   } // namespace __detail
 
   // Below is the definition of the STDEXEC_COMPLSIGS_LET portability macro. It

--- a/include/stdexec/__detail/__get_completion_signatures.hpp
+++ b/include/stdexec/__detail/__get_completion_signatures.hpp
@@ -305,7 +305,7 @@ namespace stdexec {
   }
 
   template <class _Sender>
-  concept __is_dependent_sender = __v<__mbool<__is_dependent_sender_helper<_Sender>()>>;
+  concept __is_dependent_sender = __mbool<__is_dependent_sender_helper<_Sender>()>::value;
 #endif // ^^^ constexpr exceptions ^^^
 
   template <class _WantedTag, class _Sender, class _Env, class _Tuple, class _Variant>

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -63,7 +63,7 @@ namespace stdexec {
   struct __mconstant {
     using type = __mconstant;
     using value_type = __mtypeof<_Np>;
-    static constexpr auto value = _Np;
+    static constexpr value_type value = _Np;
 
     constexpr operator value_type() const noexcept {
       return value;
@@ -72,11 +72,6 @@ namespace stdexec {
     constexpr auto operator()() const noexcept -> value_type {
       return value;
     }
-  };
-
-  // nvbugs#4679848 and nvbugs#4668709 also preclude __mconstant from representing a compile-time
-  // size_t.
-  enum class __u8 : unsigned char {
   };
 
   template <std::size_t _Np>
@@ -92,24 +87,6 @@ namespace stdexec {
 
   template <class...>
   struct __undefined;
-
-  template <class _Tp>
-  inline constexpr auto __v = _Tp::value;
-
-  // These specializations exist because instantiating a variable template is cheaper than
-  // instantiating a class template.
-  template <class _Tp, class _Up>
-  inline constexpr bool __v<std::is_same<_Tp, _Up>> = false;
-
-  template <class _Tp>
-  inline constexpr bool __v<std::is_same<_Tp, _Tp>> = true;
-
-  template <class _Tp, _Tp _Ip>
-  inline constexpr _Tp __v<std::integral_constant<_Tp, _Ip>> = _Ip;
-
-  // `__mtypeof<_Np>` instead of `auto` to work around NVHPC/EDG bug.
-  template <auto _Np>
-  inline constexpr __mtypeof<_Np> __v<__mconstant<_Np>> = _Np;
 
   template <std::size_t... _Is>
   struct __iota;
@@ -715,7 +692,7 @@ namespace stdexec {
   template <class _Fn>
   struct __mcount_if {
     template <class... _Ts>
-    using __f = __msize_t<(bool(__v<__minvoke<_Fn, _Ts>>) + ... + 0)>;
+    using __f = __msize_t<(bool(__minvoke<_Fn, _Ts>::value) + ... + 0)>;
   };
 
   template <class _Tp>
@@ -1007,7 +984,8 @@ namespace stdexec {
   template <class _Needle>
   struct __mfind_i {
     template <class... _Args>
-    using __f = __msize_t<(sizeof...(_Args) - __v<__minvoke<__mfind<_Needle, __msize>, _Args...>>)>;
+    using __f =
+      __msize_t<(sizeof...(_Args) - __minvoke<__mfind<_Needle, __msize>, _Args...>::value)>;
   };
 
   template <bool>
@@ -1015,7 +993,7 @@ namespace stdexec {
     template <class _Fn, class _Continuation, class _Head, class... _Tail>
     using __f = __minvoke<
       __if_c<
-        __v<__minvoke<_Fn, _Head>>,
+        __minvoke<_Fn, _Head>::value,
         __mbind_front<_Continuation, _Head>,
         __mbind_front<__mfind_if_<(sizeof...(_Tail) != 0)>, _Fn, _Continuation>
       >,
@@ -1038,39 +1016,32 @@ namespace stdexec {
   template <class _Fn>
   struct __mfind_if_i {
     template <class... _Args>
-    using __f = __msize_t<(sizeof...(_Args) - __v<__minvoke<__mfind_if<_Fn, __msize>, _Args...>>)>;
+    using __f =
+      __msize_t<(sizeof...(_Args) - __minvoke<__mfind_if<_Fn, __msize>, _Args...>::value)>;
   };
 
-#if STDEXEC_MSVC()
-#  define __mvalue_of(...) __VA_ARGS__::value
-#else
-#  define __mvalue_of(...) __v<__VA_ARGS__>
-#endif
-
   template <class... _Booleans>
-  using __mand_t = __mbool<(__mvalue_of(_Booleans) && ...)>;
+  using __mand_t = __mbool<(_Booleans::value && ...)>;
   template <class... _Booleans>
   using __mand = __meval<__mand_t, _Booleans...>;
 
   template <class... _Booleans>
-  using __mor_t = __mbool<(__mvalue_of(_Booleans) || ...)>;
+  using __mor_t = __mbool<(_Booleans::value || ...)>;
   template <class... _Booleans>
   using __mor = __meval<__mor_t, _Booleans...>;
 
   template <class _Boolean>
-  using __mnot_t = __mbool<!__mvalue_of(_Boolean)>;
+  using __mnot_t = __mbool<!_Boolean::value>;
   template <class _Boolean>
   using __mnot = __meval<__mnot_t, _Boolean>;
 
 #if STDEXEC_EDG()
   template <class... _Ints>
-  struct __mplus_t : __mconstant<(__v<_Ints> + ...)> { };
+  struct __mplus_t : __mconstant<(_Ints::value + ...)> { };
 #else
   template <class... _Ints>
-  using __mplus_t = __mconstant<(__mvalue_of(_Ints) + ...)>;
+  using __mplus_t = __mconstant<(_Ints::value + ...)>;
 #endif
-
-#undef __mvalue_of
 
   template <class _Fn>
   struct __mall_of {
@@ -1097,11 +1068,11 @@ namespace stdexec {
   template <bool>
   struct __m_at_ {
     template <class _Np, class... _Ts>
-    using __f = _Ts...[__v<_Np>];
+    using __f = _Ts...[_Np::value];
   };
 
   template <class _Np, class... _Ts>
-  using __m_at = __minvoke<__m_at_<__v<_Np> == ~0ul>, _Np, _Ts...>;
+  using __m_at = __minvoke<__m_at_<_Np::value == ~0ul>, _Np, _Ts...>;
 
   template <std::size_t _Np, class... _Ts>
   using __m_at_c = __minvoke<__m_at_<_Np == ~0ul>, __msize_t<_Np>, _Ts...>;
@@ -1111,11 +1082,11 @@ namespace stdexec {
   template <bool>
   struct __m_at_ {
     template <class _Np, class... _Ts>
-    using __f = __type_pack_element<__v<_Np>, _Ts...>;
+    using __f = __type_pack_element<_Np::value, _Ts...>;
   };
 
   template <class _Np, class... _Ts>
-  using __m_at = __minvoke<__m_at_<__v<_Np> == ~0ul>, _Np, _Ts...>;
+  using __m_at = __minvoke<__m_at_<_Np::value == ~0ul>, _Np, _Ts...>;
 
   template <std::size_t _Np, class... _Ts>
   using __m_at_c = __minvoke<__m_at_<_Np == ~0ul>, __msize_t<_Np>, _Ts...>;
@@ -1141,7 +1112,7 @@ namespace stdexec {
   using __m_at_c = __minvoke<__m_at_<__make_indices<_Np>>, _Ts...>;
 
   template <class _Np, class... _Ts>
-  using __m_at = __m_at_c<__v<_Np>, _Ts...>;
+  using __m_at = __m_at_c<_Np::value, _Ts...>;
 #endif
 
   template <class... _Ts>
@@ -1274,7 +1245,7 @@ namespace stdexec {
     > &;
 
     template <class _ExpectedSet, class... _Ts>
-    concept __mset_eq = (sizeof...(_Ts) == __v<__mapply<__msize, _ExpectedSet>>)
+    concept __mset_eq = (sizeof...(_Ts) == __mapply<__msize, _ExpectedSet>::value)
                      && __mset_contains<_ExpectedSet, _Ts...>;
 
     template <class _ExpectedSet>
@@ -1294,7 +1265,7 @@ namespace stdexec {
   using __mmake_set = __mset_insert<__mset<>, _Ts...>;
 
   template <class _Set1, class _Set2>
-  concept __mset_eq = __v<__mapply<__set::__eq<_Set1>, _Set2>>;
+  concept __mset_eq = __mapply<__set::__eq<_Set1>, _Set2>::value;
 
   template <class _Continuation = __q<__types>>
   struct __munique {

--- a/include/stdexec/__detail/__on.hpp
+++ b/include/stdexec/__detail/__on.hpp
@@ -28,7 +28,6 @@
 #include "__schedulers.hpp"
 #include "__sender_adaptor_closure.hpp"
 #include "__sender_introspection.hpp"
-#include "__type_traits.hpp"
 #include "__utility.hpp"
 
 namespace stdexec {

--- a/include/stdexec/__detail/__optional.hpp
+++ b/include/stdexec/__detail/__optional.hpp
@@ -64,8 +64,8 @@ namespace stdexec {
 
       template <__not_decays_to<__optional> _Up>
         requires constructible_from<_Tp, _Up>
-      __optional(_Up&& __v) noexcept(__nothrow_constructible_from<_Tp, _Up>) {
-        emplace(static_cast<_Up&&>(__v));
+      __optional(_Up&& __val) noexcept(__nothrow_constructible_from<_Tp, _Up>) {
+        emplace(static_cast<_Up&&>(__val));
       }
 
       template <class... _Us>

--- a/include/stdexec/__detail/__ranges.hpp
+++ b/include/stdexec/__detail/__ranges.hpp
@@ -43,18 +43,18 @@ namespace stdexec::ranges {
     void end();
 
     template <class _Ty>
-    concept __has_member_begin = requires(_Ty&& __v) { static_cast<_Ty&&>(__v).begin(); };
+    concept __has_member_begin = requires(_Ty&& __val) { static_cast<_Ty&&>(__val).begin(); };
 
     template <class _Ty>
     concept __has_free_begin = __has_member_begin<_Ty>
-                            || requires(_Ty&& __v) { begin((static_cast<_Ty&&>(__v))); };
+                            || requires(_Ty&& __val) { begin((static_cast<_Ty&&>(__val))); };
 
     template <class _Ty>
-    concept __has_member_end = requires(_Ty&& __v) { static_cast<_Ty&&>(__v).end(); };
+    concept __has_member_end = requires(_Ty&& __val) { static_cast<_Ty&&>(__val).end(); };
 
     template <class _Ty>
     concept __has_free_end = __has_member_end<_Ty>
-                          || requires(_Ty&& __v) { end((static_cast<_Ty&&>(__v))); };
+                          || requires(_Ty&& __val) { end((static_cast<_Ty&&>(__val))); };
 
     struct __begin_t {
       template <class _Range>

--- a/include/stdexec/__detail/__sender_concepts.hpp
+++ b/include/stdexec/__detail/__sender_concepts.hpp
@@ -90,11 +90,11 @@ namespace stdexec {
 
   template <class _Tag, class _Sender, class... _Env>
   concept __sends = sender_in<_Sender, _Env...> //
-                 && __v<__count_of<_Tag, _Sender, _Env...>> != 0;
+                 && __count_of<_Tag, _Sender, _Env...>::value != 0;
 
   template <class _Tag, class _Sender, class... _Env>
   concept __never_sends = sender_in<_Sender, _Env...> //
-                       && __v<__count_of<_Tag, _Sender, _Env...>> == 0;
+                       && __count_of<_Tag, _Sender, _Env...>::value == 0;
 
   template <class _Sender, class... _Env>
   concept __single_value_sender = sender_in<_Sender, _Env...> //

--- a/include/stdexec/__detail/__sender_introspection.hpp
+++ b/include/stdexec/__detail/__sender_introspection.hpp
@@ -104,7 +104,7 @@ namespace stdexec {
   using __child_of = __children_of<_Sender, __q<__mfront>>;
 
   template <class _Sender>
-  inline constexpr std::size_t __nbr_children_of = __v<__children_of<_Sender, __msize>>;
+  inline constexpr std::size_t __nbr_children_of = __children_of<_Sender, __msize>::value;
 
   template <class _Tp>
     requires __mvalid<tag_of_t, _Tp>

--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -198,7 +198,8 @@ namespace stdexec {
           stdexec::__diagnose_sender_concept_failure<_Sender, __env>();
         } else {
           using __domain_t = __completion_domain_of_t<set_value_t, _Sender, __env>;
-          constexpr auto __success_completion_count = __v<__count_of<set_value_t, _Sender, __env>>;
+          constexpr auto __success_completion_count =
+            __count_of<set_value_t, _Sender, __env>::value;
 
           static_assert(
             __success_completion_count != 0,

--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -310,18 +310,19 @@ namespace stdexec {
     template <class _Receiver>
     static auto __mk_state_fn(const _Receiver&) noexcept {
       using __env_of_t = env_of_t<_Receiver>;
-      return []<__max1_sender<__env_t<__env_of_t>>... _Child>(__ignore, __ignore, _Child&&...) noexcept {
-        using _Traits = __traits<__env_of_t, _Child...>;
-        using _ErrorsVariant = _Traits::__errors_variant;
-        using _ValuesTuple = _Traits::__values_tuple;
-        using _State = __when_all_state<
-          _ErrorsVariant,
-          _ValuesTuple,
-          _Receiver,
-          (sends_stopped<_Child, __env_of_t> || ...)
-        >;
-        return _State{sizeof...(_Child)};
-      };
+      return
+        []<__max1_sender<__env_t<__env_of_t>>... _Child>(__ignore, __ignore, _Child&&...) noexcept {
+          using _Traits = __traits<__env_of_t, _Child...>;
+          using _ErrorsVariant = _Traits::__errors_variant;
+          using _ValuesTuple = _Traits::__values_tuple;
+          using _State = __when_all_state<
+            _ErrorsVariant,
+            _ValuesTuple,
+            _Receiver,
+            (sends_stopped<_Child, __env_of_t> || ...)
+          >;
+          return _State{sizeof...(_Child)};
+        };
     }
 
     template <class _Receiver>
@@ -437,7 +438,7 @@ namespace stdexec {
           // We only need to bother recording the completion values
           // if we're not already in the "error" or "stopped" state.
           if (__state.__state_.load() == __started) {
-            auto& __opt_values = stdexec::__get<__v<_Index>>(__state.__values_);
+            auto& __opt_values = stdexec::__get<_Index::value>(__state.__values_);
             using _Tuple = __decayed_tuple<_Args...>;
             static_assert(
               __same_as<decltype(*__opt_values), _Tuple&>,

--- a/test/exec/sequence/test_merge_each.cpp
+++ b/test/exec/sequence/test_merge_each.cpp
@@ -15,27 +15,24 @@
  * limitations under the License.
  */
 
-#include "exec/sequence/ignore_all_values.hpp"
-#include "exec/sequence/merge_each.hpp"
-#include "exec/sequence/merge.hpp"
 #include "exec/sequence/empty_sequence.hpp"
+#include "exec/sequence/ignore_all_values.hpp"
 #include "exec/sequence/iterate.hpp"
+#include "exec/sequence/merge.hpp"
+#include "exec/sequence/merge_each.hpp"
 #include "exec/sequence_senders.hpp"
+#include "exec/static_thread_pool.hpp"     // IWYU pragma: keep
+#include "exec/timed_thread_scheduler.hpp" // IWYU pragma: keep for duration_of_t
 #include "exec/variant_sender.hpp"
-#include "exec/static_thread_pool.hpp"
-#include "exec/timed_thread_scheduler.hpp"
 #include "stdexec/__detail/__meta.hpp"
 #include "stdexec/__detail/__read_env.hpp"
 
-#include <stdexcept>
-#include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
+#include <test_common/schedulers.hpp>
 #include <test_common/senders.hpp>
 #include <test_common/type_helpers.hpp>
 
 #include <array>
-#include <chrono>
-#include <iomanip>
 
 namespace {
   using namespace std::chrono_literals;
@@ -45,8 +42,8 @@ namespace {
   template <class _A, class _B>
   concept __equivalent = __sequence_sndr::__all_contained_in<_A, _B>
                       && __sequence_sndr::__all_contained_in<_B, _A>
-                      && ex::__v<ex::__mapply<ex::__msize, _A>>
-                           == ex::__v<ex::__mapply<ex::__msize, _B>>;
+                      && ex::__mapply<ex::__msize, _A>::value
+                           == ex::__mapply<ex::__msize, _B>::value;
 
   struct null_receiver {
     using __id = null_receiver;

--- a/test/exec/sequence/test_merge_each_threaded.cpp
+++ b/test/exec/sequence/test_merge_each_threaded.cpp
@@ -15,27 +15,26 @@
  * limitations under the License.
  */
 
-#include "exec/sequence/ignore_all_values.hpp"
-#include "exec/sequence/merge_each.hpp"
-#include "exec/sequence/merge.hpp"
 #include "exec/sequence/empty_sequence.hpp"
+#include "exec/sequence/ignore_all_values.hpp"
 #include "exec/sequence/iterate.hpp"
+#include "exec/sequence/merge.hpp"
+#include "exec/sequence/merge_each.hpp"
 #include "exec/sequence_senders.hpp"
-#include "exec/variant_sender.hpp"
 #include "exec/single_thread_context.hpp"
 #include "exec/timed_thread_scheduler.hpp"
+#include "exec/variant_sender.hpp"
 #include "stdexec/__detail/__meta.hpp"
 #include "stdexec/__detail/__read_env.hpp"
 
-#include <stdexcept>
-#include <test_common/schedulers.hpp>
 #include <test_common/receivers.hpp>
+#include <test_common/schedulers.hpp>
 #include <test_common/senders.hpp>
 #include <test_common/type_helpers.hpp>
 
-#include <array>
 #include <chrono>
 #include <iomanip>
+#include <stdexcept>
 
 namespace {
   using namespace std::chrono_literals;
@@ -45,8 +44,8 @@ namespace {
   template <class _A, class _B>
   concept __equivalent = __sequence_sndr::__all_contained_in<_A, _B>
                       && __sequence_sndr::__all_contained_in<_B, _A>
-                      && ex::__v<ex::__mapply<ex::__msize, _A>>
-                           == ex::__v<ex::__mapply<ex::__msize, _B>>;
+                      && ex::__mapply<ex::__msize, _A>::value
+                           == ex::__mapply<ex::__msize, _B>::value;
 
   struct null_receiver {
     using __id = null_receiver;

--- a/test/test_common/type_helpers.hpp
+++ b/test/test_common/type_helpers.hpp
@@ -29,7 +29,7 @@ namespace {
   };
 
   template <class Needles, class Haystack>
-  concept all_contained_in = ex::__v<ex::__mapply<mall_contained_in<Haystack>, Needles>>;
+  concept all_contained_in = ex::__mapply<mall_contained_in<Haystack>, Needles>::value;
 
   template <class Needles, class Haystack>
   concept set_equivalent =


### PR DESCRIPTION
some compilers, msvc in particular, do not like `stdexec::__v`.