### PR TITLE
Hackery to narrow down an intermittent crash

### DIFF
--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -275,6 +275,20 @@ namespace STDEXEC
       return __sexpr_impl<_Tag>::__get_env(__index_t(), const_cast<_State const &>(__state_));
     }
 
+    constexpr explicit __rcvr(_State& __state) noexcept
+      : __state_(__state)
+    {}
+
+    STDEXEC_ATTRIBUTE(always_inline)
+    constexpr __rcvr(__rcvr const & __other) noexcept
+      : __state_(__other.__state_)
+    {}
+
+    STDEXEC_ATTRIBUTE(always_inline)
+    constexpr __rcvr(__rcvr&& __other) noexcept
+      : __state_(__other.__state_)
+    {}
+
     _State& __state_;
   };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,68 +23,7 @@ function(add_compile_diagnostics TARGET)
 endfunction()
 
 set(stdexec_test_sources
-    test_main.cpp
-    stdexec/cpos/test_cpo_bulk.cpp
-    stdexec/cpos/test_cpo_receiver.cpp
-    stdexec/cpos/test_cpo_start.cpp
-    stdexec/cpos/test_cpo_connect.cpp
-    stdexec/cpos/test_cpo_connect_awaitable.cpp
-    stdexec/cpos/test_cpo_schedule.cpp
-    stdexec/cpos/test_cpo_upon_error.cpp
-    stdexec/cpos/test_cpo_upon_stopped.cpp
-    stdexec/concepts/test_concept_scheduler.cpp
-    stdexec/concepts/test_concepts_receiver.cpp
-    stdexec/concepts/test_concept_operation_state.cpp
-    stdexec/concepts/test_concepts_sender.cpp
-    stdexec/concepts/test_concepts_stop_tokens.cpp
-    stdexec/concepts/test_concepts_scope_association.cpp
-    stdexec/concepts/test_concepts_scope_token.cpp
-    stdexec/concepts/test_awaitables.cpp
-    stdexec/algos/factories/test_just.cpp
-    stdexec/algos/factories/test_transfer_just.cpp
-    stdexec/algos/factories/test_just_error.cpp
-    stdexec/algos/factories/test_just_stopped.cpp
-    stdexec/algos/factories/test_read.cpp
-    stdexec/algos/factories/test_schedule.cpp
-    stdexec/algos/adaptors/test_associate.cpp
-    stdexec/algos/adaptors/test_starts_on.cpp
-    stdexec/algos/adaptors/test_on.cpp
-    stdexec/algos/adaptors/test_on2.cpp
-    stdexec/algos/adaptors/test_on3.cpp
-    stdexec/algos/adaptors/test_continues_on.cpp
-    stdexec/algos/adaptors/test_finally.cpp
-    stdexec/algos/adaptors/test_then.cpp
-    stdexec/algos/adaptors/test_upon_error.cpp
-    stdexec/algos/adaptors/test_upon_stopped.cpp
-    stdexec/algos/adaptors/test_let_value.cpp
-    stdexec/algos/adaptors/test_let_error.cpp
-    stdexec/algos/adaptors/test_let_stopped.cpp
-    stdexec/algos/adaptors/test_bulk.cpp
-    stdexec/algos/adaptors/test_when_all.cpp
-    stdexec/algos/adaptors/test_transfer_when_all.cpp
-    stdexec/algos/adaptors/test_into_variant.cpp
-    stdexec/algos/adaptors/test_sequence.cpp
-    stdexec/algos/adaptors/test_stopped_as_optional.cpp
-    stdexec/algos/adaptors/test_stopped_as_error.cpp
     stdexec/algos/adaptors/test_write_env.cpp
-    stdexec/algos/adaptors/test_stop_when.cpp
-    stdexec/algos/adaptors/test_spawn_future.cpp
-    stdexec/algos/consumers/test_sync_wait.cpp
-    stdexec/algos/consumers/test_spawn.cpp
-    stdexec/detail/test_any.cpp
-    stdexec/detail/test_common_domain.cpp
-    stdexec/detail/test_completion_signatures.cpp
-    stdexec/detail/test_demangle.cpp
-    stdexec/detail/test_utility.cpp
-    stdexec/detail/test_intrusive_mpsc_queue.cpp
-    stdexec/schedulers/test_task_scheduler.cpp
-    stdexec/schedulers/test_parallel_scheduler.cpp
-    stdexec/queries/test_env.cpp
-    stdexec/queries/test_get_forward_progress_guarantee.cpp
-    stdexec/queries/test_get_completion_behavior.cpp
-    stdexec/queries/test_forwarding_queries.cpp
-    stdexec/types/test_task.cpp
-    stdexec/types/test_counting_scopes.cpp
     )
 
 add_library(common_test_settings INTERFACE)
