### PR TITLE
Fix variant move and swap noexcept specifications

### DIFF
--- a/include/exec/variant_sender.hpp
+++ b/include/exec/variant_sender.hpp
@@ -121,9 +121,8 @@ namespace experimental::execution
       return __sndrs_.template emplace<_Index>(static_cast<_Args&&>(__args)...);
     }
 
-    void swap(variant_sender& __other) noexcept
+    void swap(variant_sender& __other) noexcept(noexcept(__sndrs_.swap(__other.__sndrs_)))
     {
-      static_assert(noexcept(__sndrs_.swap(__other.__sndrs_)));
       __sndrs_.swap(__other.__sndrs_);
     }
 

--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -198,7 +198,8 @@ namespace STDEXEC
       }
 
       STDEXEC_ATTRIBUTE(host, device)
-      constexpr __variant &operator=(__variant &&__other) noexcept
+      constexpr __variant &
+      operator=(__variant &&__other) noexcept(__nothrow_move_constructible<_Ts...>)
         requires(std::move_constructible<_Ts> && ...)
       {
         if (this != &__other)
@@ -375,7 +376,7 @@ namespace STDEXEC
                                             static_cast<_Us &&>(__us)...);
       }
 
-      void swap(__variant &__other) noexcept
+      void swap(__variant &__other) noexcept(__nothrow_move_constructible<_Ts...>)
       {
         std::swap(*this, __other);
       }

--- a/test/exec/test_variant_sender.cpp
+++ b/test/exec/test_variant_sender.cpp
@@ -19,6 +19,9 @@
 
 #include <test_common/catch2.hpp>
 
+#include <type_traits>
+#include <utility>
+
 using namespace STDEXEC;
 using namespace exec;
 
@@ -37,6 +40,18 @@ namespace
   using just_void_t      = decltype(just());
   using just_then_void_t = decltype(then(just(), [] {}));
 
+  struct throwing_move_sender
+  {
+    using sender_concept        = sender_tag;
+    using completion_signatures = STDEXEC::completion_signatures<set_value_t()>;
+
+    throwing_move_sender()                             = default;
+    throwing_move_sender(throwing_move_sender const &) = default;
+    throwing_move_sender(throwing_move_sender &&) noexcept(false) {}
+  };
+
+  using throwing_variant_sender_t = variant_sender<throwing_move_sender>;
+
   TEST_CASE("variant_sender - default constructible", "[types][variant_sender]")
   {
     variant_sender<just_void_t, just_int_t> variant{just()};
@@ -48,6 +63,14 @@ namespace
   {
     variant_sender<just_void_t, just_then_void_t> variant{just()};
     STATIC_REQUIRE(sender_of<decltype(variant), set_value_t()>);
+  }
+
+  TEST_CASE("variant_sender - throwing move exception guarantees", "[types][variant_sender]")
+  {
+    STATIC_REQUIRE_FALSE(std::is_nothrow_move_constructible_v<throwing_variant_sender_t>);
+    STATIC_REQUIRE_FALSE(std::is_nothrow_move_assignable_v<throwing_variant_sender_t>);
+    STATIC_REQUIRE_FALSE(noexcept(std::declval<throwing_variant_sender_t &>().swap(
+      std::declval<throwing_variant_sender_t &>())));
   }
 
   TEST_CASE("variant_sender - using an overloaded then adaptor", "[types][variant_sender]")


### PR DESCRIPTION
## Summary

Make `__variant` move assignment and swap conditionally `noexcept`, matching its move constructor.

Move assignment destroys the current alternative and move-constructs the active alternative from the source. When that move construction can throw, the previous unconditional specifications reported incorrect type traits and caused an exception to terminate the process. `variant_sender::swap` also hard-coded the same unconditional guarantee.

Use the alternatives' move-construction guarantee for `__variant`, propagate the underlying swap specification through `variant_sender`, and add compile-time coverage with a sender whose move constructor can throw.

## Testing

- `cmake -S . -B build-pr-timed -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DSTDEXEC_BUILD_EXAMPLES=OFF -DSTDEXEC_BUILD_TESTS=ON`
- `cmake --build build-pr-timed -j 8`
- `./build-pr-timed/test/exec/test.exec '[variant_sender]'`
- `./build-pr-timed/test/exec/test.exec` (3,277 assertions in 317 test cases)
- `ctest --test-dir build-pr-timed --output-on-failure -j 8` (919/919 passed)
- `cmake -S . -B build-pr-noexcept -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_FLAGS=-fno-exceptions -DSTDEXEC_ENABLE_LIBDISPATCH=OFF -DSTDEXEC_BUILD_EXAMPLES=OFF -DSTDEXEC_BUILD_TESTS=ON`
- `cmake --build build-pr-noexcept --target test.exec -j 8`
- `./build-pr-noexcept/test/exec/test.exec '[variant_sender]'`
- `./build-pr-noexcept/test/exec/test.exec` (3,222 assertions in 299 test cases)
- `clang-format --dry-run --Werror include/stdexec/__detail/__variant.hpp include/exec/variant_sender.hpp test/exec/test_variant_sender.cpp`
