### PR TITLE
try to molify clangd when the `CMAKE_CXX_COMPILER_ID` is `"NVHPC"`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -21,9 +21,28 @@ If:
   PathMatch: .*\.cuh?$
   PathExclude: examples/nvexec/.*
 CompileFlags:
+  Compiler: clang++
   Add:
+    - "--offload-arch=sm_86"
+    - "-D__builtin_ia32_tmmultf32ps_internal(m,n,k,dst,src1,src2)=dst"
     # Allow variadic CUDA functions
     - "-Xclang=-fcuda-allow-variadic-functions"
+
+---
+
+# Use clang++ in CUDA mode to provide intellisense for files with `nvexec` in their path
+If:
+  PathMatch: [test/nvexec/.*, examples/nvexec/.*]
+CompileFlags:
+  Compiler: clang++
+  Add:
+    - "-x"
+    - "cuda"
+    - "--offload-arch=sm_86"
+    - "-D__builtin_ia32_tmmultf32ps_internal(m,n,k,dst,src1,src2)=dst"
+  Remove:
+    - "-x"
+    - "c++-header"
 
 ---
 
@@ -40,7 +59,6 @@ CompileFlags:
 CompileFlags:
   CompilationDatabase: .
   Add:
-    - "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
     # report all errors
     - "-ferror-limit=0"
     - "-fmacro-backtrace-limit=0"

