### PR TITLE
Fix inplace_stop_source request_stop return value

### DIFF
--- a/include/stdexec/stop_token.hpp
+++ b/include/stdexec/stop_token.hpp
@@ -263,7 +263,7 @@ STDEXEC_P2300_NAMESPACE_BEGIN()
   inline auto inplace_stop_source::request_stop() noexcept -> bool
   {
     if (!__try_lock_unless_stop_requested_(true))
-      return true;
+      return false;
 
     __notifying_thread_ = std::this_thread::get_id();
 
@@ -293,7 +293,7 @@ STDEXEC_P2300_NAMESPACE_BEGIN()
     }
 
     __state_.store(__stop_requested_flag_, STDEXEC::__std::memory_order_release);
-    return false;
+    return true;
   }
 
   inline auto inplace_stop_source::__lock_() const noexcept -> uint8_t

--- a/test/exec/test_unless_stop_requested.cpp
+++ b/test/exec/test_unless_stop_requested.cpp
@@ -74,6 +74,15 @@ namespace
     ::STDEXEC::start(op);
   }
 
+  TEST_CASE("request_stop reports whether it made a stop request", "[stop_token]")
+  {
+    ::STDEXEC::inplace_stop_source source;
+
+    CHECK(source.request_stop());
+    CHECK(source.stop_requested());
+    CHECK_FALSE(source.request_stop());
+  }
+
   TEST_CASE("No op when the associated stop token is unstoppable", "[unless_stop_requested]")
   {
     static_assert(::exec::__unless_stop_requested::__unstoppable_env<::STDEXEC::env<>>);


### PR DESCRIPTION
This fixes the boolean result returned by `inplace_stop_source::request_stop()`.

The implementation currently returns `true` when a stop request was already made and `false` after this call successfully requests stop. That is reversed. The first call should return `true`, and later calls should return `false`.

The regression test checks both calls and confirms that the stop request is visible.

Tests:
- `cmake --build build --target test.exec -j 4`
- `build/test/exec/test.exec '[stop_token]'`
- `build/test/exec/test.exec`