### PR TITLE
Clarify parallel scheduler build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,10 @@ if (NOT STDEXEC_NAMESPACE STREQUAL "stdexec")
   target_compile_definitions(stdexec INTERFACE STDEXEC_NAMESPACE=${STDEXEC_NAMESPACE})
 endif()
 
+if (NOT STDEXEC_BUILD_PARALLEL_SCHEDULER)
+  target_compile_definitions(stdexec INTERFACE STDEXEC_PARALLEL_SCHEDULER_HEADER_ONLY)
+endif()
+
 option(STDEXEC_ENABLE_EXTRA_TYPE_CHECKING "Enable extra type checking that is costly at compile-time" OFF)
 if (STDEXEC_ENABLE_EXTRA_TYPE_CHECKING)
   target_compile_definitions(stdexec INTERFACE STDEXEC_ENABLE_EXTRA_TYPE_CHECKING)
@@ -455,11 +459,14 @@ if(STDEXEC_BUILD_PARALLEL_SCHEDULER)
       $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:__cplusplus /Zc:preprocessor /Zc:externConstexpr>
       )
   target_link_libraries(parallel_scheduler PUBLIC stdexec)
-
-  add_library(STDEXEC::parallel_scheduler ALIAS parallel_scheduler)
-  add_library(system_context ALIAS parallel_scheduler)
-  add_library(STDEXEC::system_context ALIAS parallel_scheduler)
+else()
+  add_library(parallel_scheduler INTERFACE)
+  target_link_libraries(parallel_scheduler INTERFACE stdexec)
 endif()
+
+add_library(STDEXEC::parallel_scheduler ALIAS parallel_scheduler)
+add_library(system_context ALIAS parallel_scheduler)
+add_library(STDEXEC::system_context ALIAS parallel_scheduler)
 
 option(STDEXEC_ENABLE_IO_URING "Enable the use of the io_uring scheduler on Linux" OFF)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -75,11 +75,7 @@ foreach(example ${stdexec_examples})
   def_example(${example})
 endforeach()
 
-if (STDEXEC_BUILD_PARALLEL_SCHEDULER)
-  target_link_libraries(example.sudoku PRIVATE STDEXEC::parallel_scheduler)
-else()
-  target_compile_definitions(example.sudoku PRIVATE STDEXEC_PARALLEL_SCHEDULER_HEADER_ONLY)
-endif()
+target_link_libraries(example.sudoku PRIVATE STDEXEC::parallel_scheduler)
 
 if(STDEXEC_ENABLE_CUDA)
   add_subdirectory(nvexec)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,6 +32,9 @@ function(def_example example)
         $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized> # warnings being emitted from stdlib headers, why?
         $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-line-marker>
     )
