### PR TITLE
exec: fork join trailing return type

### DIFF
--- a/include/exec/fork_join.hpp
+++ b/include/exec/fork_join.hpp
@@ -293,6 +293,9 @@ namespace experimental::execution::__fork_join
 
     static constexpr auto __connect =
       []<class _Receiver, class _Sender>(_Sender&& __sndr, _Receiver&& __rcvr) noexcept
+      -> fork_join_impl_t::_opstate_t<STDEXEC::__child_of<_Sender>,
+                                      STDEXEC::__data_of<_Sender>,
+                                      _Receiver>
     {
       using _closures_t = STDEXEC::__data_of<_Sender>;
       using _sndr_t     = STDEXEC::__child_of<_Sender>;

--- a/include/exec/fork_join.hpp
+++ b/include/exec/fork_join.hpp
@@ -292,7 +292,7 @@ namespace experimental::execution::__fork_join
     }
 
     static constexpr auto __connect =
-      []<class _Receiver, class _Sender>(_Sender&& __sndr, _Receiver&& __rcvr) noexcept
+      []<class _Receiver, class _Sender>(_Sender&& __sndr, _Receiver __rcvr) noexcept
       -> fork_join_impl_t::_opstate_t<STDEXEC::__child_of<_Sender>,
                                       STDEXEC::__data_of<_Sender>,
                                       _Receiver>

--- a/include/exec/fork_join.hpp
+++ b/include/exec/fork_join.hpp
@@ -291,8 +291,8 @@ namespace experimental::execution::__fork_join
       }
     }
 
-    static constexpr auto __connect =
-      []<class _Receiver, class _Sender>(_Sender&& __sndr, _Receiver __rcvr) noexcept
+    static constexpr auto __connect = []<class _Receiver, class _Sender>(_Sender&& __sndr,
+                                                                         _Receiver __rcvr) noexcept
       -> fork_join_impl_t::_opstate_t<STDEXEC::__child_of<_Sender>,
                                       STDEXEC::__data_of<_Sender>,
                                       _Receiver>


### PR DESCRIPTION
To avoid issues with incomplete types.

In the same vein as:
* #2081