### PR TITLE
Fix BWOS queue bugs: stolen items lost across block boundaries

### DIFF
--- a/include/exec/detail/bwos_lifo_queue.hpp
+++ b/include/exec/detail/bwos_lifo_queue.hpp
@@ -21,15 +21,47 @@
 
 #include "../../stdexec/__detail/__atomic.hpp"
 #include <bit>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>
 
-/** 
+/**
  * This is an implementation of the BWOS queue as described in
  * BWoS: Formally Verified Block-based Work Stealing for Parallel Processing (Wang et al. 2023)
+ *
+ * BLOCK COUNTER ENCODING:
+ * ----------------------
+ * Block counters (last_block_, start_block_, and internal counters) are 64-bit values with:
+ *   - Bits [63:32]: Round number (32-bit unsigned, wraps on overflow)
+ *   - Bits [31:0]:  Block index within the circular block array (masked by mask_)
+ *
+ * The round number increments each time the index wraps around from mask_ to 0.
+ * This encoding allows:
+ *   - Direct comparison of counters to determine relative order
+ *   - ABA problem prevention through round tracking
+ *   - Efficient atomic operations on a single 64-bit value
+ *
+ * TWO-LEVEL ROUND SYSTEM:
+ * ----------------------
+ * 1. Queue-level rounds: Tracked in last_block_/start_block_ upper 32 bits
+ *    - Increments when the owner wraps around the circular block array
+ *    - Passed to blocks during reclaim() to initialize block-level rounds
+ *
+ * 2. Block-level rounds: Stored in head_/steal_tail_ upper 32 bits
+ *    - Prevents ABA problems when blocks are reused
+ *    - Synchronized through takeover()/grant() atomic swaps
+ *    - Verified by is_writable() before block reuse
+ *
+ * THREAD SAFETY:
+ * -------------
+ * - Owner thread: Exclusively calls push_back() and pop_back()
+ * - Thief threads: Multiple threads can concurrently call steal_front()
+ * - last_block_: Modified only by owner (relaxed ordering)
+ * - start_block_: Modified only by owner when reclaiming blocks
+ * - Block synchronization via head_/steal_tail_ swaps and acquire/release ordering
  */
 
 namespace experimental::execution::bwos
@@ -53,12 +85,6 @@ namespace experimental::execution::bwos
     Tp                    value;
   };
 
-  struct takeover_result
-  {
-    std::size_t front;
-    std::size_t back;
-  };
-
   template <class Tp, class Allocator = std::allocator<Tp>>
   class lifo_queue
   {
@@ -77,11 +103,6 @@ namespace experimental::execution::bwos
     auto push_back(Iterator first, Sentinel last) noexcept -> Iterator;
 
     [[nodiscard]]
-    auto get_available_capacity() const noexcept -> std::size_t;
-    [[nodiscard]]
-    auto get_free_capacity() const noexcept -> std::size_t;
-
-    [[nodiscard]]
     auto block_size() const noexcept -> std::size_t;
     [[nodiscard]]
     auto num_blocks() const noexcept -> std::size_t;
@@ -95,10 +116,10 @@ namespace experimental::execution::bwos
       explicit block_type(std::size_t block_size, Allocator allocator = Allocator());
 
       block_type(block_type const &);
-      auto operator=(block_type const &) -> block_type &;
+      auto operator=(block_type const &) -> block_type&;
 
-      block_type(block_type &&) noexcept;
-      auto operator=(block_type &&) noexcept -> block_type &;
+      block_type(block_type&&) noexcept;
+      auto operator=(block_type&&) noexcept -> block_type&;
 
       auto put(Tp value) noexcept -> lifo_queue_error_code;
 
@@ -107,44 +128,68 @@ namespace experimental::execution::bwos
 
       auto get() noexcept -> fetch_result<Tp>;
 
-      auto steal() noexcept -> fetch_result<Tp>;
+      auto steal(std::uint32_t round) noexcept -> fetch_result<Tp>;
 
-      auto takeover() noexcept -> takeover_result;
-      [[nodiscard]]
-      auto is_writable() const noexcept -> bool;
+      auto takeover() noexcept -> void;
 
       [[nodiscard]]
-      auto free_capacity() const noexcept -> std::size_t;
+      auto is_writable(std::uint32_t round) const noexcept -> bool;
 
       void grant() noexcept;
 
-      auto reclaim() noexcept -> bool;
-
-      [[nodiscard]]
-      auto is_stealable() const noexcept -> bool;
+      auto reclaim(std::uint32_t round) noexcept -> void;
 
       [[nodiscard]]
       auto block_size() const noexcept -> std::size_t;
 
+      auto reduce_round() noexcept -> void;
+
+      // Block-level synchronization state (each on separate cache line to avoid false sharing)
+
+      // Combined round (upper 32 bits) and index (lower 32 bits) for owner-side access.
+      // Swapped with steal_tail_ during takeover()/grant() operations.
       alignas(hardware_destructive_interference_size) STDEXEC::__std::atomic<std::uint64_t> head_{};
+
+      // Current tail position for owner push/pop operations (plain index, no round).
+      // Modified only by owner thread.
       alignas(hardware_destructive_interference_size) STDEXEC::__std::atomic<std::uint64_t> tail_{};
-      alignas(
-        hardware_destructive_interference_size) STDEXEC::__std::atomic<std::uint64_t> steal_head_{};
+
+      // Count of completed steal operations. Used to synchronize with thieves during reclaim().
+      // Incremented by thieves after successful steal.
+      alignas(hardware_destructive_interference_size)
+        STDEXEC::__std::atomic<std::uint64_t> steal_count_{};
+      // Combined round (upper 32 bits) and steal position (lower 32 bits) for thief access.
+      // When lower bits == block_size(), the block is exhausted for stealing.
+      // Swapped with head_ during takeover()/grant() operations.
       alignas(
         hardware_destructive_interference_size) STDEXEC::__std::atomic<std::uint64_t> steal_tail_{};
+
       std::vector<Tp, Allocator> ring_buffer_;
     };
 
-    auto advance_get_index() noexcept -> bool;
-    auto advance_steal_index(std::size_t expected_thief_counter) noexcept -> bool;
-    auto advance_put_index() noexcept -> bool;
+    auto advance_get_index(std::size_t& owner, std::size_t owner_index) noexcept -> bool;
+    auto advance_steal_index(std::size_t& thief) noexcept -> bool;
+    auto advance_put_index(std::size_t& owner) noexcept -> bool;
 
+    auto increase_block_counter(std::size_t counter) const noexcept -> std::size_t;
+    auto decrease_block_counter(std::size_t counter) const noexcept -> std::size_t;
+
+    // Block counter (round in upper 32 bits, index in lower bits) for the most recent
+    // block owned by push/pop operations. Modified only by the owner thread.
+    alignas(hardware_destructive_interference_size) STDEXEC::__std::atomic<std::size_t> last_block_{
+      0};
+
+    // Block counter for the oldest block available for stealing.
+    // Modified only by the owner thread when it advances to a new block and needs to
+    // reclaim the block at start_block_ position.
     alignas(
-      hardware_destructive_interference_size) STDEXEC::__std::atomic<std::size_t> owner_block_{1};
-    alignas(
-      hardware_destructive_interference_size) STDEXEC::__std::atomic<std::size_t> thief_block_{0};
+      hardware_destructive_interference_size) STDEXEC::__std::atomic<std::size_t> start_block_{0};
+
+    // Circular array of blocks. Size is always a power of 2 for efficient masking.
     std::vector<block_type, allocator_of_t<block_type>> blocks_{};
