### PR TITLE
Add missing include for std::launder

### DIFF
--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <initializer_list>
 #include <memory>   // IWYU pragma: keep for std::start_lifetime_as
+#include <new>      // IWYU pragma: keep for std::launder
 #include <utility>  // IWYU pragma: keep for std::unreachable
 
 STDEXEC_PRAGMA_PUSH()


### PR DESCRIPTION
std::launder is defined in <new> and is missing here. 

I haven't had this issue with gcc14/15 on linux but with llvm 21 on macos.

Ref:
https://en.cppreference.com/w/cpp/utility/launder.html