### PR TITLE
fix(__any_allocator): add friend declaration so the cross-specialization converting constructor compiles

### DIFF
--- a/include/stdexec/__detail/__any_allocator.hpp
+++ b/include/stdexec/__detail/__any_allocator.hpp
@@ -67,10 +67,9 @@ namespace STDEXEC
 
     __any_allocator() = default;
 
-    // MSVC does not implement [class.access]: members of a class template
-    // cannot access private members of other specializations of the same
-    // template. The converting constructor below relies on that rule, so
-    // declare the friendship explicitly.
+    // The converting constructor below accesses the private member of another
+    // specialization of this template, which is rejected by MSVC, Clang and
+    // GCC. Declare the friendship explicitly.
     template <class>
     friend struct __any_allocator;
 

--- a/include/stdexec/__detail/__any_allocator.hpp
+++ b/include/stdexec/__detail/__any_allocator.hpp
@@ -67,6 +67,13 @@ namespace STDEXEC
 
     __any_allocator() = default;
 
+    // MSVC does not implement [class.access]: members of a class template
+    // cannot access private members of other specializations of the same
+    // template. The converting constructor below relies on that rule, so
+    // declare the friendship explicitly.
+    template <class>
+    friend struct __any_allocator;
+
     template <__not_same_as<__any_allocator> _Alloc>
       requires __is_not_instance_of<_Alloc, __any_allocator> && __simple_allocator<_Alloc>
     __any_allocator(_Alloc __alloc) noexcept

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,7 @@ set(stdexec_test_sources
     stdexec/algos/consumers/test_sync_wait.cpp
     stdexec/algos/consumers/test_spawn.cpp
     stdexec/detail/test_any.cpp
+    stdexec/detail/test_any_allocator.cpp
     stdexec/detail/test_common_domain.cpp
     stdexec/detail/test_completion_signatures.cpp
     stdexec/detail/test_demangle.cpp

--- a/test/stdexec/detail/test_any_allocator.cpp
+++ b/test/stdexec/detail/test_any_allocator.cpp
@@ -22,12 +22,15 @@
 #include <utility>
 
 // The converting constructor __any_allocator(_Uy) reads the private member of
-// another specialization of the same class template. This is legal since C++17
-// ([class.access]) but MSVC rejects it with C2248; the friend declaration on
-// __any_allocator makes the conversion compile everywhere. The conversion is
-// instantiated whenever task_scheduler's type-erased backend needs to copy an
-// allocator on the heap-allocation fallback path (e.g. with an asio-based
-// scheduler), so this test guards the fix for NVIDIA/stdexec#2158.
+// another specialization of the same class template. That access is rejected by
+// all major compilers (MSVC C2248, Clang and GCC report it as accessing a
+// private member), so the constructor only compiles because it is never
+// instantiated in the upstream test matrix. It *is* instantiated whenever
+// task_scheduler's type-erased backend copies an allocator on the
+// heap-allocation fallback path (e.g. with an asio-based scheduler), breaking
+// the build on every compiler; the friend declaration makes the conversion
+// legal. This test instantiates the constructor directly and guards the fix
+// for NVIDIA/stdexec#2158.
 TEST_CASE("__any_allocator cross-specialization converting constructor compiles",
           "[detail][allocator]")
 {

--- a/test/stdexec/detail/test_any_allocator.cpp
+++ b/test/stdexec/detail/test_any_allocator.cpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 with LLVM Exceptions (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdexec/execution.hpp>
+
+#include <test_common/catch2.hpp>
+
+#include <utility>
+
+// The converting constructor __any_allocator(_Uy) reads the private member of
+// another specialization of the same class template. This is legal since C++17
+// ([class.access]) but MSVC rejects it with C2248; the friend declaration on
+// __any_allocator makes the conversion compile everywhere. The conversion is
+// instantiated whenever task_scheduler's type-erased backend needs to copy an
+// allocator on the heap-allocation fallback path (e.g. with an asio-based
+// scheduler), so this test guards the fix for NVIDIA/stdexec#2158.
+TEST_CASE("__any_allocator cross-specialization converting constructor compiles",
+          "[detail][allocator]")
+{
+  STDEXEC::__any_allocator<int> src;
+  STDEXEC::__any_allocator<std::byte> dst(std::move(src)); // instantiates the converting ctor
+  CHECK(dst.has_value() == false);
+}

--- a/test/stdexec/detail/test_any_allocator.cpp
+++ b/test/stdexec/detail/test_any_allocator.cpp
@@ -34,7 +34,7 @@
 TEST_CASE("__any_allocator cross-specialization converting constructor compiles",
           "[detail][allocator]")
 {
-  STDEXEC::__any_allocator<int> src;
-  STDEXEC::__any_allocator<std::byte> dst(std::move(src)); // instantiates the converting ctor
+  STDEXEC::__any_allocator<int>       src;
+  STDEXEC::__any_allocator<std::byte> dst(std::move(src));  // instantiates the converting ctor
   CHECK(dst.has_value() == false);
 }


### PR DESCRIPTION
## Summary

`stdexec::task_scheduler` fails to compile when its type-erased backend takes the heap-allocation fallback path: `__any_allocator<std::byte>` has a converting constructor that reads the private member of *another specialization* of the same class template. That access is **rejected by all major compilers** (MSVC `C2248`, Clang and GCC report it as accessing a private member) — verified with MSVC cl 19.51.36252, clang-cl 22.1.8 and GCC 13.3.

The constructor is only instantiated on the heap-allocation fallback path (operation state larger than `task_scheduler`'s inline storage), which the upstream test matrix never exercises — e.g. `stdexec::task` on an asio-based scheduler (`asio::post` + `use_sender`). So the build breaks on every compiler, not just MSVC. See #2158 for the full analysis and repro.

## Fix

Add an explicit friend declaration to `__any_allocator` (makes the cross-specialization access legal on every compiler):

```cpp
template <class>
friend struct __any_allocator;
```

## Test

Add `test/stdexec/detail/test_any_allocator.cpp`, which instantiates the cross-specialization converting constructor directly. The test fails on **every** compiler without the friend declaration (verified: MSVC C2248, Clang private-member error, GCC private-within-this-context), so it guards the fix on all platforms.

Verified locally on MSVC cl 19.51.36252:

| | without friend | with friend |
|---|---|---|
| `__any_allocator<int>` → `__any_allocator<std::byte>` conversion | ❌ C2248 | ✅ compiles |
| `test.stdexec` full build + run (`*any_allocator*`) | — | ✅ 1 test case passed |

clang-cl 22.1.8 also rejects the conversion without the friend declaration and compiles with it.

Fixes #2158