### PR TITLE
exec::function cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,9 @@ if (STDEXEC_BUILD_TESTS)
       BUILD_EXPORT_SET stdexec-exports
       CPM_ARGS
         URL https://github.com/catchorg/Catch2/archive/refs/tags/v${Catch2_VERSION}.zip
-        OPTIONS "CMAKE_CXX_STANDARD 20"
+        OPTIONS
+          "CMAKE_CXX_STANDARD 20"
+          "CATCH_CONFIG_NO_POSIX_SIGNALS ON"
     )
 endif()
 

--- a/include/exec/__frame_allocator.hpp
+++ b/include/exec/__frame_allocator.hpp
@@ -104,14 +104,14 @@ namespace experimental::execution
 
         template <class _Uy>
         /*implicit*/ constexpr type(type<_Uy> const &other) noexcept
-          : __resource_(other.__resource_)
+          : __resource_(other.resource())
         {}
 
         constexpr ~type() = default;
 
         constexpr type &operator=(type const &) noexcept = default;
 
-        constexpr pointer allocator(std::size_t __n)
+        constexpr pointer allocate(std::size_t __n)
         {
           return static_cast<pointer>(
             __resource_->allocate(__n * sizeof(value_type), alignof(value_type)));
@@ -122,7 +122,24 @@ namespace experimental::execution
           __resource_->deallocate(__p, __n * sizeof(value_type), alignof(value_type));
         }
 
-        // TODO: perform uses-allocator construction in construct
+        template <class _Uy, class... _Args>
+        constexpr void construct(_Uy *__p, _Args &&...__args)
+        {
+          (void) std::uninitialized_construct_using_allocator(__p,
+                                                              *this,
+                                                              static_cast<_Args &&>(__args)...);
+        }
+
+        template <class _Uy>
+        constexpr void destroy(_Uy *__p) noexcept
+        {
+          __p->~_Uy();
+        }
+
+        constexpr _Delegate *resource() const noexcept
+        {
+          return __resource_;
+        }
 
        private:
         _Delegate *__resource_;

--- a/include/exec/__frame_allocator.hpp
+++ b/include/exec/__frame_allocator.hpp
@@ -1,0 +1,95 @@
+
+/* Copyright (c) 2026 Ian Petersen
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/__detail/__concepts.hpp"
+
+#include <memory>
+#include <memory_resource>
+
+namespace experimental::execution
+{
+  namespace __fa
+  {
+    using namespace STDEXEC;
+
+    template <class _Delegate>
+    struct __frame_allocator;
+
+    template <class _Delegate>
+      requires __simple_allocator<_Delegate>
+    struct __frame_allocator<_Delegate>
+    {
+      template <class _Ty>
+      using type = std::allocator_traits<_Delegate>::template rebind_alloc<_Ty>;
+    };
+
+    template <>
+    struct __frame_allocator<std::pmr::memory_resource *>
+    {
+      template <class _Ty>
+      using type = std::pmr::polymorphic_allocator<_Ty>;
+    };
+
+    template <class _Delegate>
+      requires __std::derived_from<_Delegate, std::pmr::memory_resource>
+    struct __frame_allocator<_Delegate *>
+    {
+      template <class _Ty>
+      struct type
+      {
+        using value_type = _Ty;
+        using pointer    = value_type *;
+
+        /*implicit*/ constexpr type(_Delegate *__resource) noexcept
+          : __resource_(__resource)
+        {}
+
+        constexpr type(type const &) noexcept = default;
+
+        template <class _Uy>
+        constexpr type(type<_Uy> const &other) noexcept
+          : __resource_(other.__resource_)
+        {}
+
+        constexpr type &operator=(type &) noexcept = default;
+
+        constexpr ~type() = default;
+
+        constexpr pointer allocator(std::size_t __n)
+        {
+          return static_cast<pointer>(
+            __resource_->allocate(__n * sizeof(value_type), alignof(value_type)));
+        }
+
+        constexpr void delegate(void *__p, std::size_t __n) noexcept
+        {
+          __resource_->deallocate(__p, __n * sizeof(value_type), alignof(value_type));
+        }
+
+       private:
+        _Delegate *__resource_;
+      };
+    };
+
+    template <class _Alloc>
+    using __frame_allocator_t =
+      __frame_allocator<std::remove_cvref_t<_Alloc>>::template type<std::byte>;
+  }  // namespace __fa
+}  // namespace experimental::execution
+
+namespace exec = experimental::execution;

--- a/include/exec/__frame_allocator.hpp
+++ b/include/exec/__frame_allocator.hpp
@@ -1,4 +1,3 @@
-
 /* Copyright (c) 2026 Ian Petersen
  * Copyright (c) 2026 NVIDIA Corporation
  *
@@ -18,9 +17,33 @@
 
 #include "../stdexec/__detail/__concepts.hpp"
 
+#include <cstddef>
 #include <memory>
 #include <memory_resource>
+#include <type_traits>
 
+#include "../stdexec/__detail/__prologue.hpp"
+
+//! Defines template <class _Delegate> exec::__frame_allocator_t
+//!
+//! The intended use for __frame_allocator_t is the dynamic allocation of operation
+//! states and/or coroutine frames. __frame_allocator_t models the Allocator named
+//! requirement in terms of its type parameter, _Delegate.
+//!
+//! _Delegate may be one of:
+//!  - Another allocator, in which case __frame_allocator_t<_Delegate> is just _Delegate
+//!    rebound to std::byte;
+//!  - std::pmr::memory_resource*, in which case __frame_allocator_t<_Delegate> is just
+//!    std::pmr::polymorphic_allocator<std::byte>; or
+//!  - T* for some T that inherits from std::pmr::memor_resource, in which case
+//!    __frame_allocator_t is an allocator that behaves like
+//!    std::pmr::polymorphic_allocator<std::byte>, but knows the concrete type of its
+//!    memory_resource and so therefore may be able to avoid virtual dispatch.
+//!
+//! Given that __frame_allocator_t<_Delegate> is just an alias to _Delegate when _Delegate
+//! is an allocator type, it's up to that type whether its construct member function does
+//! "uses-allocator construction". When _Delegate is a pointer to a memory_resource,
+//! __frame_allocator_t<_Delegate>::construct does "uses-allocator construction".
 namespace experimental::execution
 {
   namespace __fa
@@ -30,6 +53,10 @@ namespace experimental::execution
     template <class _Delegate>
     struct __frame_allocator;
 
+    //! Handle the case that _Delegate is an allocator already
+    //!
+    //! In this case, __frame_allocator_t<Delegate> is just an alias to _Delegate but
+    //! rebound to std::byte.
     template <class _Delegate>
       requires __simple_allocator<_Delegate>
     struct __frame_allocator<_Delegate>
@@ -38,6 +65,10 @@ namespace experimental::execution
       using type = std::allocator_traits<_Delegate>::template rebind_alloc<_Ty>;
     };
 
+    //! Handle the case that _Delegate is exactly std::pmr::memory_resource *
+    //!
+    //! In this case, __frame_allocator_t<_Delegate> is exactly
+    //! std::pmr::polymorphic_allocator<std::byte>.
     template <>
     struct __frame_allocator<std::pmr::memory_resource *>
     {
@@ -45,6 +76,13 @@ namespace experimental::execution
       using type = std::pmr::polymorphic_allocator<_Ty>;
     };
 
+    //! Handle the case that _Delegate is a pointer to a type that derives from
+    //! std::pmr::memory_resource
+    //!
+    //! In this case, __frame_allocator_t<_Delegate> is an allocator that behaves like
+    //! std::pmr::polymorphic_allocator<std::byte> except that it knows the concrete type
+    //! of its memory resource. In other words, allocation and deallocation are delegated
+    //! to the given resource, construct does uses-allocator construction, etc.
     template <class _Delegate>
       requires __std::derived_from<_Delegate, std::pmr::memory_resource>
     struct __frame_allocator<_Delegate *>
@@ -55,6 +93,9 @@ namespace experimental::execution
         using value_type = _Ty;
         using pointer    = value_type *;
 
+        // polymorphic_allocator's default constructor grabs the default memory resource,
+        // which we can't do because there's no default for _Delegate
+
         /*implicit*/ constexpr type(_Delegate *__resource) noexcept
           : __resource_(__resource)
         {}
@@ -62,13 +103,13 @@ namespace experimental::execution
         constexpr type(type const &) noexcept = default;
 
         template <class _Uy>
-        constexpr type(type<_Uy> const &other) noexcept
+        /*implicit*/ constexpr type(type<_Uy> const &other) noexcept
           : __resource_(other.__resource_)
         {}
 
-        constexpr type &operator=(type &) noexcept = default;
-
         constexpr ~type() = default;
+
+        constexpr type &operator=(type const &) noexcept = default;
 
         constexpr pointer allocator(std::size_t __n)
         {
@@ -76,20 +117,24 @@ namespace experimental::execution
             __resource_->allocate(__n * sizeof(value_type), alignof(value_type)));
         }
 
-        constexpr void delegate(void *__p, std::size_t __n) noexcept
+        constexpr void deallocate(void *__p, std::size_t __n) noexcept
         {
           __resource_->deallocate(__p, __n * sizeof(value_type), alignof(value_type));
         }
+
+        // TODO: perform uses-allocator construction in construct
 
        private:
         _Delegate *__resource_;
       };
     };
-
-    template <class _Alloc>
-    using __frame_allocator_t =
-      __frame_allocator<std::remove_cvref_t<_Alloc>>::template type<std::byte>;
   }  // namespace __fa
+
+  template <class _Delegate>
+  using __frame_allocator_t =
+    __fa::__frame_allocator<std::remove_cvref_t<_Delegate>>::template type<std::byte>;
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;
+
+#include "../stdexec/__detail/__epilogue.hpp"

--- a/include/exec/__memory_resource_adaptor.hpp
+++ b/include/exec/__memory_resource_adaptor.hpp
@@ -50,6 +50,14 @@ namespace experimental::execution
 {
   namespace __mem_rsc_adpt
   {
+
+// some old versions of Clang, GCC, and MSVC have non-constexpr new/delete
+#if defined(__cpp_lib_constexpr_new) && __cpp_lib_constexpr_new >= 202406L
+#  define STDEXEC_CONSTEXPR_ALLOC constexpr
+#else
+#  define STDEXEC_CONSTEXPR_ALLOC
+#endif
+
     template <class... _Args>
     concept __can_globally_delete =  //
       requires(_Args... __args) {
@@ -60,13 +68,14 @@ namespace experimental::execution
     {
       template <class _Void, class _Size, class _Align>
         requires __can_globally_delete<_Void, _Size, _Align>
-      constexpr void operator()(_Void __p, _Size __size, _Align __align) const noexcept
+      STDEXEC_CONSTEXPR_ALLOC void
+      operator()(_Void __p, _Size __size, _Align __align) const noexcept
       {
         ::operator delete(__p, __size, __align);
       }
 
       template <class _Void, class _Size, class _Align>
-      constexpr void operator()(_Void __p, _Size, _Align __align) const noexcept
+      STDEXEC_CONSTEXPR_ALLOC void operator()(_Void __p, _Size, _Align __align) const noexcept
       {
         ::operator delete(__p, __align);
       }
@@ -93,37 +102,41 @@ namespace experimental::execution
         constexpr explicit type(std::allocator<_Ty> const &) noexcept
         {}
 
-        constexpr void *
-        allocate(std::size_t __bytes, std::size_t __align = alignof(std::max_align_t)) const
+        STDEXEC_CONSTEXPR_ALLOC
+        void *allocate(std::size_t __bytes, std::size_t __align = alignof(std::max_align_t)) const
         {
           return ::operator new(__bytes, static_cast<std::align_val_t>(__align));
         }
 
-        constexpr void deallocate(void       *__p,
-                                  std::size_t __bytes,
-                                  std::size_t __align = alignof(std::max_align_t)) const noexcept
+        STDEXEC_CONSTEXPR_ALLOC void
+        deallocate(void       *__p,
+                   std::size_t __bytes,
+                   std::size_t __align = alignof(std::max_align_t)) const noexcept
         {
           __global_delete(__p, __bytes, static_cast<std::align_val_t>(__align));
         }
 
        private:
-        constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) final
+        STDEXEC_CONSTEXPR_ALLOC void *do_allocate(std::size_t __bytes, std::size_t __align) final
         {
           return allocate(__bytes, __align);
         }
 
-        constexpr void
+        STDEXEC_CONSTEXPR_ALLOC void
         do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) noexcept final
         {
           deallocate(__p, __bytes, __align);
         }
 
-        constexpr bool do_is_equal(std::pmr::memory_resource const &__other) const noexcept final
+        STDEXEC_CONSTEXPR_ALLOC bool
+        do_is_equal(std::pmr::memory_resource const &__other) const noexcept final
         {
           return !!dynamic_cast<type const *>(&__other);
         }
       };
     };