@@ -94,7 +33,6 @@ set_target_properties(common_test_settings PROPERTIES
     CXX_EXTENSIONS OFF
     MSVC_DEBUG_INFORMATION_FORMAT Embedded
     )
-target_include_directories(common_test_settings INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
 target_compile_definitions(common_test_settings INTERFACE
     STDEXEC_NAMESPACE=std::execution
     $<$<PLATFORM_ID:Windows>:NOMINMAX>
@@ -104,10 +42,6 @@ target_compile_options(common_test_settings INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized> # warnings being emitted from stdlib headers, why?
     $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-line-marker>
     )
-target_link_libraries(common_test_settings INTERFACE $<TARGET_NAME_IF_EXISTS:TBB::tbb>)
-# target_compile_definitions(
-#     common_test_settings INTERFACE
-#     $<$<NOT:$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>>:STDEXEC_ENABLE_EXTRA_TYPE_CHECKING>)
 
 add_executable(test.stdexec ${stdexec_test_sources})
 add_compile_diagnostics(test.stdexec)
@@ -115,82 +49,5 @@ target_link_libraries(test.stdexec
     PUBLIC
     STDEXEC::stdexec
     stdexec_executable_flags
-    Catch2::Catch2WithMain
     PRIVATE
     common_test_settings)
-
-if(STDEXEC_BUILD_PARALLEL_SCHEDULER)
-  add_executable(test.parallel_scheduler_replacement
-                 test_main.cpp
-                 stdexec/schedulers/test_parallel_scheduler_replacement.cpp)
-  add_compile_diagnostics(test.parallel_scheduler_replacement)
-  target_link_libraries(test.parallel_scheduler_replacement
-      PUBLIC
-      STDEXEC::stdexec
-      STDEXEC::parallel_scheduler
-      stdexec_executable_flags
-      Catch2::Catch2WithMain
-      PRIVATE
-      common_test_settings)
-endif()
-
-add_executable(test.scratch test_main.cpp test_scratch.cpp)
-add_compile_diagnostics(test.scratch)
-target_link_libraries(test.scratch
-    PUBLIC
-    STDEXEC::stdexec
-    $<TARGET_NAME_IF_EXISTS:STDEXEC::tbbexec>
-    stdexec_executable_flags
-    Catch2::Catch2WithMain
-    PRIVATE
-    common_test_settings)
-
-# Discover the Catch2 test built by the application
-include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
-
-# For testing that builds fail as expected
-include(${icm_SOURCE_DIR}/icm_build_failure_testing.cmake)
-
-catch_discover_tests(test.stdexec PROPERTIES TIMEOUT 30)
-
-catch_discover_tests(test.scratch PROPERTIES TIMEOUT 30)
-
-if(STDEXEC_BUILD_PARALLEL_SCHEDULER AND NOT STDEXEC_ENABLE_CUDA)
-    catch_discover_tests(test.parallel_scheduler_replacement PROPERTIES TIMEOUT 30)
-endif()
-
-add_subdirectory(exec)
-
-if(STDEXEC_ENABLE_CUDA)
-    add_subdirectory(nvexec)
-endif()
-
-# build failure tests: tests which parse a source file for an expected error
-# message
-icm_add_build_failure_test(
-    NAME test_let_fail1
-    TARGET test_let_fail1
-    SOURCES PARSE stdexec/algos/adaptors/test_let_fail1.cpp
-    LIBRARIES stdexec
-    FOLDER test
-)
-
-icm_add_build_failure_test(
-    NAME test_then_fail1
-    TARGET test_then_fail1
-    SOURCES PARSE stdexec/algos/adaptors/test_then_fail1.cpp
-    LIBRARIES stdexec
-    FOLDER test
-)
-
-if(STDEXEC_BUILD_RELACY_TESTS)
-    add_subdirectory(rrd)
-endif()
-
-# # Adding multiple tests with a glob
-# icm_glob_build_failure_tests(
-#     PATTERN *_fail*.cpp
-#     LIBRARIES stdexec
-#     PREFIX stdexec
-#     FOLDER test/stdexec/algos/adaptors
-# )

--- a/test/stdexec/algos/adaptors/test_write_env.cpp
+++ b/test/stdexec/algos/adaptors/test_write_env.cpp
@@ -21,6 +21,8 @@
 #include <stdexec/__detail/__optional.hpp>
 #include <stdexec/__detail/__queries.hpp>
 
+#include <optional>
+
 namespace
 {
   struct query_t
@@ -130,8 +132,6 @@ namespace STDEXEC
   {};
 }  // namespace STDEXEC
 
-#include <memory>
-
 namespace
 {
   struct logger
@@ -208,6 +208,8 @@ namespace
       : rcvr(static_cast<Rcvr&&>(rcvr_))
       , inner_opstate(connect(static_cast<Sndr&&>(sndr), rcvr_t{this}))
     {}
+
+    OpStateIncomplete(OpStateIncomplete&&) = delete;
 
     void start() & noexcept
     {

--- a/test/stdexec/algos/adaptors/test_write_env.cpp
+++ b/test/stdexec/algos/adaptors/test_write_env.cpp
@@ -16,168 +16,252 @@
  * limitations under the License.
  */
 
-#include <catch2/catch_all.hpp>
-
-#include <type_traits>
-#include <utility>
-
-#include <exec/completion_signatures.hpp>
-#include <exec/single_thread_context.hpp>
-#include <stdexec/execution.hpp>
-#include <test_common/receivers.hpp>
+#include <stdexec/__detail/__basic_sender.hpp>
+#include <stdexec/__detail/__completion_signatures.hpp>
+#include <stdexec/__detail/__optional.hpp>
+#include <stdexec/__detail/__queries.hpp>
 
 namespace
 {
-
-  template <typename T>
-  struct receiver : expect_void_receiver<>
+  struct query_t
   {
-    [[nodiscard]]
-    constexpr ::STDEXEC::env<> get_env() const noexcept
+    template <class Env>
+    decltype(auto) operator()(Env const & env) const noexcept
     {
-      return state_->get_env();
-    }
-    T* state_;
-  };
-
-  struct state
-  {
-    [[nodiscard]]
-    constexpr ::STDEXEC::env<> get_env() const noexcept
-    {
-      return {};
+      return env.query(*this);
     }
   };
 
-  static_assert(!std::is_same_v<void,
-                                decltype(::STDEXEC::connect(
-                                  ::STDEXEC::just()
-                                    | ::STDEXEC::write_env(::STDEXEC::prop{
-                                      ::STDEXEC::get_stop_token,
-                                      std::declval<::STDEXEC::inplace_stop_source&>().get_token()}),
-                                  receiver<state>{{}, nullptr}))>);
+  inline constexpr query_t query;
+}  // namespace
 
-  TEST_CASE("write_env works when the actual environment is sourced from a type which was "
-            "initially "
-            "incomplete but has since been completed",
-            "[adaptors][write_env]")
+namespace STDEXEC
+{
+  namespace __read_env
   {
-    ::STDEXEC::inplace_stop_source source;
-    state                          s;
-    auto                           op = ::STDEXEC::connect(::STDEXEC::just()
-                                   | ::STDEXEC::write_env(::STDEXEC::prop{::STDEXEC::get_stop_token,
-                                                                          source.get_token()}),
-                                 receiver<state>{{}, &s});
-    ::STDEXEC::start(op);
-  }
+    template <class _Receiver, class _Query>
+    struct __opstate
+    {
+      constexpr void start() noexcept
+      {
+        // make sure our simplification stays valid
+        static_assert(std::is_reference_v<decltype(_Query()(__rcvr_.get_env()))>);
 
-  template <class IncompleteType, class Env = STDEXEC::env_of_t<IncompleteType>>
+        // The query returns a reference type; pass it straight through to the receiver.
+        auto&& result = _Query()(__rcvr_.get_env());
+        std::printf("completing with %p\n", (void*) &result);
+        static_cast<_Receiver&&>(__rcvr_).set_value(static_cast<decltype(result)&&>(result));
+      }
+
+      _Receiver __rcvr_;
+    };
+
+    struct __read_env_impl : __sexpr_defaults
+    {
+      template <class _Self, class _Env>
+      static consteval auto __get_completion_signatures()
+      {
+        using __query_t = __data_of<_Self>;
+        {
+          using __result_t = __call_result_t<__query_t, _Env>;
+          return completion_signatures<set_value_t(__result_t)>();
+        }
+      };
+
+      static constexpr auto __connect =
+        []<class _Self, class _Receiver>(_Self const &, _Receiver&& __rcvr) noexcept
+      {
+        using __query_t = __data_of<_Self>;
+        return __opstate<_Receiver, __query_t>{static_cast<_Receiver&&>(__rcvr)};
+      };
+    };
+  }  // namespace __read_env
+
+  struct __read_env_t
+  {
+    template <class _Query>
+    constexpr auto operator()(_Query) const noexcept
+    {
+      return __make_sexpr<__read_env_t>(_Query());
+    }
+  };
+
+  inline constexpr __read_env_t read_env{};
+
+  template <>
+  struct __sexpr_impl<__read_env_t> : __read_env::__read_env_impl
+  {};
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // __write adaptor
+  namespace __write
+  {
+    struct __write_env_impl : __sexpr_defaults
+    {
+      static constexpr auto __get_env = []<class _State>(__ignore, _State const & __state) noexcept
+      {
+        auto&& logger = query(__state.__data_);
+        std::printf("write_env::get_env %p\n", (void const *) &logger);
+        return __state.__data_;
+      };
+
+      template <class _Self, class... _Env>
+      static consteval auto __get_completion_signatures()
+      {
+        return completion_signatures<set_value_t(int)>();
+      }
+    };
+  }  // namespace __write
+
+  struct __write_env_t
+  {
+    template <sender _Sender, class _Env>
+    constexpr auto operator()(_Sender&& __sndr, _Env __env) const
+    {
+      return __make_sexpr<__write_env_t>(static_cast<_Env&&>(__env),
+                                         static_cast<_Sender&&>(__sndr));
+    }
+  };
+
+  inline constexpr __write_env_t write_env{};
+
+  template <>
+  struct __sexpr_impl<__write_env_t> : __write::__write_env_impl
+  {};
+}  // namespace STDEXEC
+
+#include <memory>
+
+namespace
+{
+  struct logger
+  {
+    logger() noexcept
+    {
+      std::printf("default %p\n", (void*) this);
+    }
+
+    logger(logger const & other) noexcept
+    {
+      std::printf("copy from %p to %p\n", (void const *) &other, (void*) this);
+    }
+
+    logger(logger&& other) noexcept
+    {
+      std::printf("move from %p to %p\n", (void*) &other, (void*) this);
+    }
+
+    ~logger()
+    {
+      std::printf("destroy %p\n", (void*) this);
+    }
+
+    logger& operator=(logger const & rhs) noexcept
+    {
+      std::printf("copy= from %p to %p\n", (void const *) &rhs, (void*) this);
+      return *this;
+    }
+
+    logger& operator=(logger&& rhs) noexcept
+    {
+      std::printf("move= from %p to %p\n", (void*) &rhs, (void*) this);
+      return *this;
+    }
+  };
+  using namespace STDEXEC;
+
+  template <class IncompleteType, class Env = env_of_t<IncompleteType>>
   struct ReceiverIncomplete
   {
-    using receiver_concept = STDEXEC::receiver_tag;
+    using receiver_concept = receiver_tag;
 
     IncompleteType* m_ptr;
 
-    void set_value() && noexcept
+    template <class V>
+    void set_value(V&&) && noexcept
     {
-      STDEXEC::set_value(std::move(m_ptr->rcvr));
-    }
-
-    template <typename Error>
-    void set_error(Error&& error) && noexcept
-    {
-      STDEXEC::set_error(std::move(m_ptr->rcvr), std::forward<Error>(error));
+      using rcvr_t = decltype(m_ptr->rcvr);
+      static_cast<rcvr_t&&>(m_ptr->rcvr).set_value();
     }
 
     [[nodiscard]]
     constexpr auto get_env() const noexcept -> Env
     {
-      return STDEXEC::get_env(*m_ptr);
+      auto&& logger = query(m_ptr->rcvr.get_env());
+      std::printf("ReceiverIncomplete::get_env %p\n", (void const *) &logger);
+      return m_ptr->rcvr.get_env();
     }
   };
 
-  template <STDEXEC::sender Sndr, STDEXEC::receiver Rcvr>
+  template <sender Sndr, receiver Rcvr>
   struct OpStateIncomplete
   {
-    using operation_state_concept = STDEXEC::operation_state_tag;
+    using operation_state_concept = operation_state_tag;
 
-    using rcvr_t          = ReceiverIncomplete<OpStateIncomplete, STDEXEC::env_of_t<Rcvr>>;
-    using inner_opstate_t = STDEXEC::connect_result_t<Sndr, rcvr_t>;
+    using rcvr_t          = ReceiverIncomplete<OpStateIncomplete, env_of_t<Rcvr>>;
+    using inner_opstate_t = connect_result_t<Sndr, rcvr_t>;
 
     Rcvr            rcvr;
     inner_opstate_t inner_opstate;
 
     OpStateIncomplete(Sndr&& sndr, Rcvr rcvr_)
-      : rcvr(std::move(rcvr_))
-      , inner_opstate(STDEXEC::connect(std::forward<Sndr>(sndr), rcvr_t{this}))
+      : rcvr(static_cast<Rcvr&&>(rcvr_))
+      , inner_opstate(connect(static_cast<Sndr&&>(sndr), rcvr_t{this}))
     {}
 
     void start() & noexcept
     {
-      STDEXEC::start(inner_opstate);
-    }
-
-    [[nodiscard]]
-    constexpr auto get_env() const noexcept -> STDEXEC::env_of_t<Rcvr>
-    {
-      return STDEXEC::get_env(rcvr);
+      inner_opstate.start();
     }
   };
 
-  template <STDEXEC::sender Sndr>
+  template <sender Sndr>
   struct SenderIncomplete
   {
-    using sender_concept = STDEXEC::sender_tag;
+    using sender_concept = sender_tag;
 
     template <class Self, class... Env>
-    static consteval auto get_completion_signatures()
+    static consteval auto get_completion_signatures() -> completion_signatures<set_value_t()>
     {
-      return exec::get_child_completion_signatures<Self, Sndr, Env...>();
+      return {};
     }
 
-    template <STDEXEC::receiver Rcvr>
+    template <receiver Rcvr>
     auto connect(Rcvr rcvr) && -> OpStateIncomplete<Sndr, Rcvr>
     {
-      return {std::forward<Sndr>(sndr), std::move(rcvr)};
+      return {static_cast<Sndr&&>(sndr), static_cast<Rcvr&&>(rcvr)};
     }
 
     Sndr sndr;
   };
 
-  struct incomplete_t
+  using result_t = std::optional<int>;
+}  // namespace
+
+int main()
+{
+  //alignas(64)
+  char     state[246]{};
+  result_t result{};
+
+  struct receiver_t
   {
-    constexpr auto operator()() const noexcept
+    using receiver_concept = receiver_tag;
+
+    void set_value() && noexcept
     {
-      return STDEXEC::__closure(*this);
+      result->emplace(0);
     }
 
-    template <typename Sndr>
-    constexpr auto operator()(Sndr&& sndr) const -> SenderIncomplete<Sndr>
-    {
-      return {std::forward<Sndr>(sndr)};
-    }
+    void*     state;
+    result_t* result;
   };
 
-  inline constexpr incomplete_t incomplete{};
+  logger const alloc;
+  auto         op = write_env(SenderIncomplete(read_env(query)), prop{query, alloc})
+              .connect(receiver_t{&state, &result});
 
-  TEST_CASE("write_env with a receiver pointing to an incomplete operation state",
-            "[adaptors][write_env]")
-  {
-    exec::single_thread_context stc{};
+  op.start();
 
-    int value = 0;
-
-    STDEXEC::sender auto sndr =
-      STDEXEC::read_env(STDEXEC::get_allocator)
-      | STDEXEC::then([](auto allocator)
-                      { static_assert(std::same_as<decltype(allocator), std::allocator<int>>); })
-      | STDEXEC::continues_on(stc.get_scheduler()) | incomplete()
-      | STDEXEC::write_env(STDEXEC::prop{STDEXEC::get_allocator, std::allocator<int>{}})
-      | STDEXEC::then([&value]() { ++value; });
-
-    STDEXEC::sync_wait(std::move(sndr));
-
-    CHECK(value == 1);
-  }
-
-}  // namespace
+  return 0;
+}


### PR DESCRIPTION
Repro the crash with
```sh
$ cmake -S . -B build -GNinja \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_CXX_FLAGS="-fsanitize=address" \
  -DCMAKE_CXX_STANDARD:STRING=20 \
  -DCMAKE_CXX_EXTENSIONS:BOOL=OFF \
  -DSTDEXEC_BUILD_TESTS:BOOL=ON \
  -DCMAKE_CXX_COMPILER=$(which clang++)
$ cmake --build build && ./build/test/test.stdexec
```

This is obviously not for merging; I'm just sharing my narrowed-down repro now that it doesn't depend on apple-clang. Maybe it repros on Linux or Windows, too?