### PR TITLE
Include iostream in launch.cu

### DIFF
--- a/examples/nvexec/launch.cu
+++ b/examples/nvexec/launch.cu
@@ -20,6 +20,7 @@
 
 #include <cub/cub.cuh>
 #include <numeric>
+#include <iostream>
 
 #include <thrust/device_vector.h>
 

--- a/examples/nvexec/launch.cu
+++ b/examples/nvexec/launch.cu
@@ -19,8 +19,8 @@
 #include <stdexec/execution.hpp>
 
 #include <cub/cub.cuh>
-#include <numeric>
 #include <iostream>
+#include <numeric>
 
 #include <thrust/device_vector.h>
 


### PR DESCRIPTION
`examples/nvexec/launch.cu` uses `std::cout` but didn't include `<iostream>`.  In the past this was compiling because one of the Thrust headers (I think) was including `<iostream>`.  But Thrust recently did some more internal header cleanup and removed that indirect include, causing `launch.cu` to no longer compile.

Add the necessary include of `<iostream>` so `launch.cu` compiles again.