+
+#undef STDEXEC_CONSTEXPR_ALLOC
 
     //! Handle the case that _Adaptee is an allocator of std::bytes
     //!

--- a/include/exec/__memory_resource_adaptor.hpp
+++ b/include/exec/__memory_resource_adaptor.hpp
@@ -222,7 +222,13 @@ namespace experimental::execution
     struct __memory_resource_adaptor<_Adaptee>
       : __memory_resource_adaptor<
           typename std::allocator_traits<_Adaptee>::template rebind_alloc<std::byte>>
-    {};
+    {
+      // This class is the reason we have a nested type alias named type inside a
+      // constrained class template rather than just a constrained class template. We
+      // are not deriving a resource adaptor from another adaptor; we're deriving one
+      // meta-function from another so that we collapse the number of actual adaptor types
+      // to the minimum.
+    };
 
     //! Handle the case that _Adaptee is a pointer to a type that derives from
     //! std::pmr::memory_resource

--- a/include/exec/__memory_resource_adaptor.hpp
+++ b/include/exec/__memory_resource_adaptor.hpp
@@ -32,6 +32,52 @@ namespace experimental::execution
     template <class _Adaptee>
     struct __memory_resource_adaptor;
 
+    //! Handle the case that _Adaptee is exactly std::allocator<std::byte>
+    //!
+    //! Implement do_allocate and do_deallocate in terms of ::operator new and
+    //! ::operator delete rather than conservatively reimplementing aligned allocation
+    //! on top of an arbitrary allocator.
+    template <>
+    struct __memory_resource_adaptor<std::allocator<std::byte>>
+    {
+      struct type : std::pmr::memory_resource
+      {
+        template <class _Ty>
+        constexpr explicit type(std::allocator<_Ty> const &) noexcept
+        {}
+
+        constexpr void *
+        allocate(std::size_t __bytes, std::size_t __align = alignof(std::max_align_t)) const
+        {
+          return ::operator new(__bytes, static_cast<std::align_val_t>(__align));
+        }
+
+        constexpr void deallocate(void       *__p,
+                                  std::size_t __bytes,
+                                  std::size_t __align = alignof(std::max_align_t)) const noexcept
+        {
+          ::operator delete(__p, __bytes, static_cast<std::align_val_t>(__align));
+        }
+
+       private:
+        constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) final
+        {
+          return allocate(__bytes, __align);
+        }
+
+        constexpr void
+        do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) noexcept final
+        {
+          deallocate(__p, __bytes, __align);
+        }
+
+        constexpr bool do_is_equal(std::pmr::memory_resource const &__other) const noexcept final
+        {
+          return !!dynamic_cast<type const *>(&__other);
+        }
+      };
+    };
+
     //! Handle the case that _Adaptee is an allocator of std::bytes
     //!
     //! Implement do_allocate and do_deallocate in terms of _Adaptee's allocate and
@@ -43,13 +89,8 @@ namespace experimental::execution
     struct __memory_resource_adaptor<_Adaptee>
     {
       //! Implement memory_resource in terms of an allocator<std::byte>
-      class type : public std::pmr::memory_resource
+      struct type : public std::pmr::memory_resource
       {
-        using __traits = std::allocator_traits<_Adaptee>;
-        static_assert(__same_as<std::byte, typename __traits::value_type>);
-        typename __traits::allocator_type __alloc_;
-
-       public:
         template <class _Alloc>
           requires(!__same_as<_Alloc, type>)
         constexpr explicit type(_Alloc const &__alloc) noexcept
@@ -59,16 +100,82 @@ namespace experimental::execution
           static_assert(__same_as<__traits, __rebound_traits>);
         }
 
-        constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) override
+        constexpr void *
+        allocate(std::size_t __bytes, std::size_t __align = alignof(std::max_align_t))
         {
-          // TODO: we're not using __align, which is probably a bug
-          return __traits::allocate(__alloc_, __bytes);
+          // When asking __alloc_ for __bytes number of bytes, the worst case is that
+          // the resulting address is byte-aligned, and we need to adjust right by
+          // (__align - 1) bytes to get a properly aligned buffer; since we might have to
+          // make that shift, we need to allocate too many bytes, possibly make the shift,
+          // and return the resulting address. Since we're going to return an address that
+          // might be offset from what we got back from __alloc_, we need a way to
+          // retrieve from the offset address what the original address was so can pass to
+          // deallocate a pointer that actually originally came from allocate. To do that,
+          // we store a copy of the source address at the end of the buffer. To make room
+          // for the possible rightward shift and the copy of a pointer, we need to
+          // allocate extra space, and __bytes + __align - 1 + sizeof(void *) is the most
+          // we might need.
+          std::size_t __upstreamSize = __bytes + __align - 1 + sizeof(void *);
+          void *const __buffer       = __traits::allocate(__alloc_, __upstreamSize);
+
+          void *__ptr = __buffer;
+
+          void *__ret = std::align(__align, __bytes, __ptr, __upstreamSize);
+
+          // by asking for as much extra storage as we did, std::align ought to succeed
+          STDEXEC_ASSERT(__ret != nullptr);
+          // this is a postcondition of a successful call to std::align
+          STDEXEC_ASSERT(__ret == __ptr);
+          // we're going to store the value of __buffer in the first sizeof(void*) bytes
+          // after the end of the returned buffer so there had better be room for that
+          STDEXEC_ASSERT(__upstreamSize >= (__bytes + sizeof(void *)));
+
+          // put the address we got from __alloc_ at the end of the buffer
+          // we're going to return
+          auto *__as_bytes = new (__ret) std::byte[__upstreamSize];
+          std::memcpy(__as_bytes + __bytes, &__buffer, sizeof(__buffer));
+
+          return __ret;
         }
 
-        constexpr void do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) override
+        constexpr void deallocate(void       *__p,
+                                  std::size_t __bytes,
+                                  std::size_t __align = alignof(std::max_align_t)) noexcept
         {
-          // TODO: we're not using __align, which is probably a bug
-          __traits::deallocate(__alloc_, new (__p) std::byte[__bytes], __bytes);
+          // we have to undo the bit-banging we did in allocate
+
+          void *__address_to_free;
+          std::memcpy(&__address_to_free, static_cast<std::byte *>(__p) + __bytes, sizeof(void *));
+
+          std::size_t __size_to_free = __bytes + __align - 1 + sizeof(void *);
+
+          [=]() mutable noexcept
+          {
+            // std::align mutates its final two by-reference arguments so run this
+            // assertion inside an immediately-invoked lambda that captures the inputs by
+            // value
+            STDEXEC_ASSERT(std::align(__align, __bytes, __address_to_free, __size_to_free) == __p);
+          }();
+
+          __traits::deallocate(__alloc_,
+                               new (__address_to_free) std::byte[__size_to_free],
+                               __size_to_free);
+        }
+
+       private:
+        using __traits = std::allocator_traits<_Adaptee>;
+        static_assert(__same_as<std::byte, typename __traits::value_type>);
+        typename __traits::allocator_type __alloc_;
+
+        constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) final
+        {
+          return allocate(__bytes, __align);
+        }
+
+        constexpr void
+        do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) noexcept final
+        {
+          deallocate(__p, __bytes, __align);
         }
 
         constexpr bool do_is_equal(std::pmr::memory_resource const &__other) const noexcept override
@@ -99,12 +206,26 @@ namespace experimental::execution
     //! Handle the case that _Adaptee is a pointer to a type that derives from
     //! std::pmr::memory_resource
     //!
-    //! In this case, there's nothing to "adapt" so we just alias _Adaptee.
+    //! In this case, there's nothing to "adapt" but we need a type constructible
+    //! from _Adaptee*, and whose operator& returns _Adaptee*.
     template <class _Adaptee>
-      requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, _Adaptee>
-    struct __memory_resource_adaptor<_Adaptee>
+      requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, _Adaptee *>
+    struct __memory_resource_adaptor<_Adaptee *>
     {
-      using type = _Adaptee;
+      struct type
+      {
+        explicit constexpr type(_Adaptee *__resource) noexcept
+          : __resource_(__resource)
+        {}
+
+        constexpr _Adaptee *operator&() const noexcept
+        {
+          return __resource_;
+        }
+
+       private:
+        _Adaptee *__resource_;
+      };
     };
   }  // namespace __mem_rsc_adpt
 

--- a/include/exec/__memory_resource_adaptor.hpp
+++ b/include/exec/__memory_resource_adaptor.hpp
@@ -23,6 +23,27 @@
 
 #include "../stdexec/__detail/__prologue.hpp"
 
