### PR TITLE
make `as_awaitable` safe to use in `await_transform` without recursion

### DIFF
--- a/include/stdexec/__detail/__as_awaitable.hpp
+++ b/include/stdexec/__detail/__as_awaitable.hpp
@@ -412,18 +412,15 @@ namespace STDEXEC
     template <class _Sender, class _Promise>
     concept __awaitable_sender = __awaitable_adapted_sender<__adapted_sender_t<_Sender>, _Promise>;
 
-    struct __unspecified
-    {
-      constexpr auto get_return_object() noexcept -> __unspecified;
-      constexpr auto initial_suspend() noexcept -> __unspecified;
-      constexpr auto final_suspend() noexcept -> __unspecified;
-      constexpr void unhandled_exception() noexcept;
-      constexpr void return_void() noexcept;
-      constexpr auto unhandled_stopped() noexcept -> __std::coroutine_handle<>;
-    };
-
     template <class _Sender, class _Promise>
     concept __incompatible_sender = sender<_Sender> && __merror<__value_t<_Sender, _Promise>>;
+
+    // clang-format off
+    template <class _Ty, class _Promise>
+    concept __simple_awaitable = requires(_Ty&& __value, _Promise& __promise) {
+      { STDEXEC::__get_awaiter(static_cast<_Ty&&>(__value)) } -> __awaiter<_Promise>;
+    };
+    // clang-format on
 
     template <class _Sender, class _Promise>
     concept __has_transform_as_awaitable_member =
@@ -448,7 +445,7 @@ namespace STDEXEC
             .as_awaitable(__promise));
 
     inline constexpr auto __with_await =  //
-      []<__awaitable<__unspecified> _Tp>(_Tp&& __t, __ignore)
+      []<class _Promise, __simple_awaitable<_Promise> _Tp>(_Tp&& __t, _Promise&)
         STDEXEC_AUTO_RETURN(static_cast<_Tp&&>(__t));
 
     inline constexpr auto __with_sender =  //

--- a/include/stdexec/__detail/__awaitable.hpp
+++ b/include/stdexec/__detail/__awaitable.hpp
@@ -35,8 +35,8 @@ namespace STDEXEC
   };
 
   template <class _Awaitable, class _Promise>
-  concept __has_await_transform = requires(_Promise *__promise, _Awaitable &&__awaitable) {
-    __promise->await_transform(static_cast<_Awaitable &&>(__awaitable));
+  concept __has_await_transform = requires(_Awaitable &&__awaitable, _Promise &__promise) {
+    __promise.await_transform(static_cast<_Awaitable &&>(__awaitable));
   };
 
   template <class _Awaitable>
@@ -46,9 +46,9 @@ namespace STDEXEC
   }
 
   template <class _Promise, __has_await_transform<_Promise> _Awaitable>
-  constexpr auto __get_awaitable(_Awaitable &&__awaitable, _Promise *__promise) -> decltype(auto)
+  constexpr auto __get_awaitable(_Awaitable &&__awaitable, _Promise &__promise) -> decltype(auto)
   {
-    return __promise->await_transform(static_cast<_Awaitable &&>(__awaitable));
+    return __promise.await_transform(static_cast<_Awaitable &&>(__awaitable));
   }
 
   template <class _Awaitable>
@@ -69,7 +69,7 @@ namespace STDEXEC
   }
 
   template <class _Awaitable, class... _Promise>
-  concept __awaitable = requires(_Awaitable &&__awaitable, _Promise *...__promise) {
+  concept __awaitable = requires(_Awaitable &&__awaitable, _Promise &...__promise) {
     {
       STDEXEC::__get_awaiter(
         STDEXEC::__get_awaitable(static_cast<_Awaitable &&>(__awaitable), __promise...))
@@ -81,11 +81,11 @@ namespace STDEXEC
 
   template <class _Awaitable, class... _Promise>
     requires __awaitable<_Awaitable, _Promise...>
-  using __await_result_t =
-    decltype(STDEXEC::__as_lvalue(STDEXEC::__get_awaiter(
-                                    STDEXEC::__get_awaitable(__declval<_Awaitable>(),
-                                                             static_cast<_Promise *>(nullptr)...)))
-               .await_resume());
+  using __await_result_t = decltype(STDEXEC::__as_lvalue(
+                                      STDEXEC::__get_awaiter(
+                                        STDEXEC::__get_awaitable(__declval<_Awaitable>(),
+                                                                 __declval<_Promise &>()...)))
+                                      .await_resume());
 
 #else
 


### PR DESCRIPTION
fixes #1678