### PR TITLE
exec(at_coroutine_exit): inherit start scheduler only when available

### DIFF
--- a/include/exec/at_coroutine_exit.hpp
+++ b/include/exec/at_coroutine_exit.hpp
@@ -157,8 +157,11 @@ namespace experimental::execution
       template <__has_continuation _Promise>
       auto await_suspend(__std::coroutine_handle<_Promise> __parent) -> bool
       {
-        // Set the cleanup task's scheduler to the parent coroutine's scheduler.
-        __coro_.promise().__scheduler_ = get_start_scheduler(get_env(__parent.promise()));
+        // Set the cleanup task's scheduler to the parent coroutine's scheduler, if present
+        if constexpr (requires { get_start_scheduler(get_env(__parent.promise())); })
+        {
+          __coro_.promise().__scheduler_ = get_start_scheduler(get_env(__parent.promise()));
+        }
         // This causes the parent to be resumed after the cleanup action is performed.
         __coro_.promise().set_continuation(__parent.promise().continuation());
         // This causes the parent to invoke the cleanup action when it performs the final


### PR DESCRIPTION
The cleanup task's `await_suspend` unconditionally reads `get_start_scheduler` from the parent promise's env, which made `at_coroutine_exit` impossible to use with tasks whose context doesn't model affinity (e.g. `basic_task<T, inline_task_context<T>>`): the call failed to compile.

Gate the read on a requires-expression. When the parent's env doesn't expose `get_start_scheduler`, the cleanup task's `__scheduler_` keeps its default value (`inline_scheduler{}`), which is what callers of an inline task would expect anyway. Affinity-bearing tasks (`default_task_context`) continue to inherit the parent's scheduler as before.

-----

I understand this may not be desirable due to risk of stop requester running a complex operation but opening to start a discussion. We run a single main event loop on an embedded device so have no need for the scheduler affinity mechanism.