### PR TITLE
domain: delete broken but unused `__has_common_domain`

### DIFF
--- a/include/stdexec/__detail/__domain.hpp
+++ b/include/stdexec/__detail/__domain.hpp
@@ -171,10 +171,6 @@ namespace STDEXEC
   template <class... _Domains>
   using __common_domain_t = __t<__detail::__common_domain<_Domains...>>;
 
-  template <class... _Domains>
-  concept __has_common_domain =
-    __not_same_as<indeterminate_domain<>, __common_domain_t<_Domains...>>;
-
   template <class _Domain>
   using __ensure_valid_domain_t = __unless_one_of_t<_Domain, indeterminate_domain<>>;
 


### PR DESCRIPTION
`__has_common_domain` incorrectly returns `true` for domain pairs whose common type is `indeterminate_domain<...>`.

For example:
```c++
struct Whatever {};

struct SomeDomain : public STDEXEC::default_domain {};
struct WontBeGoodDomain : public STDEXEC::default_domain, public Whatever {};

// Passes, but shouldn't.
static_assert(STDEXEC::__has_common_domain<SomeDomain, WontBeGoodDomain>);

// Here is the common type.
static_assert(std::same_as<STDEXEC::__common_domain_t<SomeDomain, WontBeGoodDomain>, STDEXEC::indeterminate_domain<WontBeGoodDomain, SomeDomain>>);
```

It could be fixed by checking that the result is not an instance of `indeterminate_domain`, but since `__has_common_domain` is never used, let's get rid of it.