### PR TITLE
Mark include directories as SYSTEM for consuming targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,13 @@ PUBLIC
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/include/stdexec_version_config.hpp
 )
+# Mark include directories as SYSTEM so consumers don't get warnings from stdexec internals
+target_include_directories(stdexec SYSTEM INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 list(APPEND stdexec_export_targets stdexec)
 
 # Set library version


### PR DESCRIPTION
When a project enables -Wreserved-identifier (as recommended by clang for production codebases), including stdexec headers generates >8000 warnings due to the __double_underscore naming convention used internally. These warnings are expected within stdexec itself but should not propagate to consumers.

Adding SYSTEM to target_include_directories causes CMake to pass -isystem instead of -I for stdexec's include paths, suppressing warnings that originate from stdexec headers in consuming projects.

This matches the convention used by other header-heavy libraries (Boost, fmt, spdlog) that use reserved identifiers internally.