### PR TITLE
avoid clang/gcc implementation differences in `env<>`

### DIFF
--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -33,13 +33,17 @@ namespace exec {
     };
 
     template <class _Env, class _Query>
-    struct __without : STDEXEC::__env_base_t<_Env> {
-      static_assert(STDEXEC::__nothrow_move_constructible<_Env>);
+    struct __without {
+      template <STDEXEC::__not_same_as<_Query> _OtherQuery, class... _Args>
+        requires STDEXEC::__queryable_with<_Env, _OtherQuery, _Args...>
+      constexpr auto query(_OtherQuery, _Args&&... __args) const
+        noexcept(STDEXEC::__nothrow_queryable_with<_Env, _OtherQuery, _Args...>)
+          -> STDEXEC::__query_result_t<_Env, _OtherQuery, _Args...> {
+        return STDEXEC::__query<_OtherQuery>()(__env_, static_cast<_Args&&>(__args)...);
+      }
 
-      using STDEXEC::__env_base_t<_Env>::query;
-
-      STDEXEC_ATTRIBUTE(nodiscard, host, device)
-      auto query(_Query) const noexcept = delete;
+      STDEXEC_ATTRIBUTE(no_unique_address)
+      _Env __env_;
     };
 
     struct __without_t {

--- a/test/stdexec/queries/test_env.cpp
+++ b/test/stdexec/queries/test_env.cpp
@@ -25,11 +25,9 @@ namespace {
   concept can_get_domain = requires(const T& t) { t.query(::STDEXEC::get_domain); };
 
   namespace zero {
-
     using env = ::STDEXEC::env<>;
     static_assert(std::is_same_v<::STDEXEC::never_stop_token, ::STDEXEC::stop_token_of_t<env>>);
     static_assert(!can_get_domain<env>);
-
   } // namespace zero
 
   namespace one {
@@ -49,4 +47,36 @@ namespace {
     static_assert(std::is_same_v<::STDEXEC::never_stop_token, ::STDEXEC::stop_token_of_t<env>>);
     static_assert(!can_get_domain<env>);
   } // namespace three
+
+  // https://github.com/NVIDIA/stdexec/issues/1840
+  constexpr struct FwdFoo
+    : STDEXEC::__query<FwdFoo>
+    , STDEXEC::forwarding_query_t {
+    using STDEXEC::__query<FwdFoo>::operator();
+  } fwd_foo{};
+
+  constexpr struct Foo : STDEXEC::__query<Foo> {
+  } foo{};
+
+  constexpr struct Bar : STDEXEC::__query<Bar> {
+  } bar{};
+
+  constexpr bool test() {
+    auto env = STDEXEC::env{
+      STDEXEC::env{STDEXEC::prop{fwd_foo, 42.}, STDEXEC::prop{foo, 'F'}},
+      STDEXEC::prop{                        bar,                   31415}
+    };
+
+    static_assert(STDEXEC::__queryable_with<decltype(env), Foo>);
+    return fwd_foo(env) == 42. && bar(env) == 31415;
+  }
+  static_assert(test());
+
+  struct EnvOfThree
+    : STDEXEC::env<
+        STDEXEC::env<STDEXEC::prop<FwdFoo, int>, STDEXEC::prop<Foo, int>>,
+        STDEXEC::prop<Bar, int>
+      > { };
+
+  static_assert(STDEXEC::__queryable_with<EnvOfThree, Foo>);
 } // namespace


### PR DESCRIPTION
fixes #1840