### PR TITLE
Add -Wno-c2y-extensions to test/CMakeLists.txt

### DIFF
--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -24,8 +24,6 @@ jobs:
           - { name: "CPU (clang 16, Debug, TSAN)",   build: "Debug",   tag: llvm16-cuda12.9, cxxstd: "20", cxxflags: "-fsanitize=thread" }
           - { name: "CPU (clang 16, Release)",       build: "Release", tag: llvm16-cuda12.9, cxxstd: "20", cxxflags: "-stdlib=libc++" }
           - { name: "CPU (clang 16, Release, ASAN)", build: "Release", tag: llvm16-cuda12.9, cxxstd: "20", cxxflags: "-stdlib=libc++ -fsanitize=address -fsanitize-ignorelist=/home/coder/stdexec/sanitizer-ignorelist.txt" }
-          - { name: "CPU (clang 22, Debug)",         build: "Debug",   tag: llvm22-cuda12.9, cxxstd: "20", cxxflags: "-stdlib=libc++" }
-          - { name: "CPU (clang 22, Debug, c++23)",  build: "Debug",   tag: llvm22-cuda12.9, cxxstd: "23", cxxflags: "-stdlib=libc++" }
           - { name: "CPU (gcc 12, Debug)",           build: "Debug",   tag: gcc12-cuda12.9,  cxxstd: "20", cxxflags: "", }
           - { name: "CPU (gcc 12, Release)",         build: "Release", tag: gcc12-cuda12.9,  cxxstd: "20", cxxflags: "", }
           # With the following config, 2 tests mysteriously time out, but only in CI and not locally.

--- a/.github/workflows/ci.cpu.yml
+++ b/.github/workflows/ci.cpu.yml
@@ -24,6 +24,8 @@ jobs:
           - { name: "CPU (clang 16, Debug, TSAN)",   build: "Debug",   tag: llvm16-cuda12.9, cxxstd: "20", cxxflags: "-fsanitize=thread" }
           - { name: "CPU (clang 16, Release)",       build: "Release", tag: llvm16-cuda12.9, cxxstd: "20", cxxflags: "-stdlib=libc++" }
           - { name: "CPU (clang 16, Release, ASAN)", build: "Release", tag: llvm16-cuda12.9, cxxstd: "20", cxxflags: "-stdlib=libc++ -fsanitize=address -fsanitize-ignorelist=/home/coder/stdexec/sanitizer-ignorelist.txt" }
+          - { name: "CPU (clang 22, Debug)",         build: "Debug",   tag: llvm22-cuda12.9, cxxstd: "20", cxxflags: "-stdlib=libc++" }
+          - { name: "CPU (clang 22, Debug, c++23)",  build: "Debug",   tag: llvm22-cuda12.9, cxxstd: "23", cxxflags: "-stdlib=libc++" }
           - { name: "CPU (gcc 12, Debug)",           build: "Debug",   tag: gcc12-cuda12.9,  cxxstd: "20", cxxflags: "", }
           - { name: "CPU (gcc 12, Release)",         build: "Release", tag: gcc12-cuda12.9,  cxxstd: "20", cxxflags: "", }
           # With the following config, 2 tests mysteriously time out, but only in CI and not locally.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
+include(CheckCompilerFlag)
+check_compiler_flag(CXX -Wno-c2y-extensions HAVE_C2Y_EXTENSIONS_WARNING)
 
 function(add_compile_diagnostics TARGET)
     if(CMAKE_CXX_COMPILER_ID STREQUAL Clang OR CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-c2y-extensions)
+        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wpedantic -Werror $<$<BOOL:HAVE_C2Y_EXTENSIONS_WARNING>:-Wno-c2y-extensions>)
     endif()
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 function(add_compile_diagnostics TARGET)
     if(CMAKE_CXX_COMPILER_ID STREQUAL Clang OR CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wpedantic -Werror -Wno-c2y-extensions)
     endif()
 endfunction()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ check_compiler_flag(CXX -Wno-c2y-extensions HAVE_C2Y_EXTENSIONS_WARNING)
 
 function(add_compile_diagnostics TARGET)
     if(CMAKE_CXX_COMPILER_ID STREQUAL Clang OR CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wpedantic -Werror $<$<BOOL:HAVE_C2Y_EXTENSIONS_WARNING>:-Wno-c2y-extensions>)
+        target_compile_options(${TARGET} PRIVATE -Wall -Wextra -Wpedantic -Werror $<$<BOOL:${HAVE_C2Y_EXTENSIONS_WARNING}>:-Wno-c2y-extensions>)
     endif()
 endfunction()
 


### PR DESCRIPTION
As of some recent commit, building the tests with Clang 22.1 fails with errors like this:
```
git/stdexec/test/stdexec/cpos/test_cpo_start.cpp:70:3: error: '__COUNTER__' is a
C2y extension [-Werror,-Wc2y-extensions]
   70 |   TEST_CASE("can call start on an operation state", "[cpo][cpo_start]")
      |   ^
```

Adding `-Wno-c2y-extensions` (or variations, like `-Wno-pedantic`) to the `-DCMAKE_CXX_FLAGS` config-time parameters doesn't seems to help; the flags added there end up *before* `-Wpedantic` in the compiler command line, and, possibly because of llvm/llvm-project#184250, Clang doesn't override `-Wpedantic` with an earlier-supplied suppression.

This diff just adds the required warning in the required place in the hard-coded compiler warning flags to suppress the warning for everyone.