### PR TITLE
Fixes error C4426 (optimization flags changed after including header) on MSVC

### DIFF
--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -402,8 +402,8 @@ namespace STDEXEC::__std
 #endif
 
 #if STDEXEC_MSVC()
-#  define STDEXEC_PRAGMA_OPTIMIZE_BEGIN()  STDEXEC_PRAGMA(optimize("", on))
-#  define STDEXEC_PRAGMA_OPTIMIZE_END()    STDEXEC_PRAGMA(optimize("", off))
+#  define STDEXEC_PRAGMA_OPTIMIZE_BEGIN()  STDEXEC_PRAGMA(optimize("t", on))
+#  define STDEXEC_PRAGMA_OPTIMIZE_END()    STDEXEC_PRAGMA(optimize("", on))
 #else
 #  define STDEXEC_PRAGMA_OPTIMIZE_BEGIN()  STDEXEC_PRAGMA(GCC push_options) \
                                            STDEXEC_PRAGMA(GCC optimize("O3"))


### PR DESCRIPTION
According to [Microsoft Learn](https://learn.microsoft.com/en-us/cpp/preprocessor/optimize?view=msvc-170) the effects of pragma optimize with an empty string "" are the following
- When you use the off parameter, it turns all the optimizations, g, s, t, and y, off.
- When you use the on parameter, it resets the optimizations to the ones that you specified using the /O compiler option.

With the original code, the result of STDEXEC_PRAGMA_OPTIMIZE_BEGIN is always a no-op, while the effects of STDEXEC_PRAGMA_OPTIMIZE_END is to disable all optimizations. This makes compilation fail with a [C4426 error](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-c4400-through-c4599?view=msvc-170) if the library is included in a project where optimizations are enabled.
In MSVC the pragma cannot set a perfect equivalent of GCC "/O3" optimization level, so "t" (favor fast code) has been chosen as an alternative.