### PR TITLE
Mark __opstate classes as final instead of adding virtual destructors

### DIFF
--- a/include/exec/repeat_n.hpp
+++ b/include/exec/repeat_n.hpp
@@ -90,7 +90,7 @@ namespace exec {
     };
 
     template <class _Child, class _Receiver>
-    struct __opstate : __opstate_base<_Receiver> {
+    struct __opstate final : __opstate_base<_Receiver> {
       using __receiver_t = STDEXEC::__t<__receiver<__id<_Receiver>>>;
       using __bouncy_sndr_t =
         __result_of<exec::sequence, schedule_result_t<trampoline_scheduler>, _Child &>;

--- a/include/exec/repeat_until.hpp
+++ b/include/exec/repeat_until.hpp
@@ -123,7 +123,7 @@ namespace exec {
     STDEXEC_PRAGMA_IGNORE_GNU("-Wtsan")
 
     template <class _Child, class _Receiver>
-    struct __opstate : __opstate_base<_Receiver> {
+    struct __opstate final : __opstate_base<_Receiver> {
       using __receiver_t = STDEXEC::__t<__receiver<__id<_Receiver>>>;
       using __bouncy_sndr_t =
         __result_of<exec::sequence, schedule_result_t<trampoline_scheduler>, _Child &>;

--- a/include/exec/sequence/merge_each.hpp
+++ b/include/exec/sequence/merge_each.hpp
@@ -148,8 +148,6 @@ namespace exec {
 
     template <class _ErrorStorage>
     struct __operation_base_interface {
-      ~__operation_base_interface() {
-      }
       virtual void nested_value_started() noexcept = 0;
       virtual void nested_value_complete() noexcept = 0;
       virtual bool nested_value_fail() noexcept = 0;
@@ -1155,7 +1153,7 @@ namespace exec {
       using _Receiver = STDEXEC::__t<_ReceiverId>;
       using __error_storage_t = _ErrorStorage;
       using __base_t = __operation_base<_Receiver, __error_storage_t>;
-      struct __t : __base_t {
+      struct __t final : __base_t {
         using __id = __operation;
 
         using __nested_seq_op_t = __compute::__nested_sequence_ops_variant<_Sequence, _Receiver>;


### PR DESCRIPTION
- Adds missing `virtual` modifiers to destructors in virtual classes. 
- Fixes warning [1] with `clang++16`.


[1]
```bash
warning: destructor called on non-final 'exec::__repeat_n::__opstate<stdexec::(anonymous namespace)::__sexpr<stdexec::(lambda at /ascldap/users/jciesko/RAndD/stdexec/include/stdexec/__detail/__basic_sender.hpp:56:53){}>, nvexec::_strm::propagate_receiver_t<nvexec::_strm::stream_enqueue_receiver<stdexec::__env::env<stdexec::__env::prop<nvexec::_strm::get_stream_provider_t, nvexec::_strm::stream_provider_t *>, stdexec::__env::__fwd<stdexec::__sync_wait::__env>::__t>, nvexec::variant_t<cuda::std::tuple<nvexec::_strm::set_noop>, cuda::std::tuple<stdexec::__rcvrs::set_error_t, cudaError>, cuda::std::tuple<stdexec::__rcvrs::set_error_t, std::__exception_ptr::exception_ptr>, cuda::std::tuple<stdexec::__rcvrs::set_stopped_t>, cuda::std::tuple<stdexec::__rcvrs::set_value_t>>>>::__t>' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
        __location->~_Tp();
        ^
```