### PR TITLE
No when_all_fail test with NVHPC

### DIFF
--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -63,16 +63,18 @@ target_link_libraries(test.nvexec
 
 catch_discover_tests(test.nvexec PROPERTIES TIMEOUT 30)
 
-icm_add_build_failure_test(
-    NAME when_all_fail
-    TARGET when_all_fail
-    SOURCES PARSE when_all_fail.cpp
-    LIBRARIES stdexec nvexec
-    FOLDER test
-)
-set_target_properties(when_all_fail
-    PROPERTIES
-        LANGUAGE CUDA
-        LINKER_LANGUAGE CUDA)
-target_compile_options(when_all_fail PRIVATE
-    $<$<CXX_COMPILER_ID:Clang>:-x cuda>)
+if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
+    icm_add_build_failure_test(
+        NAME when_all_fail
+        TARGET when_all_fail
+        SOURCES PARSE when_all_fail.cpp
+        LIBRARIES stdexec nvexec
+        FOLDER test
+    )
+    set_target_properties(when_all_fail
+        PROPERTIES
+            LANGUAGE CUDA
+            LINKER_LANGUAGE CUDA)
+    target_compile_options(when_all_fail PRIVATE
+        $<$<CXX_COMPILER_ID:Clang>:-x cuda>)
+endif()


### PR DESCRIPTION
When building with NVHPC, CMake is not configured for CUDA.  The fact that newly added test when_all_fail was set up with "LANGUAGE CUDA" was causing CMake failures when the compiler was NVHPC.

To fix this, put the definition of test when_all_fail inside an
```
	if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
```
block.