### PR TITLE
add missing semicolon

### DIFF
--- a/include/stdexec/__detail/__completion_signatures.hpp
+++ b/include/stdexec/__detail/__completion_signatures.hpp
@@ -107,7 +107,7 @@ namespace STDEXEC {
   [[noreturn, nodiscard]]
   consteval auto
     __throw_compile_time_error([[maybe_unused]] _Values... __values) -> completion_signatures<> {
-    return
+    return;
   }
 #endif // ^^^ constexpr exceptions ^^^
 


### PR DESCRIPTION
Noticed this while compiling gcc trunk: https://godbolt.org/z/xdMzK64Eq