### PR TITLE
fix ambiguous function reference to start_detached in io_uring_context unit test

### DIFF
--- a/test/exec/test_io_uring_context.cpp
+++ b/test/exec/test_io_uring_context.cpp
@@ -25,6 +25,7 @@
 #  include "exec/linux/io_uring_context.hpp"
 #  include "exec/scope.hpp"
 #  include "exec/single_thread_context.hpp"
+#  include "exec/start_detached.hpp"
 #  include "exec/when_any.hpp"
 
 #  include "catch2/catch.hpp"
@@ -119,13 +120,13 @@ namespace
     io_uring_context   context;
     io_uring_scheduler scheduler = context.get_scheduler();
     bool               is_called = false;
-    start_detached(schedule(scheduler)
-                   | then(
-                     [&]
-                     {
-                       CHECK(context.is_running());
-                       is_called = true;
-                     }));
+    exec::start_detached(schedule(scheduler)
+                         | then(
+                           [&]
+                           {
+                             CHECK(context.is_running());
+                             is_called = true;
+                           }));
     context.run_until_empty();
     CHECK(is_called);
     CHECK(!context.is_running());
@@ -206,13 +207,13 @@ namespace
     io_uring_scheduler scheduler = context.get_scheduler();
     {
       bool is_called = false;
-      start_detached(schedule(scheduler)
-                     | then(
-                       [&]
-                       {
-                         CHECK(context.is_running());
-                         is_called = true;
-                       }));
+      exec::start_detached(schedule(scheduler)
+                           | then(
+                             [&]
+                             {
+                               CHECK(context.is_running());
+                               is_called = true;
+                             }));
       context.run_until_empty();
       CHECK(is_called);
       CHECK(!context.is_running());


### PR DESCRIPTION
Closes https://github.com/NVIDIA/stdexec/issues/1949.

~~With this change, the io_uring context submission queue max submissions no longer gets capped to 0 which allows work to actually be submitted to the kernel. In particular, the bug this is addressing was causing the `run_until_stopped()` method to break out of the main loop immediately causing both the example code and unit test to hang indefinitely at blocking `sync_wait` calls.~~  

This resolves an issue in the io_uring_context unit tests where calls to `start_detached` were ambiguous when compiling with both `g++ 15.2.1` and `clang 22.1.1`. This was necessary to compile with io_uring support enabled as well as to validate the fix since the unit test also encountered the hanging issue.