--- a/.github/workflows/ci.gpu.yml
+++ b/.github/workflows/ci.gpu.yml
@@ -19,12 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "clang 22",    cuda: "12.0", cxx: "clang++", build: "Release", tag: "llvm22-cuda12.0",  gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
-          - { name: "clang 22",    cuda: "12.9", cxx: "clang++", build: "Release", tag: "llvm22-cuda12.9",  gpu: "v100", sm: "70", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 26.1",  cuda: "13.1", cxx: "mpic++",  build: "Release", tag: "nvhpc26.1",        gpu: "l4",   sm: "75", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 26.1",  cuda: "13.1", cxx: "mpic++",  build: "Debug",   tag: "nvhpc26.1",        gpu: "l4",   sm: "75", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 26.3",  cuda: "13.1", cxx: "mpic++",  build: "Release", tag: "nvhpc26.3",        gpu: "l4",   sm: "75", driver: "latest", arch: "amd64" }
-          - { name: "nvc++ 26.3",  cuda: "13.1", cxx: "mpic++",  build: "Debug",   tag: "nvhpc26.3",        gpu: "l4",   sm: "75", driver: "latest", arch: "amd64" }
+          - { name: "clang 22",    cuda: "12.0", cxx: "clang++", build: "Release", tag: "llvm22-cuda12.0", gpu: "v100", sm: "70", driver: "latest", arch: "amd64", flags: "-Wno-deprecated-declarations" }
+          - { name: "clang 22",    cuda: "12.9", cxx: "clang++", build: "Release", tag: "llvm22-cuda12.9", gpu: "v100", sm: "70", driver: "latest", arch: "amd64", flags: "" }
+          - { name: "nvc++ 26.1",  cuda: "13.1", cxx: "mpic++",  build: "Release", tag: "nvhpc26.1",       gpu: "l4",   sm: "75", driver: "latest", arch: "amd64", flags: "" }
+          - { name: "nvc++ 26.1",  cuda: "13.1", cxx: "mpic++",  build: "Debug",   tag: "nvhpc26.1",       gpu: "l4",   sm: "75", driver: "latest", arch: "amd64", flags: "" }
+          - { name: "nvc++ 26.3",  cuda: "13.1", cxx: "mpic++",  build: "Release", tag: "nvhpc26.3",       gpu: "l4",   sm: "75", driver: "latest", arch: "amd64", flags: "" }
+          - { name: "nvc++ 26.3",  cuda: "13.1", cxx: "mpic++",  build: "Debug",   tag: "nvhpc26.3",       gpu: "l4",   sm: "75", driver: "latest", arch: "amd64", flags: "" }
     runs-on: linux-${{ matrix.arch }}-gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1
     container:
       options: -u root
@@ -99,7 +99,9 @@ jobs:
             -DSTDEXEC_ENABLE_CUDA=ON \
             -DSTDEXEC_ENABLE_IO_URING=OFF \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
+            -DCMAKE_CXX_FLAGS=${{ matrix.flags }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_CUDA_FLAGS=${{ matrix.flags }} \
             -DCMAKE_CUDA_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_CUDA_ARCHITECTURES=${{ matrix.sm }} \
             -DSTDEXEC_BUILD_TESTS:BOOL=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 24.5.0)
         set(_nvhpc_seperate_memory_flags "-gpu=nomanaged")
     endif()
+
+    # Use nvc++ -stdpar to find the location of the HPC SDK's libcudacxx headers.
+    nvhpc_find_libcudacxx_include_dir(STDEXEC_NVHPC_LIBCUDACXX_INCLUDE_DIR)
 endif()
 
 # Support target for examples and tests
@@ -343,26 +346,11 @@ if(STDEXEC_ENABLE_CUDA)
     target_compile_features(nvexec INTERFACE cuda_std_20)
     target_link_libraries(nvexec INTERFACE STDEXEC::stdexec)
 
-    if(NOT CMAKE_CUDA_ARCHITECTURES)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
       set(CMAKE_CUDA_ARCHITECTURES "native")
     endif()
 
-    set(_gpus)
-    foreach(_arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
-      if(_arch MATCHES "-real")
-        string(REPLACE "-real" "" _arch "${_arch}")
-        string(PREPEND _arch "cc")
-      elseif(_arch MATCHES "-virtual")
-        string(REPLACE "-virtual" "" _arch "${_arch}")
-        string(PREPEND _arch "cc")
-      elseif(_arch MATCHES "^[0-9]+$")
-        string(PREPEND _arch "cc")
-      elseif(_arch MATCHES "^native$")
-        string(PREPEND _arch "cc")
-      endif()
-      list(APPEND _gpus "${_arch}")
-    endforeach()
-    list(JOIN _gpus "," _gpus)
+    cuda_archs_to_gpu_list("${CMAKE_CUDA_ARCHITECTURES}" _gpus)
 
     target_compile_options(nvexec INTERFACE
       $<$<AND:$<CXX_COMPILER_ID:NVHPC>,$<COMPILE_LANGUAGE:CXX>>:-stdpar -gpu=${_gpus}>)
@@ -373,7 +361,13 @@ if(STDEXEC_ENABLE_CUDA)
         EXPORT stdexec-exports
         FILE_SET headers)
 
-    if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+        if(STDEXEC_NVHPC_LIBCUDACXX_INCLUDE_DIR)
+            # Explicitly add the libcudacxx include directory to the nvexec target so that
+            # clangd can find the libcudacxx headers.
+            target_include_directories(nvexec SYSTEM INTERFACE ${STDEXEC_NVHPC_LIBCUDACXX_INCLUDE_DIR})
+        endif()
+    else ()
         include(rapids-cuda)
         # Needs to run before `enable_language(CUDA)`
         rapids_cuda_init_architectures(STDEXEC)
@@ -388,7 +382,7 @@ if(STDEXEC_ENABLE_CUDA)
         # because the former works with clangd intellisense
         set(CMAKE_INCLUDE_SYSTEM_FLAG_CUDA "-isystem ")
 
-        set_source_files_properties(${nvexec_sources} PROPERTIES LANGUAGE CUDA)
+        set_source_files_properties(${nvexec_headers} PROPERTIES LANGUAGE CUDA)
 
         rapids_find_package(
             CUDAToolkit REQUIRED
@@ -404,7 +398,7 @@ if(STDEXEC_ENABLE_CUDA)
             INSTALL_EXPORT_SET stdexec-exports
             SYSTEM TRUE)
 
-        target_link_libraries(stdexec INTERFACE CCCL::CCCL)
+        target_link_libraries(nvexec INTERFACE CCCL::CCCL)
     endif ()
 endif ()
 
@@ -521,7 +515,7 @@ endif()
 # Install targets ------------------------------------------------------------
 if(STDEXEC_INSTALL)
 	include(CPack)
-	
+
   set(stdexec_install_targets stdexec)
   if(STDEXEC_BUILD_PARALLEL_SCHEDULER)
     list(APPEND stdexec_install_targets parallel_scheduler)
@@ -531,12 +525,12 @@ if(STDEXEC_INSTALL)
     EXPORT stdexec-exports
 		FILE_SET headers
 		FILE_SET version_config)
