### PR TITLE
shrink the size of the type-erasing wrappers

### DIFF
--- a/include/stdexec/__detail/__any.hpp
+++ b/include/stdexec/__detail/__any.hpp
@@ -186,7 +186,7 @@ namespace STDEXEC::__any
             class _Base,
             class _BaseInterfaces   = __extends<>,
             size_t _BufferSize      = __default_buffer_size,
-            size_t _BufferAlignment = alignof(std::max_align_t)>
+            size_t _BufferAlignment = alignof(void *)>
   struct __interface_base;
 
   //////////////////////////////////////////////////////////////////////////////////////////

--- a/test/stdexec/detail/test_any.cpp
+++ b/test/stdexec/detail/test_any.cpp
@@ -232,6 +232,19 @@ namespace
     auto y = any::__any_cast<foobar<T>>(pifoo);
   }
 
+  template <class Base>
+  struct iempty : any::__interface_base<iempty, Base, any::__extends<>, 0>
+  {
+    using any::__interface_base<iempty, Base, any::__extends<>, 0>::__interface_base;
+  };
+
+  TEST_CASE("size of any::__any", "[detail][any]")
+  {
+    // apart from the buffer, an empty any should only contain a pointer to the vtable
+    // and a room for the _tagged_ptr to the proxy object.
+    STATIC_REQUIRE(sizeof(any::__any<iempty>) == 2 * sizeof(void *));
+  }
+
   TEMPLATE_TEST_CASE("basic usage of any::__any", "[detail][any]", foobar<Small>, foobar<Big>)
   {
     static constexpr bool is_small = std::same_as<TestType, foobar<Small>>;


### PR DESCRIPTION
`__any`-based type-erasing wrappers are wasting space by over-aligning the internal buffer by default. this PR changes the default buffer alignment from `alignof(std::max_align_t)` to `alignof(void*)`. this eliminates two pointers worth of padding in the representation of `__any<ifooable>`.