### PR TITLE
sync_wait: terminate instead of misreporting errors as stopped when exceptions are unavailable

### DIFF
--- a/include/stdexec/__detail/__sync_wait.hpp
+++ b/include/stdexec/__detail/__sync_wait.hpp
@@ -117,6 +117,16 @@ namespace STDEXEC::__sync_wait
     template <class _Error>
     constexpr void set_error(_Error __err) noexcept
     {
+#  if STDEXEC_NO_STDCPP_EXCEPTIONS()
+      // sync_wait's only way to deliver an error to its caller is to rethrow
+      // it. Without exception support, std::make_exception_ptr returns a null
+      // exception_ptr, which the rethrow path would silently skip -- turning
+      // an error completion into an empty optional, indistinguishable from a
+      // stopped completion. Errors must not masquerade as cancellation:
+      // terminate loudly instead.
+      (void) __err;
+      STDEXEC_TERMINATE();
+#  else
       if constexpr (__same_as<_Error, std::exception_ptr>)
       {
         STDEXEC_ASSERT(__err != nullptr);  // std::exception_ptr must not be null.
@@ -131,6 +141,7 @@ namespace STDEXEC::__sync_wait
         __state_->__eptr_ = std::make_exception_ptr(static_cast<_Error&&>(__err));
       }
       __state_->__loop_.finish();
+#  endif
     }
 
     constexpr void set_stopped() noexcept


### PR DESCRIPTION
Note: this PR is independent of #2167. But the test-suite evidence below was gathered with #2167 applied. Without it, GCC on arm/aarch64 cannot compile anything that reaches the spin-loop header.

`sync_wait` has one way to deliver an error completion to its caller: rethrow it. When exception support is off (`STDEXEC_NO_STDCPP_EXCEPTIONS()`), the receiver sends every non-`exception_ptr` error completion through `std::make_exception_ptr`. At least libstdc++'s implementation then returns a **null** `exception_ptr`: the non-throwing fast path needs RTTI, the throwing path needs exceptions, and with both off the fallback returns `exception_ptr()`. The rethrow site checks the pointer, finds null, and does nothing. `sync_wait` then returns a disengaged `optional`.

This is worse than a missing report. [exec.sync.wait] reserves the disengaged optional for *stopped* completions: "For a stopped completion, a disengaged optional object is returned." So every error completion is reported as a cancellation. This corrupts the caller logic (retry, commit, abort) that must tell the two apart.

With this change, when `STDEXEC_NO_STDCPP_EXCEPTIONS()` is true, the receiver's error channel calls `STDEXEC_TERMINATE()`. A no-exceptions build has no channel that can carry the error to the caller. To terminate loudly is strictly better than to convert errors into cancellations. The library already has this exact convention: `STDEXEC_THROW` lowers to `::STDEXEC::__terminate()` when exceptions are off (`__config.hpp`).

I chose runtime termination over a `static_assert` deliberately. An error completion signature is often present but never taken at run time (any generic chain advertises one). A compile-time rejection would make `sync_wait` unusable under `-fno-exceptions`. Termination only affects executions where an error completion actually occurs.

Behavior with exceptions on is unchanged. The original body is the `#else` branch, unmodified. An A/B comparison against the unpatched tree shows identical behavior for all three `AS-EXCEPT-PTR` cases:

- A custom error type is thrown as itself and caught.
- A `std::error_code` arrives as `std::system_error` with the original code.
- An `exception_ptr` is rethrown.

Verification, on aarch64-apple-darwin with GCC 16.1:

- Under `-fno-exceptions -fno-rtti`, an error completion now terminates. Before, it returned a silent disengaged optional.
- The value and stopped channels are unchanged in both modes.
- The full default suite passes: 963/968. The 5 relacy failures are environmental on this host and unaffected by this change.
- The `-fno-exceptions` configuration from the CI matrix passes: 879/879.

On test coverage: the existing `sync_wait` error-path tests are compiled out under no-exceptions builds (`test_sync_wait.cpp`, `#if !STDEXEC_NO_STDCPP_EXCEPTIONS()`). So the no-exceptions CI legs have no error-path coverage today. That is how this behavior shipped. It is also why this change cannot alter their results. The observable fix behavior is termination, which Catch2 cannot assert in-process. I can add a subprocess death test (an exit-code assertion gated on `STDEXEC_NO_STDCPP_EXCEPTIONS()`) if you want one.
