### PR TITLE
Make spawn accept lvalue scope tokens

### DIFF
--- a/include/stdexec/__detail/__spawn.hpp
+++ b/include/stdexec/__detail/__spawn.hpp
@@ -124,13 +124,13 @@ namespace STDEXEC
     struct spawn_t
     {
       template <sender _Sender, scope_token _Token>
-      void operator()(_Sender&& __sndr, _Token&& __tkn) const
+      void operator()(_Sender&& __sndr, _Token __tkn) const
       {
         return (*this)(static_cast<_Sender&&>(__sndr), static_cast<_Token&&>(__tkn), env<>{});
       }
 
       template <sender _Sender, scope_token _Token, class _Env>
-      void operator()(_Sender&& __sndr, _Token&& __tkn, _Env&& __env) const
+      void operator()(_Sender&& __sndr, _Token __tkn, _Env&& __env) const
       {
         auto __wrapped_sender = __tkn.wrap(static_cast<_Sender&&>(__sndr));
         auto __sndr_env       = get_env(__wrapped_sender);


### PR DESCRIPTION
Spawn only accepts rvalues scope tokens, which is unexpected, since tokens are typically value-oriented, cheaply copiable, objects:
```cpp
counting_scope scope;
spawn(just(), scope.get_token()); // ok

auto token = scope.get_token();
spawn(just(), token); // error: counting_scope::token& does not satisfy the scope_token concept
spawn(just(), std::move(token)); // ok
```
See issue https://github.com/NVIDIA/stdexec/issues/1963