### PR TITLE
Add missing `<vector>` include in `libdispatch_queue.hpp`

### DIFF
--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -33,6 +33,7 @@
 #  include "sender_for.hpp"
 
 #  include <dispatch/dispatch.h>
+#  include <vector>
 
 namespace experimental::execution
 {


### PR DESCRIPTION
`exec/libdispatch_queue.hpp` uses `std::vector` (line 443 upstream, line 444 after my edits), but never includes `<vector>`. Although this typically arrives transitively through `stdexec/execution.hpp`, on libc++ 22, the include appears on C++23 but does not in C++26. `stdexec/execution.hpp` already includes the other `std` symbols used in this file transitively, but not `std::vector`.

```cpp
#include <exec/libdispatch_queue.hpp>

int main() {
    return 0;
}
```

Result:
```console
$ clang++ -std=c++2c -stdlib=libc++ -I include -fsyntax-only Test.cpp
exec/libdispatch_queue:443:12: error: no template named 'vector' in namespace 'std'
```

This, however, passes with `-std=c++23`.

This header only gets included on Apple platforms, and Linux/libstdc++ never compiles it. (I observed this on Homebrew LLVM clang 22.1.8 and bundled libc++, on macOS.)

The fix is simply adding `#include <vector>`.