### PR TITLE
stdexec::just, ::just_error, & ::just_stopped: constexpr

### DIFF
--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -175,11 +175,11 @@ namespace STDEXEC {
 
     template <class _Receiver>
     struct __receiver_box {
-      STDEXEC_ATTRIBUTE(always_inline) auto __rcvr() & noexcept -> _Receiver& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __rcvr() & noexcept -> _Receiver& {
         return this->__rcvr_;
       }
 
-      STDEXEC_ATTRIBUTE(always_inline) auto __rcvr() const & noexcept -> const _Receiver& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __rcvr() const & noexcept -> const _Receiver& {
         return this->__rcvr_;
       }
 
@@ -191,21 +191,21 @@ namespace STDEXEC {
       using __tag_t = __decay_t<_Sexpr>::__tag_t;
       using __state_t = __state_type_t<__tag_t, _Sexpr, _Receiver>;
 
-      explicit __state_box(_Sexpr&& __sndr, _Receiver& __rcvr)
+      explicit constexpr __state_box(_Sexpr&& __sndr, _Receiver& __rcvr)
         noexcept(__noexcept_of<__sexpr_impl<__tag_t>::get_state, _Sexpr, _Receiver&>) {
         ::new (static_cast<void*>(__buf_)) auto(
           __sexpr_impl<__tag_t>::get_state(static_cast<_Sexpr&&>(__sndr), __rcvr));
       }
 
-      ~__state_box() {
+      constexpr ~__state_box() {
         reinterpret_cast<__state_t*>(__buf_)->~__state_t();
       }
 
-      STDEXEC_ATTRIBUTE(always_inline) auto __state() & noexcept -> __state_t& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __state() & noexcept -> __state_t& {
         return *reinterpret_cast<__state_t*>(__buf_);
       }
 
-      STDEXEC_ATTRIBUTE(always_inline) auto __state() const & noexcept -> const __state_t& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __state() const & noexcept -> const __state_t& {
         return *reinterpret_cast<const __state_t*>(__buf_);
       }
 
@@ -240,25 +240,25 @@ namespace STDEXEC {
       using __tag_t = __decay_t<_Sexpr>::__tag_t;
       using __state_t = __state_type_t<__tag_t, _Sexpr, _Receiver>;
 
-      explicit __op_base(_Sexpr&& __sndr, _Receiver&& __rcvr) noexcept(noexcept(
+      explicit constexpr __op_base(_Sexpr&& __sndr, _Receiver&& __rcvr) noexcept(noexcept(
         __state_t(__sexpr_impl<__tag_t>::get_state(__declval<_Sexpr>(), __declval<_Receiver&>()))))
         : __rcvr_(static_cast<_Receiver&&>(__rcvr))
         , __state_(__sexpr_impl<__tag_t>::get_state(static_cast<_Sexpr&&>(__sndr), __rcvr_)) {
       }
 
-      STDEXEC_ATTRIBUTE(always_inline) auto __state() & noexcept -> __state_t& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __state() & noexcept -> __state_t& {
         return __state_;
       }
 
-      STDEXEC_ATTRIBUTE(always_inline) auto __state() const & noexcept -> const __state_t& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __state() const & noexcept -> const __state_t& {
         return __state_;
       }
 
-      STDEXEC_ATTRIBUTE(always_inline) auto __rcvr() & noexcept -> _Receiver& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __rcvr() & noexcept -> _Receiver& {
         return __rcvr_;
       }
 
-      STDEXEC_ATTRIBUTE(always_inline) auto __rcvr() const & noexcept -> const _Receiver& {
+      STDEXEC_ATTRIBUTE(always_inline) constexpr auto __rcvr() const & noexcept -> const _Receiver& {
         return __rcvr_;
       }
 
@@ -278,7 +278,7 @@ namespace STDEXEC {
 
       STDEXEC_IMMOVABLE(__op_base);
 
-      __op_base(_Sexpr&& __sndr, _Receiver&& __rcvr)
+      constexpr __op_base(_Sexpr&& __sndr, _Receiver&& __rcvr)
         noexcept(__noexcept_of<__sexpr_impl<__tag_t>::get_state, _Sexpr, _Receiver&>)
         : __receiver_box<_Receiver>{static_cast<_Receiver&&>(__rcvr)}
         , __state_box<_Sexpr, _Receiver>{static_cast<_Sexpr&&>(__sndr), this->__rcvr_} {
@@ -298,7 +298,7 @@ namespace STDEXEC {
 
       struct __impl {
         template <std::size_t... _Is, class... _Child>
-        auto operator()(__indices<_Is...>, _Child&&... __child) const
+        constexpr auto operator()(__indices<_Is...>, _Child&&... __child) const
           noexcept((__nothrow_connectable<_Child, __receiver_t<_Is>> && ...))
             -> __tuple<connect_result_t<_Child, __receiver_t<_Is>>...> {
           return __tuple{connect(static_cast<_Child&&>(__child), __receiver_t<_Is>{__op_})...};
@@ -308,13 +308,13 @@ namespace STDEXEC {
       };
 
       template <class... _Child>
-      auto operator()(__ignore, __ignore, _Child&&... __child) const
+      constexpr auto operator()(__ignore, __ignore, _Child&&... __child) const
         noexcept(__nothrow_callable<__impl, __indices_for<_Child...>, _Child...>)
           -> __call_result_t<__impl, __indices_for<_Child...>, _Child...> {
         return __impl{__op_}(__indices_for<_Child...>(), static_cast<_Child&&>(__child)...);
       }
 
-      auto operator()(__ignore, __ignore) const noexcept -> __tuple<> {
+      constexpr auto operator()(__ignore, __ignore) const noexcept -> __tuple<> {
         return {};
       }
 
@@ -384,7 +384,7 @@ namespace STDEXEC {
     using __state_t = __op_state::__op_base::__state_t;
     using __inner_ops_t = __apply_result_t<__detail::__connect_fn<_Sexpr, _Receiver>, _Sexpr>;
 
-    explicit __op_state(_Sexpr&& __sexpr, _Receiver __rcvr) noexcept(
+    constexpr explicit __op_state(_Sexpr&& __sexpr, _Receiver __rcvr) noexcept(
       __nothrow_constructible_from<__detail::__op_base<_Sexpr, _Receiver>, _Sexpr, _Receiver>
       && __nothrow_applicable<__detail::__connect_fn<_Sexpr, _Receiver>, _Sexpr>)
       : __op_state::__op_base{static_cast<_Sexpr&&>(__sexpr), static_cast<_Receiver&&>(__rcvr)}
@@ -393,7 +393,7 @@ namespace STDEXEC {
           static_cast<_Sexpr&&>(__sexpr))) {
     }
 
-    STDEXEC_ATTRIBUTE(always_inline) void start() & noexcept {
+    STDEXEC_ATTRIBUTE(always_inline) constexpr void start() & noexcept {
       using __tag_t = __op_state::__tag_t;
       auto&& __rcvr = this->__rcvr();
       STDEXEC::__apply(
@@ -405,7 +405,7 @@ namespace STDEXEC {
 
     template <class _Index, class _Tag2, class... _Args>
     STDEXEC_ATTRIBUTE(always_inline)
-    void __complete(_Index, _Tag2, _Args&&... __args) noexcept {
+    constexpr void __complete(_Index, _Tag2, _Args&&... __args) noexcept {
       using __tag_t = __op_state::__tag_t;
       auto&& __rcvr = this->__rcvr();
       using _CompleteFn = __mtypeof<__sexpr_impl<__tag_t>::complete>;
@@ -419,7 +419,7 @@ namespace STDEXEC {
 
     template <class _Index>
     STDEXEC_ATTRIBUTE(always_inline)
-    auto __get_env(_Index) const noexcept
+    constexpr auto __get_env(_Index) const noexcept
       -> __detail::__env_type_t<__tag_t, _Index, _Sexpr, _Receiver> {
       const auto& __rcvr = this->__rcvr();
       return __sexpr_impl<__tag_t>::get_env(_Index(), this->__state(), __rcvr);

--- a/include/stdexec/__detail/__domain.hpp
+++ b/include/stdexec/__detail/__domain.hpp
@@ -61,7 +61,7 @@ namespace STDEXEC {
     template <class _OpTag, class _Sender, class _Env>
       requires __detail::__has_transform_sender<tag_of_t<_Sender>, _OpTag, _Sender, _Env>
     STDEXEC_ATTRIBUTE(always_inline)
-    auto transform_sender(_OpTag, _Sender&& __sndr, const _Env& __env) const
+    constexpr auto transform_sender(_OpTag, _Sender&& __sndr, const _Env& __env) const
       noexcept(__detail::__has_nothrow_transform_sender<tag_of_t<_Sender>, _OpTag, _Sender, _Env>)
         -> __detail::__transform_sender_result_t<tag_of_t<_Sender>, _OpTag, _Sender, _Env> {
       return tag_of_t<_Sender>().transform_sender(_OpTag(), static_cast<_Sender&&>(__sndr), __env);
@@ -69,7 +69,7 @@ namespace STDEXEC {
 
     template <class _OpTag, class _Sender, class _Env>
     STDEXEC_ATTRIBUTE(always_inline)
-    auto transform_sender(_OpTag, _Sender&& __sndr, const _Env&) const
+    constexpr auto transform_sender(_OpTag, _Sender&& __sndr, const _Env&) const
       noexcept(__nothrow_move_constructible<_Sender>) -> _Sender {
       return static_cast<_Sender>(static_cast<_Sender&&>(__sndr));
     }
@@ -77,7 +77,7 @@ namespace STDEXEC {
     template <class _Tag, class... _Args>
       requires __detail::__has_apply_sender<_Tag, _Args...>
     STDEXEC_ATTRIBUTE(always_inline)
-    auto apply_sender(_Tag, _Args&&... __args) const
+    constexpr auto apply_sender(_Tag, _Args&&... __args) const
       -> __detail::__apply_sender_result_t<_Tag, _Args...> {
       return _Tag().apply_sender(static_cast<_Args&&>(__args)...);
     }

--- a/include/stdexec/__detail/__just.hpp
+++ b/include/stdexec/__detail/__just.hpp
@@ -66,7 +66,7 @@ namespace STDEXEC {
 
       template <__movable_value... _Ts>
       STDEXEC_ATTRIBUTE(host, device)
-      auto operator()(_Ts&&... __ts) const noexcept(__nothrow_decay_copyable<_Ts...>) {
+      constexpr auto operator()(_Ts&&... __ts) const noexcept(__nothrow_decay_copyable<_Ts...>) {
         return __make_sexpr<just_t>(__tuple{static_cast<_Ts&&>(__ts)...});
       }
     };
@@ -76,7 +76,7 @@ namespace STDEXEC {
 
       template <__movable_value _Error>
       STDEXEC_ATTRIBUTE(host, device)
-      auto operator()(_Error&& __err) const noexcept(__nothrow_decay_copyable<_Error>) {
+      constexpr auto operator()(_Error&& __err) const noexcept(__nothrow_decay_copyable<_Error>) {
         return __make_sexpr<just_error_t>(__tuple{static_cast<_Error&&>(__err)});
       }
     };
@@ -86,7 +86,7 @@ namespace STDEXEC {
 
       template <class _Tag = just_stopped_t>
       STDEXEC_ATTRIBUTE(host, device)
-      auto operator()() const noexcept {
+      constexpr auto operator()() const noexcept {
         return __make_sexpr<_Tag>(__tuple{});
       }
     };

--- a/include/stdexec/__detail/__operation_states.hpp
+++ b/include/stdexec/__detail/__operation_states.hpp
@@ -37,7 +37,7 @@ namespace STDEXEC {
       template <class _Op>
         requires __has_start<_Op>
       STDEXEC_ATTRIBUTE(always_inline)
-      void operator()(_Op &__op) const noexcept {
+      constexpr void operator()(_Op &__op) const noexcept {
         static_assert(noexcept(__op.start()), "start() members must be noexcept");
         static_assert(__same_as<decltype(__op.start()), void>, "start() members must return void");
         __op.start();
@@ -47,7 +47,7 @@ namespace STDEXEC {
         requires __has_start<_Op> || tag_invocable<start_t, _Op &>
       [[deprecated("the use of tag_invoke for start is deprecated")]]
       STDEXEC_ATTRIBUTE(always_inline) //
-        void operator()(_Op &__op) const noexcept {
+        constexpr void operator()(_Op &__op) const noexcept {
         static_assert(nothrow_tag_invocable<start_t, _Op &>);
         (void) tag_invoke(start_t{}, __op);
       }

--- a/include/stdexec/__detail/__receivers.hpp
+++ b/include/stdexec/__detail/__receivers.hpp
@@ -61,7 +61,7 @@ namespace STDEXEC {
       template <class _Receiver, class... _As>
         requires __set_value_member<_Receiver, _As...>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      void operator()(_Receiver &&__rcvr, _As &&...__as) const noexcept {
+      constexpr void operator()(_Receiver &&__rcvr, _As &&...__as) const noexcept {
         static_assert(
           noexcept(static_cast<_Receiver &&>(__rcvr).set_value(static_cast<_As &&>(__as)...)),
           "set_value member functions must be noexcept");
@@ -79,7 +79,7 @@ namespace STDEXEC {
               || tag_invocable<set_value_t, _Receiver, _As...>
       [[deprecated("the use of tag_invoke for set_value is deprecated")]]
       STDEXEC_ATTRIBUTE(host, device, always_inline) //
-        void operator()(_Receiver &&__rcvr, _As &&...__as) const noexcept {
+        constexpr void operator()(_Receiver &&__rcvr, _As &&...__as) const noexcept {
         static_assert(nothrow_tag_invocable<set_value_t, _Receiver, _As...>);
         (void) tag_invoke(*this, static_cast<_Receiver &&>(__rcvr), static_cast<_As &&>(__as)...);
       }
@@ -98,7 +98,7 @@ namespace STDEXEC {
       template <class _Receiver, class _Error>
         requires __set_error_member<_Receiver, _Error>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      void operator()(_Receiver &&__rcvr, _Error &&__err) const noexcept {
+      constexpr void operator()(_Receiver &&__rcvr, _Error &&__err) const noexcept {
         static_assert(
           noexcept(static_cast<_Receiver &&>(__rcvr).set_error(static_cast<_Error &&>(__err))),
           "set_error member functions must be noexcept");
@@ -116,7 +116,7 @@ namespace STDEXEC {
               || tag_invocable<set_error_t, _Receiver, _Error>
       [[deprecated("the use of tag_invoke for set_error is deprecated")]]
       STDEXEC_ATTRIBUTE(host, device, always_inline) //
-        void operator()(_Receiver &&__rcvr, _Error &&__err) const noexcept {
+        constexpr void operator()(_Receiver &&__rcvr, _Error &&__err) const noexcept {
         static_assert(nothrow_tag_invocable<set_error_t, _Receiver, _Error>);
         (void) tag_invoke(*this, static_cast<_Receiver &&>(__rcvr), static_cast<_Error &&>(__err));
       }
@@ -135,7 +135,7 @@ namespace STDEXEC {
       template <class _Receiver>
         requires __set_stopped_member<_Receiver>
       STDEXEC_ATTRIBUTE(host, device, always_inline)
-      void operator()(_Receiver &&__rcvr) const noexcept {
+      constexpr void operator()(_Receiver &&__rcvr) const noexcept {
         static_assert(
           noexcept(static_cast<_Receiver &&>(__rcvr).set_stopped()),
           "set_stopped member functions must be noexcept");
@@ -149,7 +149,7 @@ namespace STDEXEC {
         requires __set_stopped_member<_Receiver> || tag_invocable<set_stopped_t, _Receiver>
       [[deprecated("the use of tag_invoke for set_stopped is deprecated")]]
       STDEXEC_ATTRIBUTE(host, device, always_inline) //
-        void operator()(_Receiver &&__rcvr) const noexcept {
+        constexpr void operator()(_Receiver &&__rcvr) const noexcept {
         static_assert(nothrow_tag_invocable<set_stopped_t, _Receiver>);
         (void) tag_invoke(*this, static_cast<_Receiver &&>(__rcvr));
       }

--- a/test/stdexec/algos/factories/test_just.cpp
+++ b/test/stdexec/algos/factories/test_just.cpp
@@ -27,6 +27,21 @@ namespace ex = STDEXEC;
 
 namespace {
 
+  constexpr int test_constexpr() noexcept {
+    struct receiver {
+      using receiver_concept = ex::receiver_t;
+      constexpr void set_value(const int i) && noexcept {
+        this->i = i;
+      }
+      int& i;
+    };
+    int i = 0;
+    auto op = ex::connect(ex::just(5), receiver{i});
+    ex::start(op);
+    return i;
+  }
+  static_assert(test_constexpr() == 5);
+
   TEST_CASE("Simple test for just", "[factories][just]") {
     auto o1 = ex::connect(ex::just(1), expect_value_receiver(1));
     ex::start(o1);

--- a/test/stdexec/algos/factories/test_just_error.cpp
+++ b/test/stdexec/algos/factories/test_just_error.cpp
@@ -23,6 +23,21 @@ namespace ex = STDEXEC;
 
 namespace {
 
+  constexpr int test_constexpr() noexcept {
+    struct receiver {
+      using receiver_concept = ex::receiver_t;
+      constexpr void set_error(const int i) && noexcept {
+        this->i = i;
+      }
+      int& i;
+    };
+    int i = 0;
+    auto op = ex::connect(ex::just_error(5), receiver{i});
+    ex::start(op);
+    return i;
+  }
+  static_assert(test_constexpr() == 5);
+
   TEST_CASE("Simple test for just_error", "[factories][just_error]") {
     auto op = ex::connect(ex::just_error(std::exception_ptr{}), expect_error_receiver{});
     ex::start(op);

--- a/test/stdexec/algos/factories/test_just_stopped.cpp
+++ b/test/stdexec/algos/factories/test_just_stopped.cpp
@@ -21,6 +21,21 @@
 
 namespace {
 
+  constexpr int test_constexpr() noexcept {
+    struct receiver {
+      using receiver_concept = ex::receiver_t;
+      constexpr void set_stopped() && noexcept {
+        invoked = true;
+      }
+      bool& invoked;
+    };
+    bool invoked = false;
+    auto op = ex::connect(ex::just_stopped(), receiver{invoked});
+    ex::start(op);
+    return invoked;
+  }
+  static_assert(test_constexpr());
+
   TEST_CASE("Simple test for just_stopped", "[factories][just_stopped]") {
     auto op = ex::connect(ex::just_stopped(), expect_stopped_receiver{});
     ex::start(op);


### PR DESCRIPTION
Includes other changes necessary to support the above-listed algorithms being usable in a constexpr context.