### PR TITLE
test(exec): fork_join with empty value channel

### DIFF
--- a/test/exec/test_fork.cpp
+++ b/test/exec/test_fork.cpp
@@ -72,4 +72,13 @@ namespace {
     CHECK(i1 == 42);
     CHECK(i2 == 42);
   }
+
+  TEST_CASE("fork_join with empty value channel", "[adaptors][fork_join]") {
+    auto sndr = ::STDEXEC::just() | ::STDEXEC::then([]() noexcept -> void { })
+              | exec::fork_join(
+                  ::STDEXEC::then([]() noexcept -> void { }),
+                  ::STDEXEC::then([]() noexcept -> void { }));
+
+    ::STDEXEC::sync_wait(std::move(sndr));
+  }
 } // namespace


### PR DESCRIPTION
This was working 2 days ago.

I'll try to find the culprit commit later today.

- 68bcedcadd4334d57d49b257f480b563f0aeb29a :red_circle: 
- 6ddedb44be9c766ee026ce698bfc8a236bc0b03e :red_circle: 
- e726de2ff2191a40e803edb41af0e526e81fdba0 :heavy_check_mark: 

It seems it stopped working with:
- 6ddedb44be9c766ee026ce698bfc8a236bc0b03e (merged in #1772 by @ericniebler )

The compile error looks like:
```bash
[  0%] Building CXX object test/exec/CMakeFiles/test.exec.dir/test_fork.cpp.o
In file included from /workspaces/stdexec/test/exec/test_fork.cpp:17:
In file included from /workspaces/stdexec/include/exec/fork_join.hpp:18:
/workspaces/stdexec/include/exec/../stdexec/__detail/__receiver_ref.hpp:55:9: error: 
      static assertion failed: get_env() must return the same type as env_of_t<_Rcvr>
   55 |         __same_as<_Env, env_of_t<_Rcvr>>, "get_env() must return the same type as env_of_t<_Rcvr>");
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/workspaces/stdexec/include/exec/../stdexec/__detail/__env.hpp:318:31: note: in
      instantiation of member function
      'std::execution::__rcvr_ref<exec::fork_join_t::_opstate_t<std::execution::(anonymous
      namespace)::__sexpr<std::execution::(lambda at
      /workspaces/stdexec/include/exec/../stdexec/__detail/__basic_sender.hpp:59:53){}>,
      std::execution::__tup::__tuple<std::execution::__clsur::__closure<std::execution::__then::then_t,
      (lambda at /workspaces/stdexec/test/exec/test_fork.cpp:79:35)>,
      std::execution::__clsur::__closure<std::execution::__then::then_t, (lambda at
      /workspaces/stdexec/test/exec/test_fork.cpp:80:35)>>,
      std::execution::__sync_wait::__receiver<>::__t>,
      std::execution::__env::__fwd<std::execution::__sync_wait::__env>::__t>::get_env' requested here
  318 |         return __env_provider.get_env();
```

I'm not sure if the fix I'm doing is the right thing to do.