### PR TITLE
run_loop: add public get_run_loop() accessor on scheduler

### DIFF
--- a/include/stdexec/__detail/__run_loop.hpp
+++ b/include/stdexec/__detail/__run_loop.hpp
@@ -244,6 +244,17 @@ namespace STDEXEC
        public:
         using scheduler_concept = scheduler_tag;
 
+        // Returns a reference to the parent run_loop. The derived type is
+        // recovered via static_cast from the stored __basic_run_loop pointer.
+        // This is provided so that consumers holding only a `scheduler` can
+        // recover the owning loop without reaching into the schedule
+        // sender's environment for the private __loop_ member.
+        STDEXEC_ATTRIBUTE(nodiscard, host, device)
+        constexpr auto get_run_loop() const noexcept -> _Derived&
+        {
+          return *static_cast<_Derived*>(this->__loop_);
+        }
+
         struct __sndr_t
         {
           using sender_concept = sender_tag;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,7 @@ set(stdexec_test_sources
     stdexec/detail/test_demangle.cpp
     stdexec/detail/test_utility.cpp
     stdexec/detail/test_intrusive_mpsc_queue.cpp
+    stdexec/schedulers/test_run_loop.cpp
     stdexec/schedulers/test_task_scheduler.cpp
     stdexec/schedulers/test_parallel_scheduler.cpp
     stdexec/queries/test_env.cpp

--- a/test/stdexec/schedulers/test_run_loop.cpp
+++ b/test/stdexec/schedulers/test_run_loop.cpp
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 with LLVM Exceptions (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_all.hpp>
+#include <stdexec/execution.hpp>
+
+#include <test_common/receivers.hpp>
+
+#include <thread>
+#include <type_traits>
+
+namespace ex = STDEXEC;
+
+namespace
+{
+  TEST_CASE("run_loop::scheduler::get_run_loop returns the parent loop",
+            "[scheduler][run_loop]")
+  {
+    ex::run_loop loop;
+    auto         sched = loop.get_scheduler();
+
+    // The accessor returns a reference to the parent run_loop.
+    auto& recovered = sched.get_run_loop();
+
+    // It is the *same* loop, by address.
+    CHECK(&recovered == &loop);
+  }
+
+  TEST_CASE("run_loop::scheduler::get_run_loop is noexcept and returns run_loop&",
+            "[scheduler][run_loop]")
+  {
+    ex::run_loop loop;
+    auto const   sched = loop.get_scheduler();
+
+    STATIC_REQUIRE(noexcept(sched.get_run_loop()));
+    STATIC_REQUIRE(::std::is_same_v<decltype(sched.get_run_loop()), ex::run_loop&>);
+  }
+
+  TEST_CASE(
+    "run_loop::scheduler::get_run_loop enables driving the loop from a callback",
+    "[scheduler][run_loop]")
+  {
+    // The motivating use case: a consumer is given a `run_loop::scheduler`
+    // (e.g. via a sender pipeline) and needs to call `loop.finish()` from a
+    // completion callback so that a separate thread driving `loop.run()`
+    // can return. Before this accessor, recovering the `run_loop&` from the
+    // scheduler required reading the private `__loop_` member of the
+    // schedule sender's environment.
+
+    ex::run_loop loop;
+    auto         sched = loop.get_scheduler();
+
+    bool ran = false;
+
+    // Driver thread: blocks in run() until the work below calls finish().
+    ::std::thread driver([&] { loop.run(); });
+
+    auto work = ex::schedule(sched) | ex::then([&] {
+                  ran = true;
+                  // Recover the parent loop from the scheduler we were
+                  // handed, with no access to internal members.
+                  sched.get_run_loop().finish();
+                });
+
+    auto op = ex::connect(::std::move(work), expect_void_receiver{});
+    ex::start(op);
+
+    driver.join();
+
+    CHECK(ran);
+  }
+} // namespace


### PR DESCRIPTION
Add a public `get_run_loop()` accessor on `__basic_run_loop::__scheduler` so consumers holding a `run_loop::scheduler` can recover the owning `run_loop&` through a public API.