### PR TITLE
Complete start_now with no senders

### DIFF
--- a/include/exec/start_now.hpp
+++ b/include/exec/start_now.hpp
@@ -77,6 +77,7 @@ namespace experimental::execution
 
       constexpr __storage_base(_Env&& __env, std::size_t __pending)
         : __pending_(__pending)
+        , __joiner_(__pending == 0 ? nullptr : &__empty_joiner_)
         , __env_(__mkenv(static_cast<_Env&&>(__env), __source_))
       {}
 

--- a/test/exec/async_scope/test_start_now.cpp
+++ b/test/exec/async_scope/test_start_now.cpp
@@ -26,6 +26,14 @@ namespace
     REQUIRE(executed);
   }
 
+  TEST_CASE("start_now zero", "[async_scope][start_now]")
+  {
+    async_scope scope;
+    auto        stg = start_now(scope);
+
+    REQUIRE(sync_wait(stg.async_wait()).has_value());
+  }
+
   TEST_CASE("start_now two", "[async_scope][start_now]")
   {
     bool        executedA{false};


### PR DESCRIPTION
## Summary

- mark empty `start_now` storage as already complete
- add a regression test for `start_now(scope)`

## Why

`start_now` accepts an empty sender pack. The storage starts with a pending count of zero, but its joiner still points to the waiting state. `async_wait()` can then install a waiter even though no child can complete the storage. Initializing the joiner to the existing completed marker makes an empty pack complete immediately.

## Testing

- `cmake --build build --target test.exec -j 8`
- `./build/test/exec/test.exec '[async_scope][start_now]'`