### PR TITLE
revert "Fix data race in async_scope"

### DIFF
--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -51,8 +51,6 @@ namespace exec {
       inplace_stop_source __stop_source_{};
       mutable std::mutex __lock_{};
       mutable __std::atomic_ptrdiff_t __active_ = 0;
-      mutable __std::atomic_ptrdiff_t __pending_notifiers_ =
-        0; // Track in-flight __complete() calls
       mutable __intrusive_queue<&__task::__next_> __waiters_{};
 
       ~__impl() {
@@ -85,14 +83,8 @@ namespace exec {
           // the waiter is queued but after __active is checked, the waiter will never be notified
           std::unique_lock __guard{this->__scope_->__lock_};
           auto& __active = this->__scope_->__active_;
-          auto& __pending = this->__scope_->__pending_notifiers_;
           auto& __waiters = this->__scope_->__waiters_;
-          // Also check __pending_notifiers_ to avoid race with in-flight __complete() calls.
-          // A __complete() that did fetch_sub but hasn't locked the mutex yet will have
-          // incremented __pending_notifiers_, preventing us from completing immediately.
-          if (
-            __active.load(__std::memory_order_acquire) != 0
-            || __pending.load(__std::memory_order_acquire) != 0) {
+          if (__active.load(__std::memory_order_acquire) != 0) {
             __waiters.push_back(this);
             return;
           }
@@ -165,13 +157,9 @@ namespace exec {
         __nest_op_base<_ReceiverId>* __op_;
 
         static void __complete(const __impl* __scope) noexcept {
-          // Increment pending BEFORE fetch_sub to close race window with on_empty().
-          // This ensures on_empty() sees pending > 0 if we're about to lock the mutex.
-          __scope->__pending_notifiers_.fetch_add(1, __std::memory_order_acquire);
           auto& __active = __scope->__active_;
+          std::unique_lock __guard{__scope->__lock_};
           if (__active.fetch_sub(1, __std::memory_order_acq_rel) == 1) {
-            std::unique_lock __guard{__scope->__lock_};
-            __scope->__pending_notifiers_.fetch_sub(1, __std::memory_order_release);
             auto __local_waiters = std::move(__scope->__waiters_);
             __guard.unlock();
             __scope = nullptr;
@@ -181,8 +169,6 @@ namespace exec {
               __next->__notify_waiter(__next);
               // __scope must be considered deleted
             }
-          } else {
-            __scope->__pending_notifiers_.fetch_sub(1, __std::memory_order_release);
           }
         }
 


### PR DESCRIPTION
Sorry I'm here again🤦, this PR reverts https://github.com/NVIDIA/stdexec/commit/58a2a918f2738127abc64e00ba9e2bae7ec4332b, because there is still a data race when subtracting `__pending_notifiers_` in the `else` branch of `__complete()`, where the scope might already be destroyed.

also, according to the standard [exec.scope#simple.counting.general](https://eel.is/c++draft/exec.scope#simple.counting.general-1):

> For purposes of determining the existence of a data race, get_token, close, join, try-associate, disassociate, and start-join-sender behave as **atomic operations**. These operations on a single object of type simple_counting_scope appear to occur in a single total order.

IIUC it's impossible to impl a lock-free `counting_scope`. Beacuse at least start-join-sender can't be lock-free, then in order to make others atomic, all operations should share the same lock.

-----

If it can't be lock-free, I wonder in C++26, what's the recommended way to async start a sender in a hot code path, without suffering from the lock and memory allocatioin?

The best way I can think up is: make a dummy scope which ignores everything + custom allocator.

```cpp
ex::spawn(sender, dummy_scope.get_token(), my_allocator);
```

I wonder whether it's a good practice, is there any better way?
