### PR TITLE
rename `exec::` to `experimental::execution::`

### DIFF
--- a/include/exec/__detail/__atomic_intrusive_queue.hpp
+++ b/include/exec/__detail/__atomic_intrusive_queue.hpp
@@ -20,7 +20,7 @@
 
 #include "../../stdexec/__detail/__atomic.hpp"
 
-namespace exec {
+namespace experimental::execution {
   template <auto _NextPtr>
   class __atomic_intrusive_queue;
 
@@ -89,4 +89,6 @@ namespace exec {
 
     __atomic_node_pointer __head_{nullptr};
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;

--- a/include/exec/__detail/__basic_sequence.hpp
+++ b/include/exec/__detail/__basic_sequence.hpp
@@ -22,7 +22,7 @@
 
 #include "../sequence_senders.hpp"
 
-namespace exec {
+namespace experimental::execution {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // __seqexpr
   template <class...>
@@ -93,7 +93,9 @@ namespace exec {
 
   template <class _Tag, class _Domain = STDEXEC::default_domain>
   inline constexpr __mkseqexpr::make_sequence_expr_t<_Tag, _Domain> make_sequence_expr{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC::__detail {
   template <auto _DescriptorFn>

--- a/include/exec/__detail/__bit_cast.hpp
+++ b/include/exec/__detail/__bit_cast.hpp
@@ -27,7 +27,7 @@
 
 #include <cstring>
 
-namespace exec {
+namespace experimental::execution {
 
   template <class _Ty>
   concept __trivially_copyable = STDEXEC_IS_TRIVIALLY_COPYABLE(_Ty);
@@ -48,4 +48,7 @@ namespace exec {
 #  endif
   }
 #endif
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/__detail/__bwos_lifo_queue.hpp
+++ b/include/exec/__detail/__bwos_lifo_queue.hpp
@@ -32,7 +32,7 @@
  * BWoS: Formally Verified Block-based Work Stealing for Parallel Processing (Wang et al. 2023)
  */
 
-namespace exec::bwos {
+namespace experimental::execution::bwos {
   inline constexpr std::size_t hardware_destructive_interference_size = 64;
   inline constexpr std::size_t hardware_constructive_interference_size = 64;
 
@@ -497,4 +497,6 @@ namespace exec::bwos {
   auto lifo_queue<Tp, Allocator>::block_type::is_stealable() const noexcept -> bool {
     return steal_tail_.load(STDEXEC::__std::memory_order_acquire) != block_size();
   }
-} // namespace exec::bwos
+} // namespace experimental::execution::bwos
+
+namespace exec = experimental::execution;

--- a/include/exec/__detail/__numa.hpp
+++ b/include/exec/__detail/__numa.hpp
@@ -33,7 +33,7 @@
 #  define STDEXEC_NUMA_VTABLE_INLINE inline
 #endif
 
-namespace exec {
+namespace experimental::execution {
   namespace _numa {
     using _small_t = void* [1];
 
@@ -215,12 +215,14 @@ namespace exec {
       return 0;
     }
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 #if STDEXEC_ENABLE_NUMA
 #  include <numa.h>
 
-namespace exec {
+namespace experimental::execution {
   inline std::size_t _get_numa_num_cpus(int node) {
     struct ::bitmask* cpus = ::numa_allocate_cpumask();
     if (!cpus) {
@@ -375,9 +377,12 @@ namespace exec {
    private:
     ::nodemask_t mask_;
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+
 #else
-namespace exec {
+namespace experimental::execution {
   using default_numa_policy = no_numa_policy;
 
   inline auto get_numa_policy() noexcept -> numa_policy {
@@ -440,5 +445,8 @@ namespace exec {
    private:
     bool mask_{false};
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+
 #endif

--- a/include/exec/__detail/__shared.hpp
+++ b/include/exec/__detail/__shared.hpp
@@ -56,12 +56,14 @@
 // The shared state should add-ref itself when the input async
 // operation is started and release itself when its completion
 // is notified.
-namespace exec {
+namespace experimental::execution {
   struct split_t;
   struct ensure_started_t;
-} // namespace exec
+} // namespace experimental::execution
 
-namespace exec::__shared {
+namespace exec = experimental::execution;
+
+namespace experimental::execution::__shared {
   using namespace STDEXEC;
 
   template <class _Env, class _Variant>
@@ -506,4 +508,6 @@ namespace exec::__shared {
   STDEXEC_HOST_DEVICE_DEDUCTION_GUIDE
     __sndr(_Tag, _CvChild&&, _Env) -> __sndr<_Tag, _CvChild, _Env>;
 
-} // namespace exec::__shared
+} // namespace experimental::execution::__shared
+
+namespace exec = experimental::execution;

--- a/include/exec/__detail/__system_context_replaceability_api.hpp
+++ b/include/exec/__detail/__system_context_replaceability_api.hpp
@@ -23,7 +23,7 @@
 #include <cstddef>
 #include <memory>
 
-namespace exec::system_context_replaceability {
+namespace experimental::execution::system_context_replaceability {
   using STDEXEC::system_context_replaceability::__parallel_scheduler_backend_factory_t;
 
   /// Interface for the parallel scheduler backend.
@@ -65,6 +65,8 @@ namespace exec::system_context_replaceability {
   using bulk_item_receiver [[deprecated(
     "Use STDEXEC::system_context_replaceability::bulk_item_receiver_proxy instead.")]] =
     STDEXEC::system_context_replaceability::bulk_item_receiver_proxy;
-} // namespace exec::system_context_replaceability
+} // namespace experimental::execution::system_context_replaceability
+
+namespace exec = experimental::execution;
 
 #endif

--- a/include/exec/__detail/__xorshift.hpp
+++ b/include/exec/__detail/__xorshift.hpp
@@ -24,7 +24,7 @@
 #include <cstdint>
 #include <random>
 
-namespace exec {
+namespace experimental::execution {
 
   class xorshift {
    public:
@@ -73,4 +73,6 @@ namespace exec {
     std::uint64_t m_seed;
   };
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;

--- a/include/exec/__detail/intrusive_heap.hpp
+++ b/include/exec/__detail/intrusive_heap.hpp
@@ -26,7 +26,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(not_used_in_partial_spec_arg_list)
 
-namespace exec {
+namespace experimental::execution {
 #if defined(__cpp_lib_int_pow2) && __cpp_lib_int_pow2 >= 2020'02L
   namespace detail {
     using std::bit_ceil;
@@ -300,6 +300,8 @@ namespace exec {
       return cur;
     }
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/exec/any_sender_of.hpp
+++ b/include/exec/any_sender_of.hpp
@@ -22,7 +22,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace exec {
+namespace experimental::execution {
   namespace __any {
     using namespace STDEXEC;
 
@@ -1312,4 +1312,7 @@ namespace exec {
       };
     };
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/async_scope.hpp
+++ b/include/exec/async_scope.hpp
@@ -24,7 +24,7 @@
 #include "../stdexec/__detail/__atomic.hpp"
 #include <mutex>
 
-namespace exec {
+namespace experimental::execution {
   /////////////////////////////////////////////////////////////////////////////
   // async_scope
   namespace __scope {
@@ -784,4 +784,7 @@ namespace exec {
   template <class _AsyncScope, class _Sender>
   using nest_result_t = decltype(STDEXEC::__declval<_AsyncScope&>()
                                    .nest(STDEXEC::__declval<_Sender&&>()));
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -24,7 +24,7 @@
 
 #include "any_sender_of.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __at_coro_exit {
     using namespace STDEXEC;
 
@@ -249,4 +249,7 @@ namespace exec {
   } // namespace __at_coro_exit
 
   inline constexpr __at_coro_exit::__at_coro_exit_t at_coroutine_exit{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/completion_signatures.hpp
+++ b/include/exec/completion_signatures.hpp
@@ -20,7 +20,7 @@
 #include "../stdexec/__detail/__sender_concepts.hpp"
 #include "../stdexec/__detail/__transform_completion_signatures.hpp"
 
-namespace exec {
+namespace experimental::execution {
   ////////////////////////////////////////////////////////////////////////////////////////////////////
   // make_completion_signatures
   namespace detail {
@@ -119,4 +119,7 @@ namespace exec {
     return STDEXEC::__transform_completion_signatures(
       _Completions{}, __value_fn, __error_fn, __stopped_fn, _ExtraSigs{});
   }
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/create.hpp
+++ b/include/exec/create.hpp
@@ -18,7 +18,7 @@
 #include "../stdexec/__detail/__meta.hpp"
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __create {
     using namespace STDEXEC;
 
@@ -99,4 +99,7 @@ namespace exec {
   template <STDEXEC::__completion_signature... _Sigs>
   inline constexpr __create::__create_t<_Sigs...>
     create<STDEXEC::completion_signatures<_Sigs...>>{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/ensure_started.hpp
+++ b/include/exec/ensure_started.hpp
@@ -24,7 +24,7 @@
 #include "../stdexec/__detail/__transform_sender.hpp"
 #include "__detail/__shared.hpp"
 
-namespace exec {
+namespace experimental::execution {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.senders.adaptors.ensure_started]
   namespace __ensure_started {
@@ -71,7 +71,9 @@ namespace exec {
   };
 
   inline constexpr ensure_started_t ensure_started{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -20,7 +20,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(1302)
 
-namespace exec {
+namespace experimental::execution {
   template <class _Tag, class _Value>
   using with_t = STDEXEC::prop<_Tag, _Value>;
 
@@ -223,6 +223,8 @@ namespace exec {
 
   inline constexpr __write_attrs::__write_attrs_t write_attrs{};
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/exec/execute.hpp
+++ b/include/exec/execute.hpp
@@ -26,7 +26,7 @@
 
 #include "start_detached.hpp"
 
-namespace exec {
+namespace experimental::execution {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.execute]
   struct __execute_t {
@@ -58,4 +58,7 @@ namespace exec {
   using execute_t [[deprecated]] = __execute_t;
   [[deprecated]]
   inline constexpr const __execute_t& execute = __execute;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/finally.hpp
+++ b/include/exec/finally.hpp
@@ -19,7 +19,10 @@
 
 #include "../stdexec/__detail/__finally.hpp"
 
-namespace exec {
+namespace experimental::execution {
   using finally_t = STDEXEC::__finally_t;
   inline constexpr finally_t const & finally = STDEXEC::__finally_;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/fork_join.hpp
+++ b/include/exec/fork_join.hpp
@@ -20,7 +20,7 @@
 
 #include <exception>
 
-namespace exec {
+namespace experimental::execution {
   struct PREDECESSOR_RESULTS_ARE_NOT_DECAY_COPYABLE { };
 
   struct fork_join_impl_t {
@@ -236,9 +236,11 @@ namespace exec {
 
   inline constexpr fork_join_t fork_join{};
 
-} // namespace exec
+} // namespace experimental::execution
 
-namespace exec::__fork_join {
+namespace exec = experimental::execution;
+
+namespace experimental::execution::__fork_join {
   struct _INVALID_ARGUMENTS_TO_FORK_JOIN_ { };
 
   struct __impls : STDEXEC::__sexpr_defaults {
@@ -291,7 +293,9 @@ namespace exec::__fork_join {
           static_cast<_Receiver&&>(__rcvr)};
       };
   };
-} // namespace exec::__fork_join
+} // namespace experimental::execution::__fork_join
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/inline_scheduler.hpp
+++ b/include/exec/inline_scheduler.hpp
@@ -17,9 +17,12 @@
 
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   // A simple scheduler that executes its continuation inline, on the
   // thread of the caller of start().
   using inline_scheduler
     [[deprecated("Use STDEXEC::inline_scheduler instead")]] = STDEXEC::inline_scheduler;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/into_tuple.hpp
+++ b/include/exec/into_tuple.hpp
@@ -19,7 +19,7 @@
 #include "../stdexec/__detail/__meta.hpp"
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __into_tuple {
     using namespace STDEXEC;
 
@@ -115,7 +115,9 @@ namespace exec {
 
   using __into_tuple::into_tuple_t;
   inline constexpr into_tuple_t into_tuple{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/just_from.hpp
+++ b/include/exec/just_from.hpp
@@ -18,7 +18,7 @@
 #include "../stdexec/__detail/__meta.hpp"
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   struct AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT;
   struct A_STOPPED_COMPLETION_MUST_HAVE_NO_ARGUMENTS;
 
@@ -261,4 +261,7 @@ namespace exec {
   inline constexpr just_error_from_t just_error_from{};
   inline constexpr just_stopped_from_t just_stopped_from{};
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -30,7 +30,7 @@
 #  include "../stdexec/execution.hpp"
 #  include <dispatch/dispatch.h>
 
-namespace exec {
+namespace experimental::execution {
   struct libdispatch_queue;
 
   namespace __libdispatch {
@@ -453,6 +453,8 @@ namespace exec {
       inner_op_state inner_op_;
     };
   } // namespace __libdispatch
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 #endif // __has_include(<dispatch/dispatch.h>)

--- a/include/exec/linux/__detail/memory_mapped_region.hpp
+++ b/include/exec/linux/__detail/memory_mapped_region.hpp
@@ -21,7 +21,7 @@
 #include <sys/mman.h>
 #include <utility>
 
-namespace exec {
+namespace experimental::execution {
   inline memory_mapped_region::memory_mapped_region(void* __ptr, std::size_t __size) noexcept
     : __ptr_(__ptr)
     , __size_(__size) {
@@ -64,4 +64,6 @@ namespace exec {
   inline auto memory_mapped_region::size() const noexcept -> std::size_t {
     return __size_;
   }
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;

--- a/include/exec/linux/__detail/safe_file_descriptor.hpp
+++ b/include/exec/linux/__detail/safe_file_descriptor.hpp
@@ -21,7 +21,7 @@
 #include <unistd.h>
 #include <utility>
 
-namespace exec {
+namespace experimental::execution {
   inline safe_file_descriptor::safe_file_descriptor(int __fd) noexcept
     : __fd_(__fd) {
   }
@@ -63,4 +63,6 @@ namespace exec {
   inline auto safe_file_descriptor::native_handle() const noexcept -> int {
     return __fd_;
   }
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;

--- a/include/exec/linux/io_uring_context.hpp
+++ b/include/exec/linux/io_uring_context.hpp
@@ -55,7 +55,7 @@
 
 #    include <cstring>
 
-namespace exec {
+namespace experimental::execution {
   namespace __io_uring {
     inline void __throw_error_code_if(bool __cond, int __ec) {
       if (__cond) {
@@ -1180,7 +1180,9 @@ namespace exec {
 
   static_assert(__timed_scheduler<io_uring_scheduler>);
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 #  endif // if __has_include(<linux/verison.h>)
 #endif   // if __has_include(<linux/io_uring.h>)

--- a/include/exec/linux/memory_mapped_region.hpp
+++ b/include/exec/linux/memory_mapped_region.hpp
@@ -18,7 +18,7 @@
 
 #include <cstddef>
 
-namespace exec {
+namespace experimental::execution {
   class memory_mapped_region {
     void* __ptr_{nullptr};
     std::size_t __size_{0};
@@ -44,6 +44,8 @@ namespace exec {
     [[nodiscard]]
     auto size() const noexcept -> std::size_t;
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 #include "__detail/memory_mapped_region.hpp"

--- a/include/exec/linux/safe_file_descriptor.hpp
+++ b/include/exec/linux/safe_file_descriptor.hpp
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-namespace exec {
+namespace experimental::execution {
   class safe_file_descriptor {
     int __fd_{-1};
    public:
@@ -42,6 +42,8 @@ namespace exec {
     [[nodiscard]]
     auto native_handle() const noexcept -> int;
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 #include "__detail/safe_file_descriptor.hpp"

--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -18,7 +18,7 @@
 
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __materialize {
     using namespace STDEXEC;
 
@@ -212,4 +212,7 @@ namespace exec {
   } // namespace __dematerialize
 
   inline constexpr __dematerialize::__dematerialize_t dematerialize;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/on.hpp
+++ b/include/exec/on.hpp
@@ -17,11 +17,14 @@
 
 #include "../stdexec/execution.hpp" // IWYU pragma: keep
 
-namespace exec {
+namespace experimental::execution {
   /////////////////////////////////////////////////////////////////////////////
   // A scoped version of [execution.senders.adaptors.on]
   using on_t [[deprecated("on_t has been moved to the STDEXEC:: namespace")]] = STDEXEC::on_t;
 
   [[deprecated("on has been moved to the STDEXEC:: namespace")]]
   inline constexpr STDEXEC::on_t const & on = STDEXEC::on;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/on_coro_disposition.hpp
+++ b/include/exec/on_coro_disposition.hpp
@@ -26,7 +26,7 @@
 
 #include <exception>
 
-namespace exec {
+namespace experimental::execution {
   namespace __on_coro_disp {
     using namespace STDEXEC;
 
@@ -223,4 +223,7 @@ namespace exec {
   inline constexpr __on_coro_disp::__succeeded_t on_coroutine_succeeded{};
   inline constexpr __on_coro_disp::__stopped_t on_coroutine_stopped{};
   inline constexpr __on_coro_disp::__failed_t on_coroutine_failed{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/repeat_n.hpp
+++ b/include/exec/repeat_n.hpp
@@ -30,7 +30,7 @@ STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(expr_has_no_effect)
 STDEXEC_PRAGMA_IGNORE_GNU("-Wunused-value")
 
-namespace exec {
+namespace experimental::execution {
   namespace __repeat_n {
     using namespace STDEXEC;
 
@@ -227,7 +227,9 @@ namespace exec {
 
   using __repeat_n::repeat_n_t;
   inline constexpr repeat_n_t repeat_n{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/repeat_until.hpp
+++ b/include/exec/repeat_until.hpp
@@ -27,7 +27,7 @@
 #include <exception>
 #include <type_traits>
 
-namespace exec {
+namespace experimental::execution {
   namespace __repeat {
     using namespace STDEXEC;
 
@@ -311,7 +311,9 @@ namespace exec {
   inline constexpr const repeat_t &repeat_effect = repeat;
   [[deprecated("use exec::repeat_until instead")]]
   inline constexpr const repeat_until_t &repeat_effect_until = repeat_until;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/reschedule.hpp
+++ b/include/exec/reschedule.hpp
@@ -17,7 +17,7 @@
 
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   struct _CANNOT_RESCHEDULE_ { };
   using STDEXEC::_THE_CURRENT_EXECUTION_ENVIRONMENT_DOESNT_HAVE_A_SCHEDULER_;
 
@@ -88,4 +88,7 @@ namespace exec {
   } // namespace __resched
 
   inline constexpr auto reschedule = __resched::reschedule_t{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/scope.hpp
+++ b/include/exec/scope.hpp
@@ -17,7 +17,7 @@
 
 #include "../stdexec/__detail/__scope.hpp"
 
-namespace exec {
+namespace experimental::execution {
 
   template <class _Fn, class... _Ts>
     requires STDEXEC::__nothrow_callable<_Fn, _Ts...>
@@ -32,4 +32,7 @@ namespace exec {
   template <class _Fn, class... _Ts>
   STDEXEC_HOST_DEVICE_DEDUCTION_GUIDE scope_guard(_Fn, _Ts...) -> scope_guard<_Fn, _Ts...>;
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/sequence.hpp
+++ b/include/exec/sequence.hpp
@@ -22,7 +22,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 
-namespace exec {
+namespace experimental::execution {
   namespace _seq {
     template <class... Senders>
     struct _sndr;
@@ -266,7 +266,9 @@ namespace exec {
 
   using _seq::sequence_t;
   inline constexpr sequence_t sequence{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace std {
   template <class... Senders>

--- a/include/exec/sequence/any_sequence_of.hpp
+++ b/include/exec/sequence/any_sequence_of.hpp
@@ -21,7 +21,7 @@
 #include "../any_sender_of.hpp"
 #include "../sequence_senders.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __any {
     namespace __next {
       template <__valid_completion_signatures _Sigs>
@@ -246,7 +246,6 @@ namespace exec {
           static_cast<__sequence_sender&&>(*this), static_cast<_Rcvr&&>(__rcvr)};
       }
 
-
       auto get_env() const noexcept -> __env_t {
         return __env_t{__storage_.__get_vtable(), __storage_.__get_object_pointer()};
       }
@@ -333,4 +332,6 @@ namespace exec {
     }
   };
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;

--- a/include/exec/sequence/empty_sequence.hpp
+++ b/include/exec/sequence/empty_sequence.hpp
@@ -19,7 +19,7 @@
 #include "../../stdexec/execution.hpp"
 #include "../sequence_senders.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __empty_sequence {
 
     using namespace STDEXEC;
@@ -56,4 +56,7 @@ namespace exec {
   using __empty_sequence::empty_sequence_t;
   inline constexpr empty_sequence_t empty_sequence{};
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/sequence/ignore_all_values.hpp
+++ b/include/exec/sequence/ignore_all_values.hpp
@@ -25,7 +25,7 @@
 
 #include "../../stdexec/__detail/__atomic.hpp"
 
-namespace exec {
+namespace experimental::execution {
   template <class _Variant, class _Type, class... _Args>
   concept __variant_emplaceable = requires(_Variant& __var, _Args&&... __args) {
     __var.template emplace<_Type>(static_cast<_Args&&>(__args)...);
@@ -302,7 +302,9 @@ namespace exec {
 
   using __ignore_all_values::ignore_all_values_t;
   inline constexpr ignore_all_values_t ignore_all_values{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -31,7 +31,7 @@
 #  include <exception>
 #  include <ranges>
 
-namespace exec {
+namespace experimental::execution {
   namespace __iterate {
     using namespace STDEXEC;
 
@@ -223,6 +223,8 @@ namespace exec {
 
   using __iterate::iterate_t;
   inline constexpr iterate_t iterate{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 #endif // STDEXEC_HAS_STD_RANGES()

--- a/include/exec/sequence/merge.hpp
+++ b/include/exec/sequence/merge.hpp
@@ -26,7 +26,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(not_used_in_template_function_params)
 
-namespace exec {
+namespace experimental::execution {
   namespace __merge {
     using namespace STDEXEC;
 
@@ -181,6 +181,8 @@ namespace exec {
 
   using __merge::merge_t;
   inline constexpr merge_t merge{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/exec/sequence/merge_each.hpp
+++ b/include/exec/sequence/merge_each.hpp
@@ -36,7 +36,7 @@
 
 #include <atomic>
 
-namespace exec {
+namespace experimental::execution {
   namespace __merge_each {
     using namespace STDEXEC;
     struct merge_each_t;
@@ -681,7 +681,6 @@ namespace exec {
       using __nested_value_sender_t =
         __merge_each::__nested_value_sender_t<_NestedValue, __error_storage_t>;
 
-
       template <class _NestedValue>
       auto set_next(_NestedValue&& __nested_value) noexcept(
         __nothrow_callable<exec::set_next_t, __receiver_t&, __nested_value_sender_t<_NestedValue>>) {
@@ -1234,4 +1233,7 @@ namespace exec {
 
   using __merge_each::merge_each_t;
   inline constexpr merge_each_t merge_each{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/sequence/transform_each.hpp
+++ b/include/exec/sequence/transform_each.hpp
@@ -27,7 +27,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(not_used_in_template_function_params)
 
-namespace exec {
+namespace experimental::execution {
   template <class _Transform>
   struct _TRANSFORM_EACH_ADAPTOR_INVOCATION_FAILED_;
 
@@ -204,6 +204,8 @@ namespace exec {
 
   using __transform_each::transform_each_t;
   inline constexpr transform_each_t transform_each{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -74,7 +74,7 @@ STDEXEC_PRAGMA_IGNORE_EDG(not_used_in_template_function_params)
   "FAILURE: The subscribe customization did not return an `STDEXEC::operation_state`.\n"           \
   "\n" STDEXEC_ERROR_SEQUENCE_SENDER_DEFINITION
 
-namespace exec {
+namespace experimental::execution {
   template <class _Sequence>
   struct _WITH_SEQUENCE_ { };
 
@@ -1021,6 +1021,8 @@ namespace exec {
       }
     }
   } // namespace __debug
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/exec/single_thread_context.hpp
+++ b/include/exec/single_thread_context.hpp
@@ -20,7 +20,7 @@
 
 #include <thread>
 
-namespace exec {
+namespace experimental::execution {
   class single_thread_context {
     STDEXEC::run_loop loop_;
     std::thread thread_;
@@ -45,4 +45,7 @@ namespace exec {
       return thread_.get_id();
     }
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/split.hpp
+++ b/include/exec/split.hpp
@@ -24,7 +24,7 @@
 #include "../stdexec/__detail/__transform_sender.hpp"
 #include "__detail/__shared.hpp"
 
-namespace exec {
+namespace experimental::execution {
   ////////////////////////////////////////////////////////////////////////////
   // [execution.senders.adaptors.split]
   struct split_t {
@@ -55,7 +55,9 @@ namespace exec {
   };
 
   inline constexpr split_t split{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/start_detached.hpp
+++ b/include/exec/start_detached.hpp
@@ -26,7 +26,7 @@
 
 #include <memory>
 
-namespace exec {
+namespace experimental::execution {
   /////////////////////////////////////////////////////////////////////////////
   // [execution.senders.consumer.start_detached]
   namespace __start_detached {
@@ -214,4 +214,7 @@ namespace exec {
   };
 
   inline constexpr start_detached_t start_detached{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/start_now.hpp
+++ b/include/exec/start_now.hpp
@@ -31,7 +31,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 
-namespace exec {
+namespace experimental::execution {
   /////////////////////////////////////////////////////////////////////////////
   // NOT TO SPEC: __start_now
   namespace __start_now {
@@ -237,6 +237,8 @@ namespace exec {
 
   using __start_now::start_now_t;
   inline constexpr start_now_t start_now{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -42,7 +42,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace exec {
+namespace experimental::execution {
   struct bwos_params {
     std::size_t numBlocks{32};
     std::size_t blockSize{8};
@@ -1649,4 +1649,7 @@ namespace exec {
   inline constexpr _pool_::schedule_all_t schedule_all{};
 #endif
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/system_context.hpp
+++ b/include/exec/system_context.hpp
@@ -28,7 +28,7 @@
     "The header <exec/system_context.hpp> is deprecated. Please include <stdexec/execution.hpp> instead."
 #endif
 
-namespace exec {
+namespace experimental::execution {
   using parallel_scheduler
     [[deprecated("Please use stdexec::parallel_scheduler instead")]] = STDEXEC::parallel_scheduler;
 
@@ -36,4 +36,7 @@ namespace exec {
   inline auto get_parallel_scheduler() noexcept -> STDEXEC::parallel_scheduler {
     return STDEXEC::get_parallel_scheduler();
   }
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/task.hpp
+++ b/include/exec/task.hpp
@@ -32,7 +32,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wundefined-inline")
 
-namespace exec {
+namespace experimental::execution {
   namespace __task {
     using namespace STDEXEC;
 
@@ -518,7 +518,9 @@ namespace exec {
   using task = basic_task<_Ty, default_task_context<_Ty>>;
 
   inline constexpr __task::__reschedule_coroutine_on reschedule_coroutine_on{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <class _Ty, class _Context>

--- a/include/exec/timed_scheduler.hpp
+++ b/include/exec/timed_scheduler.hpp
@@ -20,7 +20,7 @@
 
 #include <chrono>
 
-namespace exec {
+namespace experimental::execution {
   namespace __now {
     using namespace STDEXEC;
 
@@ -259,4 +259,7 @@ namespace exec {
 
   template <timed_scheduler _Scheduler>
   using schedule_at_result_t = STDEXEC::__call_result_t<schedule_at_t, _Scheduler>;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/timed_thread_scheduler.hpp
+++ b/include/exec/timed_thread_scheduler.hpp
@@ -33,7 +33,7 @@
 #include <optional>
 #include <utility>
 
-namespace exec {
+namespace experimental::execution {
   class timed_thread_scheduler;
 
   namespace _time_thrd_sched {
@@ -389,4 +389,7 @@ namespace exec {
   inline constexpr auto timed_thread_context::get_scheduler() noexcept -> timed_thread_scheduler {
     return timed_thread_scheduler{*this};
   }
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -21,7 +21,7 @@
 #include <cstddef>
 #include <utility>
 
-namespace exec {
+namespace experimental::execution {
   namespace __trampoline {
     using namespace STDEXEC;
 
@@ -251,4 +251,7 @@ namespace exec {
 
   using trampoline_scheduler = __trampoline::__scheduler;
 
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/unless_stop_requested.hpp
+++ b/include/exec/unless_stop_requested.hpp
@@ -21,7 +21,7 @@
 #include "../stdexec/__detail/__receiver_ref.hpp"
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __unless_stop_requested {
     using namespace STDEXEC;
 
@@ -103,7 +103,9 @@ namespace exec {
 
   using __unless_stop_requested::unless_stop_requested_t;
   inline constexpr unless_stop_requested_t unless_stop_requested{};
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 namespace STDEXEC {
   template <>

--- a/include/exec/variant_sender.hpp
+++ b/include/exec/variant_sender.hpp
@@ -19,7 +19,7 @@
 #include "../stdexec/__detail/__variant.hpp"
 #include "../stdexec/execution.hpp"
 
-namespace exec {
+namespace experimental::execution {
   namespace __var {
     using namespace STDEXEC;
 
@@ -130,4 +130,7 @@ namespace exec {
       return {};
     }
   };
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
+

--- a/include/exec/when_any.hpp
+++ b/include/exec/when_any.hpp
@@ -24,7 +24,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 
-namespace exec {
+namespace experimental::execution {
   namespace __when_any {
     using namespace STDEXEC;
 
@@ -280,6 +280,8 @@ namespace exec {
   } // namespace __when_any
 
   using __when_any::when_any;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/exec/windows/filetime_clock.hpp
+++ b/include/exec/windows/filetime_clock.hpp
@@ -20,7 +20,7 @@
 
 #include <windows.h>
 
-namespace exec::__win32 {
+namespace experimental::execution::__win32 {
 
   class filetime_clock {
    public:
@@ -139,5 +139,6 @@ namespace exec::__win32 {
       return time_point::from_ticks(ticks.QuadPart);
     }
   };
+} // namespace experimental::execution::__win32
 
-} // namespace exec::__win32
+namespace exec = experimental::execution;

--- a/include/exec/windows/windows_thread_pool.hpp
+++ b/include/exec/windows/windows_thread_pool.hpp
@@ -37,7 +37,7 @@
 #  include <system_error>
 #  include <utility>
 
-namespace exec::__win32 {
+namespace experimental::execution::__win32 {
   class windows_thread_pool {
     struct attrs;
     class scheduler;
@@ -913,14 +913,16 @@ namespace exec::__win32 {
         static_cast<int>(errorCode), std::system_category(), "CreateThreadpoolWork()"};
     }
   }
-} // namespace exec::__win32
+} // namespace experimental::execution::__win32
 
-namespace exec {
+namespace experimental::execution {
   using __win32::windows_thread_pool;
 
   static_assert(
     STDEXEC::scheduler<decltype(windows_thread_pool{}.get_scheduler())>,
     "windows_thread_pool::scheduler must model STDEXEC::scheduler");
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 #endif

--- a/include/execpools/thread_pool_base.hpp
+++ b/include/execpools/thread_pool_base.hpp
@@ -408,7 +408,6 @@ namespace execpools {
      public:
       auto operator==(const scheduler&) const -> bool = default;
 
-
       [[nodiscard]]
       constexpr auto query(STDEXEC::get_forward_progress_guarantee_t) const noexcept
         -> STDEXEC::forward_progress_guarantee {

--- a/include/stdexec/__detail/__bulk.hpp
+++ b/include/stdexec/__detail/__bulk.hpp
@@ -164,7 +164,6 @@ namespace STDEXEC {
       __eptr_completion
     >;
 
-
     template <class _AlgoTag, class _Fun, class _Shape, class _CvSender, class... _Env>
     using __completion_signatures = transform_completion_signatures<
       __completion_signatures_of_t<_CvSender, _Env...>,

--- a/include/stdexec/__detail/__deprecations.hpp
+++ b/include/stdexec/__detail/__deprecations.hpp
@@ -58,7 +58,7 @@ namespace STDEXEC {
   [[deprecated("read has been renamed to read_env")]]
   inline constexpr const __read_env_t& read = read_env;
 
-  // Moved to namespace exec:
+  // Moved to namespace experimental::execution:
   using split_t
     [[deprecated("Include <exec/split.hpp> and use exec::split_t instead")]] = exec::split_t;
 

--- a/include/stdexec/__detail/__execution_fwd.hpp
+++ b/include/stdexec/__detail/__execution_fwd.hpp
@@ -302,8 +302,8 @@ namespace STDEXEC {
   extern const __transfer_just_t __transfer_just;
 } // namespace STDEXEC
 
-// Moved to namespace exec from namespace STDEXEC because they are no longer getting standardized:
-namespace exec {
+// Moved to namespace experimental::execution from namespace STDEXEC because they are no longer getting standardized:
+namespace experimental::execution {
   struct split_t;
   struct ensure_started_t;
   struct start_detached_t;
@@ -313,7 +313,9 @@ namespace exec {
   extern const ensure_started_t ensure_started;
   extern const start_detached_t start_detached;
   extern const __execute_t __execute;
-} // namespace exec
+} // namespace experimental::execution
+
+namespace exec = experimental::execution;
 
 STDEXEC_P2300_NAMESPACE_BEGIN()
 struct forwarding_query_t;

--- a/include/stdexec/__detail/__intrusive_mpsc_queue.hpp
+++ b/include/stdexec/__detail/__intrusive_mpsc_queue.hpp
@@ -21,7 +21,6 @@
 
 #pragma once
 
-
 #include "__atomic.hpp"
 
 #include "./__spin_loop_pause.hpp"

--- a/include/stdexec/__detail/__spawn.hpp
+++ b/include/stdexec/__detail/__spawn.hpp
@@ -108,7 +108,6 @@ namespace STDEXEC {
       }
     };
 
-
     struct spawn_t {
       template <sender _Sender, scope_token _Token>
       void operator()(_Sender&& __sndr, _Token&& __tkn) const {


### PR DESCRIPTION
`::exec` is aliased to `::experimental::execution`