### PR TITLE
ci(cpu): gcc 14 with leak sanitizer

### DIFF
--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -27,6 +27,7 @@ jobs:
           - { name: "CPU (gcc 11, Release, ASAN)",   build: "Release", tag: gcc11-cuda12.9,  cxxflags: "-fsanitize=address" }
           - { name: "CPU (gcc 12, Release, TSAN)",   build: "Release", tag: gcc12-cuda12.9,  cxxflags: "-fsanitize=thread" }
           - { name: "CPU (gcc 13, Debug)",           build: "Release", tag: gcc13-cuda12.9,  cxxflags: "", }
+          - { name: "CPU (gcc 14, Release, LEAK)",   build: "Release", tag: gcc14-cuda12.9,  cxxflags: "-fsanitize=leak", }
     container:
       options: -u root
       image: rapidsai/devcontainers:26.02-cpp-${{ matrix.tag }}


### PR DESCRIPTION
This PR adds coverage for gcc 14. I've added the leak sanitizer.