### PR TITLE
various improvements to `__variant`

### DIFF
--- a/include/exec/fork_join.hpp
+++ b/include/exec/fork_join.hpp
@@ -63,7 +63,7 @@ namespace exec {
         STDEXEC::__mset
       >,
       _maybe_eptr_completion_t<Completions>
-    >::template rebind<STDEXEC::__variant_for>;
+    >::template rebind<STDEXEC::__variant>;
 
     template <class Domain>
     struct _env_t {
@@ -207,7 +207,7 @@ namespace exec {
       }
 
       Rcvr _rcvr_;
-      _variant_t<_child_completions_t> _cache_{};
+      _variant_t<_child_completions_t> _cache_{STDEXEC::__no_init};
       STDEXEC::__manual_lifetime<_child_opstate_t> _child_opstate_{};
       _fork_opstate_t _fork_opstate_;
     };

--- a/include/exec/sequence.hpp
+++ b/include/exec/sequence.hpp
@@ -124,10 +124,8 @@ namespace exec {
       template <class Sender, class IsLast>
       using _child_opstate_t = STDEXEC::connect_result_t<Sender, _rcvr_t<IsLast::value>>;
 
-      using _mk_child_ops_variant_fn = STDEXEC::__mzip_with2<
-        STDEXEC::__q2<_child_opstate_t>,
-        STDEXEC::__qq<STDEXEC::__variant_for>
-      >;
+      using _mk_child_ops_variant_fn =
+        STDEXEC::__mzip_with2<STDEXEC::__q2<_child_opstate_t>, STDEXEC::__qq<STDEXEC::__variant>>;
 
       using _ops_variant_t = STDEXEC::__minvoke<
         _mk_child_ops_variant_fn,
@@ -174,11 +172,11 @@ namespace exec {
         if (sizeof...(Senders) != 0) {
           this->_start_next_ = &_start_next<sizeof...(Senders)>;
         }
-        STDEXEC::start(_ops.template get<0>());
+        STDEXEC::start(STDEXEC::__var::__get<0>(_ops));
       }
 
       _senders_tuple_t _sndrs;
-      _ops_variant_t _ops{};
+      _ops_variant_t _ops{STDEXEC::__no_init};
     };
 
     // The completions of the sequence sender are the error and stopped completions of all the

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -78,7 +78,7 @@ namespace exec {
         }
       }
 
-      _ResultVariant __result_{};
+      _ResultVariant __result_{STDEXEC::__no_init};
       __std::atomic<int> __emplaced_{0};
     };
 
