### PR TITLE
test(stdexec): bulk in a `constexpr` expression

### DIFF
--- a/include/stdexec/__detail/__bulk.hpp
+++ b/include/stdexec/__detail/__bulk.hpp
@@ -188,7 +188,7 @@ namespace STDEXEC {
       >
         requires is_execution_policy_v<std::remove_cvref_t<_Policy>>
       STDEXEC_ATTRIBUTE(host, device)
-      auto operator()(_Sender&& __sndr, _Policy&& __pol, _Shape __shape, _Fun __fun) const
+      constexpr auto operator()(_Sender&& __sndr, _Policy&& __pol, _Shape __shape, _Fun __fun) const
         -> __well_formed_sender auto {
         return __make_sexpr<_AlgoTag>(
           __data{__pol, __shape, static_cast<_Fun&&>(__fun)}, static_cast<_Sender&&>(__sndr));
@@ -197,7 +197,7 @@ namespace STDEXEC {
       template <typename _Policy, __std::integral _Shape, __std::copy_constructible _Fun>
         requires is_execution_policy_v<std::remove_cvref_t<_Policy>>
       STDEXEC_ATTRIBUTE(always_inline)
-      auto operator()(_Policy&& __pol, _Shape __shape, _Fun __fun) const {
+      constexpr auto operator()(_Policy&& __pol, _Shape __shape, _Fun __fun) const {
         return __closure(
           *this,
           static_cast<_Policy&&>(__pol),

--- a/test/stdexec/algos/adaptors/test_bulk.cpp
+++ b/test/stdexec/algos/adaptors/test_bulk.cpp
@@ -61,6 +61,26 @@ namespace {
     }
   };
 
+  constexpr auto test_constexpr() noexcept {
+    struct receiver {
+      using receiver_concept = ex::receiver_t;
+      constexpr void set_value(const int i) && noexcept {
+        this->i = i;
+      }
+      void set_error(std::exception_ptr) && noexcept {
+      }
+      int& i;
+    };
+    int i = 0;
+    auto op = ex::connect(
+      ex::just(666)
+        | ex::bulk(ex::par, 42, [](std::size_t item, auto& val) noexcept { val += item; }),
+      receiver{i});
+    ex::start(op);
+    return i;
+  }
+  static_assert(test_constexpr() == 666 + 42 * 41 / 2);
+
   TEST_CASE("bulk returns a sender", "[adaptors][bulk]") {
     auto snd = ex::bulk(ex::just(19), ex::par, 8, [](int, int) { });
     static_assert(ex::sender<decltype(snd)>);


### PR DESCRIPTION
Added 2 missing `constexpr` to make `bulk` allowable in a `constexpr` expression.

I've added a test.