### PR TITLE
Implement p4223 attrs

### DIFF
--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -17,6 +17,7 @@
 
 #include "../stdexec/__detail/__completion_signatures.hpp"
 #include "../stdexec/__detail/__concepts.hpp"
+#include "../stdexec/__detail/__domain.hpp"
 #include "../stdexec/__detail/__meta.hpp"
 #include "../stdexec/__detail/__read_env.hpp"
 #include "../stdexec/__detail/__receivers.hpp"
@@ -55,6 +56,11 @@
 // queries to pick the frame allocator from the environment without relying on TLS.
 namespace experimental::execution
 {
+  // for specifying required sender attributes in exec::function
+  template <_query::_query_signature... Sigs>
+  struct attrs
+  {};
+
   namespace __func
   {
     using namespace STDEXEC;
@@ -192,7 +198,7 @@ namespace experimental::execution
       }
     };
 
-    template <class _Sigs, class _Queries, class... _Args>
+    template <class _Sigs, class _Queries, class _Attrs, class... _Args>
     class __function;
 
     //! the main implementation of the type-erasing sender function<...>
@@ -206,8 +212,8 @@ namespace experimental::execution
     //! not, as appropriate
     //!
     //! \tparam _Args The argument types used to construct the erased sender
-    template <class _Sigs, class... _Queries, class... _Args>
-    class __function<_Sigs, queries<_Queries...>, _Args...>
+    template <class _Sigs, class... _Queries, class... _Attrs, class... _Args>
+    class __function<_Sigs, queries<_Queries...>, attrs<_Attrs...>, _Args...>
     {
       using __receiver_t = __receiver_wrapper<__any_receiver_ref<_Sigs, queries<_Queries...>>>;
 
@@ -342,6 +348,23 @@ namespace experimental::execution
       completion_signatures<__single_value_sig_t<_Return>, set_stopped_t()>,
       __eptr_completion_unless_t<__mbool<_NoExcept>>>>;
 
+    //! computes the set of get_completion_domain queries that must be supported by any
+    //! sender that might be erased by the corresponding function
+    //!
+    //! we should support get_completion_domain<Tag> only if _Sigs contains a completion
+    //! of type Tag
+    //!
+    //! the query form should be
+    //!
+    //!   default_domain(get_completion_domain_t<Tag>, Env)
+    //!
+    //! where Env is the environment type we'll be synthesizing from _Queries
+    template <class _Sigs, class _Queries>
+    using __default_attrs =
+      __canonical_t<attrs<default_domain(get_completion_domain_t<set_value_t>),
+                          default_domain(get_completion_domain_t<set_error_t>),
+                          default_domain(get_completion_domain_t<set_stopped_t>)>>;
+
     //! Map a variety of function<...> specifications into the canonical type-erased
     //! contract represented by the user-provided specification.
     //!
@@ -362,48 +385,74 @@ namespace experimental::execution
     //! The order of Args... is obviously important, but Sigs... and Queries... are both
     //! canonicalized into a sorted and uniqued list to ensure order is irrelevant.
     template <class...>
-    struct __make_function;
+    class __make_function;
 
     template <class _Return, class... _Args>
-    struct __make_function<_Return(_Args...)>
+    class __make_function<_Return(_Args...)>
     {
-      using type = __function<__sigs_from_t<_Return, false>, queries<>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, false>;
+      using __queries = queries<>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class _Return, class... _Args>
-    struct __make_function<_Return(_Args...) noexcept>
+    class __make_function<_Return(_Args...) noexcept>
     {
-      using type = __function<__sigs_from_t<_Return, true>, queries<>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, true>;
+      using __queries = queries<>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class... _Args, class... _Sigs>
-    struct __make_function<sender_tag(_Args...), completion_signatures<_Sigs...>>
+    class __make_function<sender_tag(_Args...), completion_signatures<_Sigs...>>
     {
-      using type = __function<__canonical_t<completion_signatures<_Sigs...>>, queries<>, _Args...>;
+      using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
+      using __queries = queries<>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class _Return, class... _Args, class... _Queries>
-    struct __make_function<_Return(_Args...), queries<_Queries...>>
+    class __make_function<_Return(_Args...), queries<_Queries...>>
     {
-      using type =
-        __function<__sigs_from_t<_Return, false>, __canonical_t<queries<_Queries...>>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, false>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class _Return, class... _Args, class... _Queries>
-    struct __make_function<_Return(_Args...) noexcept, queries<_Queries...>>
+    class __make_function<_Return(_Args...) noexcept, queries<_Queries...>>
     {
-      using type =
-        __function<__sigs_from_t<_Return, true>, __canonical_t<queries<_Queries...>>, _Args...>;
+      using __sigs    = __sigs_from_t<_Return, true>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
 
     template <class... _Args, class... _Sigs, class... _Queries>
-    struct __make_function<sender_tag(_Args...),
-                           completion_signatures<_Sigs...>,
-                           queries<_Queries...>>
+    class __make_function<sender_tag(_Args...),
+                          completion_signatures<_Sigs...>,
+                          queries<_Queries...>>
     {
-      using type = __function<__canonical_t<completion_signatures<_Sigs...>>,
-                              __canonical_t<queries<_Queries...>>,
-                              _Args...>;
+      using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __default_attrs<__sigs, __queries>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
     };
   }  // namespace __func
 

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -198,6 +198,41 @@ namespace experimental::execution
       }
     };
 
+    template <class _Tag, class _Query>
+    struct __make_domain
+    {};
+
+    template <class _Domain, class _Tag>
+    struct __make_domain<_Tag, _Domain(get_completion_domain_t<_Tag>)>
+    {
+      constexpr _Domain operator()() const noexcept
+      {
+        return _Domain();
+      }
+    };
+
+    template <class _Tag, class... _Attrs>
+    inline constexpr auto __get_completion_domain =
+      __first_callable<__make_domain<_Tag, _Attrs>...>();
+
+    template <class... _Attrs>
+    struct __attrs
+    {
+      template <class... _Env>
+      constexpr auto query(get_completion_domain_t<>, _Env &&...) const noexcept
+        -> decltype(__get_completion_domain<set_value_t, _Attrs...>)
+      {
+        return __get_completion_domain<set_value_t, _Attrs...>();
+      }
+
+      template <class _Tag, class... _Env>
+      constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
+        -> decltype(__get_completion_domain<_Tag, _Attrs...>)
+      {
+        return __get_completion_domain<_Tag, _Attrs...>();
+      }
+    };
+
     template <class _Sigs, class _Queries, class _Attrs, class... _Args>
     class __function;
 
@@ -226,8 +261,9 @@ namespace experimental::execution
         -> _any::_any_opstate_base
       {
         auto &__make_sender = *__std::start_lifetime_as<_Factory>(__storage);
-        using __alloc_t     = decltype(__choose_frame_allocator(get_env(__rcvr)));
-        auto __alloc = __frame_allocator_t<__alloc_t>(__choose_frame_allocator(get_env(__rcvr)));
+        using __alloc_t     = decltype(__choose_frame_allocator(STDEXEC::get_env(__rcvr)));
+        auto __alloc        = __frame_allocator_t<__alloc_t>(
+          __choose_frame_allocator(STDEXEC::get_env(__rcvr)));
         return _any::_any_opstate_base(__in_place_from,
                                        std::allocator_arg,
                                        __alloc,
@@ -283,6 +319,11 @@ namespace experimental::execution
           return __throw_compile_time_error(__check_queries_t());
         else
           return _Sigs();
+      }
+
+      constexpr __attrs<_Attrs...> get_env() const noexcept
+      {
+        return {};
       }
 
       template <class _Receiver>

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -211,6 +211,13 @@ namespace experimental::execution
       }
     };
 
+    //! get_completion_domain<> is a special case; its type parameter is void
+    //! and it's equivalent to get_completion_domain<set_value_t>.
+    template <class _Domain>
+    struct __make_domain<void, _Domain(get_completion_domain_t<set_value_t>)>
+      : __make_domain<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
+    {};
+
     template <class _Tag, class... _Attrs>
     inline constexpr auto __get_completion_domain =
       __first_callable<__make_domain<_Tag, _Attrs>...>();
@@ -218,16 +225,9 @@ namespace experimental::execution
     template <class... _Attrs>
     struct __attrs
     {
-      template <class... _Env>
-      constexpr auto query(get_completion_domain_t<>, _Env &&...) const noexcept
-        -> decltype(__get_completion_domain<set_value_t, _Attrs...>)
-      {
-        return __get_completion_domain<set_value_t, _Attrs...>();
-      }
-
       template <class _Tag, class... _Env>
       constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
-        -> decltype(__get_completion_domain<_Tag, _Attrs...>)
+        -> decltype(__get_completion_domain<_Tag, _Attrs...>())
       {
         return __get_completion_domain<_Tag, _Attrs...>();
       }

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -472,7 +472,8 @@ namespace experimental::execution
     //!   function<
     //!       sender_tag(Args...),
     //!       completion_signatures<Sigs...>,
-    //!       queries<Queries...>>
+    //!       queries<Queries...>,
+    //!       attrs<Attrs...>>
     //!
     //! where:
     //!  - Args... is the type-erased sender factory's parameter list
@@ -480,9 +481,11 @@ namespace experimental::execution
     //!            to advertise
     //!  - Queries... is the set of queries that the eventual receiver's environment must
     //!               support
+    //!  - Attrs... is the set of attributes the type-erased sender must report; only
+    //!             supports the specification of the sender's completion domains
     //!
-    //! The order of Args... is obviously important, but Sigs... and Queries... are both
-    //! canonicalized into a sorted and uniqued list to ensure order is irrelevant.
+    //! The order of Args... is obviously important, but Sigs..., Queries..., and Attrs...
+    //! are all canonicalized into a sorted and uniqued list to ensure order is irrelevant.
     template <class...>
     class __make_function;
 
@@ -549,6 +552,39 @@ namespace experimental::execution
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
       using __queries = __canonical_t<queries<_Queries...>>;
       using __attrs   = __default_attrs<__sigs>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
+    };
+
+    template <class _Return, class... _Args, class... _Attrs>
+    class __make_function<_Return(_Args...), attrs<_Attrs...>>
+    {
+      using __sigs    = __sigs_from_t<_Return, false>;
+      using __queries = queries<>;
+      using __attrs   = __canonical_t<attrs<_Attrs...>>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
+    };
+
+    template <class _Return, class... _Args, class... _Attrs>
+    class __make_function<_Return(_Args...) noexcept, attrs<_Attrs...>>
+    {
+      using __sigs    = __sigs_from_t<_Return, true>;
+      using __queries = queries<>;
+      using __attrs   = __canonical_t<attrs<_Attrs...>>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
+    };
+
+    template <class... _Args, class... _Sigs, class... _Attrs>
+    class __make_function<sender_tag(_Args...), completion_signatures<_Sigs...>, attrs<_Attrs...>>
+    {
+      using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
+      using __queries = queries<>;
+      using __attrs   = __canonical_t<attrs<_Attrs...>>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -199,11 +199,11 @@ namespace experimental::execution
     };
 
     template <class _Tag, class _Query>
-    struct __make_domain
+    struct __make_domain_impl
     {};
 
     template <class _Domain, class _Tag>
-    struct __make_domain<_Tag, _Domain(get_completion_domain_t<_Tag>)>
+    struct __make_domain_impl<_Tag, _Domain(get_completion_domain_t<_Tag>)>
     {
       constexpr _Domain operator()() const noexcept
       {
@@ -214,22 +214,21 @@ namespace experimental::execution
     //! get_completion_domain<> is a special case; its type parameter is void
     //! and it's equivalent to get_completion_domain<set_value_t>.
     template <class _Domain>
-    struct __make_domain<void, _Domain(get_completion_domain_t<set_value_t>)>
-      : __make_domain<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
+    struct __make_domain_impl<void, _Domain(get_completion_domain_t<set_value_t>)>
+      : __make_domain_impl<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
     {};
 
     template <class _Tag, class... _Attrs>
-    inline constexpr auto __get_completion_domain =
-      __first_callable<__make_domain<_Tag, _Attrs>...>();
+    inline constexpr auto __make_domain = __first_callable<__make_domain_impl<_Tag, _Attrs>...>();
 
     template <class... _Attrs>
     struct __attrs
     {
       template <class _Tag, class... _Env>
       constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
-        -> decltype(__get_completion_domain<_Tag, _Attrs...>())
+        -> decltype(__make_domain<_Tag, _Attrs...>())
       {
-        return __get_completion_domain<_Tag, _Attrs...>();
+        return __make_domain<_Tag, _Attrs...>();
       }
     };
 

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -294,6 +294,13 @@ namespace experimental::execution
     template <class _Sigs, class _Queries, class _Attrs, class... _Args>
     class __function
     {
+      // check these with asserts rather than requires because the only way to violate
+      // them is to circumvent the exec::function alias template so any violation is
+      // a user hitting themselves
+      static_assert(__is_instance_of<_Sigs, completion_signatures>);
+      static_assert(__is_instance_of<_Queries, queries>);
+      static_assert(__is_instance_of<_Attrs, attrs>);
+
       using __receiver_t = __receiver_wrapper<__any_receiver_ref<_Sigs, _Queries>>;
 
       template <class _Receiver>

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -232,6 +232,28 @@ namespace experimental::execution
       }
     };
 
+    template <class _Tag, class _Attrs, class... _Env>
+    using __completion_domain_t = __call_result_or_t<
+      get_completion_domain_t<_Tag>,
+      __call_result_or_t<get_completion_domain_t<_Tag>, indeterminate_domain<>, _Attrs>,
+      _Attrs,
+      _Env const &...>;
+
+    template <class _Tag, class _ActualAttrs, class _ExpectedAttrs, class... _Env>
+    concept __completion_domain_matches =
+      __same_as<__completion_domain_t<_Tag, _ActualAttrs, _Env...>,
+                __completion_domain_t<_Tag, _ExpectedAttrs, _Env...>>;
+
+    template <class _ActualAttrs, class _ExpectedAttrs, class... _Env>
+    concept __completion_domains_match_impl =
+      __completion_domain_matches<set_value_t, _ActualAttrs, _ExpectedAttrs, _Env...>
+      && __completion_domain_matches<set_error_t, _ActualAttrs, _ExpectedAttrs, _Env...>
+      && __completion_domain_matches<set_stopped_t, _ActualAttrs, _ExpectedAttrs, _Env...>;
+
+    template <class _Actual, class _Expected, class... _Env>
+    concept __completion_domains_match =
+      __completion_domains_match_impl<env_of_t<_Actual>, env_of_t<_Expected>, _Env...>;
+
     template <class _Sigs, class _Queries, class _Attrs, class... _Args>
     class __function;
 
@@ -298,6 +320,9 @@ namespace experimental::execution
                 && (STDEXEC_IS_TRIVIALLY_COPYABLE(_Factory))     //
                 && (sizeof(_Factory) <= sizeof(__make_sender_))  //
                 && sender_to<__invoke_result_t<_Factory, _Args...>, __receiver_t>
+                && __completion_domains_match<__invoke_result_t<_Factory, _Args...>,
+                                              __function,
+                                              env_of_t<receiver_t>>
       constexpr explicit __function(_Args &&...__args, _Factory __factory)
         noexcept(__nothrow_move_constructible<_Args...>)
         : __args_(static_cast<_Args &&>(__args)...)

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -246,10 +246,14 @@ namespace experimental::execution
       _Attrs,
       _Env const &...>;
 
+    template <class _ActualDomain, class _ExpectedDomain>
+    concept __completion_domain_matches_impl =
+      __same_as<_ExpectedDomain, __common_domain_t<_ActualDomain, _ExpectedDomain>>;
+
     template <class _Tag, class _ActualAttrs, class _ExpectedAttrs, class... _Env>
     concept __completion_domain_matches =
-      __same_as<__completion_domain_t<_Tag, _ActualAttrs, _Env...>,
-                __completion_domain_t<_Tag, _ExpectedAttrs, _Env...>>;
+      __completion_domain_matches_impl<__completion_domain_t<_Tag, _ActualAttrs, _Env...>,
+                                       __completion_domain_t<_Tag, _ExpectedAttrs, _Env...>>;
 
     template <class _ActualAttrs, class _ExpectedAttrs, class... _Env>
     concept __completion_domains_match_impl =

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -112,13 +112,13 @@ namespace experimental::execution
       {}
 
       constexpr auto get_env() const noexcept  //
-        -> __join_env_t<__prop_t, env_of_t<_Receiver>>
+        -> __join_env_t<__prop_t const &, env_of_t<_Receiver>>
       {
         return __env::__join(*__env_, STDEXEC::get_env(*static_cast<_Receiver const *>(this)));
       }
 
      private:
-      __prop_t *__env_;
+      __prop_t const *__env_;
     };
 
     template <class _Sigs, class _Queries>
@@ -203,7 +203,7 @@ namespace experimental::execution
     {};
 
     template <class _Domain, class _Tag>
-    struct __make_domain_impl<_Tag, _Domain(get_completion_domain_t<_Tag>)>
+    struct __make_domain_impl<_Tag, _Domain(get_completion_domain_t<_Tag>) noexcept>
     {
       constexpr _Domain operator()() const noexcept
       {
@@ -214,8 +214,15 @@ namespace experimental::execution
     //! get_completion_domain<> is a special case; its type parameter is void
     //! and it's equivalent to get_completion_domain<set_value_t>.
     template <class _Domain>
-    struct __make_domain_impl<void, _Domain(get_completion_domain_t<set_value_t>)>
-      : __make_domain_impl<set_value_t, _Domain(get_completion_domain_t<set_value_t>)>
+    struct __make_domain_impl<void, _Domain(get_completion_domain_t<set_value_t>) noexcept>
+      : __make_domain_impl<set_value_t, _Domain(get_completion_domain_t<set_value_t>) noexcept>
+    {};
+
+    //! get_completion_domain ought to be no-throw, so make it optional to specify
+    //! noexcept on the signature provided with attrs<...>
+    template <class _Domain, class _Tag1, class _Tag2>
+    struct __make_domain_impl<_Tag1, _Domain(get_completion_domain_t<_Tag2>)>
+      : __make_domain_impl<_Tag1, _Domain(get_completion_domain_t<_Tag2>) noexcept>
     {};
 
     template <class _Tag, class... _Attrs>
@@ -322,7 +329,7 @@ namespace experimental::execution
                 && sender_to<__invoke_result_t<_Factory, _Args...>, __receiver_t>
                 && __completion_domains_match<__invoke_result_t<_Factory, _Args...>,
                                               __function,
-                                              env_of_t<receiver_t>>
+                                              env_of_t<__receiver_t>>
       constexpr explicit __function(_Args &&...__args, _Factory __factory)
         noexcept(__nothrow_move_constructible<_Args...>)
         : __args_(static_cast<_Args &&>(__args)...)
@@ -418,7 +425,7 @@ namespace experimental::execution
     {
       template <class _Tag, class... _Args>
       consteval auto operator()(_Tag (*)(_Args...)) const noexcept  //
-        -> default_domain (*)(get_completion_domain_t<_Tag>)
+        -> default_domain (*)(get_completion_domain_t<_Tag>) noexcept
       {
         return nullptr;
       }
@@ -429,12 +436,12 @@ namespace experimental::execution
     class __attrs_from_domain_queries
     {
       template <class _Tag>
-      using __query_sig = default_domain (*)(get_completion_domain_t<_Tag>);
+      using __query_sig = default_domain (*)(get_completion_domain_t<_Tag>) noexcept;
 
      public:
       template <class... _Tag>
       consteval auto operator()(__query_sig<_Tag>...) const noexcept  //
-        -> __canonical_t<attrs<default_domain(get_completion_domain_t<_Tag>)...>>
+        -> __canonical_t<attrs<default_domain(get_completion_domain_t<_Tag>) noexcept...>>
       {
         return {};
       }
@@ -538,6 +545,20 @@ namespace experimental::execution
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
       using __queries = __canonical_t<queries<_Queries...>>;
       using __attrs   = __default_attrs<__sigs>;
+
+     public:
+      using type = __function<__sigs, __queries, __attrs, _Args...>;
+    };
+
+    template <class... _Args, class... _Sigs, class... _Queries, class... _Attrs>
+    class __make_function<sender_tag(_Args...),
+                          completion_signatures<_Sigs...>,
+                          queries<_Queries...>,
+                          attrs<_Attrs...>>
+    {
+      using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
+      using __queries = __canonical_t<queries<_Queries...>>;
+      using __attrs   = __canonical_t<attrs<_Attrs...>>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -280,6 +280,46 @@ namespace experimental::execution
     template <class _Queries, class... _Env>
     using __check_queries_t = __check_queries<_Queries, _Env...>::type;
 
+    template <class _Attr>
+    struct __get_completion_domain_tag;
+
+    template <class _Tag, class _Domain>
+    struct __get_completion_domain_tag<_Domain(get_completion_domain_t<_Tag>)>
+    {
+      using type = _Tag;
+    };
+
+    template <class _Domain>
+    struct __get_completion_domain_tag<_Domain(get_completion_domain_t<>)>
+    {
+      using type = set_value_t;
+    };
+
+    template <class _Tag, class _Domain>
+    struct __get_completion_domain_tag<_Domain(get_completion_domain_t<_Tag>) noexcept>
+      : __get_completion_domain_tag<_Domain(get_completion_domain_t<_Tag>)>
+    {};
+
+    template <class _Attr>
+    using __get_completion_domain_tag_t = __get_completion_domain_tag<_Attr>::type;
+
+    template <class _Attrs, class _Tag>
+    inline constexpr bool __has_completion_domain = false;
+
+    template <class... _Attrs, class _Tag>
+      requires __one_of<_Tag, __get_completion_domain_tag_t<_Attrs>...>
+    inline constexpr bool __has_completion_domain<attrs<_Attrs...>, _Tag> = true;
+
+    //! it is undefined behaviour for a sender to advertise a completion domain for a
+    //! completion channel that it never completes on so make sure there are no
+    //! completion domains required by _Attrs that correspond to completion channels
+    //! not advertised as possible by _Sigs
+    template <class _Sigs, class _Attrs>
+    concept __completion_signatures_and_domains_are_compatible =
+      ((!__has_completion_domain<_Attrs, set_value_t>) || _Sigs::__count(set_value) > 0)     //
+      && ((!__has_completion_domain<_Attrs, set_error_t>) || _Sigs::__count(set_error) > 0)  //
+      && ((!__has_completion_domain<_Attrs, set_stopped_t>) || _Sigs::__count(set_stopped) > 0);
+
     //! the main implementation of the type-erasing sender function<...>
     //
     //! \tparam _Sigs The supported completion signatures
@@ -300,6 +340,7 @@ namespace experimental::execution
       static_assert(__is_instance_of<_Sigs, completion_signatures>);
       static_assert(__is_instance_of<_Queries, queries>);
       static_assert(__is_instance_of<_Attrs, attrs>);
+      static_assert(__completion_signatures_and_domains_are_compatible<_Sigs, _Attrs>);
 
       using __receiver_t = __receiver_wrapper<__any_receiver_ref<_Sigs, _Queries>>;
 
@@ -576,6 +617,8 @@ namespace experimental::execution
     };
 
     template <class _Return, class... _Args, class... _Attrs>
+      requires __completion_signatures_and_domains_are_compatible<__sigs_from_t<_Return, false>,
+                                                                  attrs<_Attrs...>>
     class __make_function<_Return(_Args...), attrs<_Attrs...>>
     {
       using __sigs    = __sigs_from_t<_Return, false>;
@@ -587,6 +630,8 @@ namespace experimental::execution
     };
 
     template <class _Return, class... _Args, class... _Attrs>
+      requires __completion_signatures_and_domains_are_compatible<__sigs_from_t<_Return, true>,
+                                                                  attrs<_Attrs...>>
     class __make_function<_Return(_Args...) noexcept, attrs<_Attrs...>>
     {
       using __sigs    = __sigs_from_t<_Return, true>;
@@ -598,6 +643,8 @@ namespace experimental::execution
     };
 
     template <class... _Args, class... _Sigs, class... _Attrs>
+      requires __completion_signatures_and_domains_are_compatible<completion_signatures<_Sigs...>,
+                                                                  attrs<_Attrs...>>
     class __make_function<sender_tag(_Args...), completion_signatures<_Sigs...>, attrs<_Attrs...>>
     {
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
@@ -609,6 +656,8 @@ namespace experimental::execution
     };
 
     template <class... _Args, class... _Sigs, class... _Queries, class... _Attrs>
+      requires __completion_signatures_and_domains_are_compatible<completion_signatures<_Sigs...>,
+                                                                  attrs<_Attrs...>>
     class __make_function<sender_tag(_Args...),
                           completion_signatures<_Sigs...>,
                           queries<_Queries...>,

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -228,8 +228,11 @@ namespace experimental::execution
     template <class _Tag, class... _Attrs>
     inline constexpr auto __make_domain = __first_callable<__make_domain_impl<_Tag, _Attrs>...>();
 
+    template <class _Attrs>
+    struct __attrs;
+
     template <class... _Attrs>
-    struct __attrs
+    struct __attrs<attrs<_Attrs...>>
     {
       template <class _Tag, class... _Env>
       constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
@@ -265,8 +268,17 @@ namespace experimental::execution
     concept __completion_domains_match =
       __completion_domains_match_impl<env_of_t<_Actual>, env_of_t<_Expected>, _Env...>;
 
-    template <class _Sigs, class _Queries, class _Attrs, class... _Args>
-    class __function;
+    template <class _Queries, class... _Env>
+    struct __check_queries;
+
+    template <class... _Queries, class... _Env>
+    struct __check_queries<queries<_Queries...>, _Env...>
+    {
+      using type = __mfind_error<_any::_check_query_t<_Queries, _Env...>...>;
+    };
+
+    template <class _Queries, class... _Env>
+    using __check_queries_t = __check_queries<_Queries, _Env...>::type;
 
     //! the main implementation of the type-erasing sender function<...>
     //
@@ -279,13 +291,13 @@ namespace experimental::execution
     //! not, as appropriate
     //!
     //! \tparam _Args The argument types used to construct the erased sender
-    template <class _Sigs, class... _Queries, class... _Attrs, class... _Args>
-    class __function<_Sigs, queries<_Queries...>, attrs<_Attrs...>, _Args...>
+    template <class _Sigs, class _Queries, class _Attrs, class... _Args>
+    class __function
     {
-      using __receiver_t = __receiver_wrapper<__any_receiver_ref<_Sigs, queries<_Queries...>>>;
+      using __receiver_t = __receiver_wrapper<__any_receiver_ref<_Sigs, _Queries>>;
 
       template <class _Receiver>
-      using __opstate_t = __opstate<_Receiver, _Sigs, queries<_Queries...>>;
+      using __opstate_t = __opstate<_Receiver, _Sigs, _Queries>;
 
       template <class _Factory>
       static constexpr auto
@@ -349,14 +361,13 @@ namespace experimental::execution
       {
         static_assert(__decays_to_derived_from<_Self, __function>);
         //! throw if _Env does not contain the queries needed to type-erase the receiver:
-        using __check_queries_t = __mfind_error<_any::_check_query_t<_Queries, _Env...>...>;
-        if constexpr (__merror<__check_queries_t>)
-          return __throw_compile_time_error(__check_queries_t());
+        if constexpr (__merror<__check_queries_t<_Queries, _Env...>>)
+          return __throw_compile_time_error(__check_queries_t<_Queries, _Env...>());
         else
           return _Sigs();
       }
 
-      constexpr __attrs<_Attrs...> get_env() const noexcept
+      constexpr __attrs<_Attrs> get_env() const noexcept
       {
         return {};
       }

--- a/include/exec/function.hpp
+++ b/include/exec/function.hpp
@@ -348,6 +348,33 @@ namespace experimental::execution
       completion_signatures<__single_value_sig_t<_Return>, set_stopped_t()>,
       __eptr_completion_unless_t<__mbool<_NoExcept>>>>;
 
+    //! maps a completion signature to the default completion domain query
+    struct __domain_query_from_sig
+    {
+      template <class _Tag, class... _Args>
+      consteval auto operator()(_Tag (*)(_Args...)) const noexcept  //
+        -> default_domain (*)(get_completion_domain_t<_Tag>)
+      {
+        return nullptr;
+      }
+    };
+
+    //! maps a pack of domain queries produced by __domain_query_from_sig to the
+    //! corresponding attrs<_Attrs...> type
+    class __attrs_from_domain_queries
+    {
+      template <class _Tag>
+      using __query_sig = default_domain (*)(get_completion_domain_t<_Tag>);
+
+     public:
+      template <class... _Tag>
+      consteval auto operator()(__query_sig<_Tag>...) const noexcept  //
+        -> __canonical_t<attrs<default_domain(get_completion_domain_t<_Tag>)...>>
+      {
+        return {};
+      }
+    };
+
     //! computes the set of get_completion_domain queries that must be supported by any
     //! sender that might be erased by the corresponding function
     //!
@@ -356,14 +383,10 @@ namespace experimental::execution
     //!
     //! the query form should be
     //!
-    //!   default_domain(get_completion_domain_t<Tag>, Env)
-    //!
-    //! where Env is the environment type we'll be synthesizing from _Queries
-    template <class _Sigs, class _Queries>
-    using __default_attrs =
-      __canonical_t<attrs<default_domain(get_completion_domain_t<set_value_t>),
-                          default_domain(get_completion_domain_t<set_error_t>),
-                          default_domain(get_completion_domain_t<set_stopped_t>)>>;
+    //!   default_domain(get_completion_domain_t<Tag>)
+    template <class _Sigs>
+    using __default_attrs = decltype(_Sigs::__transform_reduce(__domain_query_from_sig(),
+                                                               __attrs_from_domain_queries()));
 
     //! Map a variety of function<...> specifications into the canonical type-erased
     //! contract represented by the user-provided specification.
@@ -392,7 +415,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, false>;
       using __queries = queries<>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -403,7 +426,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, true>;
       using __queries = queries<>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -414,7 +437,7 @@ namespace experimental::execution
     {
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
       using __queries = queries<>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -425,7 +448,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, false>;
       using __queries = __canonical_t<queries<_Queries...>>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -436,7 +459,7 @@ namespace experimental::execution
     {
       using __sigs    = __sigs_from_t<_Return, true>;
       using __queries = __canonical_t<queries<_Queries...>>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;
@@ -449,7 +472,7 @@ namespace experimental::execution
     {
       using __sigs    = __canonical_t<completion_signatures<_Sigs...>>;
       using __queries = __canonical_t<queries<_Queries...>>;
-      using __attrs   = __default_attrs<__sigs, __queries>;
+      using __attrs   = __default_attrs<__sigs>;
 
      public:
       using type = __function<__sigs, __queries, __attrs, _Args...>;

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -87,12 +87,12 @@ namespace
     template <class... Values>
     constexpr sender<Values...> operator()(Values... values) const noexcept
     {
-      return sender(std::move(values)...);
+      return sender<Values...>(std::move(values)...);
     }
   };
 
   template <auto Channel, class Domain>
-  inline constexpr domain_sender_t<decltype(Channel), Domain> domain_sender{};
+  inline constexpr domain_sender_t<std::remove_cvref_t<decltype(Channel)>, Domain> domain_sender{};
 
   TEST_CASE("exec::function is constructible", "[types][function]")
   {

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -709,4 +709,75 @@ namespace
       STATIC_REQUIRE(std::constructible_from<function, domain_sender_t<ex::set_stopped_t, domain>>);
     }
   }
+
+  template <class Sigs, class Attrs>
+  concept function_exists = requires { typename exec::function<ex::sender_tag(), Sigs, Attrs>; };
+
+  TEST_CASE("function can't be specialized with invalid completion specifications")
+  {
+    SECTION("specifying a completion signature with no corresponding completion domain is fine")
+    {
+      STATIC_REQUIRE(function_exists<ex::completion_signatures<ex::set_value_t()>, exec::attrs<>>);
+      STATIC_REQUIRE(
+        function_exists<ex::completion_signatures<ex::set_error_t(int)>, exec::attrs<>>);
+      STATIC_REQUIRE(
+        function_exists<ex::completion_signatures<ex::set_stopped_t()>, exec::attrs<>>);
+    }
+
+    SECTION("specifying a completion domain is fine if you also specify a corresponding signature")
+    {
+      STATIC_REQUIRE(
+        function_exists<ex::completion_signatures<ex::set_value_t()>,
+                        exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>)>>);
+      STATIC_REQUIRE(
+        function_exists<ex::completion_signatures<ex::set_error_t(int)>,
+                        exec::attrs<domain(ex::get_completion_domain_t<ex::set_error_t>)>>);
+      STATIC_REQUIRE(
+        function_exists<ex::completion_signatures<ex::set_stopped_t()>,
+                        exec::attrs<domain(ex::get_completion_domain_t<ex::set_stopped_t>)>>);
+    }
+
+    SECTION("you may not specify a completion domain if there's no corresponding signature")
+    {
+      STATIC_REQUIRE(
+        !function_exists<ex::completion_signatures<ex::set_error_t(int)>,
+                         exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>)>>);
+      STATIC_REQUIRE(
+        !function_exists<ex::completion_signatures<ex::set_value_t(int)>,
+                         exec::attrs<domain(ex::get_completion_domain_t<ex::set_error_t>)>>);
+      STATIC_REQUIRE(
+        !function_exists<ex::completion_signatures<ex::set_error_t(int)>,
+                         exec::attrs<domain(ex::get_completion_domain_t<ex::set_stopped_t>)>>);
+    }
+
+    SECTION("you may specify only some completion domains")
+    {
+      STATIC_REQUIRE(
+        function_exists<
+          ex::completion_signatures<ex::set_value_t(), ex::set_error_t(int), ex::set_stopped_t()>,
+          exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>)>>);
+      STATIC_REQUIRE(
+        function_exists<
+          ex::completion_signatures<ex::set_value_t(), ex::set_error_t(int), ex::set_stopped_t()>,
+          exec::attrs<domain(ex::get_completion_domain_t<ex::set_error_t>)>>);
+      STATIC_REQUIRE(
+        function_exists<
+          ex::completion_signatures<ex::set_value_t(), ex::set_error_t(int), ex::set_stopped_t()>,
+          exec::attrs<domain(ex::get_completion_domain_t<ex::set_stopped_t>)>>);
+    }
+
+    SECTION("sender attributes other than completion domain queries don't break")
+    {
+      // TODO: it's not obvious that it makes sense to support sender attributes other than
+      //       completion domain queries so this may be silly....
+      auto query = [](auto const &)
+      {
+        return 0;
+      };
+      using query_t = decltype(query);
+
+      STATIC_REQUIRE(
+        function_exists<ex::completion_signatures<ex::set_value_t()>, exec::attrs<int(query_t)>>);
+    }
+  }
 }  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -662,7 +662,8 @@ namespace
   }
 
   template <auto Tag>
-  using custom_domain_for = exec::attrs<domain(ex::get_completion_domain_t<decltype(Tag)>)>;
+  using custom_domain_for =
+    exec::attrs<domain(ex::get_completion_domain_t<std::remove_cvref_t<decltype(Tag)>>)>;
 
   TEST_CASE("function can't be constructed with a sender that completes in the wrong domain",
             "[types][function]")

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -27,6 +27,73 @@ namespace ex = STDEXEC;
 
 namespace
 {
+  template <class Channel, class Domain>
+  struct domain_sender_t
+  {
+    template <class... Values>
+    class sender
+    {
+      struct attrs
+      {
+        template <class... Env>
+        constexpr Domain query(ex::get_completion_domain_t<Channel>, Env const &...) const noexcept
+        {
+          return {};
+        }
+      };
+
+      template <class Receiver>
+      struct opstate
+      {
+        using operation_state_concept = ex::operation_state_tag;
+
+        void start() & noexcept
+        {
+          ex::__apply(Channel(), std::move(values), std::move(rcvr));
+        }
+
+        Receiver               rcvr;
+        ex::__tuple<Values...> values;
+      };
+
+      ex::__tuple<Values...> values_;
+
+     public:
+      using sender_concept = ex::sender_tag;
+
+      template <class S>
+      static consteval auto get_completion_signatures() noexcept  //
+        -> ex::completion_signatures<Channel(Values...)>
+      {
+        return {};
+      }
+
+      constexpr attrs get_env() const noexcept
+      {
+        return {};
+      }
+
+      constexpr explicit sender(Values... values) noexcept
+        : values_(values...)
+      {}
+
+      template <class Receiver>
+      opstate<Receiver> connect(Receiver rcvr) && noexcept
+      {
+        return opstate<Receiver>(std::move(rcvr), std::move(values_));
+      }
+    };
+
+    template <class... Values>
+    constexpr sender<Values...> operator()(Values... values) const noexcept
+    {
+      return sender(std::move(values)...);
+    }
+  };
+
+  template <auto Channel, class Domain>
+  inline constexpr domain_sender_t<decltype(Channel), Domain> domain_sender{};
+
   TEST_CASE("exec::function is constructible", "[types][function]")
   {
     SECTION("void()")
@@ -89,6 +156,49 @@ namespace
                      exec::queries<>>
         sndr(5, [](int) noexcept { return ex::just(); });
       STATIC_REQUIRE(STDEXEC::sender<decltype(sndr)>);
+    }
+
+    struct domain
+    {};
+
+    SECTION("void() with attrs but no queries")
+    {
+      exec::function<void(), exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>)>>
+        sndr(domain_sender<ex::set_value, domain>);
+
+      STATIC_REQUIRE(ex::sender<decltype(sndr)>);
+    }
+
+    SECTION("void() noexcept with attrs but no queries")
+    {
+      exec::function<void() noexcept,
+                     exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>)>>
+        sndr(domain_sender<ex::set_value, domain>);
+
+      STATIC_REQUIRE(ex::sender<decltype(sndr)>);
+    }
+
+    SECTION("sender_tag(int) with set_value_t(int) and attrs but no queries")
+    {
+      // TODO: validate that the required completion domains "match" the permitted completions
+      exec::function<ex::sender_tag(int),
+                     ex::completion_signatures<ex::set_value_t(int)>,
+                     exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>)>>
+        sndr(42, domain_sender<ex::set_value, domain>);
+
+      STATIC_REQUIRE(ex::sender<decltype(sndr)>);
+    }
+
+    SECTION("sender_tag(int) with set_error_t(int), attrs, and trivial queries")
+    {
+      // TODO: validate that the required completion domains "match" the permitted completions
+      exec::function<ex::sender_tag(int),
+                     ex::completion_signatures<ex::set_error_t(int)>,
+		     exec::queries<>,
+                     exec::attrs<domain(ex::get_completion_domain_t<ex::set_error_t>)>>
+        sndr(42, domain_sender<ex::set_error, domain>);
+
+      STATIC_REQUIRE(ex::sender<decltype(sndr)>);
     }
   }
 

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -552,4 +552,180 @@ namespace
       STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
     }
   }
