### PR TITLE
increase naming consistency of the metaprogramming utilities

### DIFF
--- a/include/exec/into_tuple.hpp
+++ b/include/exec/into_tuple.hpp
@@ -56,7 +56,7 @@ namespace exec {
     template <class _Sender, class... _Env>
     using __completions_t = transform_completion_signatures<
       __completion_signatures_of_t<_Sender, _Env...>,
-      __meval<__tuple_completions_t, __result_tuple_t<_Sender, _Env...>>,
+      __minvoke_q<__tuple_completions_t, __result_tuple_t<_Sender, _Env...>>,
       __mconst<STDEXEC::completion_signatures<>>::__f
     >;
 

--- a/include/exec/reschedule.hpp
+++ b/include/exec/reschedule.hpp
@@ -42,7 +42,7 @@ namespace exec {
 
     template <class _Env>
     using __completions =
-      __meval<__completion_signatures_of_t, __try_schedule_sender_t<_Env>, _Env>;
+      __minvoke_q<__completion_signatures_of_t, __try_schedule_sender_t<_Env>, _Env>;
 
     struct __scheduler {
       struct __sender {

--- a/include/exec/sequence/merge_each.hpp
+++ b/include/exec/sequence/merge_each.hpp
@@ -255,7 +255,7 @@ namespace exec {
     };
 
     template <class _ErrorStorage>
-    using __error_sender_t = __meval<__error_sender, _ErrorStorage>;
+    using __error_sender_t = __minvoke_q<__error_sender, _ErrorStorage>;
 
     template <class _ErrorStorage, class _EnvFn>
     struct __error_next_receiver {
@@ -553,12 +553,12 @@ namespace exec {
     };
 
     template <class _NestedValueSender, class _NestedValueReceiver, class _ErrorStorage>
-    using __nested_value_op_t = STDEXEC::__meval<
+    using __nested_value_op_t = STDEXEC::__minvoke_q<
       __nested_value_op,
       _NestedValueSender,
       _NestedValueReceiver,
       _ErrorStorage,
-      __meval<
+      __minvoke_q<
         STDEXEC::connect_result_t,
         _NestedValueSender,
         __receive_nested_value<_NestedValueReceiver, _ErrorStorage>
@@ -613,7 +613,7 @@ namespace exec {
     };
 
     template <class _NestedValue, class _ErrorStorage>
-    using __nested_value_sender_t = __meval<__nested_value_sender, _NestedValue, _ErrorStorage>;
+    using __nested_value_sender_t = __minvoke_q<__nested_value_sender, _NestedValue, _ErrorStorage>;
 
     //
     // __next_.. is returned from set_next. Unlike the rest of the
@@ -715,7 +715,7 @@ namespace exec {
     };
 
     template <class _OperationBase>
-    using __receive_nested_values_t = __meval<__receive_nested_values, _OperationBase>;
+    using __receive_nested_values_t = __minvoke_q<__receive_nested_values, _OperationBase>;
 
     struct _MERGE_WITH_REQUIRES_A_SEQUENCE_OF_SEQUENCES_ { };
 
@@ -789,7 +789,7 @@ namespace exec {
           STDEXEC::__munique<STDEXEC::__qq<__types>>,
           STDEXEC::__minvoke<
             STDEXEC::__mconcat<STDEXEC::__qq<__types>>,
-            __meval<__nested_sequences_from_item_type_t, _Sequence, _Senders, _Env...>...
+            __minvoke_q<__nested_sequences_from_item_type_t, _Sequence, _Senders, _Env...>...
           >
         >;
       };
@@ -900,7 +900,7 @@ namespace exec {
       struct __nested_sequence_op_fn {
         template <class _Sequence>
         using __f =
-          __meval<subscribe_result_t, _Sequence, __receive_nested_values_t<_OperationBase>>;
+          __minvoke_q<subscribe_result_t, _Sequence, __receive_nested_values_t<_OperationBase>>;
       };
 
       template <class _Sequence, class _OperationBase>
@@ -1121,7 +1121,7 @@ namespace exec {
     };
 
     template <class _Receiver, class _Sequence>
-    using __operation_t = __meval<
+    using __operation_t = __minvoke_q<
       __operation,
       _Receiver,
       _Sequence,
@@ -1192,7 +1192,7 @@ namespace exec {
       template <class _Self, class... _Env>
       struct __completions_fn {
         template <class... _Sequences>
-        using __f = __meval<
+        using __f = __minvoke_q<
           __concat_completion_signatures_t,
           completion_signatures<set_stopped_t()>,
           __completion_signatures_of_t<__child_of<_Self>, _Env...>,

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -279,17 +279,17 @@ namespace exec {
       typename STDEXEC_REMOVE_REFERENCE(transform_sender_result_t<_Sequence, _Env...>)::item_types;
 
     template <class _Sequence, class... _Env>
-    concept __with_member = __mvalid<__member_result_t, _Sequence, _Env...>;
+    concept __with_member = __minvocable_q<__member_result_t, _Sequence, _Env...>;
 
     template <class _Sequence, class... _Env>
-    concept __with_static_member = __mvalid<__static_member_result_t, _Sequence, _Env...>;
+    concept __with_static_member = __minvocable_q<__static_member_result_t, _Sequence, _Env...>;
 
     template <class _Sequence, class... _Env>
-    concept __with_member_alias = __mvalid<__member_alias_t, _Sequence, _Env...>;
+    concept __with_member_alias = __minvocable_q<__member_alias_t, _Sequence, _Env...>;
 
     template <class _Sequence, class... _Env>
     concept __with_consteval_static_member =
-      __mvalid<__consteval_static_member_result_t, _Sequence, _Env...>;
+      __minvocable_q<__consteval_static_member_result_t, _Sequence, _Env...>;
 
     template <class _Sequence, class... _Env>
     concept __with_tag_invoke = tag_invocable<get_item_types_t, _Sequence, _Env...>;
@@ -429,7 +429,7 @@ namespace exec {
   struct _THE_CALL_TO_GET_ITEM_TYPES_IS_ILL_FORMED_ { };
 
   template <class _Sequence>
-    requires(!STDEXEC::__merror<_Sequence>) && (!STDEXEC::__mvalid<__item_types_of_t, _Sequence>)
+    requires(!STDEXEC::__merror<_Sequence>) && (!STDEXEC::__minvocable_q<__item_types_of_t, _Sequence>)
   auto __check_sequence(_Sequence*) -> STDEXEC::__mexception<
     STDEXEC::_WHAT_(_ERROR_WHILE_COMPUTING_THE_SEQUENCE_ITEM_TYPES_),
     STDEXEC::_WHY_(_THE_CALL_TO_GET_ITEM_TYPES_IS_ILL_FORMED_),
@@ -437,7 +437,7 @@ namespace exec {
   >;
 
   template <class _Sequence>
-    requires(!STDEXEC::__merror<_Sequence>) && STDEXEC::__mvalid<__item_types_of_t, _Sequence>
+    requires(!STDEXEC::__merror<_Sequence>) && STDEXEC::__minvocable_q<__item_types_of_t, _Sequence>
   auto __check_sequence(_Sequence*) -> decltype(exec::__check_items<_Sequence>(
     static_cast<__item_types_of_t<_Sequence>*>(nullptr)));
 
@@ -647,7 +647,7 @@ namespace exec {
 
     template <class _Sequence, class _Receiver>
     concept __subscribable_with_member =
-      __mvalid<__subscribe_member_result_t, _Sequence, _Receiver>;
+      __minvocable_q<__subscribe_member_result_t, _Sequence, _Receiver>;
 
     template <class _Sequence, class _Receiver>
     using __subscribe_static_member_result_t = decltype(STDEXEC_REMOVE_REFERENCE(
@@ -655,7 +655,7 @@ namespace exec {
 
     template <class _Sequence, class _Receiver>
     concept __subscribable_with_static_member =
-      __mvalid<__subscribe_static_member_result_t, _Sequence, _Receiver>;
+      __minvocable_q<__subscribe_static_member_result_t, _Sequence, _Receiver>;
 
     template <class _Sequence, class _Receiver>
     concept __subscribable_with_tag_invoke = tag_invocable<subscribe_t, _Sequence, _Receiver>;

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -488,7 +488,7 @@ namespace exec {
 
       // Make this task generally awaitable:
       constexpr auto operator co_await() && noexcept -> __task_awaitable<>
-        requires __mvalid<awaiter_context_t, __promise>
+        requires __minvocable_q<awaiter_context_t, __promise>
       {
         return __task_awaitable<>{std::exchange(__coro_, {})};
       }

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -47,7 +47,7 @@ namespace exec {
     template <class... _Env>
     struct __completions_fn {
       template <class... _CvSenders>
-      using __all_value_args_nothrow_decay_copyable = __meval<
+      using __all_value_args_nothrow_decay_copyable = __minvoke_q<
         __mand_t,
         __value_types_t<
           __completion_signatures_of_t<_CvSenders, __env_t<_Env>...>,

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -39,7 +39,7 @@ namespace nvexec::_strm::__algo_range_init_fun {
     struct result_size_for {
       template <class... Range>
       using __f = __msize_t<sizeof(
-        typename __meval<__mfirst, DerivedReceiver, Range...>::template result_t<Range...>)>;
+        typename __minvoke_q<__mfirst, DerivedReceiver, Range...>::template result_t<Range...>)>;
     };
 
     _strm::opstate_base<Receiver>& opstate_;
@@ -88,10 +88,10 @@ namespace nvexec::_strm::__algo_range_init_fun {
     // in the following two type aliases, __mfirst is used to make DerivedSender,
     // which is incomplete in this context, dependent to avoid hard errors.
     template <class Receiver>
-    using receiver_t = __meval<__mfirst, DerivedSender, Receiver>::template receiver_t<Receiver>;
+    using receiver_t = __minvoke_q<__mfirst, DerivedSender, Receiver>::template receiver_t<Receiver>;
 
     template <class Range>
-    using _set_value_t = __meval<__mfirst, DerivedSender, Range>::template _set_value_t<Range>;
+    using _set_value_t = __minvoke_q<__mfirst, DerivedSender, Range>::template _set_value_t<Range>;
 
     template <class Self, class... Env>
     using _completions_t = STDEXEC::transform_completion_signatures<

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -133,7 +133,7 @@ namespace nvexec::_strm {
     using _set_error_t = completion_signatures<set_error_t(Error)>;
 
     template <class Self, class... Env>
-    using __error_completions_t = __meval<
+    using __error_completions_t = __minvoke_q<
       __concat_completion_signatures_t,
       __with_error_invoke_t<
         __mbind_front_q<__callable_error_t, then_t>,

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -80,7 +80,7 @@ namespace nvexec::_strm {
     template <class... Env, class... Senders>
       requires(valid_child_sender<Senders, Env...> && ...)
     struct completions<__types<Env...>, Senders...> {
-      using non_values_t = __meval<
+      using non_values_t = __minvoke_q<
         __concat_completion_signatures_t,
         completion_signatures<set_error_t(cudaError_t), set_stopped_t()>,
         transform_completion_signatures<

--- a/include/stdexec/__detail/__as_awaitable.hpp
+++ b/include/stdexec/__detail/__as_awaitable.hpp
@@ -169,7 +169,7 @@ namespace STDEXEC {
 
     template <class _Sender, class _Promise>
     concept __awaitable_sender = sender_in<_Sender, env_of_t<_Promise&>>
-                              && __mvalid<__detail::__value_t, _Sender, _Promise>
+                              && __minvocable_q<__detail::__value_t, _Sender, _Promise>
                               && sender_to<_Sender, __receiver_t<_Sender, _Promise>>
                               && requires(_Promise& __promise) {
                                    {

--- a/include/stdexec/__detail/__connect.hpp
+++ b/include/stdexec/__detail/__connect.hpp
@@ -42,10 +42,10 @@ namespace STDEXEC {
                ::static_connect(__declval<_Sender>(), __declval<_Receiver>()));
 
     template <class _Sender, class _Receiver>
-    concept __with_member = __mvalid<__member_result_t, _Sender, _Receiver>;
+    concept __with_member = __minvocable_q<__member_result_t, _Sender, _Receiver>;
 
     template <class _Sender, class _Receiver>
-    concept __with_static_member = __mvalid<__static_member_result_t, _Sender, _Receiver>;
+    concept __with_static_member = __minvocable_q<__static_member_result_t, _Sender, _Receiver>;
 
     template <class _Sender, class _Receiver>
     concept __with_legacy_tag_invoke = tag_invocable<connect_t, _Sender, _Receiver>;

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -266,7 +266,7 @@ namespace STDEXEC {
   // };
 
   template <class _EnvProvider>
-  concept environment_provider = __mvalid<__call_result_t, get_env_t, const _EnvProvider&>;
+  concept environment_provider = __minvocable_q<__call_result_t, get_env_t, const _EnvProvider&>;
 
 } // namespace STDEXEC
 

--- a/include/stdexec/__detail/__get_completion_signatures.hpp
+++ b/include/stdexec/__detail/__get_completion_signatures.hpp
@@ -132,13 +132,13 @@ namespace STDEXEC {
                ::static_get_completion_signatures(__declval<_Sender>(), __declval<_Env>()...));
 
     template <class _Sender, class... _Env>
-    concept __with_member = __mvalid<__member_result_t, _Sender, _Env...>;
+    concept __with_member = __minvocable_q<__member_result_t, _Sender, _Env...>;
 
     template <class _Sender>
     using __member_alias_t = STDEXEC_REMOVE_REFERENCE(_Sender)::completion_signatures;
 
     template <class _Sender, class... _Env>
-    concept __with_static_member = __mvalid<__static_member_result_t, _Sender, _Env...>;
+    concept __with_static_member = __minvocable_q<__static_member_result_t, _Sender, _Env...>;
 
     template <class _Sender, class... _Env>
     concept __with_consteval_static_member = //
@@ -158,7 +158,7 @@ namespace STDEXEC {
                                     && tag_invocable<get_completion_signatures_t, _Sender, env<>>;
 
     template <class _Sender>
-    concept __with_member_alias = __mvalid<__member_alias_t, _Sender>;
+    concept __with_member_alias = __minvocable_q<__member_alias_t, _Sender>;
 
     template <class _Sender, class... _Env>
     [[nodiscard]]

--- a/include/stdexec/__detail/__into_variant.hpp
+++ b/include/stdexec/__detail/__into_variant.hpp
@@ -52,7 +52,7 @@ namespace STDEXEC {
     template <class _Sender, class... _Env>
     using __completions = transform_completion_signatures<
       __completion_signatures_of_t<_Sender, _Env...>,
-      __meval<__variant_completions, __variant_t<_Sender, _Env...>>,
+      __minvoke_q<__variant_completions, __variant_t<_Sender, _Env...>>,
       __mconst<completion_signatures<>>::__f
     >;
 

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -124,7 +124,7 @@ namespace STDEXEC {
     struct _NESTED_ERROR_;
 
     template <class _Sender, class... _Env>
-    using __try_completion_signatures_of_t = __meval_or<
+    using __try_completion_signatures_of_t = __minvoke_or_q<
       __completion_signatures_of_t,
       __unrecognized_sender_error_t<_Sender, _Env...>,
       _Sender,
@@ -156,7 +156,7 @@ namespace STDEXEC {
     template <class _SetTag, class _Fun, class... _JoinEnv2>
     struct __result_sender_fn {
       template <class... _Args>
-      using __f = __meval<
+      using __f = __minvoke_q<
         __ensure_sender_t,
         _SetTag,
         __mcall<

--- a/include/stdexec/__detail/__sender_introspection.hpp
+++ b/include/stdexec/__detail/__sender_introspection.hpp
@@ -58,7 +58,7 @@ namespace STDEXEC {
     using __tag_of = __desc_of<_Sender>::__tag;
 
     template <class _Sender>
-      requires __mvalid<__tag_of, _Sender>
+      requires __minvocable_q<__tag_of, _Sender>
     extern __tag_of<_Sender> __tag_of_v;
   } // namespace __detail
 
@@ -96,7 +96,7 @@ namespace STDEXEC {
   struct __muncurry_<__sexpr<_Descriptor> const &> : decltype(_Descriptor()){};
 
   template <class _Sender>
-  concept sender_expr = __mvalid<tag_of_t, _Sender>;
+  concept sender_expr = __minvocable_q<tag_of_t, _Sender>;
 
   template <class _Sender, class _Tag>
   concept sender_expr_for = sender_expr<_Sender> && __std::same_as<tag_of_t<_Sender>, _Tag>;

--- a/include/stdexec/__detail/__transform_completion_signatures.hpp
+++ b/include/stdexec/__detail/__transform_completion_signatures.hpp
@@ -349,7 +349,7 @@ namespace STDEXEC {
     template <class... _Args, class _Fn>
     [[nodiscard]]
     consteval auto __apply_transform(const _Fn& __fn) {
-      if constexpr (__mvalid<__transform_expr_t, _Fn, _Args...>) {
+      if constexpr (__minvocable_q<__transform_expr_t, _Fn, _Args...>) {
         using __completions_t = __transform_expr_t<_Fn, _Args...>;
         if constexpr (__well_formed_completions<__completions_t>) {
           return __cmplsigs::__transform_expr<_Args...>(__fn);

--- a/include/stdexec/__detail/__tuple.hpp
+++ b/include/stdexec/__detail/__tuple.hpp
@@ -368,7 +368,7 @@ namespace STDEXEC {
       STDEXEC::__get<_Index::value>(__declval<_Tuple>())));
 
     template <size_t _Index, class _Tuple>
-      requires __mvalid<__tuple_element_t, __msize_t<_Index>, _Tuple>
+      requires __minvocable_q<__tuple_element_t, __msize_t<_Index>, _Tuple>
     extern __declfn_t<__tuple_element_t<__msize_t<_Index>, _Tuple>> __tuple_element_v;
   } // namespace __detail
 

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -29,15 +29,6 @@ namespace STDEXEC {
 
   using __empty = struct __ { };
 
-  struct __ignore {
-    constexpr __ignore() = default;
-
-    template <class... _Ts>
-    STDEXEC_ATTRIBUTE(always_inline)
-    constexpr __ignore(_Ts&&...) noexcept {
-    }
-  };
-
   struct __none_such { };
 
   namespace {

--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -66,7 +66,7 @@ namespace STDEXEC {
     template <class _Sender, class _Env>
     concept __max1_sender =
       sender_in<_Sender, _Env>
-      && __mvalid<__value_types_of_t, _Sender, _Env, __mconst<int>, __msingle_or<void>>;
+      && __minvocable_q<__value_types_of_t, _Sender, _Env, __mconst<int>, __msingle_or<void>>;
 
     struct _THE_GIVEN_SENDER_CAN_COMPLETE_SUCCESSFULLY_IN_MORE_THAN_ONE_WAY_ { };
     struct _USE_WHEN_ALL_WITH_VARIANT_INSTEAD_ { };
@@ -115,15 +115,15 @@ namespace STDEXEC {
       >;
 
       template <class... _Senders>
-      using __set_values_sig_t = __meval<
+      using __set_values_sig_t = __minvoke_q<
         completion_signatures,
         __minvoke<__mconcat<__qf<set_value_t>>, __single_values_of_t<_Senders>...>
       >;
 
       template <class... _Senders>
-      using __f = __meval<
+      using __f = __minvoke_q<
         __concat_completion_signatures_t,
-        __meval<__eptr_completion_unless_t, __all_nothrow_decay_copyable_results_t<_Senders...>>,
+        __minvoke_q<__eptr_completion_unless_t, __all_nothrow_decay_copyable_results_t<_Senders...>>,
         __minvoke<__mwith_default<__qq<__set_values_sig_t>, completion_signatures<>>, _Senders...>,
         __transform_completion_signatures_t<
           __completion_signatures_of_t<_Senders, _Env...>,
@@ -342,7 +342,7 @@ namespace STDEXEC {
       template <class _Self, class... _Env>
       static consteval auto get_completion_signatures() {
         static_assert(sender_expr_for<_Self, when_all_t>);
-        if constexpr (__mvalid<__completions_t, _Self, _Env...>) {
+        if constexpr (__minvocable_q<__completions_t, _Self, _Env...>) {
           // TODO: update this to use constant evaluation:
           return __completions_t<_Self, _Env...>{};
         } else if constexpr (sizeof...(_Env) == 0) {

--- a/include/stdexec/__detail/__write_env.hpp
+++ b/include/stdexec/__detail/__write_env.hpp
@@ -58,7 +58,7 @@ namespace STDEXEC {
         static_assert(sender_expr_for<_Self, write_env_t>);
         return STDEXEC::get_completion_signatures<
           __child_of<_Self>,
-          __meval<__join_env_t, const __decay_t<__data_of<_Self>>&, _Env>...
+          __minvoke_q<__join_env_t, const __decay_t<__data_of<_Self>>&, _Env>...
         >();
       }
     };


### PR DESCRIPTION
some notable renames:

`__meval<Fn, Args...>`  &rarr; `__minvoke_q<Fn, Args...>`
`__mvalid<Fn, Args...>`  &rarr; `__minvocable_q<Fn, Args...>`