@@ -231,7 +231,7 @@ namespace exec {
       __mconst<__mlist<>>::__f,
       __mcompose_q<__mlist, __mbind_front_q<__decayed_tuple, set_error_t>::__f>::__f,
       __mlist<__tuple<set_stopped_t>>,
-      __mconcat<__qq<__variant_for>>::__f
+      __mconcat<__qq<__variant>>::__f
     >;
 
     template <class _Sender, class _Env>

--- a/include/exec/sequence/merge_each.hpp
+++ b/include/exec/sequence/merge_each.hpp
@@ -456,7 +456,7 @@ namespace exec {
       }
 
       _Receiver __rcvr_;
-      _ErrorStorage __error_storage_{};
+      _ErrorStorage __error_storage_{__no_init};
       std::exception_ptr __ex_ = nullptr;
       std::atomic_int32_t __active_ = 0;
       std::atomic<__completion_t> __completion_{__completion_t::__started};
@@ -656,7 +656,7 @@ namespace exec {
 
       _NextReceiver __rcvr_;
       _OperationBase* __op_;
-      _NestedSeqOp __nested_seq_op_{};
+      _NestedSeqOp __nested_seq_op_{__no_init};
     };
 
     //
@@ -868,7 +868,7 @@ namespace exec {
 
       template <class _Sequence, class... _Env>
       using __error_variant_t =
-        __mapply_q<STDEXEC::__uniqued_variant_for, __errors_t<_Sequence, _Env...>>;
+        __mapply_q<STDEXEC::__uniqued_variant, __errors_t<_Sequence, _Env...>>;
 
       //
       // __nested_values extracts the types of all the nested value senders and
@@ -917,7 +917,7 @@ namespace exec {
       using __nested_sequence_ops_variant = __mapply<
         STDEXEC::__mtransform<
           __nested_sequence_op_fn<__operation_base_t<_Sequence, _Receiver>>,
-          STDEXEC::__qq<STDEXEC::__uniqued_variant_for>
+          STDEXEC::__qq<STDEXEC::__uniqued_variant>
         >,
         __nested_sequences_t<
           _Sequence,

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -264,7 +264,7 @@ namespace exec {
         __data_.template emplace<0>(std::move(value));
       }
 
-      __variant_for<_Ty, std::exception_ptr> __data_{};
+      __variant<_Ty, std::exception_ptr> __data_{__no_init};
     };
 
     template <>
@@ -275,7 +275,7 @@ namespace exec {
         __data_.template emplace<0>(__void{});
       }
 
-      __variant_for<__void, std::exception_ptr> __data_{};
+      __variant<__void, std::exception_ptr> __data_{__no_init};
     };
 
     template <class _Sch>
@@ -467,10 +467,12 @@ namespace exec {
         constexpr auto await_resume() -> _Ty {
           __context_.reset();
           scope_guard __on_exit{[this]() noexcept { std::exchange(__coro_, {}).destroy(); }};
+
           if (__coro_.promise().__data_.index() == 1)
-            std::rethrow_exception(std::move(__coro_.promise().__data_.template get<1>()));
+            std::rethrow_exception(std::move(__var::__get<1>(__coro_.promise().__data_)));
+
           if constexpr (!std::is_void_v<_Ty>)
-            return std::move(__coro_.promise().__data_.template get<0>());
+            return std::move(__var::__get<0>(__coro_.promise().__data_));
         }
       };
 

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -74,7 +74,7 @@ namespace exec {
     using __result_type_t = __for_each_completion_signature_t<
       __minvoke<__completions_fn<_Env>, _CvSenders...>,
       __decayed_tuple,
-      __uniqued_variant_for
+      __uniqued_variant
     >;
 
     template <class _Receiver>
@@ -107,7 +107,7 @@ namespace exec {
       __std::atomic<std::size_t> __count_{};
 
       _Receiver __rcvr_;
-      _ResultVariant __result_{};
+      _ResultVariant __result_{__no_init};
 
       template <class _Tag, class... _Args>
       void notify(_Tag, _Args&&... __args) noexcept {

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -55,7 +55,7 @@ namespace nvexec {
       V&& v,
       std::size_t index) {
       if (0 == index) {
-        static_cast<VisitorT&&>(visitor)((static_cast<V&&>(v)).template get<0>());
+        static_cast<VisitorT&&>(visitor)(static_cast<V&&>(v).template get<0>());
       }
     }
 
@@ -67,7 +67,7 @@ namespace nvexec {
       V&& v,
       std::size_t index) {
       if (I == index) {
-        static_cast<VisitorT&&>(visitor)((static_cast<V&&>(v)).template get<I>());
+        static_cast<VisitorT&&>(visitor)(static_cast<V&&>(v).template get<I>());
         return;
       }
 

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -325,7 +325,7 @@ namespace nvexec {
     };
 
     template <class... Ts>
-    // using _nullable_variant_t = STDEXEC::__variant_for<::cuda::std::tuple<set_noop>, Ts...>;
+    // using _nullable_variant_t = STDEXEC::__variant<::cuda::std::tuple<set_noop>, Ts...>;
     using _nullable_variant_t = variant_t<::cuda::std::tuple<set_noop>, Ts...>;
 
     template <class... Ts>
@@ -407,11 +407,13 @@ namespace nvexec {
     concept stream_sender = sender_in<Sender, E>
                          && STDEXEC_IS_BASE_OF(
                               stream_sender_base,
-                              STDEXEC_REMOVE_REFERENCE(STDEXEC::transform_sender_result_t<Sender, E>));
+                              STDEXEC_REMOVE_REFERENCE(
+                                STDEXEC::transform_sender_result_t<Sender, E>));
 
     template <class Receiver>
-    concept stream_receiver = receiver<Receiver>
-                           && STDEXEC_IS_BASE_OF(stream_receiver_base, STDEXEC_REMOVE_REFERENCE(Receiver));
+    concept stream_receiver =
+      receiver<Receiver>
+      && STDEXEC_IS_BASE_OF(stream_receiver_base, STDEXEC_REMOVE_REFERENCE(Receiver));
 
     struct stream_opstate_base { };
 
@@ -632,8 +634,7 @@ namespace nvexec {
 
       template <class... Args>
       void set_value(Args&&... args) noexcept {
-        opstate_
-          .propagate_completion_signal(set_value_t(), static_cast<Args&&>(args)...);
+        opstate_.propagate_completion_signal(set_value_t(), static_cast<Args&&>(args)...);
       }
 
       template <class Error>
@@ -775,11 +776,13 @@ namespace nvexec {
     template <class Sender, class E>
     concept stream_completing_sender =
       sender<Sender>
-      && gpu_stream_scheduler<__result_of<get_completion_scheduler<set_value_t>, env_of_t<Sender>, E>, E>;
+      && gpu_stream_scheduler<
+        __result_of<get_completion_scheduler<set_value_t>, env_of_t<Sender>, E>,
+        E
+      >;
 
     template <class InnerReceiverProvider, class OuterReceiver>
-    using inner_receiver_t =
-      __call_result_t<InnerReceiverProvider, opstate_base<OuterReceiver>&>;
+    using inner_receiver_t = __call_result_t<InnerReceiverProvider, opstate_base<OuterReceiver>&>;
 
     template <class CvSender, class InnerReceiver, class OuterReceiver>
     using stream_opstate_t = _strm::opstate<CvSender, InnerReceiver, OuterReceiver>;

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -287,10 +287,8 @@ namespace nvexec::_strm {
         stop_callback_for_t<stop_token_of_t<env_of_t<_receiver_t>>, __forward_stop_request>;
 
       template <class Sender, std::size_t Index>
-      using _child_opstate_t = exit_opstate_t<
-        __copy_cvref_t<_when_all_sender_t, Sender>,
-        receiver<CvReceiver, Index>
-      >;
+      using _child_opstate_t =
+        exit_opstate_t<__copy_cvref_t<_when_all_sender_t, Sender>, receiver<CvReceiver, Index>>;
 
       // tuple<tuple<Vs1...>, tuple<Vs2...>, ...>
       using _child_values_t = __if<
@@ -308,7 +306,7 @@ namespace nvexec::_strm {
       >;
 
       using _errors_t =
-        error_types_of_t<when_all_sender, _when_all::env_t<_env_t>, __uniqued_variant_for>;
+        error_types_of_t<when_all_sender, _when_all::env_t<_env_t>, __uniqued_variant>;
 
       template <size_t... Is>
       static auto
@@ -477,7 +475,7 @@ namespace nvexec::_strm {
       // Could be non-atomic here and atomic_ref everywhere except __completion_fn
       std::atomic<_when_all::disposition> state_{_when_all::started};
 
-      _errors_t errors_{};
+      _errors_t errors_{__no_init};
       _child_values_t* values_{};
       inplace_stop_source stop_source_{};
 

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -571,11 +571,13 @@ namespace STDEXEC {
 #endif
 
 #if defined(__cpp_if_consteval) && __cpp_if_consteval >= 2021'06L
-#  define STDEXEC_IF_CONSTEVAL if consteval
+#  define STDEXEC_IF_CONSTEVAL     if consteval
 #  define STDEXEC_IF_NOT_CONSTEVAL if !consteval
 #else
 #  define STDEXEC_IF_CONSTEVAL if (std::is_constant_evaluated())
-#  define STDEXEC_IF_NOT_CONSTEVAL if (std::is_constant_evaluated()) {} else
+#  define STDEXEC_IF_NOT_CONSTEVAL                                                                 \
+    if (std::is_constant_evaluated()) {                                                            \
+    } else
 #endif
 
 #ifdef STDEXEC_ASSERT
@@ -799,9 +801,11 @@ namespace STDEXEC {
 #endif
 
 #if __cplusplus >= 2022'11L
-#  define STDEXEC_CONSTEXPR_CXX23 constexpr
+#  define STDEXEC_CONSTEXPR_CXX23        constexpr
+#  define STDEXEC_STATIC_CONSTEXPR_LOCAL static constexpr
 #else
 #  define STDEXEC_CONSTEXPR_CXX23
+#  define STDEXEC_STATIC_CONSTEXPR_LOCAL constexpr
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/stdexec/__detail/__continues_on.hpp
+++ b/include/stdexec/__detail/__continues_on.hpp
@@ -30,7 +30,7 @@
 #include "__transform_completion_signatures.hpp"
 #include "__tuple.hpp"
 #include "__utility.hpp"
-#include "__variant.hpp" // IWYU pragma: keep for __variant_for
+#include "__variant.hpp" // IWYU pragma: keep for __variant
 
 namespace STDEXEC {
   /////////////////////////////////////////////////////////////////////////////
@@ -52,7 +52,7 @@ namespace STDEXEC {
     using __results_of = __for_each_completion_signature_t<
       __completion_signatures_of_t<_CvSender, _Env>,
       __decayed_tuple,
-      __munique<__qq<STDEXEC::__variant_for>>::__f
+      __munique<__qq<STDEXEC::__variant>>::__f
     >;
 
     template <class... _Values>
@@ -98,7 +98,7 @@ namespace STDEXEC {
       using __variant_t = __results_of<__child_of<_Sexpr>, env_of_t<_Receiver>>;
 
       _Receiver __rcvr_;
-      __variant_t __data_{};
+      __variant_t __data_{__no_init};
     };
 
     // This receiver is to be completed on the execution context associated with the scheduler. When
@@ -137,7 +137,7 @@ namespace STDEXEC {
       using __receiver2_t = __receiver2<_Sexpr, _Receiver>;
 
       constexpr explicit __state(_Scheduler __sched, _Receiver&& __rcvr)
-        : __state::__state_base{{}, static_cast<_Receiver&&>(__rcvr), {}}
+        : __state::__state_base{{}, static_cast<_Receiver&&>(__rcvr)}
         , __state2_(connect(schedule(__sched), __receiver2_t{this})) {
       }
 

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -338,7 +338,7 @@ namespace STDEXEC {
       STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS
       _Env2 __env2_;
       //! Variant to hold the child sender's results before passing them to the function:
-      __variant_for<_Tuples...> __args_{};
+      __variant<_Tuples...> __args_{__no_init};
     };
 
     template <class _SetTag, class _Fun, class _Receiver, class _Env2, class... _Tuples>
@@ -400,7 +400,7 @@ namespace STDEXEC {
       using __first_rcvr_t = __first_rcvr<_SetTag, _Fun, _Receiver, __env2_t, _Tuples...>;
       using __second_rcvr_t = __opstate::__opstate_base::__second_rcvr_t;
 
-      using __op_state_variant_t = __variant_for<
+      using __op_state_variant_t = __variant<
         connect_result_t<_Child, __first_rcvr_t>,
         __mapply<__submit_datum_for<_Receiver, _Fun, _SetTag, __env2_t>, _Tuples>...
       >;
@@ -418,7 +418,7 @@ namespace STDEXEC {
 
       constexpr void start() noexcept {
         STDEXEC_ASSERT(__storage_.index() == 0);
-        STDEXEC::start(__storage_.template get<0>());
+        STDEXEC::start(__var::__get<0>(__storage_));
       };
 
       constexpr void __start_next() final {
@@ -430,7 +430,7 @@ namespace STDEXEC {
       }
 
       //! Variant type for holding the operation state of the currently in flight operation
-      __op_state_variant_t __storage_{};
+      __op_state_variant_t __storage_{__no_init};
     };
 
     // The set_value completions of:

--- a/include/stdexec/__detail/__shared.hpp
+++ b/include/stdexec/__detail/__shared.hpp
@@ -117,7 +117,7 @@ namespace STDEXEC::__shared {
     __mbind_front_q<__decayed_tuple, set_value_t>::__f,
     __mbind_front_q<__decayed_tuple, set_error_t>::__f,
     __tuple<set_stopped_t>,
-    __munique<__qq<__variant_for>>::__f,
+    __munique<__qq<__variant>>::__f,
     __tuple<set_error_t, std::exception_ptr>,
     __tuple<set_stopped_t>
   >;
@@ -312,7 +312,7 @@ namespace STDEXEC::__shared {
     __waiters_list_t __waiters_{};
     inplace_stop_source __stop_source_{};
     __env_t<_Env> __env_;
-    _Variant __results_{}; // Initialized to the "set_stopped" state in the ctor.
+    _Variant __results_{__no_init}; // Initialized to the "set_stopped" state in the ctor.
   };
 
   template <class _Env, class _Variant>

--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -144,11 +144,11 @@ namespace STDEXEC {
     using __value_tuple_for_t = __t<__value_tuple_for<_CvSender>>;
 
     template <class _CvSender>
-    struct __variant_for {
+    struct __variant {
       using __t = __sync_wait_with_variant_result_t<_CvSender>;
     };
     template <class _CvSender>
-    using __variant_for_t = __t<__variant_for<_CvSender>>;
+    using __variant_for_t = __t<__variant<_CvSender>>;
 
     struct _SENDER_HAS_TOO_MANY_SUCCESSFUL_COMPLETIONS_ { };
     struct _USE_SYNC_WAIT_WITH_VARIANT_INSTEAD_ { };

--- a/include/stdexec/__detail/__task_scheduler.hpp
+++ b/include/stdexec/__detail/__task_scheduler.hpp
@@ -29,7 +29,7 @@
 #include "__schedulers.hpp"
 #include "__transform_completion_signatures.hpp"
 #include "__typeinfo.hpp"
-#include "__variant.hpp" // IWYU pragma: keep for __variant_for
+#include "__variant.hpp" // IWYU pragma: keep for __variant
 
 #include <cstddef>
 
@@ -371,8 +371,9 @@ namespace STDEXEC {
       void execute(size_t __begin, size_t __end) noexcept final {
         STDEXEC_TRY {
           using __policy_t = std::remove_cvref_t<decltype(__declval<_Policy>().__get())>;
-          constexpr bool __parallelize = std::same_as<__policy_t, STDEXEC::parallel_policy>
-                                      || std::same_as<__policy_t, STDEXEC::parallel_unsequenced_policy>;
+          constexpr bool __parallelize =
+            std::same_as<__policy_t, STDEXEC::parallel_policy>
+            || std::same_as<__policy_t, STDEXEC::parallel_unsequenced_policy>;
           __visit(
             __detail::__get_execute_bulk_fn<__parallelize>(
               _BulkTag(), __fn_, __shape_, __begin, __end),
@@ -389,7 +390,7 @@ namespace STDEXEC {
 
       _Fn __fn_;
       size_t __shape_;
-      _Values __values_{};
+      _Values __values_{__no_init};
       __backend_ptr_t __backend_;
       std::byte __storage_[8 * sizeof(void*)];
     };
@@ -419,7 +420,7 @@ namespace STDEXEC {
         _Sndr,
         __fwd_env_t<env_of_t<_Rcvr>>,
         __decayed_tuple,
-        __mbind_front_q<__variant_for, __monostate>::__f
+        __mbind_front_q<__variant, __monostate>::__f
       >;
       using __rcvr_t = __task_bulk_receiver<_BulkTag, _Policy, _Fn, _Rcvr, __values_t>;
       using __opstate1_t = connect_result_t<_Sndr, __rcvr_t>;

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -38,6 +38,9 @@ namespace STDEXEC {
 
   struct __none_such { };
 
+  inline constexpr struct __no_init_t {
+  } __no_init{};
+
   namespace {
     struct __anon { };
   } // namespace
@@ -334,8 +337,7 @@ namespace STDEXEC {
     STDEXEC_IF_CONSTEVAL {
       // The following `if constexpr` is needed to keep compilers from complaining that
       // neither branch of the `if consteval` (above) is a constant expression.
-      if constexpr (!__mnever<_Return>)
-      {
+      if constexpr (!__mnever<_Return>) {
         __std::unreachable();
       }
     }

--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -20,10 +20,10 @@
 #include "__type_traits.hpp"
 #include "__utility.hpp"
 
+#include <array>
 #include <cstddef>
 #include <memory>
 #include <new>
-#include <type_traits>
 #include <utility>
 
 /********************************************************************************/
@@ -50,8 +50,9 @@ namespace STDEXEC {
   struct __visit_t {
     template <class _Fn, class _Variant, class... _As>
     STDEXEC_ATTRIBUTE(host, device, always_inline)
-    constexpr void operator()(_Fn &&__fn, _Variant &&__var, _As &&...__as) const noexcept( //
-      noexcept(__var.__visit(__declval<_Fn>(), __declval<_Variant>(), __declval<_As>()...))) {
+    constexpr auto operator()(_Fn &&__fn, _Variant &&__var, _As &&...__as) const noexcept( //
+      noexcept(__var.__visit(__declval<_Fn>(), __declval<_Variant>(), __declval<_As>()...)))
+      -> decltype(auto) {
       return __var.__visit(
         static_cast<_Fn &&>(__fn), static_cast<_Variant &&>(__var), static_cast<_As &&>(__as)...);
     }
@@ -66,12 +67,29 @@ namespace STDEXEC {
       return __scope_guard{[&__index]() noexcept { __index = __variant_npos; }};
     }
 
+    template <std::size_t _Ny, class _Variant>
+    STDEXEC_ATTRIBUTE(host, device)
+    constexpr auto __get(_Variant &&__var) noexcept -> decltype(auto) {
+      return __var.template __get<_Ny>(static_cast<_Variant &&>(__var));
+    }
+
+    template <size_t _Ny, class _Fn, class _Self, class... _Us>
+    STDEXEC_ATTRIBUTE(host, device)
+    static constexpr auto __visit_alt(_Fn &&__fn, _Self &&__self, _Us &&...__us) -> decltype(auto) {
+      return static_cast<_Fn &&>(
+        __fn)(static_cast<_Us &&>(__us)..., __var::__get<_Ny>(static_cast<_Self &&>(__self)));
+    }
+
     template <auto _Idx, class... _Ts>
     class __variant;
 
     template <>
     class __variant<__indices<>{}> {
      public:
+      STDEXEC_ATTRIBUTE(host, device)
+      constexpr __variant(__no_init_t) noexcept {
+      }
+
       template <class _Fn, class... _Us>
       STDEXEC_ATTRIBUTE(host, device)
       constexpr void visit(_Fn &&, _Us &&...) const noexcept {
@@ -92,39 +110,55 @@ namespace STDEXEC {
     template <std::size_t... _Is, __indices<_Is...> _Idx, class... _Ts>
     class __variant<_Idx, _Ts...> {
       static constexpr std::size_t __max_size = STDEXEC::__umax({sizeof(_Ts)...});
-      static_assert(__max_size != 0);
-      std::size_t __index_{__variant_npos};
-      alignas(_Ts...) unsigned char __storage_[__max_size];
+
+      template <std::size_t _Ny>
+      using __at_t = __m_at_c<_Ny, _Ts...>;
+
+      struct __move_visitor {
+        template <class _Self, class _Ty>
+        constexpr void operator()(_Self &__self, _Ty &&__val) const //
+          noexcept(__nothrow_decay_copyable<_Ty>) {
+          __self.template emplace<__decay_t<_Ty>>(static_cast<_Ty &&>(__val));
+        }
+      };
+
+      struct __copy_visitor {
+        template <class _Self, class _Ty>
+        constexpr void operator()(_Self &__self, const _Ty &__val) const //
+          noexcept(__nothrow_decay_copyable<_Ty>) {
+          __self.template emplace<__decay_t<_Ty>>(__val);
+        }
+      };
 
       STDEXEC_ATTRIBUTE(host, device)
       constexpr void __destroy() noexcept {
         auto __index = std::exchange(__index_, __variant_npos);
-        void *const __ptr = __get_ptr();
+        void *const __ptr = __data();
         if (__variant_npos != __index) {
           ((_Is == __index ? std::destroy_at(static_cast<_Ts *>(__ptr)) : void(0)), ...);
         }
       }
 
-      struct __move_visitor {
-        template <class _Ty>
-        STDEXEC_ATTRIBUTE(host, device)
-        constexpr void operator()(__variant &__self, _Ty &&__val) const noexcept {
-          __self.template emplace<_Ty>(static_cast<_Ty &&>(__val));
-        }
-      };
+      std::size_t __index_{__variant_npos};
+      alignas(_Ts...) std::byte __storage_[__max_size];
 
      public:
-      template <std::size_t _Ny>
-      using __at = __m_at_c<_Ny, _Ts...>;
-
+      // Construct into the valueless state:
       STDEXEC_ATTRIBUTE(host, device)
-      __variant() noexcept = default;
+      constexpr explicit __variant(__no_init_t) noexcept {
+      }
 
       STDEXEC_ATTRIBUTE(host, device)
       constexpr __variant(__variant &&__other) noexcept {
-        static_assert(__nothrow_move_constructible<_Ts...>);
         if (!__other.__is_valueless()) {
-          __visit(__move_visitor{}, __other, *this);
+          __visit(__move_visitor{}, std::move(__other), *this);
+        }
+      }
+
+      STDEXEC_ATTRIBUTE(host, device)
+      constexpr __variant(const __variant &__other) {
+        if (!__other.__is_valueless()) {
+          __visit(__copy_visitor{}, __other, *this);
         }
       }
 
@@ -136,32 +170,46 @@ namespace STDEXEC {
       STDEXEC_ATTRIBUTE(host, device)
       constexpr __variant &operator=(__variant &&__other) noexcept {
         if (this != &__other) {
-          static_assert(__nothrow_move_constructible<_Ts...>);
-          __visit(__move_visitor{}, __other, *this);
+          __destroy();
+          if (!__other.__is_valueless()) {
+            __visit(__move_visitor{}, std::move(__other), *this);
+          }
+        }
+        return *this;
+      }
+
+      STDEXEC_ATTRIBUTE(host, device)
+      constexpr __variant &operator=(const __variant &__other) {
+        if (this != &__other) {
+          __destroy();
+          if (!__other.__is_valueless()) {
+            __visit(__copy_visitor{}, __other, *this);
+          }
         }
         return *this;
       }
 
       [[nodiscard]]
-      STDEXEC_ATTRIBUTE(host, device, always_inline) constexpr auto __get_ptr() noexcept -> void * {
+      STDEXEC_ATTRIBUTE(host, device, always_inline) //
+        constexpr auto __data() noexcept -> void * {
         return __storage_;
       }
 
       [[nodiscard]]
-      STDEXEC_ATTRIBUTE(host, device, always_inline) constexpr auto __get_ptr() const noexcept
-        -> const void * {
+      STDEXEC_ATTRIBUTE(host, device, always_inline) //
+        constexpr auto __data() const noexcept -> const void * {
         return __storage_;
       }
 
       [[nodiscard]]
-      STDEXEC_ATTRIBUTE(host, device, always_inline) constexpr auto index() const noexcept
-        -> std::size_t {
+      STDEXEC_ATTRIBUTE(host, device, always_inline) //
+        constexpr auto index() const noexcept -> std::size_t {
         return __index_;
       }
 
       [[nodiscard]]
-      STDEXEC_ATTRIBUTE(host, device, always_inline) constexpr auto __is_valueless() const noexcept
-        -> bool {
+      STDEXEC_ATTRIBUTE(host, device, always_inline) //
+        constexpr auto __is_valueless() const noexcept -> bool {
         return __index_ == __variant_npos;
       }
 
@@ -187,8 +235,7 @@ namespace STDEXEC {
 
         __destroy();
         auto __sg = __mk_index_guard(__index_, __new_index);
-        auto *__ptr =
-          std::construct_at(static_cast<_Ty *>(__get_ptr()), static_cast<_As &&>(__as)...);
+        auto *__ptr = std::construct_at(static_cast<_Ty *>(__data()), static_cast<_As &&>(__as)...);
         __sg.__dismiss();
         return *std::launder(__ptr);
       }
@@ -196,13 +243,13 @@ namespace STDEXEC {
       template <std::size_t _Ny, class... _As>
       STDEXEC_ATTRIBUTE(host, device)
       constexpr auto emplace(_As &&...__as)
-        noexcept(__nothrow_constructible_from<__at<_Ny>, _As...>) -> __at<_Ny> & {
+        noexcept(__nothrow_constructible_from<__at_t<_Ny>, _As...>) -> __at_t<_Ny> & {
         static_assert(_Ny < sizeof...(_Ts), "variant index is too large");
 
         __destroy();
         auto __sg = __mk_index_guard(__index_, _Ny);
         auto *__ptr =
-          std::construct_at(static_cast<__at<_Ny> *>(__get_ptr()), static_cast<_As &&>(__as)...);
+          std::construct_at(static_cast<__at_t<_Ny> *>(__data()), static_cast<_As &&>(__as)...);
         __sg.__dismiss();
         return *std::launder(__ptr);
       }
@@ -210,25 +257,27 @@ namespace STDEXEC {
       template <std::size_t _Ny, class _Fn, class... _As>
       STDEXEC_ATTRIBUTE(host, device)
       constexpr auto __emplace_from(_Fn &&__fn, _As &&...__as)
-        noexcept(__nothrow_callable<_Fn, _As...>) -> __at<_Ny> & {
+        noexcept(__nothrow_callable<_Fn, _As...>) -> __at_t<_Ny> & {
+        using __value_t = __at_t<_Ny>;
         static_assert(
-          __same_as<__call_result_t<_Fn, _As...>, __at<_Ny>>,
+          __same_as<__call_result_t<_Fn, _As...>, __value_t>,
           "callable does not return the correct type");
         constexpr bool __is_nothrow = __nothrow_callable<_Fn, _As...>;
 
         __destroy();
         auto __sg = __mk_index_guard(__index_, _Ny);
-        if (std::is_constant_evaluated()) {
-          auto *__ptr = std::construct_at<__at<_Ny>>(
-            static_cast<__at<_Ny> *>(__get_ptr()),
+        STDEXEC_IF_CONSTEVAL {
+          auto *__ptr = std::construct_at<__value_t>(
+            static_cast<__value_t *>(__data()),
             STDEXEC::__emplace_from([&]() noexcept(__is_nothrow) -> decltype(auto) {
               return static_cast<_Fn &&>(__fn)(static_cast<_As &&>(__as)...);
             }));
           __sg.__dismiss();
           return *std::launder(__ptr);
-        } else {
-          auto *__ptr = ::new (__get_ptr())
-            __at<_Ny>(static_cast<_Fn &&>(__fn)(static_cast<_As &&>(__as)...));
+        }
+        else {
+          auto *__ptr = ::new (__data())
+            __value_t(static_cast<_Fn &&>(__fn)(static_cast<_As &&>(__as)...));
           __sg.__dismiss();
           return *std::launder(__ptr);
         }
@@ -244,56 +293,43 @@ namespace STDEXEC {
         return __emplace_from<__new_index>(static_cast<_Fn &&>(__fn), static_cast<_As &&>(__as)...);
       }
 
-      template <class _Fn, class _Self, class... _As>
+      template <class _Fn, class _Self, class... _Us>
       STDEXEC_ATTRIBUTE(host, device)
-      static constexpr void __visit(_Fn &&__fn, _Self &&__self, _As &&...__as)
-        noexcept((__nothrow_callable<_Fn, _As..., __copy_cvref_t<_Self, _Ts>> && ...)) {
+      static constexpr auto __visit(_Fn &&__fn, _Self &&__self, _Us &&...__us)
+        noexcept((__nothrow_callable<_Fn, _Us..., __copy_cvref_t<_Self, _Ts>> && ...))
+          -> decltype(auto) {
+        STDEXEC_STATIC_CONSTEXPR_LOCAL auto __vtable = std::array{
+          &__var::__visit_alt<_Is, _Fn, _Self, _Us...>...};
         STDEXEC_ASSERT(__self.__index_ != __variant_npos);
-        auto __index = __self.__index_; // make it local so we don't access it after it's deleted.
-        ((_Is == __index
-            ? static_cast<_Fn &&>(__fn)(
-                static_cast<_As &&>(__as)..., static_cast<_Self &&>(__self).template get<_Is>())
-            : void()),
-         ...);
+        return (*__vtable[__self.__index_])(
+          static_cast<_Fn &&>(__fn), static_cast<_Self &&>(__self), static_cast<_Us &&>(__us)...);
       }
 
-      template <std::size_t _Ny>
-      STDEXEC_ATTRIBUTE(nodiscard, host, device, always_inline)
-      constexpr auto get() && noexcept -> decltype(auto) {
-        STDEXEC_ASSERT(_Ny == __index_);
-        return static_cast<__at<_Ny> &&>(*static_cast<__at<_Ny> *>(__get_ptr()));
+      void swap(__variant &__other) noexcept {
+        std::swap(*this, __other);
       }
 
-      template <std::size_t _Ny>
+      template <std::size_t _Ny, class _Self>
       STDEXEC_ATTRIBUTE(nodiscard, host, device, always_inline)
-      constexpr auto get() & noexcept -> decltype(auto) {
-        STDEXEC_ASSERT(_Ny == __index_);
-        return *static_cast<__at<_Ny> *>(__get_ptr());
-      }
-
-      template <std::size_t _Ny>
-      STDEXEC_ATTRIBUTE(nodiscard, host, device, always_inline)
-      constexpr auto get() const & noexcept -> decltype(auto) {
-        STDEXEC_ASSERT(_Ny == __index_);
-        return *static_cast<const __at<_Ny> *>(__get_ptr());
+      static constexpr auto __get(_Self &&__self) noexcept -> decltype(auto) {
+        using __value_t = __at_t<_Ny>;
+        STDEXEC_ASSERT(_Ny == __self.__index_);
+        return static_cast<__copy_cvref_t<_Self, __at_t<_Ny>> &&>(
+          *const_cast<__value_t *>(static_cast<const __value_t *>(__self.__data())));
       }
     };
+
+    template <class... _Ts>
+    using __variant_base_t = __variant<__indices_for<_Ts...>{}, _Ts...>;
   } // namespace __var
 
-  using __var::__variant;
-
   template <class... _Ts>
-  using __variant_for = __variant<__indices_for<_Ts...>{}, _Ts...>;
+  struct __variant : __var::__variant_base_t<_Ts...> {
+    using __var::__variant_base_t<_Ts...>::__variant_base_t;
+  };
 
   template <class... Ts>
-  using __uniqued_variant_for = __mcall<__munique<__qq<__variant_for>>, __decay_t<Ts>...>;
-
-  // So we can use __variant as a typelist
-  template <auto _Idx, class... _Ts>
-  struct __mfor<__variant<_Idx, _Ts...>> {
-    template <class _Fn>
-    using __f = __minvoke<_Fn, _Ts...>;
-  };
+  using __uniqued_variant = __mcall<__munique<__qq<__variant>>, __decay_t<Ts>...>;
 } // namespace STDEXEC
 
 STDEXEC_PRAGMA_POP()

--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -172,7 +172,7 @@ namespace STDEXEC {
         __error_types_of_t<_Senders, __env_t<_Env>, __q<__mlist>>...
       >;
 
-      using __errors_variant = __mapply<__q<__uniqued_variant_for>, __errors_list>;
+      using __errors_variant = __mapply<__q<__uniqued_variant>, __errors_list>;
     };
 
     struct _INVALID_ARGUMENTS_TO_WHEN_ALL_ { };
@@ -223,7 +223,7 @@ namespace STDEXEC {
           }
           break;
         case __error:
-          if constexpr (!__same_as<_ErrorsVariant, __variant_for<>>) {
+          if constexpr (!__same_as<_ErrorsVariant, __variant<>>) {
             // One or more child operations completed with an error:
             STDEXEC::__visit(
               __mk_completion_fn(set_error, __rcvr_), static_cast<_ErrorsVariant&&>(__errors_));
@@ -246,7 +246,7 @@ namespace STDEXEC {
       inplace_stop_source __stop_source_{};
       // Could be non-atomic here and atomic_ref everywhere except __completion_fn
       __std::atomic<__state_t> __state_{__started};
-      _ErrorsVariant __errors_{};
+      _ErrorsVariant __errors_{__no_init};
       STDEXEC_IMMOVABLE_NO_UNIQUE_ADDRESS
       _ValuesTuple __values_{};
       __optional<__stop_callback_t> __on_stop_{};


### PR DESCRIPTION
* rename `__variant_for` to `__variant`
* replace default constructor with one that takes a `__no_init` argument
* add `__var::__get<I>(var)` free function
