### PR TITLE
stdexec::when_all: Hang After Stop Request

### DIFF
--- a/test/stdexec/algos/adaptors/test_when_all.cpp
+++ b/test/stdexec/algos/adaptors/test_when_all.cpp
@@ -404,7 +404,7 @@ namespace {
                   ex::completion_signatures_of_t<decltype(snd), decltype(env)>,
                   ex::completion_signatures<ex::set_value_t()>
     >);
-    auto op = ex::connect(snd, expect_void_receiver{});
+    auto op = ex::connect(snd, expect_void_receiver(env));
     ex::start(op);
   }
 


### PR DESCRIPTION
std::execution::when_all forwards stop requests through to its children via the exposition-only class on-stop-request, defined as follows (see [exec.snd.general]):

```
struct on-stop-request {
  inplace_stop_source& stop-src;       // exposition only
  void operator()() noexcept { stop-src.request_stop(); }
};
```

stdexec::when_all used to be conforming in this regard, however this changed in 36a92fd776c835abd4dc5e62d43cf040c20a9add. That commit not only complicates the stop callback used by stdexec::when_all but also causes the __stopped state to be reachable even when no child is capable of sending a stopped completion signal. The change to std::execution:: when_all introduced by P3887 (see 712953b245412bf8ebdfdf369136d637beb43aec) depends on the __stopped state being impossible unless a child sends a stopped completion signal. This tension meant that 36a92fd776c835abd4dc5e62d43cf040c20a9add caused stdexec::when_all to not complete (thereby leading to hangs) when:

- No child potentially sent a stopped completion signal, and
- Stop was requested

712953b245412bf8ebdfdf369136d637beb43aec intended to include a unit test preventing the above-described regression but due to a typo (corrected in this commit) that unit test failed in this regard.

Note that 36a92fd776c835abd4dc5e62d43cf040c20a9add is a misdiagnosis and should eventually be reverted (along with this commit save the above- mentioned unit test correction). The issue that
36a92fd776c835abd4dc5e62d43cf040c20a9add aims to address has nothing to do with stdexec::when_all and is instead caused by the fact that stdexec::inplace_stop_source is not well-behaved when the lifetime of the stop source ends during the dispatch of the final stop callback. This issue should be fixed separately and this commit is only intended to workaround the issue in the meantime.

Addresses #1849, fixes issue introduced by #1718.