### PR TITLE
Make repeat_n support dependent senders

### DIFF
--- a/include/exec/repeat_n.hpp
+++ b/include/exec/repeat_n.hpp
@@ -225,11 +225,19 @@ namespace experimental::execution
         return {STDEXEC::schedule(trampoline_scheduler{}), const_cast<_Child &>(__child)};
       };
 
-      template <class _Sender, class... _Env>
+      template <class _Sender>
+        requires(!STDEXEC::dependent_sender<__child_of<_Sender>>)
       static consteval auto __get_completion_signatures()
       {
         // TODO: port this to use constant evaluation
-        return __completions_t<__child_of<_Sender>, _Env...>{};
+        return __completions_t<__child_of<_Sender>>{};
+      }
+
+      template <class _Sender, class _Env>
+      static consteval auto __get_completion_signatures()
+      {
+        // TODO: port this to use constant evaluation
+        return __completions_t<__child_of<_Sender>, _Env>{};
       }
 
       static constexpr auto __connect =  //

--- a/test/exec/test_repeat_n.cpp
+++ b/test/exec/test_repeat_n.cpp
@@ -199,4 +199,9 @@ namespace
     }
   }
 
+  TEST_CASE("repeat_n forwards the environment", "[adaptors][repeat_n]")
+  {
+    ex::sync_wait(
+      exec::repeat_n(ex::then(ex::read_env(ex::get_start_scheduler), [](auto) noexcept {}), 1));
+  }
 }  // namespace


### PR DESCRIPTION
I discovered the need for this change while trying to update the Capy benchmarks to use stdexec instead of Beman.