+
+  //! a sender that wraps another, and tells the inner sender it's starting in domain
+  //! Domain, with the expectation that saying so will influence the inner sender's
+  //! completion domain, which this sender forwards out through its attributes
+  template <ex::sender Sender, class Domain>
+  class inject_domain
+  {
+    //! our inner sender will be connected to a receiver that prepends this type to
+    //! the outer receiver's environment, ensuring that the inner sender believes it's
+    //! running in the specified domain
+    struct env
+    {
+      constexpr Domain query(ex::get_domain_t) const noexcept
+      {
+        return Domain{};
+      }
+    };
+
+    //! advertise that we complete on whichever domain the inner sender completes on
+    //!
+    //! as used, this is expected to be Domain because the just family of senders
+    //! "complete where they start" so our receiver environment should ensure our
+    //! desired result
+    struct attrs
+    {
+      template <class Tag>
+      using domain_t =
+        ex::__call_result_t<ex::get_completion_domain_t<Tag>, ex::env_of_t<Sender>, env>;
+
+      template <class Tag, class... Env>
+      constexpr auto query(ex::get_completion_domain_t<Tag>, Env const &...) const noexcept  //
+        -> domain_t<Tag>
+      {
+        return domain_t<Tag>{};
+      }
+    };
+
+    template <class Receiver>
+    class opstate
+    {
+      struct receiver
+      {
+        using receiver_concept = ex::receiver_tag;
+
+        template <class... T>
+        constexpr void set_value(T &&...t) && noexcept
+        {
+          ex::set_value(std::move(self_->rcvr_), std::forward<T>(t)...);
+        }
+
+        template <class E>
+        constexpr void set_error(E &&e) && noexcept
+        {
+          ex::set_error(std::move(self_->rcvr_), std::forward<E>(e));
+        }
+
+        constexpr void set_stopped() && noexcept
+        {
+          ex::set_stopped(std::move(self_->rcvr_));
+        }
+
+        constexpr auto get_env() const noexcept  //
+          -> ex::__join_env_t<env, ex::env_of_t<Receiver>>
+        {
+          return ex::__env::__join(env{}, ex::get_env(self_->rcvr_));
+        }
+
+        opstate *self_;
+      };
+
+      Receiver                               rcvr_;
+      ex::connect_result_t<Sender, receiver> op_;
+
+     public:
+      using operation_state_concept = ex::operation_state_tag;
+
+      constexpr explicit opstate(Sender sndr, Receiver rcvr) noexcept
+        : rcvr_(std::move(rcvr))
+        , op_(ex::connect(std::move(sndr), receiver(this)))
+      {}
+
+      void start() & noexcept
+      {
+        ex::start(op_);
+      }
+    };
+
+    Sender sndr;
+
+   public:
+    using sender_concept = ex::sender_tag;
+
+    template <class...>
+    static consteval auto get_completion_signatures()  //
+      -> decltype(ex::get_completion_signatures<Sender>())
+    {
+      return ex::get_completion_signatures<Sender>();
+    }
+
+    explicit inject_domain(Sender sndr, Domain) noexcept
+      : sndr(std::move(sndr))
+    {}
+
+    constexpr attrs get_env() const noexcept
+    {
+      return {};
+    }
+
+    template <class Receiver>
+    constexpr opstate<Receiver> connect(Receiver rcvr) && noexcept
+    {
+      return opstate<Receiver>(std::move(sndr), std::move(rcvr));
+    }
+  };
+
+  template <auto Tag>
+  using custom_domain_for = exec::attrs<domain(ex::get_completion_domain_t<decltype(Tag)>)>;
+
+  TEST_CASE("function can't be constructed with a sender that completes in the wrong domain",
+            "[types][function]")
+  {
+    //! convert the given sender factory to a factory that wraps the given factory's
+    //! result in an inject_domain sender
+    auto change_domain = [](auto &factory) noexcept
+    {
+      return [&](auto... values) noexcept
+      {
+        return inject_domain(factory(std::move(values)...), domain{});
+      };
+    };
+
+    SECTION("the constraint applies to set_value")
+    {
+      using function = exec::function<ex::sender_tag(),
+                                      ex::completion_signatures<ex::set_value_t()>,
+                                      exec::queries<>,
+                                      custom_domain_for<ex::set_value>>;
+
+      STATIC_REQUIRE(!std::constructible_from<function, ex::just_t>);
+
+      // double check that it *would* work if the sender reported a custom domain
+      using custom_just_t = decltype(change_domain(ex::just));
+
+      STATIC_REQUIRE(std::constructible_from<function, custom_just_t>);
+    }
+
+    SECTION("the constraint applies to set_error")
+    {
+      using function = exec::function<ex::sender_tag(int),
+                                      ex::completion_signatures<ex::set_error_t(int)>,
+                                      exec::queries<>,
+                                      custom_domain_for<ex::set_error>>;
+
+      STATIC_REQUIRE(!std::constructible_from<function, int, ex::just_error_t>);
+
+      // double check that it *would* work if the sender reported a custom domain
+      using custom_just_error_t = decltype(change_domain(ex::just_error));
+
+      STATIC_REQUIRE(std::constructible_from<function, int, custom_just_error_t>);
+    }
+
+    SECTION("the constraint applies to set_stopped")
+    {
+      using function = exec::function<ex::sender_tag(),
+                                      ex::completion_signatures<ex::set_stopped_t()>,
+                                      exec::queries<>,
+                                      custom_domain_for<ex::set_stopped>>;
+
+      STATIC_REQUIRE(!std::constructible_from<function, ex::just_stopped_t>);
+
+      // double check that it *would* work if the sender reported a custom domain
+      using custom_just_stopped_t = decltype(change_domain(ex::just_stopped));
+
+      STATIC_REQUIRE(std::constructible_from<function, custom_just_stopped_t>);
+    }
+  }
 }  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -489,4 +489,33 @@ namespace
       STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
     }
   }
