### PR TITLE
Give struct __rcvr user-defined ctors in __basic_sender

### DIFF
--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -236,6 +236,16 @@ namespace STDEXEC
     using receiver_concept = receiver_tag;
     using __index_t        = __msize_t<_Idx>;
 
+    STDEXEC_ATTRIBUTE(always_inline)
+    constexpr explicit __rcvr(_State& __state) noexcept
+      : __state_(__state)
+    {}
+
+    STDEXEC_ATTRIBUTE(always_inline)
+    constexpr __rcvr(__rcvr const & __other) noexcept
+      : __state_(__other.__state_)
+    {}
+
     template <class... _Args>
     STDEXEC_ATTRIBUTE(always_inline)
     constexpr void set_value(_Args&&... __args) noexcept

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -236,7 +236,6 @@ namespace STDEXEC
     using receiver_concept = receiver_tag;
     using __index_t        = __msize_t<_Idx>;
 
-
 #if STDEXEC_APPLE_CLANG()
     // These constructors are a work-around for bad codegen with apple-clang
     STDEXEC_ATTRIBUTE(always_inline)

--- a/include/stdexec/__detail/__basic_sender.hpp
+++ b/include/stdexec/__detail/__basic_sender.hpp
@@ -236,6 +236,9 @@ namespace STDEXEC
     using receiver_concept = receiver_tag;
     using __index_t        = __msize_t<_Idx>;
 
+
+#if STDEXEC_APPLE_CLANG()
+    // These constructors are a work-around for bad codegen with apple-clang
     STDEXEC_ATTRIBUTE(always_inline)
     constexpr explicit __rcvr(_State& __state) noexcept
       : __state_(__state)
@@ -245,6 +248,7 @@ namespace STDEXEC
     constexpr __rcvr(__rcvr const & __other) noexcept
       : __state_(__other.__state_)
     {}
+#endif  // STDEXEC_APPLE_CLANG()
 
     template <class... _Args>
     STDEXEC_ATTRIBUTE(always_inline)


### PR DESCRIPTION
This looks like it fixes a miscompilation leading to UB in combinations of `read_env` and `write_env` in Apple Clang.

Moots #2100.