### PR TITLE
update the metaprogramming for sequence senders

### DIFF
--- a/include/exec/completion_signatures.hpp
+++ b/include/exec/completion_signatures.hpp
@@ -17,6 +17,7 @@
 
 #include "../stdexec/__detail/__get_completion_signatures.hpp"
 #include "../stdexec/__detail/__meta.hpp"
+#include "../stdexec/__detail/__sender_concepts.hpp"
 #include "../stdexec/__detail/__tuple.hpp" // IWYU pragma: keep for STDEXEC::__tuple
 
 namespace exec {
@@ -76,20 +77,33 @@ namespace exec {
     return {};
   }
 
+  STDEXEC_PRAGMA_PUSH()
+  STDEXEC_PRAGMA_IGNORE_EDG(expr_has_no_effect)
+  STDEXEC_PRAGMA_IGNORE_GNU("-Wunused-value")
+
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   // concat_completion_signatures
   namespace detail {
     struct concat_completion_signatures_t {
-      template <class... Sigs>
+      template <STDEXEC::__valid_completion_signatures... Sigs>
       [[nodiscard]]
-      consteval auto
-        operator()(Sigs...) const noexcept -> STDEXEC::__concat_completion_signatures<Sigs...> {
+      consteval auto operator()(Sigs...) const noexcept //
+        -> STDEXEC::__concat_completion_signatures<Sigs...> {
         return {};
+      }
+
+      template <class... Errors>
+      [[nodiscard]]
+      consteval auto operator()(Errors...) const noexcept {
+        return (Errors{}, ...); // NB: uses overloaded comma operator on _ERROR_ type to produce an
+                                // error type
       }
     };
   } // namespace detail
 
   inline constexpr detail::concat_completion_signatures_t concat_completion_signatures{};
+
+  STDEXEC_PRAGMA_POP()
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // invalid_completion_signature

--- a/include/exec/linux/io_uring_context.hpp
+++ b/include/exec/linux/io_uring_context.hpp
@@ -1115,10 +1115,10 @@ namespace exec {
           return __env_;
         }
 
+        template <class>
         [[nodiscard]]
-        auto
-          get_completion_signatures(STDEXEC::__ignore = {}) const noexcept -> __completion_sigs_t {
-          return {};
+        static consteval auto get_completion_signatures() noexcept {
+          return __completion_sigs_t{};
         }
 
         template <STDEXEC::receiver_of<__completion_sigs_t> _Receiver>
@@ -1149,10 +1149,10 @@ namespace exec {
           return __env_;
         }
 
+        template <class>
         [[nodiscard]]
-        auto
-          get_completion_signatures(STDEXEC::__ignore = {}) const noexcept -> __completion_sigs_t {
-          return {};
+        static consteval auto get_completion_signatures() noexcept -> __completion_sigs_t {
+          return __completion_sigs_t{};
         }
 
         template <STDEXEC::receiver_of<__completion_sigs_t> _Receiver>

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -152,8 +152,7 @@ namespace exec {
       using __operation_t = __t<__operation<__decay_t<_Range>, _ReceiverId>>;
 
       template <class _Range>
-      auto operator()(__ignore, _Range&& __range) noexcept(__nothrow_move_constructible<_Receiver>)
-        -> __operation_t<_Range> {
+      auto operator()(__ignore, _Range&& __range) noexcept -> __operation_t<_Range> {
         return {
           {std::ranges::begin(__range), std::ranges::end(__range)},
           static_cast<_Receiver&&>(__rcvr_)

--- a/include/exec/sequence/merge_each.hpp
+++ b/include/exec/sequence/merge_each.hpp
@@ -315,7 +315,7 @@ namespace exec {
       using __interface_t = __operation_base_interface<__error_storage_t>;
 
       using __error_sender_t = __merge_each::__error_sender_t<__error_storage_t>;
-      using __error_next_sender_t = next_sender_of_t<_Receiver&, __error_sender_t>;
+      using __error_next_sender_t = next_sender_of_t<_Receiver, __error_sender_t>;
       using __env_fn_t = __env_fn<_Receiver>;
       using __error_next_receiver_t = __error_next_receiver<_ErrorStorage, __env_fn_t>;
       using __error_op_t =
@@ -329,7 +329,7 @@ namespace exec {
       __nested_stop_t __nested_stop_{};
       STDEXEC::__optional<__error_op_t> __error_op_{};
 
-      __operation_base(_Receiver __receiver) noexcept(__nothrow_move_constructible<_Receiver>)
+      __operation_base(_Receiver __receiver) noexcept
         : __interface_t{&__error_storage_}
         , __receiver_{static_cast<_Receiver&&>(__receiver)} {
         __interface_t::__token_ = __nested_stop_.get_token();
@@ -1166,8 +1166,8 @@ namespace exec {
         using __op_t = subscribe_result_t<_Sequence, __receiver>;
         __op_t __op_;
 
-        __t(_Receiver __rcvr, _Sequence __sequence) noexcept(
-          __nothrow_subscribable<_Sequence, __receiver> && __nothrow_move_constructible<_Receiver>)
+        __t(_Receiver __rcvr, _Sequence __sequence)
+          noexcept(__nothrow_subscribable<_Sequence, __receiver>)
           : __base_t{static_cast<_Receiver&&>(__rcvr)}
           , __op_{subscribe(static_cast<_Sequence&&>(__sequence), __receiver{this})} {
         }

--- a/include/exec/start_now.hpp
+++ b/include/exec/start_now.hpp
@@ -148,9 +148,7 @@ namespace exec {
         using connect_t = STDEXEC::connect_t;
 
         template <STDEXEC::receiver_of<__completions_t> _Receiver>
-        auto
-          connect(_Receiver __rcvr) const noexcept(STDEXEC::__nothrow_move_constructible<_Receiver>)
-            -> __operation<_EnvId, _Receiver> {
+        auto connect(_Receiver __rcvr) const noexcept -> __operation<_EnvId, _Receiver> {
           return {__stg_, static_cast<_Receiver&&>(__rcvr)};
         }
 

--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -149,8 +149,7 @@ namespace exec {
           using __id = __operation;
           STDEXEC_ATTRIBUTE(no_unique_address) _Receiver __receiver_;
 
-          explicit __t(_Receiver __rcvr, std::size_t __max_size, std::size_t __max_depth)
-            noexcept(__nothrow_move_constructible<_Receiver>)
+          explicit __t(_Receiver __rcvr, std::size_t __max_size, std::size_t __max_depth) noexcept
             : __operation_base(&__t::__execute_impl, __max_size, __max_depth)
             , __receiver_(static_cast<_Receiver&&>(__rcvr)) {
           }
@@ -187,8 +186,7 @@ namespace exec {
         }
 
         template <receiver_of<completion_signatures> _Receiver>
-        auto connect(_Receiver __rcvr) const noexcept(__nothrow_move_constructible<_Receiver>)
-          -> __operation_t<_Receiver> {
+        auto connect(_Receiver __rcvr) const noexcept -> __operation_t<_Receiver> {
           return __operation_t<_Receiver>{
             static_cast<_Receiver&&>(__rcvr), __max_recursion_size_, __max_recursion_depth_};
         }

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -190,8 +190,7 @@ namespace exec {
       using __op_base_t = __op_base<_Receiver, __result_t>;
 
       static constexpr bool __nothrow_construct =
-        __nothrow_move_constructible<_Receiver>
-        && (__nothrow_connectable<__cvref_t<_CvrefSenderIds>, __receiver_t> && ...);
+        (__nothrow_connectable<__cvref_t<_CvrefSenderIds>, __receiver_t> && ...);
 
       class __t : __op_base_t {
         using __opstate_tuple =

--- a/include/stdexec/__detail/__completion_signatures.hpp
+++ b/include/stdexec/__detail/__completion_signatures.hpp
@@ -216,6 +216,10 @@ namespace STDEXEC {
   //! @endcode
   template <class... _Sigs>
   struct completion_signatures {
+    static_assert(
+      (__completion_signature<_Sigs> && ...),
+      "All types in completion_signatures must be valid completion signatures.");
+
     //! @brief Partitioned view of the completion signatures for efficient querying.
     struct __partitioned {
       // This is defined in a nested struct to avoid computing these types if they are not

--- a/include/stdexec/__detail/__run_loop.hpp
+++ b/include/stdexec/__detail/__run_loop.hpp
@@ -220,8 +220,9 @@ namespace STDEXEC {
             &__loop_->__task_count_, &__loop_->__queue_, static_cast<_Rcvr&&>(__rcvr)};
         }
 
+        template <class, class...>
         STDEXEC_ATTRIBUTE(nodiscard, host, device)
-        static constexpr auto get_completion_signatures(__ignore) noexcept {
+        static consteval auto get_completion_signatures() noexcept {
           return completion_signatures<set_value_t(), set_stopped_t()>{};
         }
 

--- a/test/exec/sequence/test_empty_sequence.cpp
+++ b/test/exec/sequence/test_empty_sequence.cpp
@@ -29,11 +29,9 @@ namespace {
     "[sequence_senders][empty_sequence]") {
     using empty_t = decltype(empty_sequence());
     STATIC_REQUIRE(sequence_sender<empty_t, env<>>);
-    STATIC_REQUIRE(
-      std::same_as<
-        __sequence_completion_signatures_of_t<empty_t, env<>>,
-        completion_signatures<set_value_t()>
-      >);
+    [[maybe_unused]]
+    auto cs = __sequence_completion_signatures_of<empty_t, env<>>();
+    STATIC_REQUIRE(std::same_as<decltype(cs), completion_signatures<set_value_t()>>);
     STATIC_REQUIRE(
       std::same_as<completion_signatures_of_t<empty_t>, completion_signatures<set_value_t()>>);
     STATIC_REQUIRE(std::same_as<item_types_of_t<empty_t, env<>>, item_types<>>);

--- a/test/exec/sequence/test_merge_each_threaded.cpp
+++ b/test/exec/sequence/test_merge_each_threaded.cpp
@@ -88,12 +88,14 @@ namespace {
   static constexpr auto then_each = [](auto f) {
     return exec::transform_each(ex::then(f));
   };
+
   // a sequence adaptor that schedules each item to complete
   // on the specified scheduler
   [[maybe_unused]]
   static constexpr auto continues_each_on = [](auto sched) {
     return exec::transform_each(ex::continues_on(sched));
   };
+
   // a sequence adaptor that schedules each item to complete
   // on the specified scheduler after the specified duration
   [[maybe_unused]]
@@ -104,6 +106,7 @@ namespace {
     auto delay_adaptor = STDEXEC::__closure(delay_value, sched, after);
     return exec::transform_each(delay_adaptor);
   };
+
   // a sequence adaptor that applies a function to each item
   // the function must produce a sequence
   // all the sequences returned from the function are merged
@@ -116,6 +119,7 @@ namespace {
     };
     return STDEXEC::__closure(map_merge, static_cast<decltype(f)&&>(f));
   };
+
   // when_all requires a successful completion
   // however stop_after_on has no successful completion
   // this uses variant_sender to add a successful completion
@@ -125,12 +129,14 @@ namespace {
     -> variant_sender<STDEXEC::__call_result_t<ex::just_t>, decltype(sender)> {
     return {static_cast<decltype(sender)&&>(sender)};
   };
+
   // with_stop_token_from adds get_stop_token query, that returns the
   // token for the provided stop_source, to the receiver env
   [[maybe_unused]]
   static constexpr auto with_stop_token_from = [](auto& stop_source) noexcept {
     return ex::write_env(ex::prop{ex::get_stop_token, stop_source.get_token()});
   };
+
   // log_start completes with the provided sequence after printing provided string
   [[maybe_unused]]
   auto log_start = [](auto sequence, auto message) {
@@ -142,6 +148,7 @@ namespace {
       }),
       ex::just(sequence));
   };
+
   // log_sequence prints the message when each value in the sequence is emitted
   [[maybe_unused]]
   auto log_sequence = [](auto sequence, auto message) {
@@ -150,6 +157,7 @@ namespace {
              return value;
            });
   };
+
   // emits_stopped completes with set_stopped after printing info
   [[maybe_unused]]
   auto emits_stopped = []() {
@@ -158,6 +166,7 @@ namespace {
              return ex::just_stopped();
            });
   };
+
   // emits_error completes with set_error(error) after printing info
   [[maybe_unused]]
   auto emits_error = [](auto error) {
@@ -179,7 +188,8 @@ namespace {
   struct as_sequence_t : Sender {
     using sender_concept = sequence_sender_t;
     using item_types = exec::item_types<Sender>;
-    auto subscribe(auto receiver) {
+    template <ex::receiver Receiver>
+    auto subscribe(Receiver receiver) {
       return connect(set_next(receiver, *static_cast<Sender*>(this)), receiver);
     }
   };


### PR DESCRIPTION
use `consteval` functions instead of template metaprogramming for computing completion signatures and item types of sequence senders. this is in anticipation for C++26 `consteval` exceptions.