+
+  struct domain : ex::default_domain
+  {};
+
+  TEST_CASE("function's constructor is constrained based on the common domain", "[types][function]")
+  {
+    using queries = exec::queries<domain(ex::get_domain_t) noexcept>;
+
+    SECTION("the constraint applies to set_value")
+    {
+      using function =
+        exec::function<ex::sender_tag(),
+                       ex::completion_signatures<ex::set_value_t()>,
+                       queries,
+                       exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>) noexcept>>;
+
+      STATIC_REQUIRE(std::constructible_from<function, ex::just_t>);
+
+      function fn(ex::just);
+      auto     attrs        = ex::get_env(fn);
+      auto     value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+  }
 }  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -411,4 +411,82 @@ namespace
       STATIC_REQUIRE(std::assignable_from<func2_t &, func2_t const &>);
     }
   }
+
+  struct none_such
+  {};
+
+  template <class Completion>
+  inline constexpr auto get_completion_domain =
+    ex::__first_callable{ex::get_completion_domain<Completion>, ex::__always{none_such()}};
+
+  TEST_CASE("function reports a default completion domain by default", "[types][function]")
+  {
+    SECTION("throwing function reports a completion domain for all three channels")
+    {
+      exec::function<void()> fn(ex::just);
+      auto                   attrs        = ex::get_env(fn);
+      auto                   value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto                   error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto                   stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
+    }
+
+    SECTION("no-throw function reports a completion domain for value and stop channels only")
+    {
+      exec::function<void() noexcept> fn(ex::just);
+      auto                            attrs        = ex::get_env(fn);
+      auto                            value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto                            error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto                            stop_domain = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
+    }
+
+    SECTION("infallible function reports a completion domain for value channel only")
+    {
+      exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_value_t()>> fn(ex::just);
+      auto attrs        = ex::get_env(fn);
+      auto value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("just_error function reports a completion domain for error channel only")
+    {
+      exec::function<ex::sender_tag(int), ex::completion_signatures<ex::set_error_t(int)>> fn(
+        42,
+        ex::just_error);
+      auto attrs        = ex::get_env(fn);
+      auto value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("just_stopped function reports a completion domain for stop channel only")
+    {
+      exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_stopped_t()>> fn(
+        ex::just_stopped);
+      auto attrs        = ex::get_env(fn);
+      auto value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
+    }
+  }
 }  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -180,7 +180,6 @@ namespace
 
     SECTION("sender_tag(int) with set_value_t(int) and attrs but no queries")
     {
-      // TODO: validate that the required completion domains "match" the permitted completions
       exec::function<ex::sender_tag(int),
                      ex::completion_signatures<ex::set_value_t(int)>,
                      exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>)>>
@@ -191,7 +190,6 @@ namespace
 
     SECTION("sender_tag(int) with set_error_t(int), attrs, and trivial queries")
     {
-      // TODO: validate that the required completion domains "match" the permitted completions
       exec::function<ex::sender_tag(int),
                      ex::completion_signatures<ex::set_error_t(int)>,
                      exec::queries<>,

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -500,10 +500,7 @@ namespace
     SECTION("the constraint applies to set_value")
     {
       using function =
-        exec::function<ex::sender_tag(),
-                       ex::completion_signatures<ex::set_value_t()>,
-                       queries,
-                       exec::attrs<domain(ex::get_completion_domain_t<ex::set_value_t>) noexcept>>;
+        exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_value_t()>, queries>;
 
       STATIC_REQUIRE(std::constructible_from<function, ex::just_t>);
 
@@ -513,9 +510,46 @@ namespace
       auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
       auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
 
-      STATIC_REQUIRE(std::same_as<domain, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(value_domain)>);
       STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
       STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("the constraint applies to set_error")
+    {
+      using function = exec::function<ex::sender_tag(int),
+                                      ex::completion_signatures<ex::set_error_t(int)>,
+                                      queries>;
+
+      STATIC_REQUIRE(std::constructible_from<function, int, ex::just_error_t>);
+
+      function fn(42, ex::just_error);
+      auto     attrs        = ex::get_env(fn);
+      auto     value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(stop_domain)>);
+    }
+
+    SECTION("the constraint applies to set_stopped")
+    {
+      using function =
+        exec::function<ex::sender_tag(), ex::completion_signatures<ex::set_stopped_t()>, queries>;
+
+      STATIC_REQUIRE(std::constructible_from<function, ex::just_stopped_t>);
+
+      function fn(ex::just_stopped);
+      auto     attrs        = ex::get_env(fn);
+      auto     value_domain = get_completion_domain<ex::set_value_t>(attrs);
+      auto     error_domain = get_completion_domain<ex::set_error_t>(attrs);
+      auto     stop_domain  = get_completion_domain<ex::set_stopped_t>(attrs);
+
+      STATIC_REQUIRE(std::same_as<none_such, decltype(value_domain)>);
+      STATIC_REQUIRE(std::same_as<none_such, decltype(error_domain)>);
+      STATIC_REQUIRE(std::same_as<ex::default_domain, decltype(stop_domain)>);
     }
   }
 }  // namespace

