### PR TITLE
Forward rooted environment in start_detached

### DIFF
--- a/include/exec/start_detached.hpp
+++ b/include/exec/start_detached.hpp
@@ -251,7 +251,10 @@ namespace experimental::execution
     {
       auto __env2      = STDEXEC::__as_root_env(static_cast<_Env&&>(__env));
       using __domain_t = __compl_domain_t<_Sender, STDEXEC::__as_root_env_t<_Env>>;
-      STDEXEC::apply_sender(__domain_t{}, *this, static_cast<_Sender&&>(__sndr), __env2);
+      STDEXEC::apply_sender(__domain_t{},
+                            *this,
+                            static_cast<_Sender&&>(__sndr),
+                            static_cast<decltype(__env2)&&>(__env2));
     }
 
     // Below is the default implementation for `start_detached`.

--- a/test/exec/test_start_detached.cpp
+++ b/test/exec/test_start_detached.cpp
@@ -293,6 +293,19 @@ namespace
   struct env
   {};
 
+  struct move_only_env
+  {
+    move_only_env() = default;
+    move_only_env(move_only_env&&) noexcept = default;
+    move_only_env(move_only_env const &) = delete;
+  };
+
+  TEST_CASE("start_detached works with a move-only environment",
+            "[consumers][start_detached]")
+  {
+    exec::start_detached(ex::just(), move_only_env{});
+  }
+
   TEST_CASE("ex::on can be passed to start_detached with env", "[adaptors][ex::on]")
   {
     ex::run_loop loop;

--- a/test/exec/test_start_detached.cpp
+++ b/test/exec/test_start_detached.cpp
@@ -295,13 +295,12 @@ namespace
 
   struct move_only_env
   {
-    move_only_env() = default;
+    move_only_env()                         = default;
     move_only_env(move_only_env&&) noexcept = default;
-    move_only_env(move_only_env const &) = delete;
+    move_only_env(move_only_env const &)    = delete;
   };
 
-  TEST_CASE("start_detached works with a move-only environment",
-            "[consumers][start_detached]")
+  TEST_CASE("start_detached works with a move-only environment", "[consumers][start_detached]")
   {
     exec::start_detached(ex::just(), move_only_env{});
   }


### PR DESCRIPTION
## Summary

- forward the rooted environment into `apply_sender`
- add coverage for a move-only environment

## Why

The two-argument overload stores the rooted environment in `__env2` and then passes that named variable as an lvalue. The default implementation stores the decayed environment by value, so a move-only environment cannot be used. Forwarding `__env2` keeps the value category expected by the constraints.

## Testing

- `cmake --build build --target test.exec -j 8`
- `./build/test/exec/test.exec '[start_detached]'`