-	
+
 	##############################################################################
 	# Install exports ------------------------------------------------------------
-	
+
 	set(code_string "")
-	
+
 	# Install side of the export set
 	rapids_export(
 	  INSTALL ${stdexec_export_targets}
@@ -545,7 +539,7 @@ if(STDEXEC_INSTALL)
 	  NAMESPACE STDEXEC::
 	  FINAL_CODE_BLOCK code_string
 	)
-	
+
 	# Build side of the export set so a user can use the build dir as a CMake package root
 	rapids_export(
 	  BUILD ${stdexec_export_targets}

--- a/cmake/Modules/CompilerHelpers.cmake
+++ b/cmake/Modules/CompilerHelpers.cmake
@@ -16,6 +16,40 @@
 
 include_guard(GLOBAL)
 
+# nvhpc_find_libcudacxx_include_dir(<out_var>)
+# Invokes nvc++ -stdpar to locate the libcudacxx include root (the directory
+# that contains cuda/std/bit) and stores it in <out_var>.
+function(nvhpc_find_libcudacxx_include_dir out_var)
+  set(_src "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/find_libcudacxx.cu")
+  file(WRITE "${_src}" "#include <cuda/std/bit>\n")
+  execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} -stdpar -E -M "${_src}"
+      OUTPUT_VARIABLE _output
+      ERROR_STRIP_TRAILING_WHITESPACE
+  )
+  string(REGEX MATCH "(/[^\n]*/cuda/std/bit) " _match "${_output}")
+  if(CMAKE_MATCH_1)
+    string(REGEX REPLACE "/cuda/std/bit$" "" _dir "${CMAKE_MATCH_1}")
+    set(${out_var} "${_dir}" PARENT_SCOPE)
+  else()
+    set(${out_var} "" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# cuda_archs_to_gpu_list(<archs> <out_var>) Converts a list of CUDA architectures (e.g.
+# 80, 86, 90) to a comma-separated list of GPU names (e.g. cc80, cc86, cc90) and stores it
+# in <out_var>. This is useful for passing to the -gpu option of nvc++.
+function(cuda_archs_to_gpu_list archs out_var)
+  set(_gpus)
+  foreach(_arch IN LISTS archs)
+    string(REGEX REPLACE "-(real|virtual)$" "" _arch "${_arch}")
+    string(PREPEND _arch "cc")
+    list(APPEND _gpus "${_arch}")
+  endforeach()
+  list(JOIN _gpus "," _gpus)
+  set(${out_var} "${_gpus}" PARENT_SCOPE)
+endfunction()
+
 function(disable_compiler)
   cmake_parse_arguments("" "" "LANG;VAR" "" ${ARGN})
   set(_val)

--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -58,10 +58,6 @@ target_link_libraries(test.nvexec
                       Catch2::Catch2WithMain
                       nvexec_executable_flags)
 
-# if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
-#     target_compile_options(test.nvexec PRIVATE "-ftemplate-backtrace-limit=9999")
-# endif()
-
 catch_discover_tests(test.nvexec PROPERTIES TIMEOUT 30)
 
 icm_add_build_failure_test(
@@ -71,9 +67,6 @@ icm_add_build_failure_test(
     LIBRARIES stdexec nvexec
     FOLDER test
 )
-set_target_properties(when_all_fail
-    PROPERTIES
-        LANGUAGE CUDA
-        LINKER_LANGUAGE CUDA)
-target_compile_options(when_all_fail PRIVATE
-    $<$<CXX_COMPILER_ID:Clang>:-x cuda>)
+if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC"))
+    set_source_files_properties(when_all_fail.cpp PROPERTIES LANGUAGE CUDA)
+endif()


### PR DESCRIPTION
clangd is crashing when processing c++ files that make use of the nvexec headers when the c++ compiler is nvc++. this pr attempts to make clangd work in that configuration.