### PR TITLE
make `STDEXEC::__umin` actually work

### DIFF
--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -126,7 +126,7 @@ namespace STDEXEC
 
   inline constexpr auto __umin(std::initializer_list<std::size_t> __il) noexcept -> std::size_t
   {
-    std::size_t __m = 0;
+    std::size_t __m = ~0UL;
     for (std::size_t __i: __il)
     {
       if (__i < __m)


### PR DESCRIPTION
well this is embarrassing