### PR TITLE
fix: add inline to constexpr vars and extern C to _mm_pause for C++ module compat

### DIFF
--- a/include/stdexec/__detail/__any.hpp
+++ b/include/stdexec/__detail/__any.hpp
@@ -141,8 +141,8 @@ namespace STDEXEC::__any
   //!   4. @c Interface<...Bases...<__value_proxy_root<Interface>>...>
   //!   5. @c Interface<...Bases...<__reference_proxy_root<Interface>>...>
 
-  constexpr size_t      __default_buffer_size = 3 * sizeof(void *);
-  constexpr char const *__pure_virt_msg       = "internal error: pure virtual %s() called\n";
+  inline constexpr size_t      __default_buffer_size = 3 * sizeof(void *);
+  inline constexpr char const *__pure_virt_msg       = "internal error: pure virtual %s() called\n";
 
   //////////////////////////////////////////////////////////////////////////////////////////
   // forward declarations

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -781,7 +781,7 @@ namespace STDEXEC
 namespace STDEXEC
 {
   // Used by the STDEXEC_CATCH macro to provide a stub initialization of the exception object.
-  constexpr struct __catch_any_lvalue_t
+  inline constexpr struct __catch_any_lvalue_t
   {
     template <class _Tp>
     STDEXEC_ATTRIBUTE(host, device)

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -246,7 +246,7 @@ namespace STDEXEC
       return STDEXEC::__invoke(static_cast<_Fun&&>(__fn), __args...);
     };
 
-    constexpr auto __start_next_fn =
+    inline constexpr auto __start_next_fn =
       []<class _Fun, class _Receiver, class _Env2, class _Storage, class _Tuple>(
         _Fun&      __fn,
         _Receiver& __rcvr,

--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -899,8 +899,8 @@ namespace STDEXEC
       {};
     };
 
-    constexpr char __type_name_prefix[] = "__xyzzy<";
-    constexpr char __type_name_suffix[] = ">::__plugh";
+    inline constexpr char __type_name_prefix[] = "__xyzzy<";
+    inline constexpr char __type_name_suffix[] = ">::__plugh";
 
     [[nodiscard]]
     consteval std::string_view __find_pretty_name(std::string_view __sv) noexcept

--- a/include/stdexec/__detail/__query.hpp
+++ b/include/stdexec/__detail/__query.hpp
@@ -51,7 +51,7 @@ namespace STDEXEC
   using __member_query_result_t = decltype(__declval<_Env const &>().query(__declval<_Qy const &>(),
                                                                            __declval<_Args>()...));
 
-  constexpr __none_such __no_default{};
+  inline constexpr __none_such __no_default{};
 
   template <class _Query, class _Env, class... _Args>
   concept __has_validation = requires { _Query::template __validate<_Env, _Args...>(); };

--- a/include/stdexec/__detail/__utility.hpp
+++ b/include/stdexec/__detail/__utility.hpp
@@ -31,7 +31,7 @@ STDEXEC_PRAGMA_IGNORE_GNU("-Wduplicate-decl-specifier")
 
 namespace STDEXEC
 {
-  constexpr std::size_t __npos = ~0UL;
+  inline constexpr std::size_t __npos = ~0UL;
 
   template <class...>
   struct __undefined;

--- a/include/stdexec/stop_token.hpp
+++ b/include/stdexec/stop_token.hpp
@@ -33,7 +33,7 @@ STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_GNU("-Warray-bounds")
 
 #if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
-extern void _mm_pause();
+extern "C" void _mm_pause();
 #endif
 
 namespace STDEXEC::__stok


### PR DESCRIPTION
Add `inline` to namespace-scope `constexpr` variable definitions in`__any.hpp`, `__config.hpp`, `__query.hpp`, `__utility.hpp`, `__let.hpp`,and `__meta.hpp` to prevent duplicate symbol errors when multiple C++ module
units include the same stdexec headers. Also add `extern "C"` to the`_mm_pause` declaration in `stop_token.hpp` to match the C linkage expected by MSVC's intrinsic headers in module builds