### PR TITLE
fix: correct deprecated header warning in asioexec/completion_token.hpp

### DIFF
--- a/include/asioexec/completion_token.hpp
+++ b/include/asioexec/completion_token.hpp
@@ -22,7 +22,7 @@
 
 #if STDEXEC_MSVC()
 #  pragma message(                                                                                 \
-    "WARNING: The header <asioexec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
+    "WARNING: The header <asioexec/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
 #else
 #  warning                                                                                         \
     "The header <asioexec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead."

--- a/include/asioexec/completion_token.hpp
+++ b/include/asioexec/completion_token.hpp
@@ -25,7 +25,7 @@
     "WARNING: The header <asioexec/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
 #else
 #  warning                                                                                         \
-    "The header <asioexec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead."
+    "The header <asioexec/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead."
 #endif
 
 #include "../exec/asio/completion_token.hpp"  // IWYU pragma: export

--- a/include/asioexec/completion_token.hpp
+++ b/include/asioexec/completion_token.hpp
@@ -22,10 +22,10 @@
 
 #if STDEXEC_MSVC()
 #  pragma message(                                                                                 \
-    "WARNING: The header <exec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
+    "WARNING: The header <asioexec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
 #else
 #  warning                                                                                         \
-    "The header <exec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead."
+    "The header <asioexec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead."
 #endif
 
 #include "../exec/asio/completion_token.hpp"  // IWYU pragma: export


### PR DESCRIPTION
```diff
// include/asioexec/completion_token.hpp

 #if STDEXEC_MSVC()
 #  pragma message(                                                                                 \
-    "WARNING: The header <exec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
+    "WARNING: The header <asioexec/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
 #else
 #  warning                                                                                         \
-    "The header <exec/asio/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead."
+    "The header <asioexec/completion_token.hpp> is deprecated. Please include <exec/asio/completion_token.hpp> instead.")
 #endif