### PR TITLE
fix: add parallel_scheduler also to export targets in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,8 @@ if(STDEXEC_BUILD_PARALLEL_SCHEDULER)
   add_library(STDEXEC::parallel_scheduler ALIAS parallel_scheduler)
   add_library(system_context ALIAS parallel_scheduler)
   add_library(STDEXEC::system_context ALIAS parallel_scheduler)
+
+  set(stdexec_export_targets ${stdexec_export_targets} parallel_scheduler)
 endif()
 
 option(STDEXEC_ENABLE_IO_URING "Enable the use of the io_uring scheduler on Linux" OFF)


### PR DESCRIPTION
I noticed that the generated `stdexec-config.cmake` made the CMake target `STDEXEC::stdexec` IMPORTED_GLOBAL, but not `STDEXEC::parallel_scheduler`.

```CMake
set(rapids_global_targets stdexec)
set(rapids_namespaced_global_targets stdexec)
if((NOT "STDEXEC::" STREQUAL "") AND rapids_namespaced_global_targets)
  list(TRANSFORM rapids_namespaced_global_targets PREPEND "STDEXEC::")
endif()

foreach(target IN LISTS rapids_namespaced_global_targets)
  if(TARGET ${target})
    get_target_property(_is_imported ${target} IMPORTED)
    get_target_property(_already_global ${target} IMPORTED_GLOBAL)
    if(_is_imported AND NOT _already_global)
      set_target_properties(${target} PROPERTIES IMPORTED_GLOBAL TRUE)
    endif()
  endif()
endforeach()

# For backwards compat
if("rapids_config_install" STREQUAL "rapids_config_build")
  foreach(target IN LISTS rapids_global_targets)
    if(TARGET ${target})
      get_target_property(_is_imported ${target} IMPORTED)
      get_target_property(_already_global ${target} IMPORTED_GLOBAL)
      if(_is_imported AND NOT _already_global)
        set_target_properties(${target} PROPERTIES IMPORTED_GLOBAL TRUE)
      endif()
      if(NOT TARGET STDEXEC::${target})
        add_library(STDEXEC::${target} ALIAS ${target})
      endif()
    endif()
  endforeach()
endif()
```

This would cause an error in CMake if you were to use `find_package(stdexec)` in many CMake sub-projects, because some but not all targets of the package are already defined.

```
  CMake Error at .deps/share/stdexec/stdexec-targets.cmake:42 (message):
    Some (but not all) targets in this export set were already defined.
  
    Targets Defined: STDEXEC::stdexec
  
    Targets not yet defined: STDEXEC::parallel_scheduler
  
  Call Stack (most recent call first):
    .deps/share/stdexec/stdexec-config.cmake:68 (include)
    C:/Program Files/CMake/share/cmake-4.2/Modules/CMakeFindDependencyMacro.cmake:93 (find_package)
    C:/Program Files/CMake/share/cmake-4.2/Modules/CMakeFindDependencyMacro.cmake:113 (__find_dependency_common)
```

Solution is rather simple I think: make sure parallel_scheduler is also in the variable rapids_global_targets, which we can do by adding it to `stdexec_export_targets`.