### PR TITLE
Only forward declare '_mm_pause' if it is used

### DIFF
--- a/include/stdexec/stop_token.hpp
+++ b/include/stdexec/stop_token.hpp
@@ -29,7 +29,9 @@
 #  include <stop_token>  // IWYU pragma: export
 #endif
 
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 extern void _mm_pause();
+#endif
 
 namespace STDEXEC::__stok
 {


### PR DESCRIPTION
The forward declaration of `extern void _mm_pause()` leads to a compilation failure on GCC on Windows. The error message says that the forward declaration conflicts with the declaration in `<xmmintrin.h>` because only the latter is `extern "C"`.

The function is not called on GCC because of a preprocessor conditional. Guard the forward declaration with the same conditional.
