### PR TITLE
exec(fork_join): don't use `__rcvr_ref` if it will create env issues

### DIFF
--- a/test/exec/test_fork.cpp
+++ b/test/exec/test_fork.cpp
@@ -147,4 +147,19 @@ namespace {
       std::get<0>(STDEXEC::sync_wait(std::move(sndr)).value())
       == "congrats on customizing fork_join_t");
   }
+
+  TEST_CASE("fork_join following a continues_on", "[adaptors][fork_join]") {
+    std::atomic<int> witness = 0;
+
+    auto make_then = [&witness]() {
+      return ::STDEXEC::then([&witness]() noexcept { ++witness; });
+    };
+
+    auto sndr = ::STDEXEC::just() | ::STDEXEC::continues_on(::STDEXEC::inline_scheduler{})
+              | exec::fork_join(make_then(), make_then());
+
+    ::STDEXEC::sync_wait(std::move(sndr));
+
+    CHECK(witness == 2);
+  }
 } // namespace


### PR DESCRIPTION
This PR is an attempt for fixing:
* #1823

As I understand it, `__rcvr_ref::get_env` will be instantiated before the compiler sees the definition of `_opstate_t::get_env`. The relevant compiler error is:
```bash
In file included from /workspaces/stdexec/include/exec/fork_join.hpp:18:
/workspaces/stdexec/include/exec/../stdexec/__detail/__receiver_ref.hpp:55:9: error: static assertion failed: get_env() must return the same type as env_of_t<_Rcvr>
   55 |         __same_as<_Env, env_of_t<_Rcvr>>, "get_env() must return the same type as env_of_t<_Rcvr>");
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

...

/workspaces/stdexec/include/exec/../stdexec/__detail/__receiver_ref.hpp:55:9: note: because '__same_as<std::execution::__env::__fwd<std::execution::__sync_wait::__env>, env_of_t<exec::fork_join_impl_t::_opstate_t<std::execution::(anonymous namespace)::__sexpr<std::execution::(lambda at /workspaces/stdexec/include/exec/../stdexec/__detail/__basic_sender.hpp:56:53){}>, std::execution::__tup::__tuple<std::execution::__clsur::__closure<std::execution::__then::then_t, (lambda at /workspaces/stdexec/test/exec/test_fork.cpp:155:30)>, std::execution::__clsur::__closure<std::execution::__then::then_t, (lambda at /workspaces/stdexec/test/exec/test_fork.cpp:155:30)>>, std::execution::__sync_wait::__receiver<>>>>' evaluated to false
   55 |         __same_as<_Env, env_of_t<_Rcvr>>, "get_env() must return the same type as env_of_t<_Rcvr>");
      |         ^
/workspaces/stdexec/include/exec/../stdexec/__detail/__concepts.hpp:64:23: note: because '__is_same(std::execution::__env::__fwd<std::execution::__sync_wait::__env>, std::execution::__env::env<>)' evaluated to false
   64 |   concept __same_as = STDEXEC_IS_SAME(_Ap, _Bp);
```
meaning that somehow the `env_of_t` got evaluated to `env<>`...