### PR TITLE
Implement p4223 attrs

### DIFF
--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -17,6 +17,7 @@
 
 #include "../stdexec/__detail/__completion_signatures.hpp"
 #include "../stdexec/__detail/__concepts.hpp"
+#include "../stdexec/__detail/__domain.hpp"
 #include "../stdexec/__detail/__meta.hpp"
 #include "../stdexec/__detail/__read_env.hpp"
 #include "../stdexec/__detail/__receivers.hpp"
@@ -55,6 +56,11 @@
 // queries to pick the frame allocator from the environment without relying on TLS.
 namespace experimental::execution
 {
+  // for specifying required sender attributes in exec::function
+  template <_query::_query_signature... Sigs>
+  struct attrs
+  {};
+
   namespace __func
   {
     using namespace STDEXEC;
@@ -192,7 +198,7 @@ namespace experimental::execution
       }
     };
 
-    template <class _Sigs, class _Queries, class... _Args>
+    template <class _Sigs, class _Queries, class _Attrs, class... _Args>
     class __function;
 
     //! the main implementation of the type-erasing sender function<...>
@@ -206,8 +212,8 @@ namespace experimental::execution
     //! not, as appropriate
     //!
     //! \tparam _Args The argument types used to construct the erased sender
-    template <class _Sigs, class... _Queries, class... _Args>
-    class __function<_Sigs, queries<_Queries...>, _Args...>
+    template <class _Sigs, class... _Queries, class... _Attrs, class... _Args>
+    class __function<_Sigs, queries<_Queries...>, attrs<_Attrs...>, _Args...>
     {
       using __receiver_t = __receiver_wrapper<__any_receiver_ref<_Sigs, queries<_Queries...>>>;
 
@@ -342,6 +348,23 @@ namespace experimental::execution
       completion_signatures<__single_value_sig_t<_Return>, set_stopped_t()>,
       __eptr_completion_unless_t<__mbool<_NoExcept>>>>;
 
+    //! computes the set of get_completion_domain queries that must be supported by any
+    //! sender that might be erased by the corresponding function
+    //!
+    //! we should support get_completion_domain<Tag> only if _Sigs contains a completion
+    //! of type Tag
+    //!
+    //! the query form should be
+    //!
+    //!   default_domain(get_completion_domain_t<Tag>, Env)
+    //!
+    //! where Env is the environment type we'll be synthesizing from _Queries
+    template <class _Sigs, class _Queries>
+    using __default_attrs =
+      __canonical_t<attrs<default_domain(get_completion_domain_t<set_value_t>),
+                          default_domain(get_completion_domain_t<set_error_t>),
+                          default_domain(get_completion_domain_t<set_stopped_t>)>>;
+
     //! Map a variety of function<...> specifications into the canonical type-erased
     //! contract represented by the user-provided specification.
     //!
@@ -362,48 +385,74 @@ namespace experimental::execution
     //! The order of Args... is obviously important, but Sigs... and Queries... are both
     //! canonicalized into a sorted and uniqued list to ensure order is irrelevant.
     template <class...>
-    struct __make_function;
+    class __make_function;
 
     template <class _Return, class... _Args>
-    struct __make_function<_Return(_Args...)>
+    class __make_function<_Return(_Args...)>
     {
-      using type = __function<__sigs_from_t<_Return, false>, queries<>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, false>;
+      using __queries = queries<>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class _Return, class... _Args>
-    struct __make_function<_Return(_Args...) noexcept>
+    class __make_function<_Return(_Args...) noexcept>
     {
-      using type = __function<__sigs_from_t<_Return, true>, queries<>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, true>;
+      using __queries = queries<>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class... _Args, class... _Sigs>
-    struct __make_function<sender_tag(_Args...), completion_signatures<_Sigs...>>
+    class __make_function<sender_tag(_Args...), completion_signatures<_Sigs...>>
     {
-      using type = __function<__canonical_t<completion_signatures<_Sigs...>>, queries<>, _Args...>;
+      using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
+      using __queries = queries<>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class _Return, class... _Args, class... _Queries>
-    struct __make_function<_Return(_Args...), queries<_Queries...>>
+    class __make_function<_Return(_Args...), queries<_Queries...>>
     {
-      using type =
-        __function<__sigs_from_t<_Return, false>, __canonical_t<queries<_Queries...>>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, false>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class _Return, class... _Args, class... _Queries>
-    struct __make_function<_Return(_Args...) noexcept, queries<_Queries...>>
+    class __make_function<_Return(_Args...) noexcept, queries<_Queries...>>
     {
-      using type =
-        __function<__sigs_from_t<_Return, true>, __canonical_t<queries<_Queries...>>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, true>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class... _Args, class... _Sigs, class... _Queries>
-    struct __make_function<sender_tag(_Args...),
-                           completion_signatures<_Sigs...>,
-                           queries<_Queries...>>
+    class __make_function<sender_tag(_Args...),
+                          completion_signatures<_Sigs...>,
+                          queries<_Queries...>>
     {
-      using type = __function<__canonical_t<completion_signatures<_Sigs...>>,
-                              __canonical_t<queries<_Queries...>>,
-                              _Args...>;
+      using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
   }  // namespace __func
 

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -198,6 +198,41 @@ namespace experimental::execution
       }
     };
 
+    template <class _Tag, class _Query>
+    struct __make_domain
+    {};
+
+    template <class _Domain, class _Tag>
+    struct __make_domain<_Tag, _Domain(get_completion_domain_t<_Tag>)>
+    {
+      constexpr _Domain operator()() const noexcept
+      {
+        return _Domain();
+      }
+    };
+
+    template <class _Tag, class... _Attrs>
+    inline constexpr auto __get_completion_domain =
+      __first_callable<__make_domain<_Tag, _Attrs>...>();
+
+    template <class... _Attrs>
+    struct __attrs
+    {
+      template <class... _Env>
+      constexpr auto query(get_completion_domain_t<>, _Env &&...) const noexcept
+        -> decltype(__get_completion_domain<set_value_t, _Attrs...>)
+      {
+        return __get_completion_domain<set_value_t, _Attrs...>();
+      }
+
+      template <class _Tag, class... _Env>
+      constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
+        -> decltype(__get_completion_domain<_Tag, _Attrs...>)
+      {
+        return __get_completion_domain<_Tag, _Attrs...>();
+      }
+    };
+
     template <class _Sigs, class _Queries, class _Attrs, class... _Args>
     class __function;
 
@@ -226,8 +261,9 @@ namespace experimental::execution
         -> _any::_any_opstate_base
       {
         auto &__make_sender = *__std::start_lifetime_as<_Factory>(__storage);
-        using __alloc_t     = decltype(__choose_frame_allocator(get_env(__rcvr)));
-        auto __alloc = __frame_allocator_t<__alloc_t>(__choose_frame_allocator(get_env(__rcvr)));
+        using __alloc_t     = decltype(__choose_frame_allocator(STDEXEC::get_env(__rcvr)));
+        auto __alloc        = __frame_allocator_t<__alloc_t>(
+          __choose_frame_allocator(STDEXEC::get_env(__rcvr)));
         return _any::_any_opstate_base(__in_place_from,
                                        std::allocator_arg,
                                        __alloc,
@@ -283,6 +319,11 @@ namespace experimental::execution
           return __throw_compile_time_error(__check_queries_t());
         else
           return _Sigs();
+      }
+
+      constexpr __attrs<_Attrs...> get_env() const noexcept
+      {
+        return {};
       }
 
       template <class _Receiver>

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -211,6 +211,13 @@ namespace experimental::execution
       }
     };
 
+    //! get_completion_domain<> is a special case; its type parameter is void
+    //! and it's equivalent to get_completion_domain<set_value_t>.
+    template <class _Domain>
+    struct __make_domain<void, _Domain(get_completion_domain_t<set_value_t>)>
+      : __make_domain<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
+    {};
+
     template <class _Tag, class... _Attrs>
     inline constexpr auto __get_completion_domain =
       __first_callable<__make_domain<_Tag, _Attrs>...>();
@@ -218,16 +225,9 @@ namespace experimental::execution
     template <class... _Attrs>
     struct __attrs
     {
-      template <class... _Env>
-      constexpr auto query(get_completion_domain_t<>, _Env &&...) const noexcept
-        -> decltype(__get_completion_domain<set_value_t, _Attrs...>)
-      {
-        return __get_completion_domain<set_value_t, _Attrs...>();
-      }
-
       template <class _Tag, class... _Env>
       constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
-        -> decltype(__get_completion_domain<_Tag, _Attrs...>)
+        -> decltype(__get_completion_domain<_Tag, _Attrs...>())
       {
         return __get_completion_domain<_Tag, _Attrs...>();
       }

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -199,11 +199,11 @@ namespace experimental::execution
     };
 
     template <class _Tag, class _Query>
-    struct __make_domain
+    struct __make_domain_impl
     {};
 
     template <class _Domain, class _Tag>
-    struct __make_domain<_Tag, _Domain(get_completion_domain_t<_Tag>)>
+    struct __make_domain_impl<_Tag, _Domain(get_completion_domain_t<_Tag>)>
     {
       constexpr _Domain operator()() const noexcept
       {
@@ -214,22 +214,21 @@ namespace experimental::execution
     //! get_completion_domain<> is a special case; its type parameter is void
     //! and it's equivalent to get_completion_domain<set_value_t>.
     template <class _Domain>
-    struct __make_domain<void, _Domain(get_completion_domain_t<set_value_t>)>
-      : __make_domain<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
+    struct __make_domain_impl<void, _Domain(get_completion_domain_t<set_value_t>)>
+      : __make_domain_impl<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
     {};
 
     template <class _Tag, class... _Attrs>
-    inline constexpr auto __get_completion_domain =
-      __first_callable<__make_domain<_Tag, _Attrs>...>();
+    inline constexpr auto __make_domain = __first_callable<__make_domain_impl<_Tag, _Attrs>...>();
 
     template <class... _Attrs>
     struct __attrs
     {
       template <class _Tag, class... _Env>
       constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
-        -> decltype(__get_completion_domain<_Tag, _Attrs...>())
+        -> decltype(__make_domain<_Tag, _Attrs...>())
       {
-        return __get_completion_domain<_Tag, _Attrs...>();
+        return __make_domain<_Tag, _Attrs...>();
       }
     };
 

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -232,6 +232,28 @@ namespace experimental::execution
       }
     };
 
+    template <class _Tag, class _Attrs, class... _Env>
+    using __completion_domain_t = __call_result_or_t<
+      get_completion_domain_t<_Tag>,
+      __call_result_or_t<get_completion_domain_t<_Tag>, indeterminate_domain<>, _Attrs>,
+      _Attrs,
+      _Env const &...>;
+
+    template <class _Tag, class _ActualAttrs, class _ExpectedAttrs, class... _Env>
+    concept __completion_domain_matches =
+      __same_as<__completion_domain_t<_Tag, _ActualAttrs, _Env...>,
+                __completion_domain_t<_Tag, _ExpectedAttrs, _Env...>>;
+
+    template <class _ActualAttrs, class _ExpectedAttrs, class... _Env>
+    concept __completion_domains_match_impl =
+      __completion_domain_matches<set_value_t, _ActualAttrs, _ExpectedAttrs, _Env...>
+      && __completion_domain_matches<set_error_t, _ActualAttrs, _ExpectedAttrs, _Env...>
+      && __completion_domain_matches<set_stopped_t, _ActualAttrs, _ExpectedAttrs, _Env...>;
+
+    template <class _Actual, class _Expected, class... _Env>
+    concept __completion_domains_match =
+      __completion_domains_match_impl<env_of_t<_Actual>, env_of_t<_Expected>, _Env...>;
+
     template <class _Sigs, class _Queries, class _Attrs, class... _Args>
     class __function;
 
@@ -298,6 +320,9 @@ namespace experimental::execution
                 && (STDEXEC_IS_TRIVIALLY_COPYABLE(_Factory))     //
                 && (sizeof(_Factory) <= sizeof(__make_sender_))  //
                 && sender_to<__invoke_result_t<_Factory, _Args...>, __receiver_t>
+                && __completion_domains_match<__invoke_result_t<_Factory, _Args...>,
+                                              __function,
+                                              env_of_t<receiver_t>>
       constexpr explicit __function(_Args &&...__args, _Factory __factory)
         noexcept(__nothrow_move_constructible<_Args...>)
         : __args_(static_cast<_Args &&>(__args)...)

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -246,10 +246,14 @@ namespace experimental::execution
       _Attrs,
       _Env const &...>;
 
+    template <class _ActualDomain, class _ExpectedDomain>
+    concept __completion_domain_matches_impl =
+      __same_as<_ExpectedDomain, __common_domain_t<_ActualDomain, _ExpectedDomain>>;
+
     template <class _Tag, class _ActualAttrs, class _ExpectedAttrs, class... _Env>
     concept __completion_domain_matches =
-      __same_as<__completion_domain_t<_Tag, _ActualAttrs, _Env...>,
-                __completion_domain_t<_Tag, _ExpectedAttrs, _Env...>>;
+      __completion_domain_matches_impl<__completion_domain_t<_Tag, _ActualAttrs, _Env...>,
+                                       __completion_domain_t<_Tag, _ExpectedAttrs, _Env...>>;
 
     template <class _ActualAttrs, class _ExpectedAttrs, class... _Env>
     concept __completion_domains_match_impl =

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -112,13 +112,13 @@ namespace experimental::execution
       {}
 
       constexpr auto get_env() const noexcept  //
-        -> __join_env_t<__prop_t, env_of_t<_Receiver>>
+        -> __join_env_t<__prop_t const &, env_of_t<_Receiver>>
       {
         return __env::__join(*__env_, STDEXEC::get_env(*static_cast<_Receiver const *>(this)));
       }
 
      private:
-      __prop_t *__env_;
+      __prop_t const *__env_;
     };
 
     template <class _Sigs, class _Queries>
@@ -203,7 +203,7 @@ namespace experimental::execution
     {};
 
     template <class _Domain, class _Tag>
-    struct __make_domain_impl<_Tag, _Domain(get_completion_domain_t<_Tag>)>
+    struct __make_domain_impl<_Tag, _Domain(get_completion_domain_t<_Tag>) noexcept>
     {
       constexpr _Domain operator()() const noexcept
       {
@@ -214,8 +214,15 @@ namespace experimental::execution
     //! get_completion_domain<> is a special case; its type parameter is void
     //! and it's equivalent to get_completion_domain<set_value_t>.
     template <class _Domain>
-    struct __make_domain_impl<void, _Domain(get_completion_domain_t<set_value_t>)>
-      : __make_domain_impl<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
+    struct __make_domain_impl<void, _Domain(get_completion_domain_t<set_value_t>) noexcept>
+      : __make_domain_impl<set_value_t, _Domain(get_completion_domain_t<set_value_t>) noexcept>
+    {};
+
+    //! get_completion_domain ought to be no-throw, so make it optional to specify
+    //! noexcept on the signature provided with attrs<...>
+    template <class _Domain, class _Tag1, class _Tag2>
+    struct __make_domain_impl<_Tag1, _Domain(get_completion_domain_t<_Tag2>)>
+      : __make_domain_impl<_Tag1, _Domain(get_completion_domain_t<_Tag2>) noexcept>
     {};
 
     template <class _Tag, class... _Attrs>
@@ -322,7 +329,7 @@ namespace experimental::execution
                 && sender_to<__invoke_result_t<_Factory, _Args...>, __receiver_t>
                 && __completion_domains_match<__invoke_result_t<_Factory, _Args...>,
                                               __function,
-                                              env_of_t<receiver_t>>
+                                              env_of_t<__receiver_t>>
       constexpr explicit __function(_Args &&...__args, _Factory __factory)
         noexcept(__nothrow_move_constructible<_Args...>)
         : __args_(static_cast<_Args &&>(__args)...)
@@ -418,7 +425,7 @@ namespace experimental::execution
     {
       template <class _Tag, class... _Args>
       consteval auto operator()(_Tag (*)(_Args...)) const noexcept  //
-        -> default_domain (*)(get_completion_domain_t<_Tag>)
+        -> default_domain (*)(get_completion_domain_t<_Tag>) noexcept
       {
         return nullptr;
       }
@@ -429,12 +436,12 @@ namespace experimental::execution
     class __attrs_from_domain_queries
     {
       template <class _Tag>
-      using __query_sig = default_domain (*)(get_completion_domain_t<_Tag>);
+      using __query_sig = default_domain (*)(get_completion_domain_t<_Tag>) noexcept;
 
      public:
       template <class... _Tag>
       consteval auto operator()(__query_sig<_Tag>...) const noexcept  //
-        -> __canonical_t<attrs<default_domain(get_completion_domain_t<_Tag>)...>>
+        -> __canonical_t<attrs<default_domain(get_completion_domain_t<_Tag>) noexcept...>>
       {
         return {};
       }
@@ -538,6 +545,20 @@ namespace experimental::execution
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
       using __queries = __canonical_t<queries<_Queries...>>;
       using __attrs   = __default_attrs<__sigs>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
+    };
+
+    template <class... _Args, class... _Sigs, class... _Queries, class... _Attrs>
+    class __make_function<sender_tag(_Args...),
+                          completion_signatures<_Sigs...>,
+                          queries<_Queries...>,
+                          attrs<_Attrs...>>
+    {
+      using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __canonical_t<attrs<_Attrs...>>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -348,6 +348,33 @@ namespace experimental::execution
       completion_signatures<__single_value_sig_t<_Return>, set_stopped_t()>,
       __eptr_completion_unless_t<__mbool<_NoExcept>>>>;
 
+    //! maps a completion signature to the default completion domain query
+    struct __domain_query_from_sig
+    {
+      template <class _Tag, class... _Args>
+      consteval auto operator()(_Tag (*)(_Args...)) const noexcept  //
+        -> default_domain (*)(get_completion_domain_t<_Tag>)
+      {
+        return nullptr;
+      }
+    };
+
+    //! maps a pack of domain queries produced by __domain_query_from_sig to the
+    //! corresponding attrs<_Attrs...> type
+    class __attrs_from_domain_queries
+    {
+      template <class _Tag>
+      using __query_sig = default_domain (*)(get_completion_domain_t<_Tag>);
+
+     public:
+      template <class... _Tag>
+      consteval auto operator()(__query_sig<_Tag>...) const noexcept  //
+        -> __canonical_t<attrs<default_domain(get_completion_domain_t<_Tag>)...>>
+      {
+        return {};
+      }
+    };
+
     //! computes the set of get_completion_domain queries that must be supported by any
     //! sender that might be erased by the corresponding function
     //!
@@ -356,14 +383,10 @@ namespace experimental::execution
     //!
     //! the query form should be
     //!
-    //!   default_domain(get_completion_domain_t<Tag>, Env)
-    //!
-    //! where Env is the environment type we'll be synthesizing from _Queries
-    template <class _Sigs, class _Queries>
-    using __default_attrs =
-      __canonical_t<attrs<default_domain(get_completion_domain_t<set_value_t>),
-                          default_domain(get_completion_domain_t<set_error_t>),
-                          default_domain(get_completion_domain_t<set_stopped_t>)>>;
+    //!   default_domain(get_completion_domain_t<Tag>)
+    template <class _Sigs>
+    using __default_attrs = decltype(_Sigs::__transform_reduce(__domain_query_from_sig(),
+                                                               __attrs_from_domain_queries()));
 
     //! Map a variety of function<...> specifications into the canonical type-erased
     //! contract represented by the user-provided specification.
@@ -392,7 +415,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, false>;
       using __queries = queries<>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -403,7 +426,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, true>;
       using __queries = queries<>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -414,7 +437,7 @@ namespace experimental::execution
     {
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
       using __queries = queries<>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -425,7 +448,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, false>;
       using __queries = __canonical_t<queries<_Queries...>>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -436,7 +459,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, true>;
       using __queries = __canonical_t<queries<_Queries...>>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -449,7 +472,7 @@ namespace experimental::execution
     {
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
       using __queries = __canonical_t<queries<_Queries...>>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -489,4 +489,33 @@ namespace
       STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
     }
   }
+
+  struct domain : ex::default_domain
+  {};
+
+  TEST_CASE("function's constructor is constrained based on the common domain", "[types][function]")
+  {
+    using queries = exec::queries<domain(ex::get_domain_t) noexcept>;
+
+    SECTION("the constraint applies to set_value")
+    {
+      using function =
+        exec::function<ex::sender_tag(),
+                       ex::completion_signatures<ex::set_value_t()>,
+                       queries,
+                       exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>) noexcept>>;
+
+      STATIC_REQUIRE(std::constructible_from<function, ex::just_t>);
+
+      function fn(ex::just);
+      auto     attrs        = ex::get_env(fn);
+      auto     value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+  }
 }  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -411,4 +411,82 @@ namespace
       STATIC_REQUIRE(std::assignable_from<func2_t &, func2_t const &>);
     }
   }
+
+  struct none_such
+  {};
+
+  template <class Completion>
+  inline constexpr auto get_completion_domain =
+    ex::__first_callable{ex::get_completion_domain<Completion>, ex::__always{none_such()}};
+
+  TEST_CASE("function reports a default completion domain by default", "[types][function]")
+  {
+    SECTION("throwing function reports a completion domain for all three channels")
+    {
+      exec::function<void()> fn(ex::just);
+      auto                   attrs        = ex::get_env(fn);
+      auto                   value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto                   error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto                   stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
+    }
+
+    SECTION("no-throw function reports a completion domain for value and stop channels only")
+    {
+      exec::function<void() noexcept> fn(ex::just);
+      auto                            attrs        = ex::get_env(fn);
+      auto                            value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto                            error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto                            stop_domain = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
+    }
+
+    SECTION("infallible function reports a completion domain for value channel only")
+    {
+      exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_value_t()>> fn(ex::just);
+      auto attrs        = ex::get_env(fn);
+      auto value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("just_error function reports a completion domain for error channel only")
+    {
+      exec::function<ex::sender_tag(int), ex::completion_signatures<ex::set_error_t(int)>> fn(
+        42,
+        ex::just_error);
+      auto attrs        = ex::get_env(fn);
+      auto value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("just_stopped function reports a completion domain for stop channel only")
+    {
+      exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_stopped_t()>> fn(
+        ex::just_stopped);
+      auto attrs        = ex::get_env(fn);
+      auto value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
+    }
+  }
 }  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -500,10 +500,7 @@ namespace
     SECTION("the constraint applies to set_value")
     {
       using function =
-        exec::function<ex::sender_tag(),
-                       ex::completion_signatures<ex::set_value_t()>,
-                       queries,
-                       exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>) noexcept>>;
+        exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_value_t()>, queries>;
 
       STATIC_REQUIRE(std::constructible_from<function, ex::just_t>);
 
@@ -513,9 +510,46 @@ namespace
       auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
       auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
 
-      STATIC_REQUIRE(std::same_as<domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
       STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
       STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("the constraint applies to set_error")
+    {
+      using function = exec::function<ex::sender_tag(int),
+                                      ex::completion_signatures<ex::set_error_t(int)>,
+                                      queries>;
+
+      STATIC_REQUIRE(std::constructible_from<function, int, ex::just_error_t>);
+
+      function fn(42, ex::just_error);
+      auto     attrs        = ex::get_env(fn);
+      auto     value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("the constraint applies to set_stopped")
+    {
+      using function =
+        exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_stopped_t()>, queries>;
+
+      STATIC_REQUIRE(std::constructible_from<function, ex::just_stopped_t>);
+
+      function fn(ex::just_stopped);
+      auto     attrs        = ex::get_env(fn);
+      auto     value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
     }
   }
 }  // namespace


### PR DESCRIPTION
[P4223R0](https://wg21.link/p4223r0) calls for `function` to support a type parameter of the form `attrs<…>` that specifies the required attributes of the type-erased sender. This PR started out as an attempt to implement this missing feature in `exec::function`, but, along the way, I discovered that's not as trivial as I expected when I added the requirement to the paper. Unlike `exec::any_sender_of`, `function` doesn't know the type of the sender it's erasing except in its constructor and, at that point, it knows _only_ the type—it doesn't have the sender as a value until `connect` gets called—so we can't check that the erased sender's attributes meet the specified requirements.

The simplest resolution to this conflict is obviously to just not support sender attributes in `function` but, after consulting with @ericniebler on the subject, he pointed out that `get_completion_domain` is a function of a sender's attributes, and it's a critical part of the algorithm customization logic. So, this PR is an implementation of the compromise: you can specify the required completion domains of the erased sender because we need only the sender's type to validate the constraint is met, and we can do that in the `function` constructor.

New in this PR:
 * `template <class...> exec::attrs`, which is like `template <class...> exec::queries` but for sender attribute queries instead of receiver environment queries;
 * some more specializations of `exec::__make_function` to support specifying the completion domain requirements of the erased sender;
 * new constraints on `function`'s constructor to validate that the erased sender meets the aforementioned new domain requirements; and
 * some tests to validate that everything works as intended.

The new requirement is that `__common_domain_t<ExpectedDomain, ActualDomain>` is the same as `ExpectedDomain` (i.e. the completion domain of the erased sender must be, or inherit from, the completion domain specified in the `function`'s type).

TODO:
- [ ] negative tests to confirm the constructor constraints prevent invalid constructions
- [ ] more specializations of `__make_function` so you can specify required sender attributes without having to fully specify all of the type parameters
- [ ] tests for the above
- [ ] probably more documentation
- [ ] maybe confirmation that the only required sender attributes are `get_completion_domain`
- [ ] an R1 of P4223 that updates the spec to reflect this new implementation experience