### PR TITLE
rename `nvexec::` to `nv::execution::`

### DIFF
--- a/examples/nvexec/maxwell/snr.cuh
+++ b/examples/nvexec/maxwell/snr.cuh
@@ -29,11 +29,13 @@
 #  include <nvexec/multi_gpu_context.cuh> // IWYU pragma: export
 #  include <nvexec/stream_context.cuh>    // IWYU pragma: export
 #else
-namespace nvexec {
+namespace nv::execution {
   inline constexpr bool is_on_gpu() noexcept {
     return false;
   }
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;
 #endif
 
 namespace ex = stdexec;

--- a/include/nvexec/detail/config.cuh
+++ b/include/nvexec/detail/config.cuh
@@ -25,6 +25,8 @@
 #  error The NVIDIA schedulers and utilities require CUDA support
 #endif
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   using namespace STDEXEC;
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/detail/event.cuh
+++ b/include/nvexec/detail/event.cuh
@@ -24,7 +24,7 @@
 
 #include <utility>
 
-namespace nvexec::detail {
+namespace nv::execution::detail {
   struct cuda_event {
     cuda_event() {
       STDEXEC_TRY_CUDA_API(::cudaEventCreateWithFlags(&event_, cudaEventDisableTiming));
@@ -56,4 +56,6 @@ namespace nvexec::detail {
    private:
     cudaEvent_t event_{};
   };
-} // namespace nvexec::detail
+} // namespace nv::execution::detail
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/detail/memory.cuh
+++ b/include/nvexec/detail/memory.cuh
@@ -33,7 +33,7 @@
 #include "config.cuh"
 #include "throw_on_cuda_error.cuh"
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
 
   struct device_deleter {
     template <class Type>
@@ -377,4 +377,6 @@ namespace nvexec::_strm {
       return &resource_;
     }
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/detail/queue.cuh
+++ b/include/nvexec/detail/queue.cuh
@@ -27,7 +27,7 @@
 #include "memory.cuh"
 #include "throw_on_cuda_error.cuh"
 
-namespace nvexec::_strm::queue {
+namespace nv::execution::_strm::queue {
   struct task_base {
     using fn_t = void(task_base*) noexcept;
 
@@ -133,4 +133,6 @@ namespace nvexec::_strm::queue {
       return queue::producer{tail_ptr_.get()};
     }
   };
-} // namespace nvexec::_strm::queue
+} // namespace nv::execution::_strm::queue
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/detail/throw_on_cuda_error.cuh
+++ b/include/nvexec/detail/throw_on_cuda_error.cuh
@@ -25,7 +25,7 @@
 
 #include <cuda_runtime_api.h>
 
-namespace nvexec::detail {
+namespace nv::execution::detail {
   struct _msg_storage {
     char buffer[256];
   };
@@ -99,4 +99,6 @@ namespace nvexec::detail {
 #define STDEXEC_LOG_CUDA_API(...) \
   ::nvexec::detail::log_on_cuda_error((__VA_ARGS__), __FILE__, __LINE__)
   // clang-format on
-} // namespace nvexec::detail
+} // namespace nv::execution::detail
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/detail/variant.cuh
+++ b/include/nvexec/detail/variant.cuh
@@ -29,7 +29,7 @@
 
 #include <cuda/std/tuple>
 
-namespace nvexec {
+namespace nv::execution {
 
   namespace detail {
     template <std::unsigned_integral IndexT>
@@ -176,4 +176,6 @@ namespace nvexec {
     union_t storage_;
     index_t index_;
   };
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/multi_gpu_context.cuh
+++ b/include/nvexec/multi_gpu_context.cuh
@@ -25,7 +25,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec {
+namespace nv::execution {
   namespace _strm {
     struct multi_gpu_stream_scheduler : private stream_scheduler_env<multi_gpu_stream_scheduler> {
       multi_gpu_stream_scheduler(int num_devices, context ctx)
@@ -187,6 +187,8 @@ namespace nvexec {
     int dev_id_{};
     _strm::queue::task_hub hub_;
   };
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/nvexec/nvtx.cuh
+++ b/include/nvexec/nvtx.cuh
@@ -29,7 +29,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 
-namespace nvexec {
+namespace nv::execution {
 
   namespace _strm::nvtx {
 
@@ -169,7 +169,9 @@ namespace nvexec {
     using _strm::nvtx::scoped;
   } // namespace nvtx
 
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <nvexec::_strm::nvtx::kind Kind, class Sender>

--- a/include/nvexec/stream/algorithm_base.cuh
+++ b/include/nvexec/stream/algorithm_base.cuh
@@ -28,7 +28,7 @@
 
 #include "common.cuh"
 
-namespace nvexec::_strm::__algo_range_init_fun {
+namespace nv::execution::_strm::__algo_range_init_fun {
   template <class Range, class InitT, class Fun>
   using binary_invoke_result_t = ::cuda::std::decay_t<
     ::cuda::std::invoke_result_t<Fun, STDEXEC::ranges::range_reference_t<Range>, InitT>
@@ -128,7 +128,9 @@ namespace nvexec::_strm::__algo_range_init_fun {
     STDEXEC_ATTRIBUTE(no_unique_address) InitT init_;
     STDEXEC_ATTRIBUTE(no_unique_address) Fun fun_;
   };
-} // namespace nvexec::_strm::__algo_range_init_fun
+} // namespace nv::execution::_strm::__algo_range_init_fun
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class InitT, class Fun, class DerivedSender>

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -33,7 +33,7 @@ STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 __host__ auto operator new[](std::size_t) -> void*;
 #endif
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _bulk {
     template <int BlockThreads, class... Args, std::integral Shape, class Fun>
     STDEXEC_ATTRIBUTE(launch_bounds(BlockThreads))
@@ -382,7 +382,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class Shape, class Fun>

--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -37,7 +37,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec {
+namespace nv::execution {
   enum class stream_priority {
     high,
     normal,
@@ -76,9 +76,11 @@ namespace nvexec {
     template <class Tag>
     struct apply_sender_for;
   } // namespace _strm
-} // namespace nvexec
+} // namespace nv::execution
 
-namespace nvexec {
+namespace nvexec = nv::execution;
+
+namespace nv::execution {
   struct stream_context;
 
   // The stream_domain is how the stream scheduler customizes the sender algorithms. All of the
@@ -853,6 +855,8 @@ namespace nvexec {
     template <class Fun, class... Args>
     using __f = STDEXEC::__msize_t<_sizeof_v<STDEXEC::__call_result_t<Fun, Args...>>>;
   };
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/continues_on.cuh
+++ b/include/nvexec/stream/continues_on.cuh
@@ -31,7 +31,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _trnsfr {
     template <class Tag, class Storage, class... Args>
     STDEXEC_ATTRIBUTE(launch_bounds(1))
@@ -249,7 +249,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 // Decode the sender name for diagnostics:
 namespace STDEXEC::__detail {

--- a/include/nvexec/stream/ensure_started.cuh
+++ b/include/nvexec/stream/ensure_started.cuh
@@ -36,7 +36,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _ensure_started {
     template <class Tag, class... Args, class Variant>
     STDEXEC_ATTRIBUTE(launch_bounds(1))
@@ -372,7 +372,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender>

--- a/include/nvexec/stream/launch.cuh
+++ b/include/nvexec/stream/launch.cuh
@@ -30,7 +30,7 @@ STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec {
+namespace nv::execution {
   namespace _strm {
     struct launch_t;
 
@@ -178,7 +178,9 @@ namespace nvexec {
 
   inline constexpr _strm::launch_t launch{};
 
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class Fun>

--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -29,7 +29,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace let_xxx {
     using namespace STDEXEC;
 
@@ -256,7 +256,9 @@ namespace nvexec::_strm {
   template <class Env>
   struct transform_sender_for<STDEXEC::let_stopped_t, Env>
     : _transform_let_xxx_sender<set_stopped_t, Env> { };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class Fun, class Set>

--- a/include/nvexec/stream/reduce.cuh
+++ b/include/nvexec/stream/reduce.cuh
@@ -31,7 +31,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 
-namespace nvexec {
+namespace nv::execution {
   namespace _strm {
     namespace reduce_ {
       template <class Sender, class Receiver, class InitT, class Fun>
@@ -160,7 +160,9 @@ namespace nvexec {
   } // namespace _strm
 
   inline constexpr _strm::reduce_t reduce{};
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class Init, class Fun>

--- a/include/nvexec/stream/repeat_n.cuh
+++ b/include/nvexec/stream/repeat_n.cuh
@@ -27,7 +27,7 @@ STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(expr_has_no_effect)
 STDEXEC_PRAGMA_IGNORE_GNU("-Wunused-value")
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace repeat_n {
     template <class OpState>
     struct receiver : stream_receiver_base {
@@ -167,6 +167,8 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 STDEXEC_PRAGMA_POP()

--- a/include/nvexec/stream/schedule_from.cuh
+++ b/include/nvexec/stream/schedule_from.cuh
@@ -25,7 +25,7 @@
 
 #include "common.cuh"
 
-namespace nvexec {
+namespace nv::execution {
   struct CANNOT_DISPATCH_THE_SCHEDULE_FROM_ALGORITHM_TO_THE_CUDA_STREAM_SCHEDULER;
   struct BECAUSE_THERE_IS_NO_CUDA_STREAM_SCHEDULER_IN_THE_ENVIRONMENT;
   struct ADD_A_CONTINUES_ON_TRANSITION_TO_THE_CUDA_STREAM_SCHEDULER_BEFORE_THE_SCHEDULE_FROM_ALGORITHM;
@@ -188,7 +188,9 @@ namespace nvexec {
       const Env& env_;
     };
   } // namespace _strm
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender>

--- a/include/nvexec/stream/split.cuh
+++ b/include/nvexec/stream/split.cuh
@@ -37,7 +37,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _split {
     inline auto _make_env(
       const inplace_stop_source& stop_source,
@@ -355,7 +355,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender>

--- a/include/nvexec/stream/start_detached.cuh
+++ b/include/nvexec/stream/start_detached.cuh
@@ -27,7 +27,7 @@
 
 #include "common.cuh"
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _start_detached {
     struct submit_receiver {
       using receiver_concept = receiver_t;
@@ -181,4 +181,6 @@ namespace nvexec::_strm {
       }
     }
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -29,7 +29,7 @@
 #include <utility>
 #include <variant>
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _sync_wait {
     struct env {
       [[nodiscard]]
@@ -195,4 +195,6 @@ namespace nvexec::_strm {
       return _sync_wait::sync_wait_t{}(sched.ctx_, static_cast<Sender&&>(sndr));
     }
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;

--- a/include/nvexec/stream/then.cuh
+++ b/include/nvexec/stream/then.cuh
@@ -32,7 +32,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
 
   namespace _then {
     template <class... Args, class Fun>
@@ -198,7 +198,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class Fun>

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -32,7 +32,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _upon_error {
     template <class... Args, class Fun>
     STDEXEC_ATTRIBUTE(launch_bounds(1))
@@ -182,7 +182,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class Fun>

--- a/include/nvexec/stream/upon_stopped.cuh
+++ b/include/nvexec/stream/upon_stopped.cuh
@@ -30,7 +30,7 @@
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _upon_stopped {
     template <class Fun>
     STDEXEC_ATTRIBUTE(launch_bounds(1))
@@ -174,7 +174,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class Sender, class Fun>

--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -34,7 +34,7 @@ STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(cuda_compile)
 STDEXEC_PRAGMA_IGNORE_GNU("-Wmissing-braces")
 
-namespace nvexec::_strm {
+namespace nv::execution::_strm {
   namespace _when_all {
     enum disposition : std::uint32_t {
       started,
@@ -512,7 +512,9 @@ namespace nvexec::_strm {
 
     const Env& env_;
   };
-} // namespace nvexec::_strm
+} // namespace nv::execution::_strm
+
+namespace nvexec = nv::execution;
 
 namespace STDEXEC::__detail {
   template <class WhenAllTag, class Scheduler, class... Senders>

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -41,7 +41,7 @@
 #include "stream/upon_stopped.cuh"        // IWYU pragma: export
 #include "stream/when_all.cuh"            // IWYU pragma: export
 
-namespace nvexec {
+namespace nv::execution {
   namespace _strm {
     struct stream_scheduler;
 
@@ -174,4 +174,6 @@ namespace nvexec {
     int dev_id_{};
     _strm::queue::task_hub hub_;
   };
-} // namespace nvexec
+} // namespace nv::execution
+
+namespace nvexec = nv::execution;


### PR DESCRIPTION
`::nvexec` is aliased to `::nv::execution`