### PR TITLE
nvexec(continues_on): basic transition

### DIFF
--- a/include/nvexec/stream/continues_on.cuh
+++ b/include/nvexec/stream/continues_on.cuh
@@ -172,15 +172,13 @@ namespace nv::execution::_strm
     template <class Sender>
     struct source_sender : stream_sender_base
     {
-      using schedule_from_sender_t = __result_of<schedule_from, Sender>;
-
       explicit source_sender(Sender sndr)
-        : sndr_(schedule_from(static_cast<Sender&&>(sndr)))
+        : sndr_(static_cast<Sender&&>(sndr))
       {}
 
       template <__decay_copyable Self, STDEXEC::receiver Receiver>
       STDEXEC_EXPLICIT_THIS_BEGIN(auto connect)(this Self&& self, Receiver rcvr)
-        -> connect_result_t<__copy_cvref_t<Self, schedule_from_sender_t>, Receiver>
+        -> connect_result_t<__copy_cvref_t<Self, Sender>, Receiver>
       {
         return STDEXEC::connect(static_cast<Self&&>(self).sndr_, static_cast<Receiver&&>(rcvr));
       }
@@ -201,7 +199,7 @@ namespace nv::execution::_strm
       }
 
      private:
-      __result_of<schedule_from, Sender> sndr_;
+      Sender sndr_;
     };
 
     template <class... Ty>

--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -15,6 +15,7 @@
 #=============================================================================
 
 set(nvexec_test_sources
+    continues_on.cpp
     bulk.cpp
     ensure_started.cpp
     start_detached.cpp

--- a/test/nvexec/continues_on.cpp
+++ b/test/nvexec/continues_on.cpp
@@ -1,0 +1,35 @@
+#include <catch2/catch_all.hpp>
+#include <stdexec/execution.hpp>
+
+#include "nvexec/stream_context.cuh"
+
+namespace
+{
+  TEST_CASE("continues on after just", "[cuda][stream][adaptors][continues_on]")
+  {
+    nvexec::stream_context ctx;
+
+    auto sndr = STDEXEC::just() | STDEXEC::continues_on(ctx.get_scheduler());
+
+    STDEXEC::sync_wait(std::move(sndr));
+  }
+
+  TEST_CASE("continues on after schedule", "[cuda][stream][adaptors][continues_on]")
+  {
+    nvexec::stream_context ctx;
+
+    auto sndr = STDEXEC::schedule(ctx.get_scheduler()) | STDEXEC::continues_on(ctx.get_scheduler());
+
+    STDEXEC::sync_wait(std::move(sndr));
+  }
+
+  TEST_CASE("continues on twice in a row", "[cuda][stream][adaptors][continues_on]")
+  {
+    nvexec::stream_context ctx;
+
+    auto sndr = STDEXEC::just() | STDEXEC::continues_on(ctx.get_scheduler())
+              | STDEXEC::continues_on(ctx.get_scheduler());
+
+    STDEXEC::sync_wait(std::move(sndr));
+  }
+}  // namespace


### PR DESCRIPTION
On the machines I could test, very basic transitions with `nvexec::strean_context` never work (it segfaults).

I already flagged this in:
- #1563

@ericniebler I haven't looked for a fix, but this bug seems quite important to fix. Feel free to work with this branch, I won't touch anymore :wink: 

For the record, here is the stack trace reported by `cuda-gdb`: [output.log](https://github.com/user-attachments/files/26815681/output.log).