-    std::size_t                                         mask_{};
+
+    // Bitmask (blocks_.size() - 1) for extracting block index from counters.
+    std::size_t mask_{};
   };
 
   /////////////////////////////////////////////////////////////////////////////
@@ -154,21 +199,23 @@ namespace experimental::execution::bwos
   lifo_queue<Tp, Allocator>::lifo_queue(std::size_t num_blocks,
                                         std::size_t block_size,
                                         Allocator   allocator)
-    : blocks_((std::max) (static_cast<size_t>(2), std::bit_ceil(num_blocks)),
+    : blocks_(std::bit_ceil(num_blocks),
               block_type(block_size, allocator),
               allocator_of_t<block_type>(allocator))
     , mask_(blocks_.size() - 1)
   {
-    blocks_[owner_block_.load()].reclaim();
+    blocks_[0].reclaim(0);
   }
 
   template <class Tp, class Allocator>
   auto lifo_queue<Tp, Allocator>::pop_back() noexcept -> Tp
   {
+    std::size_t owner = last_block_.load(STDEXEC::__std::memory_order_relaxed);
+    std::size_t owner_index{};
     do
     {
-      std::size_t owner_index   = owner_block_.load(STDEXEC::__std::memory_order_relaxed) & mask_;
-      block_type &current_block = blocks_[owner_index];
+      owner_index               = owner & mask_;
+      block_type& current_block = blocks_[owner_index];
       auto [ec, value]          = current_block.get();
       if (ec == lifo_queue_error_code::success)
       {
@@ -178,21 +225,22 @@ namespace experimental::execution::bwos
       {
         return Tp{};
       }
+      assert(ec == lifo_queue_error_code::empty);
     }
-    while (advance_get_index());
+    while (advance_get_index(owner, owner_index));
     return Tp{};
   }
 
   template <class Tp, class Allocator>
   auto lifo_queue<Tp, Allocator>::steal_front() noexcept -> Tp
   {
-    std::size_t thief = 0;
+    std::size_t thief = start_block_.load(STDEXEC::__std::memory_order_relaxed);
     do
     {
-      thief                    = thief_block_.load(STDEXEC::__std::memory_order_relaxed);
-      std::size_t  thief_index = thief & mask_;
-      block_type  &block       = blocks_[thief_index];
-      fetch_result result      = block.steal();
+      auto const        thief_round = static_cast<std::uint32_t>(thief >> 32);
+      std::size_t const thief_index = thief & mask_;
+      block_type&       block       = blocks_[thief_index];
+      fetch_result      result      = block.steal(thief_round);
       while (result.status != lifo_queue_error_code::done)
       {
         if (result.status == lifo_queue_error_code::success)
@@ -203,7 +251,8 @@ namespace experimental::execution::bwos
         {
           return Tp{};
         }
-        result = block.steal();
+        assert(result.status == lifo_queue_error_code::conflict);
+        result = block.steal(thief_round);
       }
     }
     while (advance_steal_index(thief));
@@ -213,17 +262,19 @@ namespace experimental::execution::bwos
   template <class Tp, class Allocator>
   auto lifo_queue<Tp, Allocator>::push_back(Tp value) noexcept -> bool
   {
+    std::size_t owner = last_block_.load(STDEXEC::__std::memory_order_relaxed);
     do
     {
-      std::size_t owner_index   = owner_block_.load(STDEXEC::__std::memory_order_relaxed) & mask_;
-      block_type &current_block = blocks_[owner_index];
+      std::size_t owner_index   = owner & mask_;
+      block_type& current_block = blocks_[owner_index];
       auto        ec            = current_block.put(value);
       if (ec == lifo_queue_error_code::success)
       {
         return true;
       }
+      assert(ec == lifo_queue_error_code::full);
     }
-    while (advance_put_index());
+    while (advance_put_index(owner));
     return false;
   }
 
@@ -231,32 +282,15 @@ namespace experimental::execution::bwos
   template <class Iterator, class Sentinel>
   auto lifo_queue<Tp, Allocator>::push_back(Iterator first, Sentinel last) noexcept -> Iterator
   {
+    std::size_t owner = last_block_.load(STDEXEC::__std::memory_order_relaxed);
     do
     {
-      std::size_t owner_index   = owner_block_.load(STDEXEC::__std::memory_order_relaxed) & mask_;
-      block_type &current_block = blocks_[owner_index];
+      std::size_t owner_index   = owner & mask_;
+      block_type& current_block = blocks_[owner_index];
       first                     = current_block.bulk_put(first, last);
     }
-    while (first != last && advance_put_index());
+    while (first != last && advance_put_index(owner));
     return first;
-  }
-
-  template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::get_free_capacity() const noexcept -> std::size_t
-  {
-    std::size_t owner_counter  = owner_block_.load(STDEXEC::__std::memory_order_relaxed);
-    std::size_t owner_index    = owner_counter & mask_;
-    std::size_t local_capacity = blocks_[owner_index].free_capacity();
-    std::size_t thief_counter  = thief_block_.load(STDEXEC::__std::memory_order_relaxed);
-    std::size_t diff           = owner_counter - thief_counter;
-    std::size_t rest           = blocks_.size() - diff - 1;
-    return local_capacity + rest * block_size();
-  }
-
-  template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::get_available_capacity() const noexcept -> std::size_t
-  {
-    return num_blocks() * block_size();
   }
 
   template <class Tp, class Allocator>
@@ -272,69 +306,90 @@ namespace experimental::execution::bwos
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::advance_get_index() noexcept -> bool
+  auto lifo_queue<Tp, Allocator>::increase_block_counter(std::size_t counter) const noexcept
+    -> std::size_t
   {
-    std::size_t     owner_counter     = owner_block_.load(STDEXEC::__std::memory_order_relaxed);
-    std::size_t     predecessor       = owner_counter - 1ul;
-    std::size_t     predecessor_index = predecessor & mask_;
-    block_type     &previous_block    = blocks_[predecessor_index];
-    takeover_result result            = previous_block.takeover();
-    if (result.front != result.back)
-    {
-      std::size_t thief_counter = thief_block_.load(STDEXEC::__std::memory_order_relaxed);
-      if (thief_counter == predecessor)
-      {
-        predecessor += blocks_.size();
-        thief_counter += blocks_.size() - 1ul;
-        thief_block_.store(thief_counter, STDEXEC::__std::memory_order_relaxed);
-      }
-      owner_block_.store(predecessor, STDEXEC::__std::memory_order_relaxed);
-      return true;
-    }
-    return false;
+    std::uint32_t round      = static_cast<std::uint32_t>(counter >> 32);
+    std::size_t   index      = counter & mask_;
+    std::size_t   next_index = (index + 1) & mask_;
+    std::uint32_t next_round = round + static_cast<std::uint32_t>(next_index == 0);
+    return (static_cast<std::size_t>(next_round) << 32) | next_index;
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::advance_put_index() noexcept -> bool
+  auto lifo_queue<Tp, Allocator>::decrease_block_counter(std::size_t counter) const noexcept
+    -> std::size_t
   {
-    std::size_t owner_counter = owner_block_.load(STDEXEC::__std::memory_order_relaxed);
-    std::size_t next_counter  = owner_counter + 1ul;
-    std::size_t thief_counter = thief_block_.load(STDEXEC::__std::memory_order_relaxed);
-    STDEXEC_ASSERT(thief_counter < next_counter);
-    if (next_counter - thief_counter >= blocks_.size())
+    std::uint32_t round      = static_cast<std::uint32_t>(counter >> 32);
+    std::size_t   index      = counter & mask_;
+    std::size_t   prev_index = static_cast<std::size_t>(static_cast<std::ptrdiff_t>(index) - 1)
+                           & mask_;
+    std::uint32_t prev_round = round - static_cast<std::uint32_t>(index == 0);
+    return (static_cast<std::size_t>(prev_round) << 32) | prev_index;
+  }
+
+  template <class Tp, class Allocator>
+  auto
+  lifo_queue<Tp, Allocator>::advance_get_index(std::size_t& owner, std::size_t owner_index) noexcept
+    -> bool
+  {
+    std::size_t start = start_block_.load(STDEXEC::__std::memory_order_relaxed);
+    if (start == owner)
     {
+      // Cannot move backward past start_block_ - queue is empty
       return false;
     }
-    std::size_t next_index = next_counter & mask_;
-    block_type &next_block = blocks_[next_index];
-    if (!next_block.is_writable()) [[unlikely]]
-    {
-      return false;
-    }
-    std::size_t owner_index   = owner_counter & mask_;
-    block_type &current_block = blocks_[owner_index];
-    current_block.grant();
-    owner_block_.store(next_counter, STDEXEC::__std::memory_order_relaxed);
-    next_block.reclaim();
+    // Move to predecessor block, properly decrementing round if wrapping backward
+    std::size_t predecessor       = decrease_block_counter(owner);
+    std::size_t predecessor_index = predecessor & mask_;
+    block_type& previous_block    = blocks_[predecessor_index];
+    block_type& current_block     = blocks_[owner_index];
+    current_block.reduce_round();
+    previous_block.takeover();
+    last_block_.store(predecessor, STDEXEC::__std::memory_order_relaxed);
+    owner = predecessor;
     return true;
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::advance_steal_index(std::size_t expected_thief_counter) noexcept
-    -> bool
+  auto lifo_queue<Tp, Allocator>::advance_put_index(std::size_t& owner) noexcept -> bool
   {
-    std::size_t thief_counter = expected_thief_counter;
-    std::size_t next_counter  = thief_counter + 1;
-    std::size_t next_index    = next_counter & mask_;
-    block_type &next_block    = blocks_[next_index];
-    if (next_block.is_stealable())
+    std::size_t next_index  = (owner + 1ul) & mask_;
+    std::size_t owner_index = owner & mask_;
+    if (next_index == owner_index)
     {
-      thief_block_.compare_exchange_strong(thief_counter,
-                                           next_counter,
-                                           STDEXEC::__std::memory_order_relaxed);
-      return true;
+      // Wrap-around would hit the same block - queue is full
+      return false;
     }
-    return thief_block_.load(STDEXEC::__std::memory_order_relaxed) != thief_counter;
+    // Calculate next round, incrementing when wrapping to index 0
+    std::uint32_t next_round = static_cast<std::uint32_t>(owner >> 32)
+                             + static_cast<std::uint32_t>(next_index == 0);
+    block_type& next_block = blocks_[next_index];
+    if (!next_block.is_writable(next_round))
+    {
+      // Block is not yet safe to reuse (thieves still accessing previous generation)
+      return false;
+    }
+    std::size_t first       = start_block_.load(STDEXEC::__std::memory_order_relaxed);
+    std::size_t first_index = first & mask_;
+    if (next_index == first_index)
+    {
+      // About to reuse the block at start_block_, so advance start_block_ forward
+      start_block_.store(increase_block_counter(first), STDEXEC::__std::memory_order_relaxed);
+    }
+    block_type& current_block = blocks_[owner_index];
+    current_block.grant();
+    owner = (static_cast<std::size_t>(next_round) << 32) | next_index;
+    next_block.reclaim(next_round);
+    last_block_.store(owner, STDEXEC::__std::memory_order_relaxed);
+    return true;
+  }
+
+  template <class Tp, class Allocator>
+  auto lifo_queue<Tp, Allocator>::advance_steal_index(std::size_t& thief) noexcept -> bool
+  {
+    thief = increase_block_counter(thief);
+    return thief < last_block_.load(STDEXEC::__std::memory_order_relaxed);
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -342,15 +397,15 @@ namespace experimental::execution::bwos
 
   template <class Tp, class Allocator>
   lifo_queue<Tp, Allocator>::block_type::block_type(std::size_t block_size, Allocator allocator)
-    : head_{0}
-    , tail_{0}
-    , steal_head_{0}
-    , steal_tail_{block_size}
+    : head_{0xFFFF'FFFF'0000'0000 | block_size}
+    , tail_{block_size}
+    , steal_count_{block_size}
+    , steal_tail_{0xFFFF'FFFF'0000'0000 | block_size}
     , ring_buffer_(block_size, allocator)
   {}
 
   template <class Tp, class Allocator>
-  lifo_queue<Tp, Allocator>::block_type::block_type(block_type const &other)
+  lifo_queue<Tp, Allocator>::block_type::block_type(block_type const & other)
     : ring_buffer_(other.ring_buffer_)
   {
     head_.store(other.head_.load(STDEXEC::__std::memory_order_relaxed),
@@ -359,13 +414,13 @@ namespace experimental::execution::bwos
                 STDEXEC::__std::memory_order_relaxed);
     steal_tail_.store(other.steal_tail_.load(STDEXEC::__std::memory_order_relaxed),
                       STDEXEC::__std::memory_order_relaxed);
-    steal_head_.store(other.steal_head_.load(STDEXEC::__std::memory_order_relaxed),
-                      STDEXEC::__std::memory_order_relaxed);
+    steal_count_.store(other.steal_count_.load(STDEXEC::__std::memory_order_relaxed),
+                       STDEXEC::__std::memory_order_relaxed);
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::operator=(block_type const &other)
-    -> lifo_queue<Tp, Allocator>::block_type &
+  auto lifo_queue<Tp, Allocator>::block_type::operator=(block_type const & other)
+    -> lifo_queue<Tp, Allocator>::block_type&
   {
     head_.store(other.head_.load(STDEXEC::__std::memory_order_relaxed),
                 STDEXEC::__std::memory_order_relaxed);
@@ -373,14 +428,14 @@ namespace experimental::execution::bwos
                 STDEXEC::__std::memory_order_relaxed);
     steal_tail_.store(other.steal_tail_.load(STDEXEC::__std::memory_order_relaxed),
                       STDEXEC::__std::memory_order_relaxed);
-    steal_head_.store(other.steal_head_.load(STDEXEC::__std::memory_order_relaxed),
-                      STDEXEC::__std::memory_order_relaxed);
+    steal_count_.store(other.steal_count_.load(STDEXEC::__std::memory_order_relaxed),
+                       STDEXEC::__std::memory_order_relaxed);
     ring_buffer_ = other.ring_buffer_;
     return *this;
   }
 
   template <class Tp, class Allocator>
-  lifo_queue<Tp, Allocator>::block_type::block_type(block_type &&other) noexcept
+  lifo_queue<Tp, Allocator>::block_type::block_type(block_type&& other) noexcept
   {
     head_.store(other.head_.load(STDEXEC::__std::memory_order_relaxed),
                 STDEXEC::__std::memory_order_relaxed);
@@ -388,14 +443,14 @@ namespace experimental::execution::bwos
                 STDEXEC::__std::memory_order_relaxed);
     steal_tail_.store(other.steal_tail_.load(STDEXEC::__std::memory_order_relaxed),
                       STDEXEC::__std::memory_order_relaxed);
-    steal_head_.store(other.steal_head_.load(STDEXEC::__std::memory_order_relaxed),
-                      STDEXEC::__std::memory_order_relaxed);
+    steal_count_.store(other.steal_count_.load(STDEXEC::__std::memory_order_relaxed),
+                       STDEXEC::__std::memory_order_relaxed);
     ring_buffer_ = std::exchange(std::move(other.ring_buffer_), {});
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::operator=(block_type &&other) noexcept
-    -> lifo_queue<Tp, Allocator>::block_type &
+  auto lifo_queue<Tp, Allocator>::block_type::operator=(block_type&& other) noexcept
+    -> lifo_queue<Tp, Allocator>::block_type&
   {
     head_.store(other.head_.load(STDEXEC::__std::memory_order_relaxed),
                 STDEXEC::__std::memory_order_relaxed);
@@ -403,8 +458,8 @@ namespace experimental::execution::bwos
                 STDEXEC::__std::memory_order_relaxed);
     steal_tail_.store(other.steal_tail_.load(STDEXEC::__std::memory_order_relaxed),
                       STDEXEC::__std::memory_order_relaxed);
-    steal_head_.store(other.steal_head_.load(STDEXEC::__std::memory_order_relaxed),
-                      STDEXEC::__std::memory_order_relaxed);
+    steal_count_.store(other.steal_count_.load(STDEXEC::__std::memory_order_relaxed),
+                       STDEXEC::__std::memory_order_relaxed);
     ring_buffer_ = std::exchange(std::move(other.ring_buffer_), {});
     return *this;
   }
@@ -412,10 +467,11 @@ namespace experimental::execution::bwos
   template <class Tp, class Allocator>
   auto lifo_queue<Tp, Allocator>::block_type::put(Tp value) noexcept -> lifo_queue_error_code
   {
-    std::uint64_t back = tail_.load(STDEXEC::__std::memory_order_relaxed);
-    if (back < block_size()) [[likely]]
+    std::uint64_t back     = tail_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t back_idx = back & 0xFFFF'FFFFu;
+    if (back_idx < block_size()) [[likely]]
     {
-      ring_buffer_[static_cast<std::size_t>(back)] = static_cast<Tp &&>(value);
+      ring_buffer_[static_cast<std::size_t>(back_idx)] = static_cast<Tp&&>(value);
       tail_.store(back + 1, STDEXEC::__std::memory_order_release);
       return lifo_queue_error_code::success;
     }
@@ -427,11 +483,13 @@ namespace experimental::execution::bwos
   auto lifo_queue<Tp, Allocator>::block_type::bulk_put(Iterator first, Sentinel last) noexcept
     -> Iterator
   {
-    std::uint64_t back = tail_.load(STDEXEC::__std::memory_order_relaxed);
-    while (first != last && back < block_size())
+    std::uint64_t back     = tail_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t back_idx = back & 0xFFFF'FFFFu;
+    while (first != last && back_idx < block_size())
     {
-      ring_buffer_[static_cast<std::size_t>(back)] = static_cast<Tp &&>(*first);
+      ring_buffer_[static_cast<std::size_t>(back_idx)] = static_cast<Tp&&>(*first);
       ++back;
+      ++back_idx;
       ++first;
     }
     tail_.store(back, STDEXEC::__std::memory_order_release);
@@ -441,90 +499,124 @@ namespace experimental::execution::bwos
   template <class Tp, class Allocator>
   auto lifo_queue<Tp, Allocator>::block_type::get() noexcept -> fetch_result<Tp>
   {
-    std::uint64_t front = head_.load(STDEXEC::__std::memory_order_relaxed);
-    if (front == block_size()) [[unlikely]]
+    std::uint64_t back     = tail_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t back_idx = back & 0xFFFF'FFFFu;
+    if (back_idx == 0) [[unlikely]]
     {
-      return {lifo_queue_error_code::done, nullptr};
+      return {lifo_queue_error_code::empty, Tp{}};
     }
-    std::uint64_t back = tail_.load(STDEXEC::__std::memory_order_relaxed);
-    if (front == back) [[unlikely]]
+    // Extract index from head_ (which contains round in upper 32 bits)
+    std::uint64_t front     = head_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t front_idx = front & 0xFFFF'FFFFu;
+    if (front_idx == back_idx) [[unlikely]]
     {
-      return {lifo_queue_error_code::empty, nullptr};
+      // Block is empty (head and tail indices match)
+      return {lifo_queue_error_code::empty, Tp{}};
     }
-    Tp value = static_cast<Tp &&>(ring_buffer_[static_cast<std::size_t>(back - 1)]);
+    Tp value = static_cast<Tp&&>(ring_buffer_[static_cast<std::size_t>(back_idx - 1)]);
     tail_.store(back - 1, STDEXEC::__std::memory_order_release);
     return {lifo_queue_error_code::success, value};
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::steal() noexcept -> fetch_result<Tp>
+  auto lifo_queue<Tp, Allocator>::block_type::steal(std::uint32_t thief_round) noexcept
+    -> fetch_result<Tp>
   {
-    std::uint64_t    spos = steal_tail_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t    spos  = steal_tail_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t    sidx  = spos & 0xFFFF'FFFFu;
+    std::uint64_t    round = spos >> 32;
     fetch_result<Tp> result{};
-    if (spos == block_size()) [[unlikely]]
+    if (sidx == block_size())
     {
-      result.status = lifo_queue_error_code::done;
+      // Block is marked as exhausted for stealing (steal_tail index == block_size)
+      // Check round to distinguish between:
+      //   - done: This is the correct generation (thief_round matches)
+      //   - empty: This is a stale/future generation (round mismatch)
+      result.status = thief_round == round ? lifo_queue_error_code::done
+                                           : lifo_queue_error_code::empty;
       return result;
     }
+    // Acquire ordering ensures we see items written by owner's release in put()
     std::uint64_t back = tail_.load(STDEXEC::__std::memory_order_acquire);
-    if (spos == back) [[unlikely]]
+    if (sidx == back)
     {
+      // No items available between steal_tail and tail
       result.status = lifo_queue_error_code::empty;
       return result;
     }
+    // Try to claim the item at spos by atomically incrementing steal_tail_
     if (!steal_tail_.compare_exchange_strong(spos, spos + 1, STDEXEC::__std::memory_order_relaxed))
     {
+      // Another thief claimed this item, retry
       result.status = lifo_queue_error_code::conflict;
       return result;
     }
-    result.value = static_cast<Tp &&>(ring_buffer_[static_cast<std::size_t>(spos)]);
-    steal_head_.fetch_add(1, STDEXEC::__std::memory_order_release);
+    // Successfully claimed the item
+    result.value = static_cast<Tp&&>(ring_buffer_[static_cast<std::size_t>(sidx)]);
+    // Release ordering ensures reclaim() sees this increment after we've read the value
+    steal_count_.fetch_add(1, STDEXEC::__std::memory_order_release);
     result.status = lifo_queue_error_code::success;
     return result;
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::takeover() noexcept -> takeover_result
+  auto lifo_queue<Tp, Allocator>::block_type::reduce_round() noexcept -> void
   {
-    std::uint64_t spos = steal_tail_.exchange(block_size(), STDEXEC::__std::memory_order_relaxed);
-    if (spos == block_size()) [[unlikely]]
-    {
-      return {.front = static_cast<std::size_t>(head_.load(STDEXEC::__std::memory_order_relaxed)),
-              .back  = static_cast<std::size_t>(tail_.load(STDEXEC::__std::memory_order_relaxed))};
-    }
+    // Decrement the round in steal_tail_ when moving backward in the block array.
+    // Called by advance_get_index() when the owner retreats to a previous block.
+    std::uint64_t steal_tail     = steal_tail_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint32_t round          = static_cast<std::uint32_t>(steal_tail >> 32);
+    std::uint64_t steal_index    = steal_tail & 0xFFFF'FFFFu;
+    std::uint64_t new_steal_tail = (static_cast<std::uint64_t>(round - 1) << 32) | steal_index;
+    steal_tail_.store(new_steal_tail, STDEXEC::__std::memory_order_relaxed);
+  }
+
+  template <class Tp, class Allocator>
+  auto lifo_queue<Tp, Allocator>::block_type::takeover() noexcept -> void
+  {
+    // Called when the owner moves backward to this block.
+    // Swaps head_ and steal_tail_ to establish new boundaries.
+    // The old steal_tail_ becomes the new head_ (start of owner's range).
+    std::uint64_t head = head_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t spos = steal_tail_.exchange(head, STDEXEC::__std::memory_order_relaxed);
     head_.store(spos, STDEXEC::__std::memory_order_relaxed);
-    return {.front = static_cast<std::size_t>(spos),
-            .back  = static_cast<std::size_t>(tail_.load(STDEXEC::__std::memory_order_relaxed))};
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::is_writable() const noexcept -> bool
+  auto
+  lifo_queue<Tp, Allocator>::block_type::is_writable(std::uint32_t round) const noexcept -> bool
   {
-    std::uint64_t expected_steal = block_size();
-    std::uint64_t spos           = steal_tail_.load(STDEXEC::__std::memory_order_relaxed);
-    return spos == expected_steal;
+    // Check if this block can be safely reused for the given round.
+    // The block is writable if steal_tail_ shows it's exhausted (index == block_size)
+    // and the round is from the previous generation (round - 1).
+    // This prevents reusing a block while thieves might still be accessing it.
+    std::uint64_t expanded_old_round = static_cast<std::uint64_t>(round - 1) << 32;
+    std::uint64_t writeable_spos     = expanded_old_round | block_size();
+    std::uint64_t spos               = steal_tail_.load(STDEXEC::__std::memory_order_relaxed);
+    return spos == writeable_spos;
   }
 
   template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::free_capacity() const noexcept -> std::size_t
+  auto lifo_queue<Tp, Allocator>::block_type::reclaim(std::uint32_t round) noexcept -> void
   {
-    std::uint64_t back = tail_.load(STDEXEC::__std::memory_order_relaxed);
-    return block_size() - back;
-  }
+    // Reset this block for reuse with a new round number.
+    // Must wait for all thieves to finish accessing this block from previous generation.
 
-  template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::reclaim() noexcept -> bool
-  {
-    std::uint64_t expected_steal_head_ = tail_.load(STDEXEC::__std::memory_order_relaxed);
-    while (steal_head_.load(STDEXEC::__std::memory_order_acquire) != expected_steal_head_)
+    // Expected steal_count is the index from head_ (number of items that were available to steal)
+    std::uint64_t expected_steal_count_ = head_.load(STDEXEC::__std::memory_order_relaxed)
+                                        & 0xFFFF'FFFFu;
+    // Spin until all thieves have reported completion via steal_count_
+    // Acquire ordering ensures we see all thief modifications before proceeding
+    while (steal_count_.load(STDEXEC::__std::memory_order_acquire) != expected_steal_count_)
     {
       STDEXEC::__spin_loop_pause();
     }
-    head_.store(0, STDEXEC::__std::memory_order_relaxed);
+    // All thieves have finished - safe to reset the block
+    std::uint64_t expanded_round = static_cast<std::uint64_t>(round) << 32;
+    head_.store(expanded_round, STDEXEC::__std::memory_order_relaxed);
     tail_.store(0, STDEXEC::__std::memory_order_relaxed);
-    steal_tail_.store(block_size(), STDEXEC::__std::memory_order_relaxed);
-    steal_head_.store(0, STDEXEC::__std::memory_order_relaxed);
-    return false;
+    steal_tail_.store(expanded_round | block_size(), STDEXEC::__std::memory_order_relaxed);
+    steal_count_.store(0, STDEXEC::__std::memory_order_relaxed);
   }
 
   template <class Tp, class Allocator>
@@ -536,14 +628,14 @@ namespace experimental::execution::bwos
   template <class Tp, class Allocator>
   void lifo_queue<Tp, Allocator>::block_type::grant() noexcept
   {
-    std::uint64_t old_head = head_.exchange(block_size(), STDEXEC::__std::memory_order_relaxed);
+    // Called when the owner moves forward to a new block.
+    // Makes the current block fully available for stealing by swapping head_ and steal_tail_.
+    // The old head_ becomes steal_tail_ (starting point for thieves).
+    // The old steal_tail_ (at block_size()) becomes head_ (marking end of owner's range).
+    std::uint64_t block_end = steal_tail_.load(STDEXEC::__std::memory_order_relaxed);
+    std::uint64_t old_head  = head_.exchange(block_end, STDEXEC::__std::memory_order_relaxed);
+    // Release ordering ensures thieves see all items we wrote before starting to steal
     steal_tail_.store(old_head, STDEXEC::__std::memory_order_release);
-  }
-
-  template <class Tp, class Allocator>
-  auto lifo_queue<Tp, Allocator>::block_type::is_stealable() const noexcept -> bool
-  {
-    return steal_tail_.load(STDEXEC::__std::memory_order_acquire) != block_size();
   }
 }  // namespace experimental::execution::bwos
 

--- a/test/exec/test_bwos_lifo_queue.cpp
+++ b/test/exec/test_bwos_lifo_queue.cpp
@@ -16,6 +16,13 @@
  */
 #include "exec/detail/bwos_lifo_queue.hpp"
 
+#include <algorithm>
+#include <atomic>
+#include <numeric>
+#include <ranges>
+#include <thread>
+#include <vector>
+
 #include <catch2/catch.hpp>
 
 TEST_CASE("exec::bwos::lifo_queue - ", "[bwos]")
@@ -87,4 +94,408 @@ TEST_CASE("exec::bwos::lifo_queue - ", "[bwos]")
     CHECK(queue.pop_back() == &y);
     CHECK(queue.pop_back() == nullptr);
   }
+}
+
+TEST_CASE("exec::bwos::lifo_queue - size one block", "[bwos]")
+{
+  exec::bwos::lifo_queue<int*> queue(1, 1);
+  int                          x = 1;
+  int                          y = 2;
+  CHECK(queue.push_back(&x));
+  CHECK_FALSE(queue.push_back(&y));
+  CHECK(queue.steal_front() == nullptr);
+  CHECK(queue.pop_back() == &x);
+  CHECK(queue.pop_back() == nullptr);
+}
+
+TEST_CASE("exec::bwos::lifo_queue - two blocks of size one", "[bwos]")
+{
+  exec::bwos::lifo_queue<int*> queue(2, 1);
+  int                          x = 1;
+  int                          y = 2;
+
+  // First cycle: push, no steal possible from current block, pop
+  CHECK(queue.push_back(&x));
+  CHECK(queue.steal_front() == nullptr);
+  CHECK(queue.pop_back() == &x);
+  CHECK(queue.pop_back() == nullptr);
+
+  // Second cycle: push two items across blocks
+  CHECK(queue.push_back(&x));
+  CHECK(queue.push_back(&y));
+  CHECK_FALSE(queue.push_back(&x));  // queue full
+  CHECK(queue.steal_front() == &x);  // steal from first granted block
+  CHECK(queue.steal_front() == nullptr);
+  CHECK(queue.pop_back() == &y);
+  CHECK(queue.pop_back() == nullptr);
+
+  // Third cycle: push and pop again after wraparound
+  CHECK(queue.push_back(&x));
+  CHECK(queue.pop_back() == &x);
+  CHECK(queue.pop_back() == nullptr);
+}
+
+TEST_CASE("exec::bwos::lifo_queue - round counter wraparound", "[bwos]")
+{
+  constexpr std::size_t numBlocks = 4;
+  constexpr std::size_t blockSize = 2;
+  constexpr std::size_t numItems  = numBlocks * blockSize * 3;  // 3 full rounds
+
+  exec::bwos::lifo_queue<int> queue(numBlocks, blockSize);
+  std::vector<int>            stolenItems;
+
+  for (int val = 1; val <= static_cast<int>(numItems); ++val)
+  {
+    if (!queue.push_back(val))
+    {
+      // Queue full, steal some items to make space
+      while (true)
+      {
+        int stolen = queue.steal_front();
+        if (stolen == 0)
+        {
+          break;
+        }
+        stolenItems.push_back(stolen);
+      }
+      REQUIRE(queue.push_back(val));
+    }
+  }
+
+  // Stolen items should be a prefix of the values in order
+  auto prefix = std::views::iota(1, static_cast<int>(stolenItems.size()) + 1);
+  CHECK(std::ranges::equal(stolenItems, prefix));
+
+  std::vector<int> remainingItems;
+  while (true)
+  {
+    int item = queue.pop_back();
+    if (item == 0)
+    {
+      break;
+    }
+    remainingItems.push_back(item);
+  }
+  CHECK(std::ranges::is_sorted(remainingItems.rbegin(), remainingItems.rend()));
+  CHECK(stolenItems.size() + remainingItems.size() == numItems);
+  CHECK(queue.pop_back() == 0);
+}
+
+TEST_CASE("exec::bwos::lifo_queue - concurrent stealing", "[bwos]")
+{
+  constexpr std::size_t numItems   = 2000;
+  constexpr std::size_t numThieves = 4;
+
+  exec::bwos::lifo_queue<std::size_t> queue(32, 64);
+
+  for (std::size_t i = 1; i <= numItems; ++i)
+  {
+    REQUIRE(queue.push_back(i));
+  }
+
+  std::vector<std::vector<std::size_t>> stolen(numThieves);
+  std::vector<std::thread>              thieves;
+  thieves.reserve(numThieves);
+  for (std::size_t t = 0; t < numThieves; ++t)
+  {
+    thieves.emplace_back(
+      [&queue, &stolen, t]()
+      {
+        while (true)
+        {
+          std::size_t item = queue.steal_front();
+          if (item == 0)
+          {
+            break;
+          }
+          stolen[t].push_back(item);
+        }
+      });
+  }
+
+  for (auto& thief: thieves)
+  {
+    thief.join();
+  }
+
+  std::vector<std::size_t> allStolen;
+  for (auto const & vec: stolen)
+  {
+    allStolen.insert(allStolen.end(), vec.begin(), vec.end());
+  }
+
+  std::ranges::sort(allStolen);
+  auto [first, last] = std::ranges::unique(allStolen);
+  CHECK(first == last);  // no duplicates
+  CHECK(allStolen.size() <= numItems);
+}
+
+TEST_CASE("exec::bwos::lifo_queue - concurrent owner and thieves", "[bwos]")
+{
+  constexpr std::size_t numItems   = 10000;
+  constexpr std::size_t numThieves = 2;
+
+  exec::bwos::lifo_queue<std::size_t> queue(16, 32);
+  std::atomic<bool>                   done{false};
+  std::atomic<std::size_t>            ownerPopped{0};
+  std::atomic<std::size_t>            totalStolen{0};
+
+  std::thread owner(
+    [&]()
+    {
+      for (std::size_t i = 1; i <= numItems; ++i)
+      {
+        while (!queue.push_back(i))
+        {
+          if (queue.pop_back() != 0)
+          {
+            ownerPopped++;
+          }
+        }
+        if (i % 100 == 0)
+        {
+          if (queue.pop_back() != 0)
+          {
+            ownerPopped++;
+          }
+        }
+      }
+      done = true;
+    });
+
+  std::vector<std::thread> thieves;
+  thieves.reserve(numThieves);
+  for (std::size_t t = 0; t < numThieves; ++t)
+  {
+    thieves.emplace_back(
+      [&]()
+      {
+        while (!done.load(std::memory_order_relaxed))
+        {
+          if (queue.steal_front() != 0)
+          {
+            totalStolen++;
+          }
+        }
+        while (queue.steal_front() != 0)
+        {
+          totalStolen++;
+        }
+      });
+  }
+
+  owner.join();
+  for (auto& thief: thieves)
+  {
+    thief.join();
+  }
+
+  std::size_t remaining = 0;
+  while (queue.pop_back() != 0)
+  {
+    remaining++;
+  }
+
+  CHECK(ownerPopped + totalStolen + remaining == numItems);
+}
+
+TEST_CASE("exec::bwos::lifo_queue - block wraparound with stealing", "[bwos]")
+{
+  constexpr std::size_t numBlocks     = 4;
+  constexpr std::size_t blockSize     = 8;
+  constexpr std::size_t rounds        = 5;
+  constexpr std::size_t itemsPerRound = numBlocks * blockSize;
+
+  exec::bwos::lifo_queue<std::size_t> queue(numBlocks, blockSize);
+  std::atomic<std::size_t>            stolenCount{0};
+  std::atomic<bool>                   thiefActive{true};
+
+  std::thread thief(
+    [&]()
+    {
+      while (thiefActive)
+      {
+        if (queue.steal_front())
+        {
+          stolenCount++;
+        }
+      }
+    });
+
+  for (std::size_t round = 0; round < rounds; ++round)
+  {
+    for (std::size_t i = 0; i < itemsPerRound; ++i)
+    {
+      std::size_t value = (round * itemsPerRound) + i + 1;
+      while (!queue.push_back(value))
+      {
+        queue.pop_back();
+      }
+    }
+  }
+
+  thiefActive = false;
+  thief.join();
+}
+
+TEST_CASE("exec::bwos::lifo_queue - high contention stress", "[bwos]")
+{
+  constexpr std::size_t numItems   = 50000;
+  constexpr std::size_t numThieves = 8;
+  constexpr std::size_t numBlocks  = 16;
+  constexpr std::size_t blockSize  = 32;
+
+  exec::bwos::lifo_queue<std::size_t> queue(numBlocks, blockSize);
+  std::atomic<std::size_t>            totalStolen{0};
+  std::atomic<std::size_t>            pushCount{0};
+  std::atomic<bool>                   done{false};
+
+  std::thread owner(
+    [&]()
+    {
+      for (std::size_t i = 1; i <= numItems; ++i)
+      {
+        while (!queue.push_back(i))
+        {
+          std::this_thread::yield();
+        }
+        pushCount++;
+      }
+      done = true;
+    });
+
+  std::vector<std::thread>              thieves;
+  std::vector<std::atomic<std::size_t>> thiefCounts(numThieves);
+
+  thieves.reserve(numThieves);
+  for (std::size_t t = 0; t < numThieves; ++t)
+  {
+    thieves.emplace_back(
+      [&, t]()
+      {
+        std::size_t localCount = 0;
+        while (true)
+        {
+          auto val = queue.steal_front();
+          if (val != 0)
+          {
+            localCount++;
+          }
+          else if (done)
+          {
+            break;
+          }
+        }
+        thiefCounts[t] = localCount;
+      });
+  }
+
+  owner.join();
+  for (auto& thief: thieves)
+  {
+    thief.join();
+  }
+
+  for (auto const & count: thiefCounts)
+  {
+    totalStolen += count.load();
+  }
+
+  std::size_t remaining = 0;
+  while (queue.pop_back() != 0)
+  {
+    remaining++;
+  }
+
+  CHECK(pushCount == numItems);
+  CHECK(totalStolen + remaining == numItems);
+}
+
+TEST_CASE("exec::bwos::lifo_queue - steal during wraparound", "[bwos]")
+{
+  constexpr std::size_t numBlocks = 4;
+  constexpr std::size_t blockSize = 4;
+
+  exec::bwos::lifo_queue<std::size_t> queue(numBlocks, blockSize);
+  std::atomic<bool>                   startStealing{false};
+  std::atomic<std::size_t>            stolen{0};
+
+  std::thread thief(
+    [&]()
+    {
+      while (!startStealing)
+      {
+        std::this_thread::yield();
+      }
+      while (queue.steal_front() != 0)
+      {
+        stolen++;
+      }
+    });
+
+  for (std::size_t round = 0; round < 3; ++round)
+  {
+    for (std::size_t i = 0; i < numBlocks * blockSize; ++i)
+    {
+      if (!queue.push_back((round * 100) + i + 1))
+      {
+        startStealing = true;
+        while (!queue.push_back((round * 100) + i + 1))
+        {
+          std::this_thread::yield();
+        }
+      }
+    }
+  }
+
+  startStealing = true;
+  thief.join();
+}
+
+TEST_CASE("exec::bwos::lifo_queue - takeover grant synchronization", "[bwos]")
+{
+  constexpr std::size_t numBlocks  = 4;
+  constexpr std::size_t blockSize  = 16;
+  constexpr std::size_t iterations = 1000;
+
+  exec::bwos::lifo_queue<std::size_t> queue(numBlocks, blockSize);
+  std::atomic<std::size_t>            totalStolen{0};
+  std::atomic<std::size_t>            totalPopped{0};
+
+  std::thread owner(
+    [&]()
+    {
+      for (std::size_t iter = 0; iter < iterations; ++iter)
+      {
+        for (std::size_t i = 0; i < blockSize; ++i)
+        {
+          while (!queue.push_back((iter * blockSize) + i + 1))
+          {
+            std::this_thread::yield();
+          }
+        }
+        for (std::size_t i = 0; i < blockSize / 2; ++i)
+        {
+          if (queue.pop_back() != 0)
+          {
+            totalPopped++;
+          }
+        }
+      }
+    });
+
+  std::thread thief(
+    [&]()
+    {
+      while (totalPopped < iterations * blockSize / 2)
+      {
+        if (queue.steal_front() != 0)
+        {
+          totalStolen++;
+        }
+      }
+    });
+
+  owner.join();
+  thief.join();
 }

--- a/test/rrd/CMakeLists.txt
+++ b/test/rrd/CMakeLists.txt
@@ -33,6 +33,7 @@ endfunction()
 
 set(relacy_tests
   async_scope
+  bwos_lifo_queue
   intrusive_mpsc_queue
   split
   sync_wait

--- a/test/rrd/bwos_lifo_queue.cpp
+++ b/test/rrd/bwos_lifo_queue.cpp
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2026 Maikel Nadolski
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdexec_relacy.hpp>
+
+#include <exec/detail/bwos_lifo_queue.hpp>
+
+#include <optional>
+
+// Test 1: Owner pushes items, single thief steals.
+// Invariant: every pushed item is either popped by owner or stolen by thief exactly once.
+struct bwos_push_steal_no_loss : rl::test_suite<bwos_push_steal_no_loss, 2>
+{
+  static constexpr std::size_t num_blocks = 2;
+  static constexpr std::size_t block_size = 2;
+  static constexpr std::size_t num_items  = 4;
+
+  std::optional<exec::bwos::lifo_queue<int>> queue{};
+  int                                        owner_sum{0};
+  int                                        thief_sum{0};
+
+  void before()
+  {
+    queue.emplace(num_blocks, block_size);
+    owner_sum = 0;
+    thief_sum = 0;
+  }
+
+  void after()
+  {
+    // Sum of 1..num_items = num_items*(num_items+1)/2
+    int expected = static_cast<int>(num_items * (num_items + 1) / 2);
+    RL_ASSERT(owner_sum + thief_sum == expected);
+    queue.reset();
+  }
+
+  void thread(unsigned thread_id)
+  {
+    if (thread_id == 0)
+    {
+      // Owner: push all items then pop remaining
+      for (int i = 1; i <= static_cast<int>(num_items); ++i)
+      {
+        while (!queue->push_back(i))
+        {
+          int val = queue->pop_back();
+          if (val != 0)
+          {
+            owner_sum += val;
+          }
+        }
+      }
+      // Drain remaining
+      while (true)
+      {
+        int val = queue->pop_back();
+        if (val == 0)
+        {
+          break;
+        }
+        owner_sum += val;
+      }
+    }
+    else
+    {
+      // Thief: steal until no more items
+      for (std::size_t attempt = 0; attempt < num_items * 4; ++attempt)
+      {
+        int val = queue->steal_front();
+        if (val != 0)
+        {
+          thief_sum += val;
+        }
+      }
+    }
+  }
+};
+
+// Test 2: Owner fills a block, grants it, thief steals while owner pushes to next block.
+// This exercises the grant()/steal() race on block boundaries.
+struct bwos_grant_steal_race : rl::test_suite<bwos_grant_steal_race, 2>
+{
+  static constexpr std::size_t num_blocks = 4;
+  static constexpr std::size_t block_size = 2;
+
+  std::optional<exec::bwos::lifo_queue<int>> queue{};
+  int                                        owner_count{0};
+  int                                        thief_count{0};
+  bool                                       seen[7]{};
+
+  void before()
+  {
+    queue.emplace(num_blocks, block_size);
+    owner_count = 0;
+    thief_count = 0;
+    for (auto& s: seen)
+    {
+      s = false;
+    }
+  }
+
+  void after()
+  {
+    RL_ASSERT(owner_count + thief_count == 6);
+    for (int i = 1; i <= 6; ++i)
+    {
+      RL_ASSERT(seen[i]);
+    }
+    queue.reset();
+  }
+
+  void thread(unsigned thread_id)
+  {
+    if (thread_id == 0)
+    {
+      // Push enough to force block transitions (grant)
+      for (int i = 1; i <= 6; ++i)
+      {
+        while (!queue->push_back(i))
+        {
+          int val = queue->pop_back();
+          if (val != 0)
+          {
+            RL_ASSERT(val >= 1 && val <= 6);
+            RL_ASSERT(!seen[val]);
+            seen[val] = true;
+            owner_count++;
+          }
+        }
+      }
+      // Drain remaining
+      while (true)
+      {
+        int val = queue->pop_back();
+        if (val == 0)
+        {
+          break;
+        }
+        RL_ASSERT(val >= 1 && val <= 6);
+        RL_ASSERT(!seen[val]);
+        seen[val] = true;
+        owner_count++;
+      }
+    }
+    else
+    {
+      // Thief steals concurrently
+      for (std::size_t attempt = 0; attempt < 24; ++attempt)
+      {
+        int val = queue->steal_front();
+        if (val != 0)
+        {
+          RL_ASSERT(val >= 1 && val <= 6);
+          RL_ASSERT(!seen[val]);
+          seen[val] = true;
+          thief_count++;
+        }
+      }
+    }
+  }
+};
+
+// Test 3: Owner pushes, pops (triggering takeover), while thief steals.
+// This exercises the takeover()/steal() race which was the original bug.
+struct bwos_takeover_steal_race : rl::test_suite<bwos_takeover_steal_race, 2>
+{
+  static constexpr std::size_t num_blocks = 4;
+  static constexpr std::size_t block_size = 2;
+
+  std::optional<exec::bwos::lifo_queue<int>> queue{};
+  int                                        owner_count{0};
+  int                                        thief_count{0};
+
+  void before()
+  {
+    queue.emplace(num_blocks, block_size);
+    owner_count = 0;
+    thief_count = 0;
+  }
+
+  void after()
+  {
+    RL_ASSERT(owner_count + thief_count == 3);
+    queue.reset();
+  }
+
+  void thread(unsigned thread_id)
+  {
+    if (thread_id == 0)
+    {
+      // Push items to fill first block, then push more to advance blocks
+      queue->push_back(1);
+      queue->push_back(2);
+      queue->push_back(3);  // forces advance to block 1
+
+      // Now pop: 3 from block 1, then 2 triggers takeover back to block 0
+      int val = queue->pop_back();
+      if (val != 0)
+      {
+        owner_count++;
+      }
+      val = queue->pop_back();
+      if (val != 0)
+      {
+        owner_count++;
+      }
+      val = queue->pop_back();
+      if (val != 0)
+      {
+        owner_count++;
+      }
+    }
+    else
+    {
+      // Thief steals concurrently during takeover
+      for (std::size_t attempt = 0; attempt < 12; ++attempt)
+      {
+        int val = queue->steal_front();
+        if (val != 0)
+        {
+          thief_count++;
+        }
+      }
+    }
+  }
+};
+
+// Test 4: Two thieves competing to steal from the same block.
+// Tests the CAS contention in steal().
+struct bwos_two_thieves : rl::test_suite<bwos_two_thieves, 3>
+{
+  static constexpr std::size_t num_blocks = 4;
+  static constexpr std::size_t block_size = 2;
+  static constexpr int         num_items  = 4;
+
+  std::optional<exec::bwos::lifo_queue<int>> queue{};
+  int                                        owner_count{0};
+  int                                        thief1_count{0};
+  int                                        thief2_count{0};
+  bool                                       seen[5]{};
+
+  void before()
+  {
+    queue.emplace(num_blocks, block_size);
+    owner_count  = 0;
+    thief1_count = 0;
+    thief2_count = 0;
+    for (auto& s: seen)
+    {
+      s = false;
+    }
+  }
+
+  void after()
+  {
+    RL_ASSERT(owner_count + thief1_count + thief2_count == num_items);
+    for (int i = 1; i <= num_items; ++i)
+    {
+      RL_ASSERT(seen[i]);
+    }
+    queue.reset();
+  }
+
+  void thread(unsigned thread_id)
+  {
+    if (thread_id == 0)
+    {
+      // Owner pushes items across blocks, then drains
+      for (int i = 1; i <= num_items; ++i)
+      {
+        while (!queue->push_back(i))
+        {
+          int val = queue->pop_back();
+          if (val != 0)
+          {
+            RL_ASSERT(!seen[val]);
+            seen[val] = true;
+            owner_count++;
+          }
+        }
+      }
+      while (true)
+      {
+        int val = queue->pop_back();
+        if (val == 0)
+        {
+          break;
+        }
+        RL_ASSERT(!seen[val]);
+        seen[val] = true;
+        owner_count++;
+      }
+    }
+    else
+    {
+      int& my_count = (thread_id == 1) ? thief1_count : thief2_count;
+      for (std::size_t attempt = 0; attempt < num_items * 4; ++attempt)
+      {
+        int val = queue->steal_front();
+        if (val != 0)
+        {
+          RL_ASSERT(val >= 1 && val <= num_items);
+          RL_ASSERT(!seen[val]);
+          seen[val] = true;
+          my_count++;
+        }
+      }
+    }
+  }
+};
+
+// Test 5: Owner does push-pop-push-pop cycles forcing block wraparound with reclaim.
+// Thief steals concurrently. Tests reclaim()/steal_count synchronization.
+struct bwos_reclaim_race : rl::test_suite<bwos_reclaim_race, 2>
+{
+  static constexpr std::size_t num_blocks = 2;
+  static constexpr std::size_t block_size = 2;
+
+  std::optional<exec::bwos::lifo_queue<int>> queue{};
+  int                                        total_owner{0};
+  int                                        total_thief{0};
+  int                                        total_pushed{0};
+
+  void before()
+  {
+    queue.emplace(num_blocks, block_size);
+    total_owner  = 0;
+    total_thief  = 0;
+    total_pushed = 0;
+  }
+
+  void after()
+  {
+    RL_ASSERT(total_owner + total_thief == total_pushed);
+    queue.reset();
+  }
+
+  void thread(unsigned thread_id)
+  {
+    if (thread_id == 0)
+    {
+      // Cycle 1: push 2 items (fill block 0), push 1 more (advance to block 1)
+      queue->push_back(1);
+      total_pushed++;
+      queue->push_back(2);
+      total_pushed++;
+      if (queue->push_back(3))
+      {
+        total_pushed++;
+      }
+
+      // Pop everything to retreat
+      while (true)
+      {
+        int val = queue->pop_back();
+        if (val == 0)
+        {
+          break;
+        }
+        total_owner++;
+      }
+
+      // Cycle 2: push again - this forces block reuse after reclaim
+      if (queue->push_back(10))
+      {
+        total_pushed++;
+      }
+      if (queue->push_back(20))
+      {
+        total_pushed++;
+      }
+
+      // Drain
+      while (true)
+      {
+        int val = queue->pop_back();
+        if (val == 0)
+        {
+          break;
+        }
+        total_owner++;
+      }
+    }
+    else
+    {
+      for (std::size_t attempt = 0; attempt < 20; ++attempt)
+      {
+        int val = queue->steal_front();
+        if (val != 0)
+        {
+          total_thief++;
+        }
+      }
+    }
+  }
+};
+
+auto main() -> int
+{
+  rl::test_params p;
+  p.iteration_count       = 100000;
+  p.execution_depth_limit = 10000;
+  p.search_type           = rl::random_scheduler_type;
+
+  rl::simulate<bwos_push_steal_no_loss>(p);
+  rl::simulate<bwos_grant_steal_race>(p);
+  rl::simulate<bwos_takeover_steal_race>(p);
+  rl::simulate<bwos_two_thieves>(p);
+  rl::simulate<bwos_reclaim_race>(p);
+  return 0;
+}


### PR DESCRIPTION
This fixes an issue where tasks can be lost without being completed

This PR rewrites the block-level indexing in the BWOS work-stealing queue to use round-tagged counters, preventing items from being silently lost when blocks are reused across wraparounds. This prevents ABA problems