### PR TITLE
asioexec::completion_token & ::use_sender: Non-Dependent Senders

### DIFF
--- a/include/asioexec/completion_token.hpp
+++ b/include/asioexec/completion_token.hpp
@@ -365,17 +365,10 @@ namespace asioexec {
         , args_(static_cast<Us&&>(us)...) {
       }
 
-      template <typename Env>
-        requires std::is_copy_constructible_v<Initiation>
-              && std::is_copy_constructible_v<args_type_>
-      constexpr Signatures get_completion_signatures(const Env&) const & noexcept {
-        return {};
-      }
-
-      template <typename Env>
-        requires std::is_move_constructible_v<Initiation>
-              && std::is_move_constructible_v<args_type_>
-      constexpr Signatures get_completion_signatures(const Env&) && noexcept {
+      template <typename Self, typename... Env>
+        requires std::is_constructible_v<Initiation, ::STDEXEC::__copy_cvref_t<Self, Initiation>>
+              && std::is_constructible_v<args_type_, ::STDEXEC::__copy_cvref_t<Self, args_type_>>
+      static consteval Signatures get_completion_signatures() noexcept {
         return {};
       }
 

--- a/include/asioexec/use_sender.hpp
+++ b/include/asioexec/use_sender.hpp
@@ -158,15 +158,10 @@ namespace asioexec {
 
       using sender_concept = ::STDEXEC::sender_t;
 
-      template <typename Env>
-      constexpr completion_signatures<::STDEXEC::completion_signatures_of_t<Sender, Env>>
-        get_completion_signatures(const Env&) && noexcept {
-        return {};
-      }
-
-      template <typename Env>
-      constexpr completion_signatures<::STDEXEC::completion_signatures_of_t<const Sender&, Env>>
-        get_completion_signatures(const Env&) const & noexcept {
+      template <typename Self, typename... Env>
+      static consteval completion_signatures<
+        ::STDEXEC::completion_signatures_of_t<::STDEXEC::__copy_cvref_t<Self, Sender>, Env...>>
+        get_completion_signatures() noexcept {
         return {};
       }
 

--- a/test/asioexec/test_use_sender.cpp
+++ b/test/asioexec/test_use_sender.cpp
@@ -83,6 +83,11 @@ namespace {
     asio_impl::system_timer t(ctx);
     t.expires_after(std::chrono::years(1));
     auto sender = t.async_wait(use_sender);
+    static_assert(::STDEXEC::sender_in<decltype(sender)>);
+    static_assert(
+      ::STDEXEC::sender_of<
+        decltype(sender),
+        ::STDEXEC::set_value_t()>);
     static_assert(
       set_equivalent<
         ::STDEXEC::completion_signatures_of_t<decltype(sender), ::STDEXEC::env<>>,


### PR DESCRIPTION
asioexec::completion_token and ::use_sender are completion tokens which induce an initiating function to return a sender. Previously these senders were dependent, but this was not necessary: The completion signatures thereof are not changed by the environment. Updated the implementation so that the senders yielded by initiating functions parameterized by asioexec::completion_token or ::use_sender are no longer dependent.

Addresses #1836.