### PR TITLE
Fix intrusive_heap fallback bit_ceil

### DIFF
--- a/include/exec/detail/intrusive_heap.hpp
+++ b/include/exec/detail/intrusive_heap.hpp
@@ -39,9 +39,12 @@ namespace experimental::execution
   {
     inline std::size_t bit_ceil(std::size_t n) noexcept
     {
-      int const         leading_zeros = __builtin_clzll(n);
-      std::size_t const p             = std::size_t{1} << (sizeof(std::size_t) * 8 - leading_zeros);
-      return p < n ? p << 1 : p;
+      if (n <= 1)
+      {
+        return 1;
+      }
+      int const leading_zeros = __builtin_clzll(n - 1);
+      return std::size_t{1} << (sizeof(unsigned long long) * 8 - leading_zeros);
     }
   }  // namespace detail
 #  else

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -26,6 +26,7 @@ set(exec_test_sources
     test_create.cpp
     test_env.cpp
     test_into_tuple.cpp
+    test_intrusive_heap.cpp
     test_repeat_until.cpp
     test_repeat_n.cpp
     async_scope/test_dtor.cpp

--- a/test/exec/test_intrusive_heap.cpp
+++ b/test/exec/test_intrusive_heap.cpp
@@ -1,4 +1,7 @@
+#include <stdexec/__detail/__config.hpp>
+
 #include <bit>
+#include <cstddef>
 
 // Exercise the fallback even when the standard library provides std::bit_ceil.
 #undef __cpp_lib_int_pow2
@@ -22,12 +25,12 @@ namespace
 
   TEST_CASE("intrusive_heap fallback bit_ceil handles powers of two", "[intrusive_heap]")
   {
-    CHECK(exec::detail::bit_ceil(1) == 1);
-    CHECK(exec::detail::bit_ceil(2) == 2);
-    CHECK(exec::detail::bit_ceil(3) == 4);
-    CHECK(exec::detail::bit_ceil(4) == 4);
-    CHECK(exec::detail::bit_ceil(5) == 8);
-    CHECK(exec::detail::bit_ceil(8) == 8);
+    CHECK(exec::detail::bit_ceil(std::size_t{1}) == 1);
+    CHECK(exec::detail::bit_ceil(std::size_t{2}) == 2);
+    CHECK(exec::detail::bit_ceil(std::size_t{3}) == 4);
+    CHECK(exec::detail::bit_ceil(std::size_t{4}) == 4);
+    CHECK(exec::detail::bit_ceil(std::size_t{5}) == 8);
+    CHECK(exec::detail::bit_ceil(std::size_t{8}) == 8);
   }
 
   TEST_CASE("intrusive_heap fallback inserts three nodes", "[intrusive_heap]")

--- a/test/exec/test_intrusive_heap.cpp
+++ b/test/exec/test_intrusive_heap.cpp
@@ -1,0 +1,46 @@
+#include <bit>
+
+// Exercise the fallback even when the standard library provides std::bit_ceil.
+#undef __cpp_lib_int_pow2
+
+#include <exec/detail/intrusive_heap.hpp>
+
+#include <test_common/catch2.hpp>
+
+namespace
+{
+  struct node
+  {
+    int   key_{};
+    node* prev_{};
+    node* left_{};
+    node* right_{};
+  };
+
+  using heap_t =
+    exec::intrusive_heap<node, int, &node::key_, &node::prev_, &node::left_, &node::right_>;
+
+  TEST_CASE("intrusive_heap fallback bit_ceil handles powers of two", "[intrusive_heap]")
+  {
+    CHECK(exec::detail::bit_ceil(1) == 1);
+    CHECK(exec::detail::bit_ceil(2) == 2);
+    CHECK(exec::detail::bit_ceil(3) == 4);
+    CHECK(exec::detail::bit_ceil(4) == 4);
+    CHECK(exec::detail::bit_ceil(5) == 8);
+    CHECK(exec::detail::bit_ceil(8) == 8);
+  }
+
+  TEST_CASE("intrusive_heap fallback inserts three nodes", "[intrusive_heap]")
+  {
+    node   first{1};
+    node   second{2};
+    node   third{3};
+    heap_t heap;
+
+    heap.insert(&first);
+    heap.insert(&second);
+    heap.insert(&third);
+
+    CHECK(heap.front() == &first);
+  }
+}  // namespace


### PR DESCRIPTION
## Summary

Fix the `intrusive_heap` fallback used when the standard library does not provide `std::bit_ceil`.

The builtin implementation called `__builtin_clzll(n)`, which selects the next bit above an exact power of two. For example, `bit_ceil(4)` returned 8 instead of 4. `intrusive_heap` uses this value to select an insertion path, so inserting a third node with the fallback enabled followed a nonexistent tree level and dereferenced a null pointer.

Handle the small inputs separately and compute the leading-zero count from `n - 1`. The shift now also uses the width corresponding to `__builtin_clzll`. The regression tests force the fallback path, cover power-of-two boundaries, and exercise the three-node insertion.

## Testing

- `cmake -S . -B build-pr-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DSTDEXEC_BUILD_EXAMPLES=OFF -DSTDEXEC_BUILD_TESTS=ON`
- `cmake --build build-pr-debug -j 8`
- `./build-pr-debug/test/exec/test.exec '[intrusive_heap]'`
- `./build-pr-debug/test/exec/test.exec`
- `ctest --test-dir build-pr-debug --output-on-failure -j 8` (920/920 passed)
- `ASAN_OPTIONS=abort_on_error=1 ./build-pr-asan/test/exec/test.exec '[intrusive_heap]'`
- `ASAN_OPTIONS=abort_on_error=1 ./build-pr-asan/test/exec/test.exec`
- `clang-format --dry-run --Werror include/exec/detail/intrusive_heap.hpp test/exec/test_intrusive_heap.cpp`