--- a/test/exec/test_function.cpp
+++ b/test/exec/test_function.cpp
@@ -194,7 +194,7 @@ namespace
       // TODO: validate that the required completion domains "match" the permitted completions
       exec::function<ex::sender_tag(int),
                      ex::completion_signatures<ex::set_error_t(int)>,
-		     exec::queries<>,
+                     exec::queries<>,
                      exec::attrs<domain(ex::get_completion_domain_t<ex::set_error_t>)>>
         sndr(42, domain_sender<ex::set_error, domain>);
 
@@ -663,136 +663,12 @@ namespace
     }
   }
 
-  //! a sender that wraps another, and tells the inner sender it's starting in domain
-  //! Domain, with the expectation that saying so will influence the inner sender's
-  //! completion domain, which this sender forwards out through its attributes
-  template <ex::sender Sender, class Domain>
-  class inject_domain
-  {
-    //! our inner sender will be connected to a receiver that prepends this type to
-    //! the outer receiver's environment, ensuring that the inner sender believes it's
-    //! running in the specified domain
-    struct env
-    {
-      constexpr Domain query(ex::get_domain_t) const noexcept
-      {
-        return Domain{};
-      }
-    };
-
-    //! advertise that we complete on whichever domain the inner sender completes on
-    //!
-    //! as used, this is expected to be Domain because the just family of senders
-    //! "complete where they start" so our receiver environment should ensure our
-    //! desired result
-    struct attrs
-    {
-      template <class Tag>
-      using domain_t =
-        ex::__call_result_t<ex::get_completion_domain_t<Tag>, ex::env_of_t<Sender>, env>;
-
-      template <class Tag, class... Env>
-      constexpr auto query(ex::get_completion_domain_t<Tag>, Env const &...) const noexcept  //
-        -> domain_t<Tag>
-      {
-        return domain_t<Tag>{};
-      }
-    };
-
-    template <class Receiver>
-    class opstate
-    {
-      struct receiver
-      {
-        using receiver_concept = ex::receiver_tag;
-
-        template <class... T>
-        constexpr void set_value(T &&...t) && noexcept
-        {
-          ex::set_value(std::move(self_->rcvr_), std::forward<T>(t)...);
-        }
-
-        template <class E>
-        constexpr void set_error(E &&e) && noexcept
-        {
-          ex::set_error(std::move(self_->rcvr_), std::forward<E>(e));
-        }
-
-        constexpr void set_stopped() && noexcept
-        {
-          ex::set_stopped(std::move(self_->rcvr_));
-        }
-
-        constexpr auto get_env() const noexcept  //
-          -> ex::__join_env_t<env, ex::env_of_t<Receiver>>
-        {
-          return ex::__env::__join(env{}, ex::get_env(self_->rcvr_));
-        }
-
-        opstate *self_;
-      };
-
-      Receiver                               rcvr_;
-      ex::connect_result_t<Sender, receiver> op_;
-
-     public:
-      using operation_state_concept = ex::operation_state_tag;
-
-      constexpr explicit opstate(Sender sndr, Receiver rcvr) noexcept
-        : rcvr_(std::move(rcvr))
-        , op_(ex::connect(std::move(sndr), receiver(this)))
-      {}
-
-      void start() & noexcept
-      {
-        ex::start(op_);
-      }
-    };
-
-    Sender sndr;
-
-   public:
-    using sender_concept = ex::sender_tag;
-
-    template <class...>
-    static consteval auto get_completion_signatures()  //
-      -> decltype(ex::get_completion_signatures<Sender>())
-    {
-      return ex::get_completion_signatures<Sender>();
-    }
-
-    explicit inject_domain(Sender sndr, Domain) noexcept
-      : sndr(std::move(sndr))
-    {}
-
-    constexpr attrs get_env() const noexcept
-    {
-      return {};
-    }
-
-    template <class Receiver>
-    constexpr opstate<Receiver> connect(Receiver rcvr) && noexcept
-    {
-      return opstate<Receiver>(std::move(sndr), std::move(rcvr));
-    }
-  };
-
   template <auto Tag>
   using custom_domain_for = exec::attrs<domain(ex::get_completion_domain_t<decltype(Tag)>)>;
 
   TEST_CASE("function can't be constructed with a sender that completes in the wrong domain",
             "[types][function]")
   {
-    //! convert the given sender factory to a factory that wraps the given factory's
-    //! result in an inject_domain sender
-    auto change_domain = [](auto &factory) noexcept
-    {
-      return [&](auto... values) noexcept
-      {
-        return inject_domain(factory(std::move(values)...), domain{});
-      };
-    };
-
     SECTION("the constraint applies to set_value")
     {
       using function = exec::function<ex::sender_tag(),
@@ -803,9 +679,7 @@ namespace
       STATIC_REQUIRE(!std::constructible_from<function, ex::just_t>);
 
       // double check that it *would* work if the sender reported a custom domain
-      using custom_just_t = decltype(change_domain(ex::just));
-
-      STATIC_REQUIRE(std::constructible_from<function, custom_just_t>);
+      STATIC_REQUIRE(std::constructible_from<function, domain_sender_t<ex::set_value_t, domain>>);
     }
 
     SECTION("the constraint applies to set_error")
@@ -818,9 +692,8 @@ namespace
       STATIC_REQUIRE(!std::constructible_from<function, int, ex::just_error_t>);
 
       // double check that it *would* work if the sender reported a custom domain
-      using custom_just_error_t = decltype(change_domain(ex::just_error));
-
-      STATIC_REQUIRE(std::constructible_from<function, int, custom_just_error_t>);
+      STATIC_REQUIRE(
+        std::constructible_from<function, int, domain_sender_t<ex::set_error_t, domain>>);
     }
 
     SECTION("the constraint applies to set_stopped")
