### PR TITLE
guard against self-exchange in the `get_completion_scheduler` query

### DIFF
--- a/include/stdexec/__detail/__schedulers.hpp
+++ b/include/stdexec/__detail/__schedulers.hpp
@@ -141,7 +141,7 @@ namespace STDEXEC {
       template <class _Attrs, class _GetComplSch = get_completion_scheduler_t>
         requires __queryable_with<_Attrs, _GetComplSch>
       constexpr auto operator()(const _Attrs& __attrs, __ignore = {}) const noexcept
-        -> __query_result_t<_Attrs, _GetComplSch> {
+        -> __decay_t<__query_result_t<_Attrs, _GetComplSch>> {
         static_assert(noexcept(__attrs.query(_GetComplSch{})));
         static_assert(scheduler<__query_result_t<_Attrs, _GetComplSch>>);
         return __attrs.query(_GetComplSch{});
@@ -150,7 +150,7 @@ namespace STDEXEC {
       template <class _Attrs, class _Env, class _GetComplSch = get_completion_scheduler_t>
         requires __queryable_with<_Attrs, _GetComplSch, const _Env&>
       constexpr auto operator()(const _Attrs& __attrs, const _Env& __env) const noexcept
-        -> __query_result_t<_Attrs, _GetComplSch, const _Env&> {
+        -> __decay_t<__query_result_t<_Attrs, _GetComplSch, const _Env&>> {
         static_assert(noexcept(__attrs.query(_GetComplSch{}, __env)));
         static_assert(scheduler<__query_result_t<_Attrs, _GetComplSch, const _Env&>>);
         return __attrs.query(_GetComplSch{}, __env);


### PR DESCRIPTION
in `get_completion_scheduler_t`, we have the following:

```c++
__prev = std::exchange(__sch, __read_query_t{}(__sch, __env...));
```

when `__sch.query(get_completion_scheduler)` returns a reference to `*this`, the code above is essentially doing `std::exchange(__sch, __sch)`. `std::exchange` does:

```c++
template <class T, class U = T>
T exchange(T& old_value, U&& new_value) {
  auto old = std::move(old_value);
  old_value = std::forward<U>(new_value);
  return old;
}
```
when `&old_value == &new_value`, the first line puts `new_value` into a moved-from state. then we assign that moved-from object to `old_value`, which is UB in most cases, and never what you want to happen.