### PR TITLE
Make just_from conditionally noexcept

### DIFF
--- a/include/exec/just_from.hpp
+++ b/include/exec/just_from.hpp
@@ -193,7 +193,7 @@ namespace experimental::execution
    public:
     template <class Fn>
     STDEXEC_ATTRIBUTE(always_inline, host, device)
-    auto operator()(Fn fn) const noexcept
+    auto operator()(Fn fn) const noexcept(STDEXEC::__nothrow_move_constructible<Fn>)
     {
       if constexpr (STDEXEC::__callable<Fn, _probe_fn>)
       {

--- a/test/exec/test_just_from.cpp
+++ b/test/exec/test_just_from.cpp
@@ -40,7 +40,7 @@ namespace
     }
 
     template <class Sink>
-    auto operator()(Sink sink)
+    auto operator()(Sink sink) noexcept
     {
       return sink();
     }
@@ -86,8 +86,14 @@ namespace
     CHECK(c == 44);
   }
 
-  TEST_CASE("just_from propagates exceptions from storing the callable", "[just_from]")
+  TEST_CASE("just_from is conditionally noexcept when storing the callable", "[just_from]")
   {
+    auto nothrow_fn = [](auto sink) noexcept
+    {
+      return sink();
+    };
+    STATIC_REQUIRE(noexcept(exec::just_from(nothrow_fn)));
+
     throwing_move_callable fn;
     STATIC_REQUIRE_FALSE(noexcept(exec::just_from(fn)));
 

--- a/test/exec/test_just_from.cpp
+++ b/test/exec/test_just_from.cpp
@@ -24,6 +24,30 @@ namespace
 {
   constinit int global_int = 0;
 
+  struct throwing_move_callable
+  {
+    throwing_move_callable()                                        = default;
+    throwing_move_callable(throwing_move_callable const &) noexcept = default;
+    throwing_move_callable(throwing_move_callable &&other) noexcept(false)
+      : should_throw_(other.should_throw_)
+    {
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+      if (should_throw_)
+      {
+        throw 42;
+      }
+#endif
+    }
+
+    template <class Sink>
+    auto operator()(Sink sink)
+    {
+      return sink();
+    }
+
+    bool should_throw_{false};
+  };
+
   TEST_CASE("just_from is a sender", "[just_from]")
   {
     SECTION("potentially throwing")
@@ -60,6 +84,17 @@ namespace
     CHECK(a == 42);
     CHECK(b == 43);
     CHECK(c == 44);
+  }
+
+  TEST_CASE("just_from propagates exceptions from storing the callable", "[just_from]")
+  {
+    throwing_move_callable fn;
+    STATIC_REQUIRE_FALSE(noexcept(exec::just_from(fn)));
+
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+    fn.should_throw_ = true;
+    CHECK_THROWS_AS(exec::just_from(fn), int);
+#endif
   }
 
   TEST_CASE("just_from with multiple completions", "[just_from]")
@@ -100,7 +135,7 @@ namespace
     global_int = 42;
     auto s     = exec::just_from([](auto sink) noexcept { return sink(global_int); })
            | ex::then(
-               [](int& i) noexcept
+               [](int &i) noexcept
                {
                  CHECK(&i == &global_int);
                  return std::ref(i);


### PR DESCRIPTION
## Summary

Make the `just_from` factory family conditionally `noexcept` based on whether the callable can be moved without throwing.

The factory accepts the callable by value and then moves it into the sender. For an lvalue callable with a non-throwing copy constructor and a potentially throwing move constructor, parameter construction succeeds but storing the callable can throw. The previous unconditional specification caused that exception to terminate the process and incorrectly reported the call as non-throwing.

Add coverage showing that nothrow-movable callables retain the `noexcept` guarantee, potentially throwing moves are reported correctly, and exceptions thrown while storing the callable propagate to the caller.

## Testing

- `cmake -S . -B build-pr-timed -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=OFF -DSTDEXEC_BUILD_EXAMPLES=OFF -DSTDEXEC_BUILD_TESTS=ON`
- `cmake --build build-pr-timed --target test.exec -j 8`
- `./build-pr-timed/test/exec/test.exec '[just_from]'`
- `./build-pr-timed/test/exec/test.exec` (3,277 assertions in 317 test cases)
- `ctest --test-dir build-pr-timed --output-on-failure -j 8` (919/919 passed)
- `cmake -S . -B build-pr-noexcept -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=23 -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_CXX_FLAGS=-fno-exceptions -DSTDEXEC_ENABLE_LIBDISPATCH=OFF -DSTDEXEC_BUILD_EXAMPLES=OFF -DSTDEXEC_BUILD_TESTS=ON`
- `cmake --build build-pr-noexcept --target test.exec -j 8`
- `./build-pr-noexcept/test/exec/test.exec '[just_from]'`
- `./build-pr-noexcept/test/exec/test.exec` (3,221 assertions in 299 test cases)
- `clang-format --dry-run --Werror include/exec/just_from.hpp test/exec/test_just_from.cpp`