+//! Defines template <class _Adaptee> exec::__memory_resource_adaptor_t
+//!
+//! A "memory resource adaptor" adapts a "thing that can allocate memory" to the
+//! std::pmr::memory_resource interface. It's used in exec::function when the function's
+//! type parameters do not require that its eventual receiver have an environment that's
+//! queryable with exec::get_frame_allocator. In those circumstances, function will ensure
+//! that the receiver to which its erased sender is connected *does* have an environment
+//! that responds to get_frame_allocator with a type-erased frame allocator. The
+//! type-erased frame allocator is a std::pmr::polymorphic_allocator<>, and the
+//! memory_resource given to it is a __memory_resoure_adaptor<_Adaptee>, where _Adaptee is
+//! the type of "allocator" used to allocate the function's operation state. _Adaptee may
+//! be one of:
+//!  - a type that models Allocator;
+//!  - std::pmr::memory_resource*; or
+//!  - T*, where T derives from std::pmr::memory_resource.
+//!
+//! Given an appropriate type, _Adaptee, __memory_resource_adaptor_t<_Adaptee> is a type
+//! T, such that:
+//!  - T is constructible from an lvalue reference to an object of type _Adaptee; and
+//!  - given an object rsrc of type T, std::pmr::polymorphic_allocator<>(&rsrc) is a valid
+//!    expression.
 namespace experimental::execution
 {
   namespace __mem_rsc_adpt
@@ -89,7 +110,7 @@ namespace experimental::execution
     struct __memory_resource_adaptor<_Adaptee>
     {
       //! Implement memory_resource in terms of an allocator<std::byte>
-      struct type : public std::pmr::memory_resource
+      struct type : std::pmr::memory_resource
       {
         template <class _Alloc>
           requires(!__same_as<_Alloc, type>)

--- a/include/exec/__memory_resource_adaptor.hpp
+++ b/include/exec/__memory_resource_adaptor.hpp
@@ -1,0 +1,124 @@
+/* Copyright (c) 2026 Ian Petersen
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/__detail/__concepts.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <memory_resource>
+
+#include "../stdexec/__detail/__prologue.hpp"
+
+namespace experimental::execution
+{
+  namespace __mem_rsc_adpt
+  {
+    using namespace STDEXEC;
+
+    template <class _Adaptee>
+    struct __memory_resource_adaptor;
+
+    //! Handle the case that _Adaptee is an allocator of std::bytes
+    //!
+    //! Implement do_allocate and do_deallocate in terms of _Adaptee's allocate and
+    //! deallocate, respectively. Implement do_is_equal in terms of _Adaptee's
+    //! operator==.
+    template <class _Adaptee>
+      requires __simple_allocator<_Adaptee>
+            && __same_as<std::byte, typename std::allocator_traits<_Adaptee>::value_type>
+    struct __memory_resource_adaptor<_Adaptee>
+    {
+      //! Implement memory_resource in terms of an allocator<std::byte>
+      class type : public std::pmr::memory_resource
+      {
+        using __traits = std::allocator_traits<_Adaptee>;
+        static_assert(__same_as<std::byte, typename __traits::value_type>);
+        typename __traits::allocator_type __alloc_;
+
+       public:
+        template <class _Alloc>
+          requires(!__same_as<_Alloc, type>)
+        constexpr explicit type(_Alloc const &__alloc) noexcept
+          : __alloc_(__alloc)
+        {
+          using __rebound_traits = std::allocator_traits<_Alloc>::template rebind_traits<std::byte>;
+          static_assert(__same_as<__traits, __rebound_traits>);
+        }
+
+        constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) override
+        {
+          // TODO: we're not using __align, which is probably a bug
+          return __traits::allocate(__alloc_, __bytes);
+        }
+
+        constexpr void do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) override
+        {
+          // TODO: we're not using __align, which is probably a bug
+          __traits::deallocate(__alloc_, new (__p) std::byte[__bytes], __bytes);
+        }
+
+        constexpr bool do_is_equal(std::pmr::memory_resource const &__other) const noexcept override
+        {
+          if (auto *__ptr = dynamic_cast<type const *>(&__other))
+          {
+            return __alloc_ == __ptr->__alloc_;
+          }
+
+          return false;
+        }
+      };
+    };
+
+    //! Handle the case that _Adaptee is an allocator of some type other than std::byte
+    //!
+    //! We just rebind _Adaptee to be an allocator of std::bytes and inherit our nested
+    //! alias from the adaptor for that type. This strategy ensures that there's only one
+    //! adaptor for an entire family of adapted allocator types, reducing template bloat
+    //! and making the do_is_equals implementation sensible.
+    template <class _Adaptee>
+      requires __simple_allocator<_Adaptee>
+    struct __memory_resource_adaptor<_Adaptee>
+      : __memory_resource_adaptor<
+          typename std::allocator_traits<_Adaptee>::template rebind_alloc<std::byte>>
+    {};
+
+    //! Handle the case that _Adaptee is a pointer to a type that derives from
+    //! std::pmr::memory_resource
+    //!
+    //! In this case, there's nothing to "adapt" so we just alias _Adaptee.
+    template <class _Adaptee>
+      requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, _Adaptee>
+    struct __memory_resource_adaptor<_Adaptee>
+    {
+      using type = _Adaptee;
+    };
+  }  // namespace __mem_rsc_adpt
+
+  //! Adapt _Adaptee to be a std::pmr::memory_resource
+  //!
+  //! This alias is the identity when _Adaptee is a pointer to a type that derives from
+  //! std::pmr::memory_resource. When _Adaptee is an allocator type, it is a type that
+  //! derives from std::pmr::memory_resource and implements its pure-virtual member
+  //! functions in terms of that allocator type rebound to std::byte.
+  template <class _Adaptee>
+  using __memory_resource_adaptor_t =
+    __mem_rsc_adpt::__memory_resource_adaptor<std::remove_cvref_t<_Adaptee>>::type;
+}  // namespace experimental::execution
+
+namespace exec = experimental::execution;
+
+#include "../stdexec/__detail/__epilogue.hpp"

--- a/include/exec/__memory_resource_adaptor.hpp
+++ b/include/exec/__memory_resource_adaptor.hpp
@@ -18,8 +18,10 @@
 #include "../stdexec/__detail/__concepts.hpp"
 
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <memory_resource>
+#include <new>
 
 #include "../stdexec/__detail/__prologue.hpp"
 
@@ -48,6 +50,30 @@ namespace experimental::execution
 {
   namespace __mem_rsc_adpt
   {
+    template <class... _Args>
+    concept __can_globally_delete =  //
+      requires(_Args... __args) {
+        { ::operator delete(__args...) } -> std::same_as<void>;
+      };
+
+    struct __global_delete_fn
+    {
+      template <class _Void, class _Size, class _Align>
+        requires __can_globally_delete<_Void, _Size, _Align>
+      constexpr void operator()(_Void __p, _Size __size, _Align __align) const noexcept
+      {
+        ::operator delete(__p, __size, __align);
+      }
+
+      template <class _Void, class _Size, class _Align>
+      constexpr void operator()(_Void __p, _Size, _Align __align) const noexcept
+      {
+        ::operator delete(__p, __align);
+      }
+    };
+
+    inline constexpr __global_delete_fn __global_delete{};
+
     using namespace STDEXEC;
 
     template <class _Adaptee>
@@ -77,7 +103,7 @@ namespace experimental::execution
                                   std::size_t __bytes,
                                   std::size_t __align = alignof(std::max_align_t)) const noexcept
         {
-          ::operator delete(__p, __bytes, static_cast<std::align_val_t>(__align));
+          __global_delete(__p, __bytes, static_cast<std::align_val_t>(__align));
         }
 
        private:

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -54,90 +54,90 @@
 // queries to pick the frame allocator from the environment without relying on TLS.
 namespace experimental::execution
 {
-  namespace _func
+  namespace __func
   {
     using namespace STDEXEC;
 
     //! given the concrete receiver's environment, choose the frame allocator; first
     //! choice is the result of get_frame_allocator(env), second choice is
     //! get_allocator(env), and the default is std::allocator
-    inline constexpr auto choose_frame_allocator =
+    inline constexpr auto __choose_frame_allocator =
       __first_callable{get_frame_allocator, get_allocator, __always{std::allocator<std::byte>()}};
 
-    template <class Receiver>
-    struct _receiver_wrapper : public Receiver
+    template <class _Receiver>
+    struct __receiver_wrapper : public _Receiver
     {
-      template <class Opstate>
-      constexpr explicit _receiver_wrapper(Opstate *opstate)
-        : Receiver(opstate->rcvr_)
+      template <class _Opstate>
+      constexpr explicit __receiver_wrapper(_Opstate *__opstate)
+        : _Receiver(__opstate->__rcvr_)
       {}
     };
 
-    template <class Receiver>
-      requires(!__queryable_with<env_of_t<Receiver>, get_frame_allocator_t>)
-    struct _receiver_wrapper<Receiver> : public Receiver
+    template <class _Receiver>
+      requires(!__queryable_with<env_of_t<_Receiver>, get_frame_allocator_t>)
+    struct __receiver_wrapper<_Receiver> : public _Receiver
     {
-      using _prop_t = prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>>;
+      using __prop_t = prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>>;
 
-      template <class Opstate>
-      constexpr explicit _receiver_wrapper(Opstate *opstate)
-        : Receiver(opstate->rcvr_)
-        , env_(&opstate->env_)
+      template <class _Opstate>
+      constexpr explicit __receiver_wrapper(_Opstate *__opstate)
+        : _Receiver(__opstate->__rcvr_)
+        , __env_(&__opstate->__env_)
       {}
 
       constexpr auto get_env() const noexcept  //
-        -> __join_env_t<_prop_t, env_of_t<Receiver>>
+        -> __join_env_t<__prop_t, env_of_t<_Receiver>>
       {
-        return __env::__join(*env_, STDEXEC::get_env(*static_cast<Receiver const *>(this)));
+        return __env::__join(*__env_, STDEXEC::get_env(*static_cast<_Receiver const *>(this)));
       }
 
      private:
-      _prop_t *env_;
+      __prop_t *__env_;
     };
 
-    template <class Sigs, class Queries>
-    using _any_receiver_ref = ::exec::_any::_any_receiver_ref<Sigs, Queries>;
+    template <class _Sigs, class _Queries>
+    using __any_receiver_ref = ::exec::_any::_any_receiver_ref<_Sigs, _Queries>;
 
-    template <class Adaptee>
-    struct _memory_resource_adaptor;
+    template <class _Adaptee>
+    struct __memory_resource_adaptor;
 
-    template <class Adaptee>
-      requires __simple_allocator<Adaptee>
-            && __same_as<std::byte, typename std::allocator_traits<Adaptee>::value_type>
-    struct _memory_resource_adaptor<Adaptee>
+    template <class _Adaptee>
+      requires __simple_allocator<_Adaptee>
+            && __same_as<std::byte, typename std::allocator_traits<_Adaptee>::value_type>
+    struct __memory_resource_adaptor<_Adaptee>
     {
       //! Implement memory_resource in terms of an allocator<std::byte>
       class type : public std::pmr::memory_resource
       {
-        using traits = std::allocator_traits<Adaptee>;
-        static_assert(__same_as<std::byte, typename traits::value_type>);
-        typename traits::allocator_type alloc_;
+        using __traits = std::allocator_traits<_Adaptee>;
+        static_assert(__same_as<std::byte, typename __traits::value_type>);
+        typename __traits::allocator_type __alloc_;
 
        public:
-        template <class Alloc>
-          requires(!__same_as<Alloc, type>)
-        constexpr explicit type(Alloc const &alloc) noexcept
-          : alloc_(alloc)
+        template <class _Alloc>
+          requires(!__same_as<_Alloc, type>)
+        constexpr explicit type(_Alloc const &__alloc) noexcept
+          : __alloc_(__alloc)
         {
-          using rebound_traits = std::allocator_traits<Alloc>::template rebind_traits<std::byte>;
-          static_assert(__same_as<traits, rebound_traits>);
+          using __rebound_traits = std::allocator_traits<_Alloc>::template rebind_traits<std::byte>;
+          static_assert(__same_as<__traits, __rebound_traits>);
         }
 
         constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) override
         {
-          return traits::allocate(alloc_, __bytes);
+          return __traits::allocate(__alloc_, __bytes);
         }
 
         constexpr void do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) override
         {
-          traits::deallocate(alloc_, new (__p) std::byte[__bytes], __bytes);
+          __traits::deallocate(__alloc_, new (__p) std::byte[__bytes], __bytes);
         }
 
         constexpr bool do_is_equal(std::pmr::memory_resource const &__other) const noexcept override
         {
-          if (auto *ptr = dynamic_cast<type const *>(&__other))
+          if (auto *__ptr = dynamic_cast<type const *>(&__other))
           {
-            return alloc_ == ptr->alloc_;
+            return __alloc_ == __ptr->__alloc_;
           }
 
           return false;
@@ -145,53 +145,55 @@ namespace experimental::execution
       };
     };
 
-    template <class Adaptee>
-      requires __simple_allocator<Adaptee>
-    struct _memory_resource_adaptor<Adaptee>
+    template <class _Adaptee>
+      requires __simple_allocator<_Adaptee>
+    struct __memory_resource_adaptor<_Adaptee>
       //! for an arbitrary allocator, inherit from the adaptor that's implemented
       //! in terms of that allocator rebound to std::byte to minimize template
       //! instantiations, and to make the dynamic_cast in do_is_equal work
-      : _memory_resource_adaptor<
-          typename std::allocator_traits<Adaptee>::template rebind_alloc<std::byte>>
+      : __memory_resource_adaptor<
+          typename std::allocator_traits<_Adaptee>::template rebind_alloc<std::byte>>
     {};
 
-    template <class Adaptee>
-      requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, Adaptee>
-    struct _memory_resource_adaptor<Adaptee>
+    template <class _Adaptee>
+      requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, _Adaptee>
+    struct __memory_resource_adaptor<_Adaptee>
     {
       //! no need to "adapt" a memory_resource
-      using type = Adaptee;
+      using type = _Adaptee;
     };
 
-    template <class Adaptee>
-    using _memory_resource_adaptor_t = _memory_resource_adaptor<std::remove_cvref_t<Adaptee>>::type;
+    template <class _Adaptee>
+    using __memory_resource_adaptor_t =
+      __memory_resource_adaptor<std::remove_cvref_t<_Adaptee>>::type;
 
-    template <class Receiver, class Sigs, class Queries>
-    struct _opstate_base
+    template <class _Receiver, class _Sigs, class _Queries>
+    struct __opstate_base
     {
-      using _receiver_t   = _receiver_wrapper<_any_receiver_ref<Sigs, Queries>>;
-      using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
+      using __receiver_t   = __receiver_wrapper<__any_receiver_ref<_Sigs, _Queries>>;
+      using __stop_token_t = stop_token_of_t<env_of_t<__receiver_t>>;
 
-      _any::_state<Receiver, _stop_token_t> rcvr_;
+      _any::_state<_Receiver, __stop_token_t> __rcvr_;
     };
 
-    template <class Receiver, class Sigs, class Queries>
-      requires(!__queryable_with<env_of_t<_any_receiver_ref<Sigs, Queries>>, get_frame_allocator_t>)
-    struct _opstate_base<Receiver, Sigs, Queries>
+    template <class _Receiver, class _Sigs, class _Queries>
+      requires(
+        !__queryable_with<env_of_t<__any_receiver_ref<_Sigs, _Queries>>, get_frame_allocator_t>)
+    struct __opstate_base<_Receiver, _Sigs, _Queries>
     {
-      using _receiver_t   = _receiver_wrapper<_any_receiver_ref<Sigs, Queries>>;
-      using _prop_t       = _receiver_t::_prop_t;
-      using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
-      using _adaptee_t    = decltype(choose_frame_allocator(__declval<Receiver const &>()));
+      using __receiver_t   = __receiver_wrapper<__any_receiver_ref<_Sigs, _Queries>>;
+      using __prop_t       = __receiver_t::__prop_t;
+      using __stop_token_t = stop_token_of_t<env_of_t<__receiver_t>>;
+      using __adaptee_t    = decltype(__choose_frame_allocator(__declval<_Receiver const &>()));
 
-      _memory_resource_adaptor_t<_adaptee_t> resource_;
-      _prop_t                                env_;
-      _any::_state<Receiver, _stop_token_t>  rcvr_;
+      __memory_resource_adaptor_t<__adaptee_t> __resource_;
+      __prop_t                                 __env_;
+      _any::_state<_Receiver, __stop_token_t>  __rcvr_;
 
-      constexpr explicit _opstate_base(Receiver &&rcvr)
-        : resource_(choose_frame_allocator(rcvr))
-        , env_{get_frame_allocator, &resource_}
-        , rcvr_(static_cast<Receiver &&>(rcvr))
+      constexpr explicit __opstate_base(_Receiver &&__rcvr)
+        : __resource_(__choose_frame_allocator(__rcvr))
+        , __env_{get_frame_allocator, &__resource_}
+        , __rcvr_(static_cast<_Receiver &&>(__rcvr))
       {}
     };
 
@@ -200,214 +202,217 @@ namespace experimental::execution
     //! instance, which is the type-erased operation state resulting from connecting the
     //! type-erased sender to an _any::_any_receiver_ref with the given completion
     //! signatures and queries.
-    template <class Receiver, class Sigs, class Queries>
-    class _opstate : public _opstate_base<Receiver, Sigs, Queries>
+    template <class _Receiver, class _Sigs, class _Queries>
+    class __opstate : public __opstate_base<_Receiver, _Sigs, _Queries>
     {
-      using _base = _opstate_base<Receiver, Sigs, Queries>;
-      using typename _base::_receiver_t;
+      using __base = __opstate_base<_Receiver, _Sigs, _Queries>;
+      using typename __base::__receiver_t;
 
-      _any::_any_opstate_base op_;
+      _any::_any_opstate_base __op_;
 
      public:
       using operation_state_concept = operation_state_tag;
 
-      template <class Factory>
-      explicit constexpr _opstate(Receiver rcvr, Factory factory)
-        : _base(static_cast<Receiver &&>(rcvr))
-        , op_(factory(_receiver_t(this)))
+      template <class _Factory>
+      explicit constexpr __opstate(_Receiver __rcvr, _Factory __factory)
+        : __base(static_cast<_Receiver &&>(__rcvr))
+        , __op_(__factory(__receiver_t(this)))
       {}
 
       constexpr void start() & noexcept
       {
-        op_.start();
+        __op_.start();
       }
     };
 
-    template <class Sigs, class Queries, class... Args>
-    class _function;
+    template <class _Sigs, class _Queries, class... _Args>
+    class __function;
 
     //! the main implementation of the type-erasing sender function<...>
     //
-    //! \tparam Sigs The supported completion signatures
+    //! \tparam _Sigs The supported completion signatures
     //!
-    //! \tparam Queries The list of environment queries that must be supported by
+    //! \tparam _Queries The list of environment queries that must be supported by
     //! the eventual receiver; it's a pack of function type like Return(Query, Args...) or
     //! Return(Query, Args...) noexcept. The named query, when given the specified
     //! arguments, must return a value convertible to Return, and it must be noexcept, or
     //! not, as appropriate
     //!
-    //! \tparam Args The argument types used to construct the erased sender
-    template <class Sigs, class... Queries, class... Args>
-    class _function<Sigs, queries<Queries...>, Args...>
+    //! \tparam _Args The argument types used to construct the erased sender
+    template <class _Sigs, class... _Queries, class... _Args>
+    class __function<_Sigs, queries<_Queries...>, _Args...>
     {
-      using _receiver_t = _receiver_wrapper<_any_receiver_ref<Sigs, queries<Queries...>>>;
+      using __receiver_t = __receiver_wrapper<__any_receiver_ref<_Sigs, queries<_Queries...>>>;
 
-      template <class Receiver>
-      using _opstate_t = _opstate<Receiver, Sigs, queries<Queries...>>;
+      template <class _Receiver>
+      using __opstate_t = __opstate<_Receiver, _Sigs, queries<_Queries...>>;
 
-      template <class Factory>
-      static constexpr auto _mk_opstate(void *storage, _receiver_t rcvr, Args &&...args)  //
+      template <class _Factory>
+      static constexpr auto
+      __mk_opstate(void *__storage, __receiver_t __rcvr, _Args &&...__args)  //
         -> _any::_any_opstate_base
       {
-        auto &make_sender = *__std::start_lifetime_as<Factory>(storage);
-        using alloc_t     = decltype(choose_frame_allocator(get_env(rcvr)));
-        auto alloc        = __frame_allocator_t<alloc_t>(choose_frame_allocator(get_env(rcvr)));
+        auto &__make_sender = *__std::start_lifetime_as<_Factory>(__storage);
+        using __alloc_t     = decltype(__choose_frame_allocator(get_env(__rcvr)));
+        auto __alloc = __frame_allocator_t<__alloc_t>(__choose_frame_allocator(get_env(__rcvr)));
         return _any::_any_opstate_base(__in_place_from,
                                        std::allocator_arg,
-                                       alloc,
+                                       __alloc,
                                        STDEXEC::connect,
-                                       __invoke(make_sender, static_cast<Args &&>(args)...),
-                                       static_cast<_receiver_t &&>(rcvr));
+                                       __invoke(__make_sender, static_cast<_Args &&>(__args)...),
+                                       static_cast<__receiver_t &&>(__rcvr));
       }
 
       //! The curried arguments that will be passed to make_sender_ from inside make_opstate_.
       STDEXEC_ATTRIBUTE(no_unique_address)
-      __tuple<Args...> args_;
+      __tuple<_Args...> __args_;
       //! The type-erased operation state factory; it points to a function that knows the
       //! concrete type of the sender factory stored in make_sender_ so that it can
       //! construct the desired sender on demand and connect it to the given receiver. The
       //! expected arguments are the address of make_sender_, the _any_receiver_ref to
       //! connect the sender to, and the arguments to pass to make_sender_ to construct
       //! the sender.
-      _any::_any_opstate_base (*make_opstate_)(void *, _receiver_t, Args &&...);
+      _any::_any_opstate_base (*__make_opstate_)(void *, __receiver_t, _Args &&...);
       //! Storage for the sender factory passed to our constructor template; make_opstate_ will
       //! reconstitute the actual factory from this bag-of-bytes with start_lifetime_as
       //! because it internally knows the concrete type of the user-provided sender
       //! factory. We're reserving 2 * sizeof(void *) bytes to permit the factory to be a
       //! pointer to member function, which usually requires two pointers.
-      std::byte make_sender_[2 * sizeof(void *)]{};
+      std::byte __make_sender_[2 * sizeof(void *)]{};
 
      public:
       using sender_concept = sender_tag;
 
-      template <__invocable<Args...> Factory>
-        requires __not_decays_to<Factory, _function>          //
-                && (STDEXEC_IS_TRIVIALLY_COPYABLE(Factory))   //
-                && (sizeof(Factory) <= sizeof(make_sender_))  //
-                && sender_to<__invoke_result_t<Factory, Args...>, _receiver_t>
-      constexpr explicit _function(Args &&...args, Factory factory)
-        noexcept(__nothrow_move_constructible<Args...>)
-        : args_(static_cast<Args &&>(args)...)
-        , make_opstate_(&_mk_opstate<Factory>)
+      template <__invocable<_Args...> _Factory>
+        requires __not_decays_to<_Factory, __function>           //
+                && (STDEXEC_IS_TRIVIALLY_COPYABLE(_Factory))     //
+                && (sizeof(_Factory) <= sizeof(__make_sender_))  //
+                && sender_to<__invoke_result_t<_Factory, _Args...>, __receiver_t>
+      constexpr explicit __function(_Args &&...__args, _Factory __factory)
+        noexcept(__nothrow_move_constructible<_Args...>)
+        : __args_(static_cast<_Args &&>(__args)...)
+        , __make_opstate_(&__mk_opstate<_Factory>)
       {
-        std::memcpy(make_sender_, std::addressof(factory), sizeof(Factory));
+        std::memcpy(__make_sender_, std::addressof(__factory), sizeof(_Factory));
       }
 
       //! this implementation of get_completion_signatures is taken directly from the
       //! equivalent function on any_sender_of
-      template <class Self, class... Env>
+      template <class _Self, class... _Env>
       static consteval auto get_completion_signatures()
       {
-        static_assert(__decays_to_derived_from<Self, _function>);
+        static_assert(__decays_to_derived_from<_Self, __function>);
         //! throw if Env does not contain the queries needed to type-erase the receiver:
-        using _check_queries_t = __mfind_error<_any::_check_query_t<Queries, Env...>...>;
-        if constexpr (__merror<_check_queries_t>)
-          return __throw_compile_time_error(_check_queries_t());
+        using __check_queries_t = __mfind_error<_any::_check_query_t<_Queries, _Env...>...>;
+        if constexpr (__merror<__check_queries_t>)
+          return __throw_compile_time_error(__check_queries_t());
         else
-          return Sigs();
+          return _Sigs();
       }
 
-      template <class Receiver>
-      constexpr auto connect(Receiver rcvr) &&  //
-        -> _opstate_t<Receiver>
+      template <class _Receiver>
+      constexpr auto connect(_Receiver __rcvr) &&  //
+        -> __opstate_t<_Receiver>
       {
-        auto factory = [this]<class RcvrRef>(RcvrRef rcvr)
+        auto __factory = [this]<class _RcvrRef>(_RcvrRef __rcvr)
         {
-          return __apply(make_opstate_,
-                         static_cast<__tuple<Args...> &&>(args_),
-                         make_sender_,
-                         static_cast<RcvrRef &&>(rcvr));
+          return __apply(__make_opstate_,
+                         static_cast<__tuple<_Args...> &&>(__args_),
+                         __make_sender_,
+                         static_cast<_RcvrRef &&>(__rcvr));
         };
-        return _opstate_t<Receiver>{static_cast<Receiver &&>(rcvr), factory};
+        return __opstate_t<_Receiver>{static_cast<_Receiver &&>(__rcvr), __factory};
       }
 
-      template <class Receiver>
-        requires __std::copy_constructible<_function>
-      constexpr auto connect(Receiver rcvr) const &  //
-        -> _opstate_t<Receiver>
+      template <class _Receiver>
+        requires __std::copy_constructible<__function>
+      constexpr auto connect(_Receiver __rcvr) const &  //
+        -> __opstate_t<_Receiver>
       {
-        return _function(*this).connect(static_cast<Receiver &&>(rcvr));
+        return __function(*this).connect(static_cast<_Receiver &&>(__rcvr));
       }
     };
 
-    template <auto Types, template <class...> class Template, std::size_t... Is>
-    consteval auto _canonicalize_splice(__indices<Is...>) noexcept
+    template <auto _Types, template <class...> class _Template, std::size_t... _Is>
+    consteval auto __canonicalize_splice(__indices<_Is...>) noexcept
     {
-      return Template<__msplice<Types[Is]>...>();
+      return _Template<__msplice<_Types[_Is]>...>();
     }
 
-    template <std::size_t Size>
-    consteval auto _canonicalize_impl(__static_vector<__type_index, Size> types) noexcept
+    template <std::size_t _Size>
+    consteval auto __canonicalize_impl(__static_vector<__type_index, _Size> __types) noexcept
     {
-      std::ranges::sort(types);
-      auto const rest = std::ranges::unique(types);
-      types.erase(rest.begin(), types.end());
-      return types;
+      std::ranges::sort(__types);
+      auto const __rest = std::ranges::unique(__types);
+      __types.erase(__rest.begin(), __types.end());
+      return __types;
     }
 
-    template <template <class...> class List, class... Types>
-    consteval auto _canonicalize(List<Types...> *) noexcept
+    template <template <class...> class _List, class... _Types>
+    consteval auto __canonicalize(_List<_Types...> *) noexcept
     {
-      using types_t        = __static_vector<__type_index, sizeof...(Types)>;
-      constexpr auto types = _func::_canonicalize_impl(types_t{__mtypeid<Types>...});
-      return _func::_canonicalize_splice<types, List>(__make_indices<types.size()>());
+      using __types_t        = __static_vector<__type_index, sizeof...(_Types)>;
+      constexpr auto __types = __func::__canonicalize_impl(__types_t{__mtypeid<_Types>...});
+      return __func::__canonicalize_splice<__types, _List>(__make_indices<__types.size()>());
     }
 
-    template <class Sigs>
-    using _canonical_t = decltype(_func::_canonicalize(static_cast<Sigs *>(nullptr)));
+    template <class _Sigs>
+    using __canonical_t = decltype(__func::__canonicalize(static_cast<_Sigs *>(nullptr)));
 
     //! Given a return type and a bool indicating whether the function is noexcept,
     //! compute the appropriate completion_signatures. The result is a set_value overload
     //! taking either Return&& or no args when Return is void, set_stopped, and, when the
     //! function type is not noexcept, set_error(std::exception_ptr)
-    template <class Return, bool NoExcept>
-    using _sigs_from_t = _canonical_t<__concat_completion_signatures_t<
-      completion_signatures<__single_value_sig_t<Return>, set_stopped_t()>,
-      __eptr_completion_unless_t<__mbool<NoExcept>>>>;
+    template <class _Return, bool _NoExcept>
+    using __sigs_from_t = __canonical_t<__concat_completion_signatures_t<
+      completion_signatures<__single_value_sig_t<_Return>, set_stopped_t()>,
+      __eptr_completion_unless_t<__mbool<_NoExcept>>>>;
 
     template <class...>
-    struct _make_function;
+    struct __make_function;
 
-    template <class Return, class... Args>
-    struct _make_function<Return(Args...)>
+    template <class _Return, class... _Args>
+    struct __make_function<_Return(_Args...)>
     {
-      using type = _function<_sigs_from_t<Return, false>, queries<>, Args...>;
+      using type = __function<__sigs_from_t<_Return, false>, queries<>, _Args...>;
     };
 
-    template <class Return, class... Args>
-    struct _make_function<Return(Args...) noexcept>
+    template <class _Return, class... _Args>
+    struct __make_function<_Return(_Args...) noexcept>
     {
-      using type = _function<_sigs_from_t<Return, true>, queries<>, Args...>;
+      using type = __function<__sigs_from_t<_Return, true>, queries<>, _Args...>;
     };
 
-    template <class... Args, class... Sigs>
-    struct _make_function<sender_tag(Args...), completion_signatures<Sigs...>>
+    template <class... _Args, class... _Sigs>
+    struct __make_function<sender_tag(_Args...), completion_signatures<_Sigs...>>
     {
-      using type = _function<_canonical_t<completion_signatures<Sigs...>>, queries<>, Args...>;
+      using type = __function<__canonical_t<completion_signatures<_Sigs...>>, queries<>, _Args...>;
     };
 
-    template <class Return, class... Args, class... Queries>
-    struct _make_function<Return(Args...), queries<Queries...>>
-    {
-      using type =
-        _function<_sigs_from_t<Return, false>, _canonical_t<queries<Queries...>>, Args...>;
-    };
-
-    template <class Return, class... Args, class... Queries>
-    struct _make_function<Return(Args...) noexcept, queries<Queries...>>
+    template <class _Return, class... _Args, class... _Queries>
+    struct __make_function<_Return(_Args...), queries<_Queries...>>
     {
       using type =
-        _function<_sigs_from_t<Return, true>, _canonical_t<queries<Queries...>>, Args...>;
+        __function<__sigs_from_t<_Return, false>, __canonical_t<queries<_Queries...>>, _Args...>;
     };
 
-    template <class... Args, class... Sigs, class... Queries>
-    struct _make_function<sender_tag(Args...), completion_signatures<Sigs...>, queries<Queries...>>
+    template <class _Return, class... _Args, class... _Queries>
+    struct __make_function<_Return(_Args...) noexcept, queries<_Queries...>>
     {
-      using type = _function<_canonical_t<completion_signatures<Sigs...>>,
-                             _canonical_t<queries<Queries...>>,
-                             Args...>;
+      using type =
+        __function<__sigs_from_t<_Return, true>, __canonical_t<queries<_Queries...>>, _Args...>;
     };
-  }  // namespace _func
+
+    template <class... _Args, class... _Sigs, class... _Queries>
+    struct __make_function<sender_tag(_Args...),
+                           completion_signatures<_Sigs...>,
+                           queries<_Queries...>>
+    {
+      using type = __function<__canonical_t<completion_signatures<_Sigs...>>,
+                              __canonical_t<queries<_Queries...>>,
+                              _Args...>;
+    };
+  }  // namespace __func
 
   //! the user-facing interface to exec::function that supports several different
   //! declaration styles, including:
@@ -430,8 +435,8 @@ namespace experimental::execution
   //! Future: support C-style ellipsis arguments in the function signature to permit
   //! type-erased arguments as well, like function<int(bar, baz, ...)> (a fallible
   //! function from (bar, baz) plus unspecified, erased additional arguments to int)
-  template <class... Ts>
-  using function = _func::_make_function<Ts...>::type;
+  template <class... _Ts>
+  using function = __func::__make_function<_Ts...>::type;
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -64,30 +64,157 @@ namespace experimental::execution
     inline constexpr auto choose_frame_allocator =
       __first_callable{get_frame_allocator, get_allocator, __always{std::allocator<std::byte>()}};
 
+    template <class Receiver>
+    struct _choose_receiver
+    {
+      struct type : Receiver
+      {
+        template <class Opstate>
+        constexpr explicit type(Opstate *opstate)
+          : Receiver(opstate->rcvr_)
+        {}
+      };
+    };
+
+    template <class Receiver>
+      requires(!__queryable_with<env_of_t<Receiver>, get_frame_allocator_t>)
+    struct _choose_receiver<Receiver>
+    {
+      class type : public Receiver
+      {
+        using _prop_t = prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>>;
+        _prop_t *env_;
+
+       public:
+        template <class Opstate>
+        constexpr explicit type(Opstate *opstate)
+          : Receiver(opstate->rcvr_)
+          , env_(&opstate->env_)
+        {}
+
+        constexpr auto get_env() const noexcept -> __join_env_t<_prop_t, env_of_t<Receiver>>
+        {
+          return __env::__join(*env_, STDEXEC::get_env(*static_cast<Receiver const*>(this)));
+        }
+      };
+    };
+
+    template <class Sigs, class Queries>
+    using _any_receiver_ref = ::exec::_any::_any_receiver_ref<Sigs, Queries>;
+
+    template <class Receiver>
+    using _choose_receiver_t = _choose_receiver<Receiver>::type;
+
+    template <class Receiver, class Sigs, class Queries>
+    struct _opstate_base
+    {
+      using _receiver_t   = _choose_receiver_t<_any_receiver_ref<Sigs, Queries>>;
+      using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
+
+      _any::_state<Receiver, _stop_token_t> rcvr_;
+    };
+
+    template <class Adaptee>
+    struct _memory_resource_adaptor;
+
+    template <class Adaptee>
+      requires __simple_allocator<Adaptee>
+            && __same_as<std::byte, typename std::allocator_traits<Adaptee>::value_type>
+    struct _memory_resource_adaptor<Adaptee>
+    {
+      class type : public std::pmr::memory_resource
+      {
+        using traits = std::allocator_traits<Adaptee>;
+        static_assert(__same_as<std::byte, typename traits::value_type>);
+        typename traits::allocator_type alloc_;
+
+       public:
+        template <class Alloc>
+          requires __same_as<
+            traits,
+            typename std::allocator_traits<Alloc>::template rebind_traits<std::byte>>
+        explicit type(Alloc const &alloc) noexcept
+          : alloc_(alloc)
+        {}
+
+        constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) override
+        {
+          return traits::allocate(alloc_, __bytes);
+        }
+
+        constexpr void do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) override
+        {
+          traits::deallocate(alloc_, new (__p) std::byte[__bytes], __bytes);
+        }
+
+        constexpr bool do_is_equal(std::pmr::memory_resource const &__other) const noexcept override
+        {
+          if (auto *ptr = dynamic_cast<type const *>(&__other))
+          {
+            return alloc_ == ptr->alloc_;
+          }
+
+          return false;
+        }
+      };
+    };
+
+    template <class Adaptee>
+      requires __simple_allocator<Adaptee>
+    struct _memory_resource_adaptor<Adaptee>
+      : _memory_resource_adaptor<
+          typename std::allocator_traits<Adaptee>::template rebind_alloc<std::byte>>
+    {};
+
+    template <class Adaptee>
+      requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, Adaptee>
+    struct _memory_resource_adaptor<Adaptee>
+    {
+      using type = Adaptee;
+    };
+
+    template <class Adaptee>
+    using _memory_resource_adaptor_t = _memory_resource_adaptor<std::remove_cvref_t<Adaptee>>::type;
+
+    template <class Receiver, class Sigs, class Queries>
+      requires(!__queryable_with<env_of_t<_any_receiver_ref<Sigs, Queries>>, get_frame_allocator_t>)
+    struct _opstate_base<Receiver, Sigs, Queries>
+    {
+      using _receiver_t   = _choose_receiver_t<_any_receiver_ref<Sigs, Queries>>;
+      using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
+      using _adaptee_t    = decltype(choose_frame_allocator(__declval<Receiver const &>()));
+
+      _memory_resource_adaptor_t<_adaptee_t>                                  resource_;
+      _any::_state<Receiver, _stop_token_t>                                   rcvr_;
+      prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>> env_;
+
+      constexpr explicit _opstate_base(Receiver &&rcvr)
+        : resource_(choose_frame_allocator(rcvr))
+        , rcvr_(static_cast<Receiver &&>(rcvr))
+        , env_{get_frame_allocator, &resource_}
+      {}
+    };
+
     //! The concrete operation state resulting from connecting a function<...> to a
     //! concrete receiver of type Receiver. This type manages an _any::_any_opstate_base
     //! instance, which is the type-erased operation state resulting from connecting the
     //! type-erased sender to an _any::_any_receiver_ref with the given completion
     //! signatures and queries.
     template <class Receiver, class Sigs, class Queries>
-    class _opstate
+    class _opstate : public _opstate_base<Receiver, Sigs, Queries>
     {
-      using _receiver_t   = ::exec::_any::_any_receiver_ref<Sigs, Queries>;
-      using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
+      using _base = _opstate_base<Receiver, Sigs, Queries>;
+      using typename _base::_receiver_t;
 
-      //! rcvr_ has to be initialized before op_ because our implementation of get_env is
-      //! empirically accessed during our constructor and depends on rcvr_ being
-      //! initialized
-      _any::_state<Receiver, _stop_token_t> rcvr_;
-      _any::_any_opstate_base               op_;
+      _any::_any_opstate_base op_;
 
      public:
       using operation_state_concept = operation_state_tag;
 
       template <class Factory>
       explicit constexpr _opstate(Receiver rcvr, Factory factory)
-        : rcvr_(static_cast<Receiver &&>(rcvr))
-        , op_(factory(_receiver_t(rcvr_)))
+        : _base(static_cast<Receiver &&>(rcvr))
+        , op_(factory(_receiver_t(this)))
       {}
 
       constexpr void start() & noexcept
@@ -113,7 +240,7 @@ namespace experimental::execution
     template <class Sigs, class... Queries, class... Args>
     class _function<Sigs, queries<Queries...>, Args...>
     {
-      using _receiver_t = ::exec::_any::_any_receiver_ref<Sigs, queries<Queries...>>;
+      using _receiver_t = _choose_receiver_t<_any_receiver_ref<Sigs, queries<Queries...>>>;
 
       template <class Receiver>
       using _opstate_t = _opstate<Receiver, Sigs, queries<Queries...>>;

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -64,6 +64,12 @@ namespace experimental::execution
     inline constexpr auto __choose_frame_allocator =
       __first_callable{get_frame_allocator, get_allocator, __always{std::allocator<std::byte>()}};
 
+    //! Wrap _Receiver, which is a type-erased receiver, in a type that can extract the
+    //! concrete, to-be-erased receiver from the operation state that contains it.
+    //!
+    //! This wrapper exists primarily as a hook for injecting a defaulted frame allocator
+    //! when _Receiver *doesn't* have get_frame_allocator in its environment. That
+    //! injection happens in the partial specialization, below.
     template <class _Receiver>
     struct __receiver_wrapper : public _Receiver
     {
@@ -73,10 +79,23 @@ namespace experimental::execution
       {}
     };
 
+    //! Wrap _Receiver, which is a type-erased receiver, in a type that can extract the
+    //! concrete, to-be-erased receiver from the operation state that contains it, and
+    //! inject an environment that contains a defaulted frame allocator.
+    //!
+    //! This partial specialization handles the case that _Receiver doesn't have a frame
+    //! allocator in its environment, in which case we need to provide a type-erasing
+    //! frame allocator in the injected environment because we won't know the concrete
+    //! type of the allocator that's actually used as our frame allocator until we're
+    //! connected to a concrete receiver. We could provide either
+    //! std::pmr::memory_resource*, or std::pmr::polymorphic_allocator<> with basically
+    //! the same tradeoffs so we provide an allocator rather than a memory resource to
+    //! better match the name of the injected query.
     template <class _Receiver>
       requires(!__queryable_with<env_of_t<_Receiver>, get_frame_allocator_t>)
     struct __receiver_wrapper<_Receiver> : public _Receiver
     {
+      //! the injected query response for the frame allocator
       using __prop_t = prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>>;
 
       template <class _Opstate>
@@ -95,12 +114,21 @@ namespace experimental::execution
       __prop_t *__env_;
     };
 
-    template <class _Sigs, class _Queries>
-    using __any_receiver_ref = ::exec::_any::_any_receiver_ref<_Sigs, _Queries>;
-
+    //! Adapt _Adaptee to be a std::pmr::memory_resource
+    //!
+    //! The alias __memory_resource_adaptor_t<_Adaptee> is the identity when _Adaptee is
+    //! a pointer to a type that derives from std::pmr::memory_resource. When _Adaptee
+    //! is an allocator type, __memory_resource_adaptor_t<_Adaptee> is a type that
+    //! derives from std::pmr::memory_resource and implements its pure-virtual member
+    //! functions in terms of that allocator type rebound to std::byte.
     template <class _Adaptee>
     struct __memory_resource_adaptor;
 
+    //! Handle the case that _Adaptee is an allocator of std::bytes
+    //!
+    //! Implement do_allocate and do_deallocate in terms of _Adaptee's allocate and
+    //! deallocate, respectively. Implement do_is_equal in terms of _Adaptee's
+    //! operator==.
     template <class _Adaptee>
       requires __simple_allocator<_Adaptee>
             && __same_as<std::byte, typename std::allocator_traits<_Adaptee>::value_type>
@@ -145,27 +173,36 @@ namespace experimental::execution
       };
     };
 
+    //! Handle the case that _Adaptee is an allocator of some type other than std::byte
+    //!
+    //! We just rebind _Adaptee to be an allocator of std::bytes and inherit our nested
+    //! alias from the adaptor for that type. This strategy ensures that there's only one
+    //! adaptor for an entire family of adapted allocator types, reducing template bloat
+    //! and making the do_is_equals implementation sensible.
     template <class _Adaptee>
       requires __simple_allocator<_Adaptee>
     struct __memory_resource_adaptor<_Adaptee>
-      //! for an arbitrary allocator, inherit from the adaptor that's implemented
-      //! in terms of that allocator rebound to std::byte to minimize template
-      //! instantiations, and to make the dynamic_cast in do_is_equal work
       : __memory_resource_adaptor<
           typename std::allocator_traits<_Adaptee>::template rebind_alloc<std::byte>>
     {};
 
+    //! Handle the case that _Adaptee is a pointer to a type that derives from
+    //! std::pmr::memory_resource
+    //!
+    //! In this case, there's nothing to "adapt" so we just alias _Adaptee.
     template <class _Adaptee>
       requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, _Adaptee>
     struct __memory_resource_adaptor<_Adaptee>
     {
-      //! no need to "adapt" a memory_resource
       using type = _Adaptee;
     };
 
     template <class _Adaptee>
     using __memory_resource_adaptor_t =
       __memory_resource_adaptor<std::remove_cvref_t<_Adaptee>>::type;
+
+    template <class _Sigs, class _Queries>
+    using __any_receiver_ref = ::exec::_any::_any_receiver_ref<_Sigs, _Queries>;
 
     template <class _Receiver, class _Sigs, class _Queries>
     struct __opstate_base
@@ -263,21 +300,23 @@ namespace experimental::execution
                                        static_cast<__receiver_t &&>(__rcvr));
       }
 
-      //! The curried arguments that will be passed to make_sender_ from inside make_opstate_.
+      //! The curried arguments that will be passed to __make_sender_ from inside
+      //! __make_opstate_.
       STDEXEC_ATTRIBUTE(no_unique_address)
       __tuple<_Args...> __args_;
       //! The type-erased operation state factory; it points to a function that knows the
-      //! concrete type of the sender factory stored in make_sender_ so that it can
+      //! concrete type of the sender factory stored in __make_sender_ so that it can
       //! construct the desired sender on demand and connect it to the given receiver. The
-      //! expected arguments are the address of make_sender_, the _any_receiver_ref to
-      //! connect the sender to, and the arguments to pass to make_sender_ to construct
+      //! expected arguments are the address of __make_sender_, the __any_receiver_ref to
+      //! connect the sender to, and the arguments to pass to __make_sender_ to construct
       //! the sender.
       _any::_any_opstate_base (*__make_opstate_)(void *, __receiver_t, _Args &&...);
-      //! Storage for the sender factory passed to our constructor template; make_opstate_ will
-      //! reconstitute the actual factory from this bag-of-bytes with start_lifetime_as
-      //! because it internally knows the concrete type of the user-provided sender
-      //! factory. We're reserving 2 * sizeof(void *) bytes to permit the factory to be a
-      //! pointer to member function, which usually requires two pointers.
+      //! Storage for the sender factory passed to our constructor template;
+      //! __make_opstate_ will reconstitute the actual factory from this bag-of-bytes with
+      //! start_lifetime_as because it internally knows the concrete type of the
+      //! user-provided sender factory. We're reserving 2 * sizeof(void *) bytes to permit
+      //! the factory to be a pointer to member function, which usually requires two
+      //! pointers.
       std::byte __make_sender_[2 * sizeof(void *)]{};
 
      public:
@@ -302,7 +341,7 @@ namespace experimental::execution
       static consteval auto get_completion_signatures()
       {
         static_assert(__decays_to_derived_from<_Self, __function>);
-        //! throw if Env does not contain the queries needed to type-erase the receiver:
+        //! throw if _Env does not contain the queries needed to type-erase the receiver:
         using __check_queries_t = __mfind_error<_any::_check_query_t<_Queries, _Env...>...>;
         if constexpr (__merror<__check_queries_t>)
           return __throw_compile_time_error(__check_queries_t());
@@ -356,6 +395,11 @@ namespace experimental::execution
       return __func::__canonicalize_splice<__types, _List>(__make_indices<__types.size()>());
     }
 
+    //! Map the type-list _Sigs to a canonical form, which sorts and uniques the contained
+    //! elements to ensure user-specified type-lists are not order-dependent.
+    //!
+    //! \tparam _Sigs a type-list of types to be sorted and uniqued; expected to be a
+    //!         specialization of completion_signatures or queries.
     template <class _Sigs>
     using __canonical_t = decltype(__func::__canonicalize(static_cast<_Sigs *>(nullptr)));
 
@@ -368,6 +412,25 @@ namespace experimental::execution
       completion_signatures<__single_value_sig_t<_Return>, set_stopped_t()>,
       __eptr_completion_unless_t<__mbool<_NoExcept>>>>;
 
+    //! Map a variety of function<...> specifications into the canonical type-erased
+    //! contract represented by the user-provided specification.
+    //!
+    //! The canonical specification looks like this:
+    //!
+    //!   function<
+    //!       sender_tag(Args...),
+    //!       completion_signatures<Sigs...>,
+    //!       queries<Queries...>>
+    //!
+    //! where:
+    //!  - Args... is the type-erased sender factory's parameter list
+    //!  - Sigs... is the set of completion signatures that the erased sender is allowed
+    //!            to advertise
+    //!  - Queries... is the set of queries that the eventual receiver's environment must
+    //!               support
+    //!
+    //! The order of Args... is obviously important, but Sigs... and Queries... are both
+    //! canonicalized into a sorted and uniqued list to ensure order is irrelevant.
     template <class...>
     struct __make_function;
 

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -143,7 +143,7 @@ namespace experimental::execution
 
       constexpr explicit __opstate_base(_Receiver &&__rcvr)
         : __resource_(__choose_frame_allocator(__rcvr))
-        , __env_{get_frame_allocator, &__resource_}
+        , __env_(get_frame_allocator, std::pmr::polymorphic_allocator<>(&__resource_))
         , __rcvr_(static_cast<_Receiver &&>(__rcvr))
       {}
     };

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -143,7 +143,7 @@ namespace experimental::execution
 
       explicit __opstate_base(_Receiver __rcvr)
         : __resource_(__choose_frame_allocator(std::as_const(__rcvr)))
-        , __env_(get_frame_allocator, std::pmr::polymorphic_allocator<>(&__resource_))
+        , __env_(__make_env())
         , __rcvr_(static_cast<_Receiver &&>(__rcvr))
       {}
 

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -29,6 +29,7 @@
 
 // TODO: split this header into pieces
 #include "any_sender_of.hpp"
+#include "get_frame_allocator.hpp"
 
 #include <cstddef>
 #include <cstring>
@@ -52,33 +53,6 @@
 // queries to pick the frame allocator from the environment without relying on TLS.
 namespace experimental::execution
 {
-  //! A forwarding query for a "frame allocator", to be used for dynamically allocating
-  //! the operation states of senders type-erased by exec::function.
-  struct get_frame_allocator_t : STDEXEC::__query<get_frame_allocator_t>
-  {
-    using STDEXEC::__query<get_frame_allocator_t>::operator();
-
-    constexpr auto operator()() const noexcept
-    {
-      return STDEXEC::read_env(get_frame_allocator_t{});
-    }
-
-    template <class Env>
-    static constexpr void __validate() noexcept
-    {
-      static_assert(STDEXEC::__nothrow_callable<get_frame_allocator_t, Env const &>);
-      using __alloc_t = STDEXEC::__call_result_t<get_frame_allocator_t, Env const &>;
-      static_assert(STDEXEC::__simple_allocator<STDEXEC::__decay_t<__alloc_t>>);
-    }
-
-    static consteval auto query(STDEXEC::forwarding_query_t) noexcept -> bool
-    {
-      return true;
-    }
-  };
-
-  inline constexpr get_frame_allocator_t get_frame_allocator{};
-
   namespace _func
   {
     using namespace STDEXEC;

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -27,6 +27,7 @@
 #include "../stdexec/__detail/__utility.hpp"
 #include "../stdexec/functional.hpp"
 
+#include "__frame_allocator.hpp"
 // TODO: split this header into pieces
 #include "any_sender_of.hpp"
 #include "get_frame_allocator.hpp"
@@ -122,7 +123,8 @@ namespace experimental::execution
         -> _any::_any_opstate_base
       {
         auto &make_sender = *__std::start_lifetime_as<Factory>(storage);
-        auto  alloc       = choose_frame_allocator(get_env(rcvr));
+        using alloc_t     = decltype(choose_frame_allocator(get_env(rcvr)));
+        auto alloc = __fa::__frame_allocator_t<alloc_t>(choose_frame_allocator(get_env(rcvr)));
         return _any::_any_opstate_base(__in_place_from,
                                        std::allocator_arg,
                                        alloc,

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -65,54 +65,38 @@ namespace experimental::execution
       __first_callable{get_frame_allocator, get_allocator, __always{std::allocator<std::byte>()}};
 
     template <class Receiver>
-    struct _choose_receiver
+    struct _receiver_wrapper : public Receiver
     {
-      struct type : Receiver
-      {
-        template <class Opstate>
-        constexpr explicit type(Opstate *opstate)
-          : Receiver(opstate->rcvr_)
-        {}
-      };
+      template <class Opstate>
+      constexpr explicit _receiver_wrapper(Opstate *opstate)
+        : Receiver(opstate->rcvr_)
+      {}
     };
 
     template <class Receiver>
       requires(!__queryable_with<env_of_t<Receiver>, get_frame_allocator_t>)
-    struct _choose_receiver<Receiver>
+    struct _receiver_wrapper<Receiver> : public Receiver
     {
-      class type : public Receiver
+      using _prop_t = prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>>;
+
+      template <class Opstate>
+      constexpr explicit _receiver_wrapper(Opstate *opstate)
+        : Receiver(opstate->rcvr_)
+        , env_(&opstate->env_)
+      {}
+
+      constexpr auto get_env() const noexcept  //
+        -> __join_env_t<_prop_t, env_of_t<Receiver>>
       {
-        using _prop_t = prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>>;
-        _prop_t *env_;
+        return __env::__join(*env_, STDEXEC::get_env(*static_cast<Receiver const *>(this)));
+      }
 
-       public:
-        template <class Opstate>
-        constexpr explicit type(Opstate *opstate)
-          : Receiver(opstate->rcvr_)
-          , env_(&opstate->env_)
-        {}
-
-        constexpr auto get_env() const noexcept -> __join_env_t<_prop_t, env_of_t<Receiver>>
-        {
-          return __env::__join(*env_, STDEXEC::get_env(*static_cast<Receiver const*>(this)));
-        }
-      };
+     private:
+      _prop_t *env_;
     };
 
     template <class Sigs, class Queries>
     using _any_receiver_ref = ::exec::_any::_any_receiver_ref<Sigs, Queries>;
-
-    template <class Receiver>
-    using _choose_receiver_t = _choose_receiver<Receiver>::type;
-
-    template <class Receiver, class Sigs, class Queries>
-    struct _opstate_base
-    {
-      using _receiver_t   = _choose_receiver_t<_any_receiver_ref<Sigs, Queries>>;
-      using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
-
-      _any::_state<Receiver, _stop_token_t> rcvr_;
-    };
 
     template <class Adaptee>
     struct _memory_resource_adaptor;
@@ -122,6 +106,7 @@ namespace experimental::execution
             && __same_as<std::byte, typename std::allocator_traits<Adaptee>::value_type>
     struct _memory_resource_adaptor<Adaptee>
     {
+      //! Implement memory_resource in terms of an allocator<std::byte>
       class type : public std::pmr::memory_resource
       {
         using traits = std::allocator_traits<Adaptee>;
@@ -130,12 +115,13 @@ namespace experimental::execution
 
        public:
         template <class Alloc>
-          requires __same_as<
-            traits,
-            typename std::allocator_traits<Alloc>::template rebind_traits<std::byte>>
-        explicit type(Alloc const &alloc) noexcept
+          requires(!__same_as<Alloc, type>)
+        constexpr explicit type(Alloc const &alloc) noexcept
           : alloc_(alloc)
-        {}
+        {
+          using rebound_traits = std::allocator_traits<Alloc>::template rebind_traits<std::byte>;
+          static_assert(__same_as<traits, rebound_traits>);
+        }
 
         constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) override
         {
@@ -162,6 +148,9 @@ namespace experimental::execution
     template <class Adaptee>
       requires __simple_allocator<Adaptee>
     struct _memory_resource_adaptor<Adaptee>
+      //! for an arbitrary allocator, inherit from the adaptor that's implemented
+      //! in terms of that allocator rebound to std::byte to minimize template
+      //! instantiations, and to make the dynamic_cast in do_is_equal work
       : _memory_resource_adaptor<
           typename std::allocator_traits<Adaptee>::template rebind_alloc<std::byte>>
     {};
@@ -170,6 +159,7 @@ namespace experimental::execution
       requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, Adaptee>
     struct _memory_resource_adaptor<Adaptee>
     {
+      //! no need to "adapt" a memory_resource
       using type = Adaptee;
     };
 
@@ -177,21 +167,31 @@ namespace experimental::execution
     using _memory_resource_adaptor_t = _memory_resource_adaptor<std::remove_cvref_t<Adaptee>>::type;
 
     template <class Receiver, class Sigs, class Queries>
+    struct _opstate_base
+    {
+      using _receiver_t   = _receiver_wrapper<_any_receiver_ref<Sigs, Queries>>;
+      using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
+
+      _any::_state<Receiver, _stop_token_t> rcvr_;
+    };
+
+    template <class Receiver, class Sigs, class Queries>
       requires(!__queryable_with<env_of_t<_any_receiver_ref<Sigs, Queries>>, get_frame_allocator_t>)
     struct _opstate_base<Receiver, Sigs, Queries>
     {
-      using _receiver_t   = _choose_receiver_t<_any_receiver_ref<Sigs, Queries>>;
+      using _receiver_t   = _receiver_wrapper<_any_receiver_ref<Sigs, Queries>>;
+      using _prop_t       = _receiver_t::_prop_t;
       using _stop_token_t = stop_token_of_t<env_of_t<_receiver_t>>;
       using _adaptee_t    = decltype(choose_frame_allocator(__declval<Receiver const &>()));
 
-      _memory_resource_adaptor_t<_adaptee_t>                                  resource_;
-      _any::_state<Receiver, _stop_token_t>                                   rcvr_;
-      prop<get_frame_allocator_t, std::pmr::polymorphic_allocator<std::byte>> env_;
+      _memory_resource_adaptor_t<_adaptee_t> resource_;
+      _prop_t                                env_;
+      _any::_state<Receiver, _stop_token_t>  rcvr_;
 
       constexpr explicit _opstate_base(Receiver &&rcvr)
         : resource_(choose_frame_allocator(rcvr))
-        , rcvr_(static_cast<Receiver &&>(rcvr))
         , env_{get_frame_allocator, &resource_}
+        , rcvr_(static_cast<Receiver &&>(rcvr))
       {}
     };
 
@@ -240,7 +240,7 @@ namespace experimental::execution
     template <class Sigs, class... Queries, class... Args>
     class _function<Sigs, queries<Queries...>, Args...>
     {
-      using _receiver_t = _choose_receiver_t<_any_receiver_ref<Sigs, queries<Queries...>>>;
+      using _receiver_t = _receiver_wrapper<_any_receiver_ref<Sigs, queries<Queries...>>>;
 
       template <class Receiver>
       using _opstate_t = _opstate<Receiver, Sigs, queries<Queries...>>;
@@ -308,7 +308,8 @@ namespace experimental::execution
       }
 
       template <class Receiver>
-      constexpr auto connect(Receiver rcvr) && -> _opstate_t<Receiver>
+      constexpr auto connect(Receiver rcvr) &&  //
+        -> _opstate_t<Receiver>
       {
         auto factory = [this]<class RcvrRef>(RcvrRef rcvr)
         {
@@ -322,7 +323,8 @@ namespace experimental::execution
 
       template <class Receiver>
         requires __std::copy_constructible<_function>
-      constexpr auto connect(Receiver rcvr) const & -> _opstate_t<Receiver>
+      constexpr auto connect(Receiver rcvr) const &  //
+        -> _opstate_t<Receiver>
       {
         return _function(*this).connect(static_cast<Receiver &&>(rcvr));
       }

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -28,6 +28,7 @@
 #include "../stdexec/functional.hpp"
 
 #include "__frame_allocator.hpp"
+#include "__memory_resource_adaptor.hpp"
 // TODO: split this header into pieces
 #include "any_sender_of.hpp"
 #include "get_frame_allocator.hpp"
@@ -113,93 +114,6 @@ namespace experimental::execution
      private:
       __prop_t *__env_;
     };
-
-    //! Adapt _Adaptee to be a std::pmr::memory_resource
-    //!
-    //! The alias __memory_resource_adaptor_t<_Adaptee> is the identity when _Adaptee is
-    //! a pointer to a type that derives from std::pmr::memory_resource. When _Adaptee
-    //! is an allocator type, __memory_resource_adaptor_t<_Adaptee> is a type that
-    //! derives from std::pmr::memory_resource and implements its pure-virtual member
-    //! functions in terms of that allocator type rebound to std::byte.
-    template <class _Adaptee>
-    struct __memory_resource_adaptor;
-
-    //! Handle the case that _Adaptee is an allocator of std::bytes
-    //!
-    //! Implement do_allocate and do_deallocate in terms of _Adaptee's allocate and
-    //! deallocate, respectively. Implement do_is_equal in terms of _Adaptee's
-    //! operator==.
-    template <class _Adaptee>
-      requires __simple_allocator<_Adaptee>
-            && __same_as<std::byte, typename std::allocator_traits<_Adaptee>::value_type>
-    struct __memory_resource_adaptor<_Adaptee>
-    {
-      //! Implement memory_resource in terms of an allocator<std::byte>
-      class type : public std::pmr::memory_resource
-      {
-        using __traits = std::allocator_traits<_Adaptee>;
-        static_assert(__same_as<std::byte, typename __traits::value_type>);
-        typename __traits::allocator_type __alloc_;
-
-       public:
-        template <class _Alloc>
-          requires(!__same_as<_Alloc, type>)
-        constexpr explicit type(_Alloc const &__alloc) noexcept
-          : __alloc_(__alloc)
-        {
-          using __rebound_traits = std::allocator_traits<_Alloc>::template rebind_traits<std::byte>;
-          static_assert(__same_as<__traits, __rebound_traits>);
-        }
-
-        constexpr void *do_allocate(std::size_t __bytes, std::size_t __align) override
-        {
-          return __traits::allocate(__alloc_, __bytes);
-        }
-
-        constexpr void do_deallocate(void *__p, std::size_t __bytes, std::size_t __align) override
-        {
-          __traits::deallocate(__alloc_, new (__p) std::byte[__bytes], __bytes);
-        }
-
-        constexpr bool do_is_equal(std::pmr::memory_resource const &__other) const noexcept override
-        {
-          if (auto *__ptr = dynamic_cast<type const *>(&__other))
-          {
-            return __alloc_ == __ptr->__alloc_;
-          }
-
-          return false;
-        }
-      };
-    };
-
-    //! Handle the case that _Adaptee is an allocator of some type other than std::byte
-    //!
-    //! We just rebind _Adaptee to be an allocator of std::bytes and inherit our nested
-    //! alias from the adaptor for that type. This strategy ensures that there's only one
-    //! adaptor for an entire family of adapted allocator types, reducing template bloat
-    //! and making the do_is_equals implementation sensible.
-    template <class _Adaptee>
-      requires __simple_allocator<_Adaptee>
-    struct __memory_resource_adaptor<_Adaptee>
-      : __memory_resource_adaptor<
-          typename std::allocator_traits<_Adaptee>::template rebind_alloc<std::byte>>
-    {};
-
-    //! Handle the case that _Adaptee is a pointer to a type that derives from
-    //! std::pmr::memory_resource
-    //!
-    //! In this case, there's nothing to "adapt" so we just alias _Adaptee.
-    template <class _Adaptee>
-      requires __std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, _Adaptee>
-    struct __memory_resource_adaptor<_Adaptee>
-    {
-      using type = _Adaptee;
-    };
-
-    template <class _Adaptee>
-    using __memory_resource_adaptor_t =
-      __memory_resource_adaptor<std::remove_cvref_t<_Adaptee>>::type;
 
     template <class _Sigs, class _Queries>
     using __any_receiver_ref = ::exec::_any::_any_receiver_ref<_Sigs, _Queries>;

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -251,7 +251,7 @@ namespace experimental::execution
       {
         auto &make_sender = *__std::start_lifetime_as<Factory>(storage);
         using alloc_t     = decltype(choose_frame_allocator(get_env(rcvr)));
-        auto alloc = __fa::__frame_allocator_t<alloc_t>(choose_frame_allocator(get_env(rcvr)));
+        auto alloc        = __frame_allocator_t<alloc_t>(choose_frame_allocator(get_env(rcvr)));
         return _any::_any_opstate_base(__in_place_from,
                                        std::allocator_arg,
                                        alloc,

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -141,11 +141,27 @@ namespace experimental::execution
       __prop_t                                 __env_;
       _any::_state<_Receiver, __stop_token_t>  __rcvr_;
 
-      constexpr explicit __opstate_base(_Receiver &&__rcvr)
-        : __resource_(__choose_frame_allocator(__rcvr))
+      explicit __opstate_base(_Receiver __rcvr)
+        : __resource_(__choose_frame_allocator(std::as_const(__rcvr)))
         , __env_(get_frame_allocator, std::pmr::polymorphic_allocator<>(&__resource_))
         , __rcvr_(static_cast<_Receiver &&>(__rcvr))
       {}
+
+     private:
+      //! the indirection through __make_env and __make_alloc is to work around what
+      //! appears to be miscompilation with Clang 16; initializing __env_ inline
+      //! rather than delegating to these helpers results in passing an invalid
+      //! address to the polymorphic_allocator constructor instead of the address of
+      //! __resource_, leading to segfaults
+      __prop_t __make_env()
+      {
+        return __prop_t(get_frame_allocator, __make_alloc());
+      }
+
+      std::pmr::polymorphic_allocator<> __make_alloc()
+      {
+        return std::pmr::polymorphic_allocator<>(&__resource_);
+      }
     };
 
     //! The concrete operation state resulting from connecting a function<...> to a

--- a/include/exec/get_frame_allocator.hpp
+++ b/include/exec/get_frame_allocator.hpp
@@ -39,7 +39,9 @@ namespace experimental::execution
     {
       static_assert(STDEXEC::__nothrow_callable<get_frame_allocator_t, Env const &>);
       using __alloc_t = STDEXEC::__call_result_t<get_frame_allocator_t, Env const &>;
-      static_assert(STDEXEC::__simple_allocator<STDEXEC::__decay_t<__alloc_t>>);
+      static_assert(
+        STDEXEC::__std::constructible_from<std::pmr::polymorphic_allocator<std::byte>, __alloc_t>
+        || STDEXEC::__simple_allocator<STDEXEC::__decay_t<__alloc_t>>);
     }
 
     static consteval auto query(STDEXEC::forwarding_query_t) noexcept -> bool

--- a/include/exec/get_frame_allocator.hpp
+++ b/include/exec/get_frame_allocator.hpp
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 Ian Petersen
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "../stdexec/__detail/__concepts.hpp"
+#include "../stdexec/__detail/__query.hpp"
+#include "../stdexec/__detail/__read_env.hpp"
+#include "../stdexec/__detail/__type_traits.hpp"
+#include "../stdexec/__detail/__utility.hpp"
+
+namespace experimental::execution
+{
+  //! A forwarding query for a "frame allocator", to be used for dynamically allocating
+  //! the operation states of senders type-erased by exec::function.
+  struct get_frame_allocator_t : STDEXEC::__query<get_frame_allocator_t>
+  {
+    using STDEXEC::__query<get_frame_allocator_t>::operator();
+
+    constexpr auto operator()() const noexcept
+    {
+      return STDEXEC::read_env(get_frame_allocator_t{});
+    }
+
+    template <class Env>
+    static constexpr void __validate() noexcept
+    {
+      static_assert(STDEXEC::__nothrow_callable<get_frame_allocator_t, Env const &>);
+      using __alloc_t = STDEXEC::__call_result_t<get_frame_allocator_t, Env const &>;
+      static_assert(STDEXEC::__simple_allocator<STDEXEC::__decay_t<__alloc_t>>);
+    }
+
+    static consteval auto query(STDEXEC::forwarding_query_t) noexcept -> bool
+    {
+      return true;
+    }
+  };
+
+  inline constexpr get_frame_allocator_t get_frame_allocator{};
+}  // namespace experimental::execution
+
+namespace exec = experimental::execution;

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -63,6 +63,7 @@ set(exec_test_sources
     test_unless_stop_requested.cpp
     test_function.cpp
     test_frame_allocator.cpp
+    test_memory_resource_adaptor.cpp
     )
 
 set_source_files_properties(test_any_sender.cpp

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -62,6 +62,7 @@ set(exec_test_sources
     $<$<BOOL:${STDEXEC_ENABLE_LIBDISPATCH}>:test_libdispatch.cpp>
     test_unless_stop_requested.cpp
     test_function.cpp
+    test_frame_allocator.cpp
     )
 
 set_source_files_properties(test_any_sender.cpp

--- a/test/exec/test_frame_allocator.cpp
+++ b/test/exec/test_frame_allocator.cpp
@@ -30,7 +30,7 @@ namespace
 {
   TEST_CASE("exec::__frame_allocator is constructible", "[types][frame_allocator]")
   {
-    using namespace exec::__fa;
+    using namespace exec;
 
     SECTION("with a memory_resource*")
     {

--- a/test/exec/test_frame_allocator.cpp
+++ b/test/exec/test_frame_allocator.cpp
@@ -56,4 +56,135 @@ namespace
       STATIC_REQUIRE(std::same_as<decltype(fa), std::allocator<std::byte>>);
     }
   }
+
+  template <class Resource>
+  struct resource_for
+  {
+    using type = Resource;
+  };
+
+  template <class Resource>
+    requires std::is_pointer_v<Resource>
+  struct resource_for<Resource>
+  {
+    using type = std::pmr::unsynchronized_pool_resource;
+  };
+
+  template <class Resource>
+  using resource_for_t = resource_for<Resource>::type;
+
+  template <class Resource>
+  constexpr decltype(auto) frame_allocator_arg_from(Resource& resource) noexcept
+  {
+    if constexpr (ex::__std::derived_from<Resource, std::pmr::memory_resource>)
+    {
+      return &resource;
+    }
+    else
+    {
+      return resource;
+    }
+  }
+
+  template <class Alloc>
+  struct uses_leading_allocator
+  {
+    using allocator_type = Alloc;
+
+    constexpr explicit uses_leading_allocator(int) noexcept
+      : usedAllocator(false)
+    {}
+
+    constexpr explicit uses_leading_allocator(std::allocator_arg_t, Alloc const &, int) noexcept
+      : usedAllocator(true)
+    {}
+
+    bool usedAllocator;
+  };
+
+  TEMPLATE_TEST_CASE("__frame_allocator correctly does uses-allocator construction with "
+                     "leading-allocator types",
+                     "[types][frame_allocator]",
+                     std::allocator<int>,
+                     std::pmr::memory_resource*,
+                     std::pmr::unsynchronized_pool_resource*)
+  {
+    using raw_alloc = exec::__frame_allocator_t<TestType>;
+    using traits_t =
+      std::allocator_traits<exec::__frame_allocator_t<TestType>>::template rebind_traits<
+        uses_leading_allocator<raw_alloc>>;
+    using alloc_t = traits_t::allocator_type;
+
+    resource_for_t<TestType> rsc;
+    alloc_t                  alloc(frame_allocator_arg_from(rsc));
+
+    uses_leading_allocator<raw_alloc>* p = traits_t::allocate(alloc, 1);
+    traits_t::construct(alloc, p, 42);
+
+    if (std::is_pointer_v<TestType>)
+    {
+      // std::pmr::polymorphic_allocator and the static equivalent do uses-allocator
+      // construction
+      REQUIRE(p->usedAllocator);
+    }
+    else
+    {
+      // std::allocator does not do uses-allocator construction
+      REQUIRE(!p->usedAllocator);
+    }
+
+    traits_t::destroy(alloc, p);
+    traits_t::deallocate(alloc, p, 1);
+  }
+
+  template <class Alloc>
+  struct uses_trailing_allocator
+  {
+    using allocator_type = Alloc;
+
+    constexpr explicit uses_trailing_allocator(int) noexcept
+      : usedAllocator(false)
+    {}
+
+    constexpr explicit uses_trailing_allocator(int, Alloc const &) noexcept
+      : usedAllocator(true)
+    {}
+
+    bool usedAllocator;
+  };
+
+  TEMPLATE_TEST_CASE("__frame_allocator correctly does uses-allocator construction with "
+                     "trailing-allocator types",
+                     "[types][frame_allocator]",
+                     std::allocator<int>,
+                     std::pmr::memory_resource*,
+                     std::pmr::unsynchronized_pool_resource*)
+  {
+    using raw_alloc = exec::__frame_allocator_t<TestType>;
+    using traits_t =
+      std::allocator_traits<exec::__frame_allocator_t<TestType>>::template rebind_traits<
+        uses_trailing_allocator<raw_alloc>>;
+    using alloc_t = traits_t::allocator_type;
+
+    resource_for_t<TestType> rsc;
+    alloc_t                  alloc(frame_allocator_arg_from(rsc));
+
+    uses_trailing_allocator<raw_alloc>* p = traits_t::allocate(alloc, 1);
+    traits_t::construct(alloc, p, 42);
+
+    if (std::is_pointer_v<TestType>)
+    {
+      // std::pmr::polymorphic_allocator and the static equivalent do uses-allocator
+      // construction
+      REQUIRE(p->usedAllocator);
+    }
+    else
+    {
+      // std::allocator does not do uses-allocator construction
+      REQUIRE(!p->usedAllocator);
+    }
+
+    traits_t::destroy(alloc, p);
+    traits_t::deallocate(alloc, p, 1);
+  }
 }  // namespace

--- a/test/exec/test_frame_allocator.cpp
+++ b/test/exec/test_frame_allocator.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Ian Petersen
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <exec/__frame_allocator.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <stdexec/execution.hpp>
+
+#include <concepts>
+#include <memory>
+
+namespace ex = STDEXEC;
+
+namespace
+{
+  TEST_CASE("exec::__frame_allocator is constructible", "[types][frame_allocator]")
+  {
+    using namespace exec::__fa;
+
+    SECTION("with a memory_resource*")
+    {
+      std::pmr::memory_resource*         rsc = std::pmr::new_delete_resource();
+      __frame_allocator_t<decltype(rsc)> fa(rsc);
+
+      STATIC_REQUIRE(std::same_as<decltype(fa), std::pmr::polymorphic_allocator<std::byte>>);
+    }
+
+    SECTION("with a specific resource")
+    {
+      std::pmr::unsynchronized_pool_resource rsc;
+      __frame_allocator_t<decltype(rsc)*>    fa(&rsc);
+
+      STATIC_REQUIRE(!std::same_as<decltype(fa), std::pmr::polymorphic_allocator<std::byte>>);
+    }
+
+    SECTION("with an allocator")
+    {
+      std::allocator<int>                rsc;
+      __frame_allocator_t<decltype(rsc)> fa(rsc);
+
+      STATIC_REQUIRE(std::same_as<decltype(fa), std::allocator<std::byte>>);
+    }
+  }
+}  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -139,11 +139,7 @@ namespace
 
   TEST_CASE("exec::function forwards get_frame_allocator", "[types][function]")
   {
-    // TODO: you probably shouldn't have to specify the frame allocator query like this
-    using Queries = exec::queries<std::pmr::polymorphic_allocator<std::byte>(
-      exec::get_frame_allocator_t) noexcept>;
-
-    exec::function<bool() noexcept, Queries> sndr(
+    exec::function<bool() noexcept> sndr(
       []() noexcept
       {
         return ex::read_env(exec::get_frame_allocator)

--- a/test/exec/test_memory_resource_adaptor.cpp
+++ b/test/exec/test_memory_resource_adaptor.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Ian Petersen
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <exec/__memory_resource_adaptor.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <stdexec/execution.hpp>
+
+#include <bit>
+#include <concepts>
+#include <memory>
+
+namespace ex = STDEXEC;
+
+namespace
+{
+  // this is a trivial class template that satisfies __simple_allocator but isn't
+  // exactly std::allocator
+  template <class T>
+  struct custom_allocator : std::allocator<T>
+  {};
+
+  template <class Resource>
+  auto make_underlying_resource()
+  {
+    if constexpr (std::is_pointer_v<Resource>)
+    {
+      return std::pmr::unsynchronized_pool_resource();
+    }
+    else
+    {
+      return Resource();
+    }
+  }
+
+  template <class Resource>
+  decltype(auto) adaptor_arg_from_resource(Resource* rsc) noexcept
+  {
+    if constexpr (ex::__simple_allocator<Resource>)
+    {
+      return *rsc;
+    }
+    else
+    {
+      return rsc;
+    }
+  }
+
+  TEMPLATE_TEST_CASE("exec::__memory_resource_adaptor is constructible",
+                     "[types][memory_resource_adaptor]",
+                     std::allocator<std::byte>,
+                     std::allocator<int>,
+                     custom_allocator<std::byte>,
+                     custom_allocator<int>,
+                     std::pmr::memory_resource*,
+                     std::pmr::unsynchronized_pool_resource*)
+  {
+    using adaptor_t = exec::__memory_resource_adaptor_t<TestType>;
+
+    auto      underlying = make_underlying_resource<TestType>();
+    adaptor_t rsc(adaptor_arg_from_resource(&underlying));
+
+    std::pmr::polymorphic_allocator<> alloc(&rsc);
+
+    auto* p = alloc.allocate(4);
+    REQUIRE(p != nullptr);
+    alloc.deallocate(p, 4);
+  }
+
+  template <std::size_t Alignment>
+  using alignment = std::integral_constant<std::size_t, Alignment>;
+
+  TEMPLATE_TEST_CASE("exec::__memory_resource_adaptor supports over-alignment",
+                     "[types][memory_resource_adaptor]",
+                     std::allocator<std::byte>,
+                     std::allocator<int>,
+                     custom_allocator<std::byte>,
+                     custom_allocator<int>,
+                     std::pmr::memory_resource*,
+                     std::pmr::unsynchronized_pool_resource*)
+  {
+    using adaptor_t = exec::__memory_resource_adaptor_t<TestType>;
+
+    auto      underlying = make_underlying_resource<TestType>();
+    adaptor_t rsc(adaptor_arg_from_resource(&underlying));
+
+    std::pmr::polymorphic_allocator<> alloc(&rsc);
+
+    auto make_assertion = [&alloc]<std::size_t Alignment>(alignment<Alignment>)
+    {
+      auto* p = alloc.allocate_bytes(10, Alignment);
+
+      // this inlines std::is_sufficiently_aligned<Alignment>(p) so that failures read
+      // more clearly in the output (the actual and expected alignment show up in the
+      // output this way, instead of "false").
+      REQUIRE(std::countr_zero(std::bit_cast<std::uintptr_t>(p)) >= std::countr_zero(Alignment));
+
+      alloc.deallocate_bytes(p, 10, Alignment);
+    };
+
+    make_assertion(alignment<1>());
+    make_assertion(alignment<2>());
+    make_assertion(alignment<4>());
+    make_assertion(alignment<8>());
+    make_assertion(alignment<16>());
+    make_assertion(alignment<32>());
+    make_assertion(alignment<64>());
+    make_assertion(alignment<128>());
+    make_assertion(alignment<256>());
+    make_assertion(alignment<512>());
+    make_assertion(alignment<1'024>());
+    make_assertion(alignment<2'048>());
+  }
+}  // namespace


### PR DESCRIPTION
This stack tidies up `exec::function` some:
 * pulls the `get_frame_allocator` query out of `function.hpp` into its own header;
 * loosens the constraints so that `get_frame_allocator` can return either an
   allocator (as it already could) or a `std::pmr::memory_resource*`;
 * ensures that descendant senders of `exec::function` always see an inherited
   frame allocator in their environment, whether the `function` has a `get_frame_allocator`
   query in its type-erased environment queries or not; and
 * adds documentation to `function.hpp` and `__uglifies` its identifiers.

Still TODO:
- [x] there are a few missing tests;
- [x] the `__frame_allocator` class needs to implement "uses-allocator construction" to
     match `std::pmr::polymorphic_allocator<>::construct`'s behaviour; and
- [x] figure out what to do with the unused `__align` arguments to `__memory_resource_adaptor`'s
     `do_allocate` and `do_deallocate` member functions.