### PR TITLE
Preserve error references in materialize

### DIFF
--- a/include/exec/materialize.hpp
+++ b/include/exec/materialize.hpp
@@ -43,7 +43,7 @@ namespace experimental::execution
       }
 
       template <class _Error>
-      constexpr void set_error(_Error __err) noexcept
+      constexpr void set_error(_Error&& __err) noexcept
       {
         STDEXEC::set_value(static_cast<_Receiver&&>(__upstream_),
                            set_error_t(),

--- a/test/exec/test_materialize.cpp
+++ b/test/exec/test_materialize.cpp
@@ -13,15 +13,15 @@ namespace
 
   struct noncopyable_error
   {
-    noncopyable_error() = default;
-    noncopyable_error(noncopyable_error const &) = delete;
+    noncopyable_error()                                     = default;
+    noncopyable_error(noncopyable_error const &)            = delete;
     noncopyable_error& operator=(noncopyable_error const &) = delete;
   };
 
   struct error_sender
   {
-    using sender_concept = ex::sender_tag;
-    using completion_signatures = ex::completion_signatures<ex::set_error_t(noncopyable_error &)>;
+    using sender_concept        = ex::sender_tag;
+    using completion_signatures = ex::completion_signatures<ex::set_error_t(noncopyable_error&)>;
 
     template <class Receiver>
     struct operation
@@ -59,7 +59,7 @@ namespace
     }
 
     noncopyable_error* expected_;
-    bool*             called_;
+    bool*              called_;
   };
 
   template <class _Tag, class... _Args>
@@ -119,9 +119,9 @@ namespace
     bool              called = false;
     auto              sndr   = materialize(error_sender{&error});
 
-    static_assert(set_equivalent<completion_signatures_of_t<decltype(sndr)>,
-                                 completion_signatures<set_value_t(set_error_t,
-                                                                    noncopyable_error &)>>);
+    static_assert(
+      set_equivalent<completion_signatures_of_t<decltype(sndr)>,
+                     completion_signatures<set_value_t(set_error_t, noncopyable_error&)>>);
 
     auto op = connect(std::move(sndr), error_receiver{&error, &called});
     start(op);

--- a/test/exec/test_materialize.cpp
+++ b/test/exec/test_materialize.cpp
@@ -11,6 +11,57 @@ using namespace exec;
 namespace
 {
 
+  struct noncopyable_error
+  {
+    noncopyable_error() = default;
+    noncopyable_error(noncopyable_error const &) = delete;
+    noncopyable_error& operator=(noncopyable_error const &) = delete;
+  };
+
+  struct error_sender
+  {
+    using sender_concept = ex::sender_tag;
+    using completion_signatures = ex::completion_signatures<ex::set_error_t(noncopyable_error &)>;
+
+    template <class Receiver>
+    struct operation
+    {
+      noncopyable_error* error_;
+      Receiver           receiver_;
+
+      void start() & noexcept
+      {
+        ex::set_error(static_cast<Receiver&&>(receiver_), *error_);
+      }
+    };
+
+    template <class Receiver>
+    auto connect(Receiver receiver) const noexcept -> operation<Receiver>
+    {
+      return {error_, static_cast<Receiver&&>(receiver)};
+    }
+
+    noncopyable_error* error_;
+  };
+
+  struct error_receiver
+  {
+    using receiver_concept = ex::receiver_tag;
+
+    void set_value(ex::set_error_t, noncopyable_error& error) && noexcept
+    {
+      *called_ = &error == expected_;
+    }
+
+    void set_stopped() && noexcept
+    {
+      *called_ = false;
+    }
+
+    noncopyable_error* expected_;
+    bool*             called_;
+  };
+
   template <class _Tag, class... _Args>
     requires __completion_tag<std::decay_t<_Tag>>
   using __dematerialize_value = completion_signatures<std::decay_t<_Tag>(_Args...)>;
@@ -60,6 +111,21 @@ namespace
     auto just_stop = materialize(just_stopped());
     auto [tag]     = *sync_wait(just_stop);
     static_assert(std::same_as<decltype(tag), set_stopped_t>);
+  }
+
+  TEST_CASE("materialize preserves error references", "[adaptors][materialize]")
+  {
+    noncopyable_error error;
+    bool              called = false;
+    auto              sndr   = materialize(error_sender{&error});
+
+    static_assert(set_equivalent<completion_signatures_of_t<decltype(sndr)>,
+                                 completion_signatures<set_value_t(set_error_t,
+                                                                    noncopyable_error &)>>);
+
+    auto op = connect(std::move(sndr), error_receiver{&error, &called});
+    start(op);
+    CHECK(called);
   }
 
   TEST_CASE("dematerialize value", "[adaptors][materialize]")


### PR DESCRIPTION
## Summary

- forward materialize errors without copying them
- add a regression test for a non-copyable error delivered by lvalue reference

## Why

`materialize` advertises `set_error_t(error_type&)` as `set_value_t(set_error_t, error_type&)`, but its receiver took errors by value. That can require a copy and changes an lvalue into an rvalue. This forwards the error so the runtime behavior matches the completion signature.

## Testing

- `cmake --build build --target test.exec -j 8`
- `./build/test/exec/test.exec '[materialize]'`