### PR TITLE
test.exec: No Printing

### DIFF
--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -769,12 +769,10 @@ namespace
     template <class Error>
     void set_error(Error &&) noexcept
       requires ex::__one_of<ex::set_error_t(Error), _Sigs...>
-    {
-    }
+    {}
     void set_stopped() noexcept
       requires ex::__one_of<ex::set_stopped_t(), _Sigs...>
-    {
-    }
+    {}
     struct env
     {
       [[nodiscard]]

--- a/test/exec/test_any_sender.cpp
+++ b/test/exec/test_any_sender.cpp
@@ -27,8 +27,6 @@
 
 #include <catch2/catch_all.hpp>
 
-#include <iostream>
-
 namespace ex = STDEXEC;
 
 STDEXEC_PRAGMA_PUSH()
@@ -766,20 +764,16 @@ namespace
     void set_value(_Args &&...__args) noexcept
       requires ex::__one_of<ex::set_value_t(_Args...), _Sigs...>
     {
-      std::printf("set_value called");
-      ((std::cout << ' ' << __args), ...);
-      std::cout << '\n';
+      (void) sizeof...(__args);
     }
     template <class Error>
     void set_error(Error &&) noexcept
       requires ex::__one_of<ex::set_error_t(Error), _Sigs...>
     {
-      std::puts("set_error called");
     }
     void set_stopped() noexcept
       requires ex::__one_of<ex::set_stopped_t(), _Sigs...>
     {
-      std::puts("set_stopped called");
     }
     struct env
     {

--- a/test/exec/test_just_from.cpp
+++ b/test/exec/test_just_from.cpp
@@ -68,12 +68,10 @@ namespace
     {
       if (sizeof(sink) == ~0ul)
       {
-        std::puts("sink(42)");
         sink(42);
       }
       else
       {
-        std::puts("sink(43, 44)");
         sink(43, 44);
       }
       return ex::completion_signatures<ex::set_value_t(int), ex::set_value_t(int, int)>{};


### PR DESCRIPTION
test.exec previously printed:

  set_value called 42
  set_error called
  set_stopped called
  set_value called 42
  set_value called
  sink(43, 44)

Due to aab5da8b7f7ed60053d16798a687d0b1549e2e1d and 09f2163acb1f4f8c22e4085f86c0c16bd40b9af9.

Updated to remove the printing.