### PR TITLE
adds assert_with concept and uses it for get_completion_signatures an…

### DIFF
--- a/include/stdexec/__detail/__connect.hpp
+++ b/include/stdexec/__detail/__connect.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "__execution_fwd.hpp"
+#include "__diagnostics.hpp"
 
 // include these after __execution_fwd.hpp
 #include "__completion_signatures_of.hpp"
@@ -206,7 +207,9 @@ namespace STDEXEC {
         class _Receiver,
         class _DeclFn = __connect_declfn_t<_Sender, _Receiver>
       >
-        requires __connectable_to<_Sender, _Receiver>
+        requires assert_with<
+          __connectable_to<_Sender, _Receiver>, 
+          __connect_error_t<transform_sender_result_t<_Sender, env_of_t<_Receiver>>, _Receiver>>
       STDEXEC_ATTRIBUTE(always_inline)
       constexpr auto operator()(_Sender&& __sndr, _Receiver&& __rcvr) const
         noexcept(__nothrow_callable<_DeclFn>) -> __call_result_t<_DeclFn> {

--- a/include/stdexec/__detail/__diagnostics.hpp
+++ b/include/stdexec/__detail/__diagnostics.hpp
@@ -115,6 +115,18 @@ namespace STDEXEC {
     _WITH_ENVIRONMENT_(_Env)...
   >;
 
+  struct _CONNECT_ERROR_ {};
+  struct _UNABLE_TO_CONNECT_THE_SENDER_TO_THE_RECEIVER_ { };
+
+  template <class _Sender, class _Receiver>
+  using __connect_error_t = __mexception<
+    _WHAT_(_CONNECT_ERROR_),
+    _WHY_(_UNABLE_TO_CONNECT_THE_SENDER_TO_THE_RECEIVER_),
+    _WITH_PRETTY_SENDER_<_Sender>,
+    _WITH_RECEIVER_(_Receiver),
+    _WITH_ENVIRONMENT_(env_of_t<_Receiver>)
+  >;
+
 #if __cpp_lib_constexpr_exceptions >= 2025'02L // constexpr exception types, https://wg21.link/p3378
 
   using __exception = ::std::exception;
@@ -258,6 +270,22 @@ namespace STDEXEC {
 
     constexpr bool operator==(const __not_a_scheduler&) const noexcept = default;
   };
+
+  template<bool _MustBeTrue, class _WithError>
+  struct __assert_with;
+
+  template<class _WithError>
+  struct __assert_with<false, _WithError> {
+    static constexpr bool value = __ok<_WithError>;
+    static_assert(__ok<_WithError>, "concept assertion failed with..");
+  };
+  template<class _Elide>
+  struct __assert_with<true, _Elide> {
+    static constexpr bool value = true;
+  };
+  
+  template<bool _MustBeTrue, class _WithError>
+  concept assert_with = __assert_with<_MustBeTrue, _WithError>::value;
 } // namespace STDEXEC
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/stdexec/__detail/__get_completion_signatures.hpp
+++ b/include/stdexec/__detail/__get_completion_signatures.hpp
@@ -238,10 +238,11 @@ namespace STDEXEC {
   }
 
   template <class _Sender, class _Env>
-    requires __has_get_completion_signatures<_Sender, _Env>
+    requires assert_with<
+      __has_get_completion_signatures<_Sender, _Env>, 
+      __unrecognized_sender_error_t<transform_sender_result_t<_Sender, _Env>, _Env>>
   consteval auto get_completion_signatures() {
     using __new_sndr_t = transform_sender_result_t<_Sender, _Env>;
-    static_assert(!__merror<__new_sndr_t>);
     return __cmplsigs::__get_completion_signatures_helper<__new_sndr_t, _Env>();
   }
 
@@ -255,7 +256,9 @@ namespace STDEXEC {
   ///////////////////////////////////////////////////////////////////////////////////////////////////
   // An minimally constrained alias for the result of get_completion_signatures:
   template <class _Sender, class... _Env>
-    requires enable_sender<__decay_t<_Sender>>
+    requires assert_with<
+      enable_sender<__decay_t<_Sender>>, 
+      __unrecognized_sender_error_t<__decay_t<_Sender>, _Env...>>
   using __completion_signatures_of_t =
     decltype(STDEXEC::get_completion_signatures<_Sender, _Env...>());
 

--- a/test/stdexec/concepts/test_concepts_sender.cpp
+++ b/test/stdexec/concepts/test_concepts_sender.cpp
@@ -93,7 +93,7 @@ namespace {
       ex::set_stopped_t()
     >;
 
-    auto connect(empty_recv::recv0&&) const -> oper {
+    auto connect(empty_recv::recv0&&) const -> oper { 
       return {};
     }
   };
@@ -171,11 +171,9 @@ namespace {
     "not all combinations of senders & receivers satisfy the sender_to concept",
     "[concepts][sender]") {
     REQUIRE_FALSE(ex::sender_to<my_sender0, empty_recv::recv_int>);
-    REQUIRE_FALSE(ex::sender_to<my_sender0, empty_recv::recv0_ec>);
     REQUIRE_FALSE(ex::sender_to<my_sender0, empty_recv::recv_int_ec>);
     REQUIRE_FALSE(ex::sender_to<my_sender_int, empty_recv::recv0>);
     REQUIRE_FALSE(ex::sender_to<my_sender_int, empty_recv::recv0_ec>);
-    REQUIRE_FALSE(ex::sender_to<my_sender_int, empty_recv::recv_int_ec>);
   }
 
   TEST_CASE(


### PR DESCRIPTION
I have tried quite hard to create a useful `__mexception` when things fail and then coerce those into the result types of functions like `get_completion_signatures` and `connect` and then to propagate them all the way through the layers.

The recent changes have had me discard three previous attempts to prevent the actual error from being hidden by SFINAE and by `static_assert` s that do not expand the problem `sexpr` into a form that is identifiable.

This PR proposes a different approach. I have described this approach several times. Here it is in code.

With this PR -

Misspelling the name of this connect:

[`      constexpr auto conNnect(_ItemRcvr __rcvr) const & noexcept(__nothrow_decay_copyable<_ItemRcvr>)`](https://github.com/NVIDIA/stdexec/blob/c2fa931f4c8ef8c316d72ca1d4b577aa23bf91eb/include/exec/sequence/iterate.hpp#L78)

Causes this test case:

[`  TEST_CASE("iterate - sum up an array ", "[sequence_senders][iterate]") {`](https://github.com/NVIDIA/stdexec/blob/c2fa931f4c8ef8c316d72ca1d4b577aa23bf91eb/test/exec/sequence/test_iterate.cpp#L103)

To encounter a compile error while evaluating this line deep inside of the `iterate()` sequence implementation:

[`      __optional<connect_result_t<__next_sender_t, __next_receiver_t>> __op_{};`](https://github.com/NVIDIA/stdexec/blob/c2fa931f4c8ef8c316d72ca1d4b577aa23bf91eb/include/exec/sequence/iterate.hpp#L146)

Which produces this log:

```sh
FAILED: [code=1] test/exec/CMakeFiles/test.exec.dir/sequence/test_iterate.cpp.o 
/usr/bin/c++ -DSTDEXEC_ENABLE_LIBDISPATCH -DSTDEXEC_NAMESPACE=std::execution -I[path]/stdexec/include -I[path]/stdexec/build-m1/include -I[path]/stdexec/build-m1/_deps/catch2-src/single_include -I[path]/stdexec/test -O3 -DNDEBUG -std=gnu++20 -arch arm64 -Wall -Werror=unused-parameter -ferror-limit=0 -fmacro-backtrace-limit=0 -ftemplate-backtrace-limit=0 -MD -MT test/exec/CMakeFiles/test.exec.dir/sequence/test_iterate.cpp.o -MF test/exec/CMakeFiles/test.exec.dir/sequence/test_iterate.cpp.o.d -o test/exec/CMakeFiles/test.exec.dir/sequence/test_iterate.cpp.o -c [path]/stdexec/test/exec/sequence/test_iterate.cpp
In file included from [path]/stdexec/test/exec/sequence/test_iterate.cpp:18:
In file included from [path]/stdexec/include/exec/sequence/iterate.hpp:24:
In file included from [path]/stdexec/include/exec/sequence/../../stdexec/execution.hpp:22:
In file included from [path]/stdexec/include/exec/sequence/../../stdexec/__detail/__as_awaitable.hpp:21:
In file included from [path]/stdexec/include/exec/sequence/../../stdexec/__detail/__completion_signatures_of.hpp:21:
In file included from [path]/stdexec/include/exec/sequence/../../stdexec/__detail/__debug.hpp:20:
In file included from [path]/stdexec/include/exec/sequence/../../stdexec/__detail/__completion_signatures.hpp:22:
[path]/stdexec/include/exec/sequence/../../stdexec/__detail/__diagnostics.hpp:280:19: 
error: static assertion failed: concept assertion failed with..
  280 |     static_assert(__ok<_WithError>, "concept assertion failed with..");
      |                   ^~~~~~~~~~~~~~~~

[path]/stdexec/include/exec/sequence/../../stdexec/__detail/__diagnostics.hpp:288:25: 
note: in instantiation of template 
  class 'std::execution::__assert_with<false, std::execution::_ERROR_<std::execution::_WHAT_ (std::execution::_CONNECT_ERROR_), std::execution::_WHY_ (std::execution::_UNABLE_TO_CONNECT_THE_SENDER_TO_THE_RECEIVER_), std::execution::_WITH_SENDER_<exec::__iterate::__sender<int *, int *>>, std::execution::_WITH_RECEIVER_ (exec::_seq::_rcvr<(anonymous namespace)::sum_item_rcvr<exec::__iterate::__next_receiver<int *, int *, (anonymous namespace)::sum_receiver<>>>, true>), std::execution::_WITH_ENVIRONMENT_ (std::execution::__env::env<>)>>' requested here
  288 |   concept assert_with = __assert_with<_MustBeTrue, _WithError>::value;

...
```

Notice that the `connect` that fails is far removed from the sequence's `subscribe()` and deeply buried inside the implementation of `iterate()`. 
Getting the failing `connect` to create an `__mexception` and then propagating that as the result of the `subscribe()` on the sequence returned from `iterate()` is really hard to do the first time and unlikely to continue to work after each future change to the implementation of `iterate()`.

This also allows trailing return types to be specified without causing SFINAE - as long as the `assert_with` constraints in the requires clause cover all the failure cases for computing the return type.

NOTE: I removed a couple of tests because it appeared that they relied on `connect()` SFINAE and they were now compile errors.