+    target_compile_definitions(${target} PRIVATE
+        $<$<PLATFORM_ID:Windows>:NOMINMAX>
+    )
     target_link_libraries(${target}
         PRIVATE STDEXEC::stdexec
                 stdexec_executable_flags

--- a/examples/benchmark/asio_thread_pool.cpp
+++ b/examples/benchmark/asio_thread_pool.cpp
@@ -14,8 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "./common.hpp"
+
+// ASIO requires a specific include order.
 #include <exec/asio/asio_thread_pool.hpp>
+//
+
+#include "./common.hpp"
 #include <exec/start_detached.hpp>
 
 struct RunThread

--- a/examples/benchmark/common.hpp
+++ b/examples/benchmark/common.hpp
@@ -38,6 +38,8 @@ namespace pmr = std::pmr;
 #  define STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE 1
 #endif
 
+#include <stdexec/__detail/__prologue.hpp>
+
 struct statistics
 {
   std::chrono::milliseconds total_time_ms;
@@ -193,3 +195,5 @@ void my_main(int argc, char** argv, exec::numa_policy policy = exec::get_numa_po
     compute_perf(starts, ends, warmup, nRuns - 1, total_scheds);
   std::cout << avg << " | " << max << " | " << min << " | " << stddev << "\n";
 }
+
+#include <stdexec/__detail/__epilogue.hpp>

--- a/examples/nvexec/maxwell/common.cuh
+++ b/examples/nvexec/maxwell/common.cuh
@@ -34,6 +34,9 @@
 #include <string_view>
 #include <vector>
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(is_constant_evaluated_in_nonconstexpr_context)
+
 #if STDEXEC_CUDA_COMPILATION()
 #  define STDEXEC_STDERR
 #  include "nvexec/detail/throw_on_cuda_error.cuh"
@@ -538,3 +541,5 @@ auto value(std::map<std::string_view, std::size_t> const &params,
   }
   return default_value;
 }
+
+STDEXEC_PRAGMA_POP()

--- a/examples/scope.cpp
+++ b/examples/scope.cpp
@@ -100,7 +100,7 @@ auto main() -> int
 
   {
     sender auto nest = scope.nest(begin);
-    auto        op   = connect(std::move(nest), noop_receiver{});
+    auto        op   = stdexec::connect(std::move(nest), noop_receiver{});
     (void) op;
   }
   sync_wait(scope.on_empty());

--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#if __has_include(<dispatch/dispatch.h>)
+#include "../stdexec/__detail/__config.hpp"
+
+#if STDEXEC_ENABLE_LIBDISPATCH
 
 // TODO: This is needed for libdispatch to compile with GCC. Need to look for
 // workaround.
@@ -525,4 +527,4 @@ namespace experimental::execution
 
 namespace exec = experimental::execution;
 
-#endif  // __has_include(<dispatch/dispatch.h>)
+#endif  // STDEXEC_ENABLE_LIBDISPATCH

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -206,10 +206,10 @@ namespace experimental::execution
       struct _is_nothrow_bulk_fn
       {
         template <class... Args>
-          requires __callable<Fun, Shape, Shape, __decay_t<Args>&...>
+          requires __callable<Fun, Shape, Shape, STDEXEC::__decay_t<Args>&...>
         using __f = __mbool<
           // If function invocation doesn't throw ...
-          __nothrow_callable<Fun, Shape, Shape, __decay_t<Args>&...> &&
+          __nothrow_callable<Fun, Shape, Shape, STDEXEC::__decay_t<Args>&...> &&
           // ... and decay-copying the arguments doesn't throw ...
           __nothrow_decay_copyable<Args...>
           // ... then there is no need to advertise completion with `exception_ptr`
@@ -250,14 +250,16 @@ namespace experimental::execution
           if constexpr (__same_as<Tag, bulk_unchunked_t>)
           {
             // Turn a bulk_unchunked into a bulk_chunked operation
-            using fun_t    = STDEXEC::__bulk::__as_bulk_chunked_fn<decltype(fun)>;
-            using sender_t = _bulk_sender<parallelize, decltype(shape), fun_t, __decay_t<CvSender>>;
+            using fun_t = STDEXEC::__bulk::__as_bulk_chunked_fn<decltype(fun)>;
+            using sender_t =
+              _bulk_sender<parallelize, decltype(shape), fun_t, STDEXEC::__decay_t<CvSender>>;
             return sender_t{pool_, static_cast<CvSender&&>(sndr), shape, fun_t(std::move(fun))};
           }
           else
           {
-            using fun_t    = decltype(fun);
-            using sender_t = _bulk_sender<parallelize, decltype(shape), fun_t, __decay_t<CvSender>>;
+            using fun_t = decltype(fun);
+            using sender_t =
+              _bulk_sender<parallelize, decltype(shape), fun_t, STDEXEC::__decay_t<CvSender>>;
             return sender_t{pool_, static_cast<CvSender&&>(sndr), shape, std::move(fun)};
           }
         }
@@ -268,7 +270,8 @@ namespace experimental::execution
       struct _transform_iterate
       {
         template <class Range>
-        auto operator()(exec::iterate_t, Range&& range) -> schedule_all_::sequence<__decay_t<Range>>
+        auto operator()(exec::iterate_t, Range&& range)
+          -> schedule_all_::sequence<STDEXEC::__decay_t<Range>>
         {
           return {static_cast<Range&&>(range), pool_};
         }

--- a/include/stdexec/__detail/__env.hpp
+++ b/include/stdexec/__detail/__env.hpp
@@ -241,8 +241,8 @@ namespace STDEXEC
       noexcept(__nothrow_queryable_with<__1st_env_t<_Query, _Args...>, _Query, _Args...>)
         -> __query_result_t<__1st_env_t<_Query, _Args...>, _Query, _Args...>
     {
-      auto const &__env = __detail::__get_1st_env<_Query, _Args...>()(*this);
-      return __query<_Query>()(__env, static_cast<_Args &&>(__args)...);
+      return __query<_Query>()(__detail::__get_1st_env<_Query, _Args...>()(*this),
+                               static_cast<_Args &&>(__args)...);
     }
   };
 

--- a/include/stdexec/__detail/__parallel_scheduler_replacement_api.hpp
+++ b/include/stdexec/__detail/__parallel_scheduler_replacement_api.hpp
@@ -27,7 +27,6 @@ namespace STDEXEC::parallel_scheduler_replacement
 {
   /// Get the backend for the parallel scheduler.
   /// Users might replace this function.
-  STDEXEC_ATTRIBUTE(weak)
   auto query_parallel_scheduler_backend() -> std::shared_ptr<parallel_scheduler_backend>;
 
   /// The type of a factory that can create `parallel_scheduler_backend` instances.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,7 +96,6 @@ set_target_properties(common_test_settings PROPERTIES
     )
 target_include_directories(common_test_settings INTERFACE "${CMAKE_CURRENT_LIST_DIR}")
 target_compile_definitions(common_test_settings INTERFACE
-    STDEXEC_NAMESPACE=std::execution
     $<$<PLATFORM_ID:Windows>:NOMINMAX>
     )
 target_compile_options(common_test_settings INTERFACE
@@ -114,6 +113,7 @@ add_compile_diagnostics(test.stdexec)
 target_link_libraries(test.stdexec
     PUBLIC
     STDEXEC::stdexec
+    STDEXEC::parallel_scheduler
     stdexec_executable_flags
     Catch2::Catch2WithMain
     PRIVATE

--- a/test/exec/asio/test_asio_thread_pool.cpp
+++ b/test/exec/asio/test_asio_thread_pool.cpp
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 
+// ASIO requires a specific include order.
+#include <exec/asio/asio_thread_pool.hpp>
+//
+
 #include <catch2/catch_all.hpp>
 
 #include <numeric>
@@ -24,8 +28,6 @@
 
 #include <exec/inline_scheduler.hpp>
 #include <test_common/schedulers.hpp>
-
-#include <exec/asio/asio_thread_pool.hpp>
 
 #include <exec/asio/use_sender.hpp>
 

--- a/test/nvexec/common.cuh
+++ b/test/nvexec/common.cuh
@@ -26,6 +26,9 @@
 #include <cstdio>
 #include <cstdlib>
 
+STDEXEC_PRAGMA_PUSH()
+STDEXEC_PRAGMA_IGNORE_EDG(is_constant_evaluated_in_nonconstexpr_context)
+
 namespace
 {
 
@@ -362,3 +365,5 @@ namespace
 
   static_assert(!std::is_trivially_copyable_v<move_only_t>);
 }  // namespace
+
+STDEXEC_PRAGMA_POP()

--- a/test/stdexec/schedulers/test_parallel_scheduler.cpp
+++ b/test/stdexec/schedulers/test_parallel_scheduler.cpp
@@ -16,9 +16,9 @@
 
 #include <thread>
 
-#define STDEXEC_PARALLEL_SCHEDULER_HEADER_ONLY 1
-
 #include <stdexec/execution.hpp>
+
+#include <stdexec/__detail/__parallel_scheduler_default_impl.hpp>
 
 #include <exec/async_scope.hpp>
 #include <exec/inline_scheduler.hpp>


### PR DESCRIPTION
* Configure `STDEXEC_PARALLEL_SCHEDULER_HEADER_ONLY` appropriately based on `STDEXEC_BUILD_PARALLEL_SCHEDULER`.

* If `STDEXEC_BUILD_PARALLEL_SCHEDULER` is off, define the `parallel_scheduler` target as an empty interface target.

  Create the `STDEXEC::parallel_scheduler` alias target unconditionally.

* Build `example.sudoku` regardless of configuration.
* Build tests using the user-defined stdexec namespace.
* Remove local header-only macro override in parallel scheduler test.

* Remove unneeded weak attribute from default parallel scheduler definition.

  The status quo with the weak attribute simply means that in the case of a missing definition, instead of producing an error, the linker ignores the symbol and creates a null reference. This ultimately results in a runtime segmentation fault when the parallel scheduler backend is queried.