### PR TITLE
Fix timed scheduler result aliases

### DIFF
--- a/include/exec/timed_scheduler.hpp
+++ b/include/exec/timed_scheduler.hpp
@@ -272,10 +272,12 @@ namespace experimental::execution
                          && __has_schedule_at<_Scheduler>;
 
   template <timed_scheduler _Scheduler>
-  using schedule_after_result_t = STDEXEC::__call_result_t<schedule_after_t, _Scheduler>;
+  using schedule_after_result_t =
+    STDEXEC::__call_result_t<schedule_after_t, _Scheduler, duration_of_t<_Scheduler> const &>;
 
   template <timed_scheduler _Scheduler>
-  using schedule_at_result_t = STDEXEC::__call_result_t<schedule_at_t, _Scheduler>;
+  using schedule_at_result_t =
+    STDEXEC::__call_result_t<schedule_at_t, _Scheduler, time_point_of_t<_Scheduler> const &>;
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;

--- a/test/exec/test_timed_thread_scheduler.cpp
+++ b/test/exec/test_timed_thread_scheduler.cpp
@@ -22,6 +22,9 @@
 #include <exec/async_scope.hpp>
 #include <exec/when_any.hpp>
 
+#include <concepts>
+#include <utility>
+
 // Avoid a TSAN bug in GCC 11 and earlier
 #if STDEXEC_GCC() && STDEXEC_GCC_VERSION < 1200 && defined(__SANITIZE_THREAD__)
 // nothing
@@ -31,7 +34,17 @@ namespace
   TEST_CASE("timed_thread_scheduler - unused context",
             "[types][timed_thread_scheduler][schedulers]")
   {
-    static_assert(exec::__timed_scheduler<exec::timed_thread_scheduler>);
+    using scheduler_t = exec::timed_thread_scheduler;
+
+    static_assert(exec::__timed_scheduler<scheduler_t>);
+    static_assert(std::same_as<exec::schedule_after_result_t<scheduler_t>,
+                               decltype(exec::schedule_after(
+                                 std::declval<scheduler_t>(),
+                                 std::declval<exec::duration_of_t<scheduler_t> const &>()))>);
+    static_assert(std::same_as<exec::schedule_at_result_t<scheduler_t>,
+                               decltype(exec::schedule_at(
+                                 std::declval<scheduler_t>(),
+                                 std::declval<exec::time_point_of_t<scheduler_t> const &>()))>);
     exec::timed_thread_context context;
   }
 


### PR DESCRIPTION
## Summary

Fix `schedule_after_result_t` and `schedule_at_result_t` so they include the duration or time-point argument required by their customization point objects.

Both aliases previously instantiated `__call_result_t` with only the scheduler type, even though `schedule_after` and `schedule_at` each take two arguments. As a result, using either result alias failed to compile for a valid timed scheduler.

Add compile-time coverage that compares each alias with the result of calling the corresponding customization point.

## Testing

- `cmake -S . -B build-pr-timed -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DSTDEXEC_BUILD_EXAMPLES=OFF -DSTDEXEC_BUILD_TESTS=ON`
- `cmake --build build-pr-timed -j 8`
- `./build-pr-timed/test/exec/test.exec '[timed_thread_scheduler]'`
- `./build-pr-timed/test/exec/test.exec`
- `ctest --test-dir build-pr-timed --output-on-failure -j 8` (918/918 passed)
- `clang-format --dry-run --Werror include/exec/timed_scheduler.hpp test/exec/test_timed_thread_scheduler.cpp`
