### PR TITLE
Fix fork_join exception fallback storage

### DIFF
--- a/include/exec/fork_join.hpp
+++ b/include/exec/fork_join.hpp
@@ -174,8 +174,7 @@ namespace experimental::execution
           if constexpr (!STDEXEC::__nothrow_decay_copyable<Args...>)
           {
             using _tuple_t = STDEXEC::__tuple<STDEXEC::set_error_t, ::std::exception_ptr>;
-            _cache_._results_.template emplace<_tuple_t>(STDEXEC::set_error,
-                                                         ::std::current_exception());
+            _cache_.template emplace<_tuple_t>(STDEXEC::set_error, ::std::current_exception());
           }
         }
         _child_opstate_.__destroy();

--- a/test/exec/test_fork_join.cpp
+++ b/test/exec/test_fork_join.cpp
@@ -54,6 +54,18 @@ namespace
     constexpr void operator()() const noexcept {}
   };
 
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+  struct throwing_copy
+  {
+    throwing_copy() = default;
+
+    throwing_copy(throwing_copy const&) noexcept(false)
+    {
+      throw 42;
+    }
+  };
+#endif
+
   template <char ID>
   struct identifiable_domain : public STDEXEC::default_domain
   {};
@@ -121,6 +133,21 @@ namespace
 
     ::STDEXEC::sync_wait(std::move(sndr));
   }
+
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+  TEST_CASE("fork_join reports failures while caching results", "[adaptors][fork_join]")
+  {
+    auto sndr = exec::fork_join(
+      exec::just_from([](auto sink) noexcept
+                      {
+                        static throwing_copy value;
+                        return sink(value);
+                      }),
+      then([](throwing_copy const&) noexcept {}));
+
+    CHECK_THROWS_AS(sync_wait(std::move(sndr)), int);
+  }
+#endif
 
   TEST_CASE("fork_join can be nested", "[adaptors][fork_join]")
   {

--- a/test/exec/test_fork_join.cpp
+++ b/test/exec/test_fork_join.cpp
@@ -59,10 +59,12 @@ namespace
   {
     throwing_copy() = default;
 
-    throwing_copy(throwing_copy const&) noexcept(false)
+    throwing_copy(throwing_copy const &) noexcept(false)
     {
       throw 42;
     }
+
+    int value = 0;
   };
 #endif
 
@@ -137,13 +139,13 @@ namespace
 #if !STDEXEC_NO_STDCPP_EXCEPTIONS()
   TEST_CASE("fork_join reports failures while caching results", "[adaptors][fork_join]")
   {
-    auto sndr = exec::fork_join(
-      exec::just_from([](auto sink) noexcept
-                      {
-                        static throwing_copy value;
-                        return sink(value);
-                      }),
-      then([](throwing_copy const&) noexcept {}));
+    auto sndr = exec::fork_join(exec::just_from(
+                                  [](auto sink) noexcept
+                                  {
+                                    static throwing_copy value;
+                                    return sink(value);
+                                  }),
+                                then([](throwing_copy const &) noexcept {}));
 
     CHECK_THROWS_AS(sync_wait(std::move(sndr)), int);
   }


### PR DESCRIPTION
This fixes the exception fallback in `exec::fork_join`.

When caching a potentially throwing completion argument, `fork_join` currently tries to emplace the exception result through `_cache_._results_`. The cache is already a `__results_storage`, so that member does not exist and the template branch fails to compile when instantiated.

The fix emplaces the `set_error(std::exception_ptr)` tuple directly into `_cache_`.

The regression test uses a value with a potentially throwing copy constructor, returns it by reference from `just_from`, and verifies that `sync_wait` rethrows the copy failure.

Tests:
- `cmake --build build --target test.exec -j 4`
- `build/test/exec/test.exec '[adaptors][fork_join]'`
- `build/test/exec/test.exec`