@@ -833,9 +706,7 @@ namespace
       STATIC_REQUIRE(!std::constructible_from<function, ex::just_stopped_t>);
 
       // double check that it *would* work if the sender reported a custom domain
-      using custom_just_stopped_t = decltype(change_domain(ex::just_stopped));
-
-      STATIC_REQUIRE(std::constructible_from<function, custom_just_stopped_t>);
+      STATIC_REQUIRE(std::constructible_from<function, domain_sender_t<ex::set_stopped_t, domain>>);
     }
   }
 }  // namespace


### PR DESCRIPTION
[P4223R0](https://wg21.link/p4223r0) calls for `function` to support a type parameter of the form `attrs<…>` that specifies the required attributes of the type-erased sender. This PR started out as an attempt to implement this missing feature in `exec::function`, but, along the way, I discovered that's not as trivial as I expected when I added the requirement to the paper. Like `exec::any_sender_of`, `function` knows the type of the sender it's erasing _only_ in its constructor but, unlike `any_sender_of`, `function` knows _only_ the erased sender's type—it doesn't have the sender as a value until `connect` gets called—so we can't check that the erased sender's attributes meet the specified requirements.

The simplest resolution to this conflict is obviously to just not support sender attributes in `function` but, after consulting with @ericniebler on the subject, he pointed out that `get_completion_domain` is a function of a sender's attributes, and it's a critical part of the algorithm customization logic. So, this PR is an implementation of the compromise: you can specify the required completion domains of the erased sender because we need only the sender's type to validate the constraint is met, and we can do that in the `function` constructor.

New in this PR:
 * `template <class...> exec::attrs`, which is like `template <class...> exec::queries` but for sender attribute queries instead of receiver environment queries;
 * some more specializations of `exec::__make_function` to support specifying the completion domain requirements of the erased sender;
 * new constraints on `function`'s constructor to validate that the erased sender meets the aforementioned new domain requirements; and
 * some tests to validate that everything works as intended.

The new requirement is that `__common_domain_t<ExpectedDomain, ActualDomain>` is the same as `ExpectedDomain` (i.e. the completion domain of the erased sender must be, or inherit from, the completion domain specified in the `function`'s type).

TODO:
- [x] negative tests to confirm the constructor constraints prevent invalid constructions
- [x] more specializations of `__make_function` so you can specify required sender attributes without having to fully specify all of the type parameters
- [x] tests for the above
- [ ] probably more documentation
- [ ] maybe confirmation that the only required sender attributes are `get_completion_domain`
- [ ] an R1 of P4223 that updates the spec to reflect this new implementation experience