### PR TITLE
fix: `write_env` breaks `task`'s affinity

### DIFF
--- a/include/stdexec/__detail/__write_env.hpp
+++ b/include/stdexec/__detail/__write_env.hpp
@@ -29,15 +29,41 @@ namespace STDEXEC
   // __write adaptor
   namespace __write
   {
+    // write_env can change the scheduler in the receiver's environment, which
+    // invalidates the child sender's completion behavior claims (e.g., a task
+    // that reports "asynchronous_affine" is affine to *its* scheduler, not to
+    // the scheduler that write_env substitutes). So we must not forward the
+    // child's completion behavior; we report __unknown instead.
+    template <class _Sender>
+    struct __write_env_attrs
+    {
+      template <__forwarding_query _Query, class... _Args>
+        requires(!__completion_query<_Query>)
+             && __queryable_with<env_of_t<_Sender>, _Query, _Args...>
+      [[nodiscard]]
+      constexpr auto query(_Query, _Args &&...__args) const
+        noexcept(__nothrow_queryable_with<env_of_t<_Sender>, _Query, _Args...>)
+          -> __query_result_t<env_of_t<_Sender>, _Query, _Args...>
+      {
+        return __query<_Query>()(get_env(__sndr_), static_cast<_Args &&>(__args)...);
+      }
+
+      _Sender const &__sndr_;
+    };
+
+    template <class _Sender>
+    STDEXEC_HOST_DEVICE_DEDUCTION_GUIDE
+    __write_env_attrs(_Sender const &) -> __write_env_attrs<_Sender>;
+
     struct __write_env_impl : __sexpr_defaults
     {
       static constexpr auto __get_attrs =
-        []<class _Child>(__ignore, __ignore, _Child const & __child) noexcept
+        []<class _Child>(__ignore, __ignore, _Child const &__child) noexcept
       {
-        return __sync_attrs{__child};
+        return __write_env_attrs{__child};
       };
 
-      static constexpr auto __get_env = []<class _State>(__ignore, _State const & __state) noexcept
+      static constexpr auto __get_env = []<class _State>(__ignore, _State const &__state) noexcept
         -> decltype(__env::__join(__state.__data_, STDEXEC::get_env(__state.__rcvr_)))
       {
         return __env::__join(__state.__data_, STDEXEC::get_env(__state.__rcvr_));
@@ -57,17 +83,17 @@ namespace STDEXEC
   struct __write_env_t
   {
     template <sender _Sender, class _Env>
-    constexpr auto operator()(_Sender&& __sndr, _Env __env) const
+    constexpr auto operator()(_Sender &&__sndr, _Env __env) const
     {
-      return __make_sexpr<__write_env_t>(static_cast<_Env&&>(__env),
-                                         static_cast<_Sender&&>(__sndr));
+      return __make_sexpr<__write_env_t>(static_cast<_Env &&>(__env),
+                                         static_cast<_Sender &&>(__sndr));
     }
 
     template <class _Env>
     STDEXEC_ATTRIBUTE(always_inline)
     constexpr auto operator()(_Env __env) const
     {
-      return __closure(*this, static_cast<_Env&&>(__env));
+      return __closure(*this, static_cast<_Env &&>(__env));
     }
   };
 

--- a/test/stdexec/types/test_task.cpp
+++ b/test/stdexec/types/test_task.cpp
@@ -244,6 +244,41 @@ namespace
     CHECK(i == 42);
   }
 
+  template <ex::scheduler Worker>
+  ex::task<int> inner_task(Worker worker)
+  {
+    CHECK(get_id() == 0);
+    int i = co_await ex::starts_on(worker,
+                                   just_int(42)
+                                     | ex::then(
+                                       [](int i)
+                                       {
+                                         CHECK(get_id() != 0);
+                                         return i;
+                                       }));
+    CHECK(get_id() != 0);
+    co_return i;
+  }
+
+  template <ex::scheduler Worker>
+  ex::task<int> test_task_affinity_with_write_env(Worker worker)
+  {
+    CHECK(get_id() == 0);
+    auto task = inner_task(worker)
+              | ex::write_env(ex::prop{ex::get_scheduler, ex::inline_scheduler{}});
+    int i = co_await std::move(task);
+    CHECK(get_id() == 0);
+    co_return i;
+  }
+
+  TEST_CASE("test task scheduler affinity works with write_env", "[types][task]")
+  {
+    exec::single_thread_context ctx;
+    auto                        t = test_task_affinity_with_write_env(ctx.get_scheduler());
+    auto [i]                      = ex::sync_wait(std::move(t)).value();
+    CHECK(i == 42);
+  }
+
 #  if !STDEXEC_GCC() || (STDEXEC_GCC_VERSION >= 13'00 && defined(__OPTIMIZE__))
   // This test is disabled on GCC due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94794
 


### PR DESCRIPTION
\When a `task` is wrapped with `write_env(prop{get_scheduler, inline_scheduler{}})`, the outer `affine_on` (added by the outer task's `await_transform`) was incorrectly skipping the rescheduling step.
