### PR TITLE
More modularization

### DIFF
--- a/include/exec/completion_signatures.hpp
+++ b/include/exec/completion_signatures.hpp
@@ -15,10 +15,15 @@
  */
 #pragma once
 
-#include "../stdexec/__detail/__get_completion_signatures.hpp"
-#include "../stdexec/__detail/__meta.hpp"
-#include "../stdexec/__detail/__sender_concepts.hpp"
-#include "../stdexec/__detail/__transform_completion_signatures.hpp"
+#include "../stdexec/__detail/__config.hpp"
+
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
+import stdexec;
+#else
+#  include "../stdexec/__detail/__get_completion_signatures.hpp"
+#  include "../stdexec/__detail/__meta.hpp"
+#  include "../stdexec/__detail/__sender_concepts.hpp"
+#  include "../stdexec/__detail/__transform_completion_signatures.hpp"
 
 namespace experimental::execution
 {
@@ -42,7 +47,11 @@ namespace experimental::execution
     using make_completion_signatures_t = decltype(detail::make_unique(
       detail::normalize(static_cast<Sigs*>(nullptr))...));
   }  // namespace detail
+}
 
+STDEXEC_MODULE_EXPORT
+namespace experimental::execution
+{
   //! Creates a compile-time completion signatures type from explicit and deduced signature types.
   //!
   //! This function is a compile-time helper that constructs a completion signatures type
@@ -234,3 +243,4 @@ namespace experimental::execution
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;
+#endif

--- a/include/exec/completion_signatures.hpp
+++ b/include/exec/completion_signatures.hpp
@@ -47,7 +47,7 @@ namespace experimental::execution
     using make_completion_signatures_t = decltype(detail::make_unique(
       detail::normalize(static_cast<Sigs*>(nullptr))...));
   }  // namespace detail
-}
+}  // namespace experimental::execution
 
 STDEXEC_MODULE_EXPORT
 namespace experimental::execution

--- a/include/exec/detail/basic_sequence.hpp
+++ b/include/exec/detail/basic_sequence.hpp
@@ -18,15 +18,14 @@
 
 #include "../../stdexec/__detail/__config.hpp"
 
-#if STDEXEC_USE_MODULES()
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
 import stdexec;
 #else
 #  include "../../stdexec/__detail/__basic_sender.hpp"
 #  include "../../stdexec/__detail/__meta.hpp"
-#endif
 
-#include "../../stdexec/__detail/__basic_sender_macros.hpp"
-#include "../sequence_senders.hpp"
+#  include "../../stdexec/__detail/__basic_sender_macros.hpp"
+#  include "../sequence_senders.hpp"
 
 namespace experimental::execution
 {
@@ -136,3 +135,4 @@ namespace STDEXEC::__detail
   extern __mtype<__minvoke<decltype(_DescriptorFn()), __q<exec::__basic_sequence_sender_t>>>
     __demangle_v<exec::__seqexpr<_DescriptorFn>>;
 }  // namespace STDEXEC::__detail
+#endif

--- a/include/exec/detail/bwos_lifo_queue.hpp
+++ b/include/exec/detail/bwos_lifo_queue.hpp
@@ -17,16 +17,23 @@
 #pragma once
 
 #include "../../stdexec/__detail/__config.hpp"
-#include "../../stdexec/__detail/__spin_loop_pause.hpp"
 
-#include "../../stdexec/__detail/__atomic.hpp"
-#include <bit>
-#include <cassert>
-#include <cstddef>
-#include <cstdint>
-#include <memory>
-#include <utility>
-#include <vector>
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
+import stdexec;
+#else
+#  include "../../stdexec/__detail/__spin_loop_pause.hpp"
+
+#  include "../../stdexec/__detail/__atomic.hpp"
+
+#  if !STDEXEC_USE_MODULES()
+#    include <bit>
+#    include <cassert>
+#    include <cstddef>
+#    include <cstdint>
+#    include <memory>
+#    include <utility>
+#    include <vector>
+#  endif
 
 /**
  * This is an implementation of the BWOS queue as described in
@@ -64,6 +71,7 @@
  * - Block synchronization via head_/steal_tail_ swaps and acquire/release ordering
  */
 
+STDEXEC_MODULE_EXPORT
 namespace experimental::execution::bwos
 {
   inline constexpr std::size_t hardware_destructive_interference_size  = 64;
@@ -640,3 +648,4 @@ namespace experimental::execution::bwos
 }  // namespace experimental::execution::bwos
 
 namespace exec = experimental::execution;
+#endif

--- a/include/exec/detail/numa.hpp
+++ b/include/exec/detail/numa.hpp
@@ -16,13 +16,19 @@
  */
 #pragma once
 
-#include "../../stdexec/__detail/__any.hpp"
 #include "../../stdexec/__detail/__config.hpp"
-#include "../scope.hpp"  // IWYU pragma: keep
 
-#include <cstddef>
-#include <thread>
-#include <vector>  // IWYU pragma: keep
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
+import stdexec;
+#else
+#  include "../../stdexec/__detail/__any.hpp"
+#  include "../scope.hpp"  // IWYU pragma: keep
+
+#  if !STDEXEC_USE_MODULES()
+#    include <cstddef>
+#    include <thread>
+#    include <vector>  // IWYU pragma: keep
+#  endif
 
 namespace experimental::execution
 {
@@ -64,7 +70,11 @@ namespace experimental::execution
     };
     // NOLINTEND(modernize-use-override)
   }  // namespace _numa
+}  // namespace experimental::execution
 
+STDEXEC_MODULE_EXPORT
+namespace experimental::execution
+{
   struct numa_policy final : STDEXEC::__any::__any<exec::_numa::_ipolicy>
   {
     using numa_policy::__any::__any;
@@ -99,8 +109,11 @@ namespace experimental::execution
 
 namespace exec = experimental::execution;
 
-#if STDEXEC_ENABLE_NUMA
-#  include <numa.h>
+#  if STDEXEC_ENABLE_NUMA
+
+#    if !STDEXEC_USE_MODULES()
+#      include <numa.h>
+#    endif
 
 namespace experimental::execution
 {
@@ -141,7 +154,11 @@ namespace experimental::execution
       return g_node_to_thread_index.get();
     }
   };
+}
 
+STDEXEC_MODULE_EXPORT
+namespace experimental::execution
+{
   struct default_numa_policy
   {
     [[nodiscard]]
@@ -297,8 +314,9 @@ namespace experimental::execution
 
 namespace exec = experimental::execution;
 
-#else
+#  else
 
+STDEXEC_MODULE_EXPORT
 namespace experimental::execution
 {
   using default_numa_policy = no_numa_policy;
@@ -358,4 +376,5 @@ namespace experimental::execution
 
 namespace exec = experimental::execution;
 
+#  endif
 #endif

--- a/include/exec/detail/numa.hpp
+++ b/include/exec/detail/numa.hpp
@@ -154,7 +154,7 @@ namespace experimental::execution
       return g_node_to_thread_index.get();
     }
   };
-}
+}  // namespace experimental::execution
 
 STDEXEC_MODULE_EXPORT
 namespace experimental::execution

--- a/include/exec/detail/xorshift.hpp
+++ b/include/exec/detail/xorshift.hpp
@@ -21,9 +21,18 @@
 
 #pragma once
 
-#include <cstdint>
-#include <random>
+#include "../../stdexec/__detail/__config.hpp"
 
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
+import stdexec;
+#else
+
+#  if !STDEXEC_USE_MODULES()
+#    include <cstdint>
+#    include <random>
+#  endif
+
+STDEXEC_MODULE_EXPORT
 namespace experimental::execution
 {
 
@@ -84,3 +93,4 @@ namespace experimental::execution
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;
+#endif

--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -18,22 +18,27 @@
 
 #if __has_include(<dispatch/dispatch.h>)
 
+#  include <stdexec/execution.hpp>
+
+#  if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
+import stdexec;
+#  else
 // TODO: This is needed for libdispatch to compile with GCC. Need to look for
 // workaround.
-#  ifndef __has_feature
-#    define __has_feature(x) false
-#  endif
-#  ifndef __has_extension
-#    define __has_extension(x) false
-#  endif
+#    ifndef __has_feature
+#      define __has_feature(x) false
+#    endif
+#    ifndef __has_extension
+#      define __has_extension(x) false
+#    endif
 
-#  include "../stdexec/execution.hpp"
+#    include "completion_signatures.hpp"
+#    include "sender_for.hpp"
 
-#  include "completion_signatures.hpp"
-#  include "sender_for.hpp"
-
-#  include <dispatch/dispatch.h>
-#  include <vector>
+#    if !STDEXEC_USE_MODULES()
+#      include <dispatch/dispatch.h>
+#      include <vector>
+#    endif
 
 namespace experimental::execution
 {
@@ -546,4 +551,5 @@ namespace experimental::execution
 
 namespace exec = experimental::execution;
 
-#endif  // __has_include(<dispatch/dispatch.h>)
+#  endif  // !STDEXEC_USE_MODULES() || defined(STDEXEC_IN_MODULE_PURVIEW)
+#endif    // __has_include(<dispatch/dispatch.h>)

--- a/include/exec/sender_for.hpp
+++ b/include/exec/sender_for.hpp
@@ -17,12 +17,12 @@
 
 #include "../stdexec/__detail/__config.hpp"
 
-#if STDEXEC_USE_MODULES()
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
 import stdexec;
 #else
 #  include "../stdexec/__detail/__sender_introspection.hpp"
-#endif
 
+STDEXEC_MODULE_EXPORT
 namespace experimental::execution
 {
   template <class _Sender, class... _Tag>
@@ -30,3 +30,4 @@ namespace experimental::execution
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;
+#endif

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -18,7 +18,7 @@
 
 #include "../../stdexec/__detail/__config.hpp"
 
-#if STDEXEC_USE_MODULES()
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
 import std;
 import stdexec;
 #else
@@ -33,15 +33,16 @@ import stdexec;
 #  include "../../stdexec/__detail/__schedulers.hpp"
 #  include "../../stdexec/__detail/__sender_concepts.hpp"
 
-#  include <exception>
-#  include <ranges>
-#endif
+#  if !STDEXEC_USE_MODULES()
+#    include <exception>
+#    include <ranges>
+#  endif
 
-#include "../detail/basic_sequence.hpp"
-#include "../sender_for.hpp"
-#include "../sequence.hpp"
-#include "../sequence_senders.hpp"
-#include "../trampoline_scheduler.hpp"
+#  include "../detail/basic_sequence.hpp"
+#  include "../sender_for.hpp"
+#  include "../sequence.hpp"
+#  include "../sequence_senders.hpp"
+#  include "../trampoline_scheduler.hpp"
 
 namespace experimental::execution
 {
@@ -187,6 +188,7 @@ namespace experimental::execution
       _Receiver __rcvr_;
     };
 
+    STDEXEC_MODULE_EXPORT
     struct iterate_t
     {
       template <std::ranges::forward_range _Range>
@@ -249,8 +251,10 @@ namespace experimental::execution
     };
   }  // namespace __iterate
 
+  STDEXEC_MODULE_EXPORT
   using __iterate::iterate_t;
   inline constexpr iterate_t iterate{};
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;
+#endif

--- a/include/exec/sequence_senders.hpp
+++ b/include/exec/sequence_senders.hpp
@@ -18,9 +18,8 @@
 
 #include "../stdexec/__detail/__config.hpp"
 
-#if STDEXEC_USE_MODULES()
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
 import stdexec;
-#  include "../stdexec/__detail/__diagnostic_macros.hpp"
 #else
 #  include "../stdexec/__detail/__execution_fwd.hpp"
 
@@ -40,15 +39,14 @@ import stdexec;
 #  include "../stdexec/__detail/__type_traits.hpp"
 #  include "../stdexec/__detail/__utility.hpp"
 #  include "../stdexec/stop_token.hpp"
-#endif
 
-#include "completion_signatures.hpp"
+#  include "completion_signatures.hpp"
 
 STDEXEC_PRAGMA_PUSH()
 STDEXEC_PRAGMA_IGNORE_EDG(not_used_in_template_function_params)
 
 ////////////////////////////////////////////////////////////////////////////////
-#define STDEXEC_ERROR_SEQUENCE_SENDER_DEFINITION                                                   \
+#  define STDEXEC_ERROR_SEQUENCE_SENDER_DEFINITION                                                   \
   "A sequence sender must provide a `subscribe` member function that takes a receiver as an\n"     \
   "argument and returns an object whose type satisfies `" STDEXEC_PP_STRINGIZE(STDEXEC)            \
   "::operation_state`,\n"                                                                          \
@@ -86,13 +84,13 @@ STDEXEC_PRAGMA_IGNORE_EDG(not_used_in_template_function_params)
   "  };\n"
 
 ////////////////////////////////////////////////////////////////////////////////
-#define STDEXEC_ERROR_CANNOT_SUBSCRIBE_SEQUENCE_TO_RECEIVER                                        \
+#  define STDEXEC_ERROR_CANNOT_SUBSCRIBE_SEQUENCE_TO_RECEIVER                                        \
   "\n"                                                                                             \
   "FAILURE: No usable subscribe customization was found.\n"                                        \
   "\n" STDEXEC_ERROR_SEQUENCE_SENDER_DEFINITION
 
 ////////////////////////////////////////////////////////////////////////////////
-#define STDEXEC_ERROR_SUBSCRIBE_DOES_NOT_RETURN_OPERATION_STATE                                    \
+#  define STDEXEC_ERROR_SUBSCRIBE_DOES_NOT_RETURN_OPERATION_STATE                                    \
   "\n"                                                                                             \
   "FAILURE: The subscribe customization did not return an `" STDEXEC_PP_STRINGIZE(STDEXEC)         \
   "::operation_state`.\n"                                                                          \
@@ -114,6 +112,7 @@ namespace experimental::execution
   template <class... _Sequences>
   using _WITH_PRETTY_SEQUENCES_ = _WITH_SEQUENCES_<STDEXEC::__demangle_t<_Sequences>...>;
 
+  STDEXEC_MODULE_EXPORT
   struct sequence_sender_tag : STDEXEC::sender_tag
   {};
 
@@ -145,6 +144,7 @@ namespace experimental::execution
     // connected to a receiver. Since calling `set_next` usually involves constructing senders it
     // is allowed to throw an exception, which needs to be handled by a calling sequence-operation.
     // The returned object is a sender that can complete with `set_value_t()` or `set_stopped_t()`.
+    STDEXEC_MODULE_EXPORT
     struct set_next_t
     {
       template <receiver _Receiver, sender _Item>
@@ -175,9 +175,12 @@ namespace experimental::execution
     };
   }  // namespace __sequence_sndr
 
+  STDEXEC_MODULE_EXPORT
   using __sequence_sndr::set_next_t;
+  STDEXEC_MODULE_EXPORT
   inline constexpr set_next_t set_next{};
 
+  STDEXEC_MODULE_EXPORT
   template <class _Receiver, class _Sender>
   using next_sender_of_t =
     decltype(exec::set_next(STDEXEC::__declval<STDEXEC::__decay_t<_Receiver>&>(),
@@ -234,6 +237,7 @@ namespace experimental::execution
   template <class _Sequence>
   inline constexpr bool enable_sequence_sender = __enable_sequence_sender<_Sequence>;
 
+  STDEXEC_MODULE_EXPORT
   template <class... _Senders>
   struct item_types
   {
@@ -512,7 +516,7 @@ namespace experimental::execution
   template <class _Sequence, class... _Env>
   static constexpr auto __diagnose_sequence_sender_concept_failure();
 
-#if STDEXEC_ENABLE_EXTRA_TYPE_CHECKING()
+#  if STDEXEC_ENABLE_EXTRA_TYPE_CHECKING()
   // __checked_completion_signatures is for catching logic bugs in a sender's metadata. If sender<S>
   // and sender_in<S, Ctx> are both true, then they had better report the same metadata. This
   // completion signatures wrapper enforces that at compile time.
@@ -529,11 +533,11 @@ namespace experimental::execution
     requires sequence_sender<_Sequence, _Env...>
   using item_types_of_t = decltype(exec::__checked_item_types(STDEXEC::__declval<_Sequence>(),
                                                               STDEXEC::__declval<_Env>()...));
-#else
+#  else
   template <class _Sequence, class... _Env>
     requires sequence_sender_in<_Sequence, _Env...>
   using item_types_of_t = __item_types_of_t<_Sequence, _Env...>;
-#endif
+#  endif
 
   template <class _Data, class... _What>
   struct __sequence_type_check_failure : STDEXEC::__compile_time_error
@@ -559,7 +563,7 @@ namespace experimental::execution
     _Data __data_{};
   };
 
-#if STDEXEC_NO_STDCPP_CONSTEXPR_EXCEPTIONS()
+#  if STDEXEC_NO_STDCPP_CONSTEXPR_EXCEPTIONS()
 
   template <class... _What, class... _Values>
   [[nodiscard]]
@@ -568,7 +572,7 @@ namespace experimental::execution
     return STDEXEC::__mexception<_What...>();
   }
 
-#else  // ^^^ no constexpr exceptions ^^^ / vvv constexpr exceptions vvv
+#  else  // ^^^ no constexpr exceptions ^^^ / vvv constexpr exceptions vvv
 
   // C++26, https://wg21.link/p3068
   template <class _What, class... _More, class... _Values>
@@ -590,7 +594,7 @@ namespace experimental::execution
     }
   }
 
-#endif  // ^^^ constexpr exceptions ^^^
+#  endif  // ^^^ constexpr exceptions ^^^
 
   template <class... _What>
   [[nodiscard]]
@@ -623,6 +627,7 @@ namespace experimental::execution
     { exec::__try_items<STDEXEC::__decay_t<_Receiver>>(__items) } -> STDEXEC::__ok;
   };
 
+  STDEXEC_MODULE_EXPORT
   template <class _Receiver, class _SequenceItems>
   concept sequence_receiver_of = STDEXEC::receiver<_Receiver>
                               && __sequence_receiver_of<_Receiver, _SequenceItems>;
@@ -797,9 +802,9 @@ namespace experimental::execution
                       "The first argument to exec::subscribe must be a sequence sender");
         static_assert(receiver<_Receiver>,
                       "The second argument to exec::subscribe must be a receiver");
-#if STDEXEC_ENABLE_EXTRA_TYPE_CHECKING()
+#  if STDEXEC_ENABLE_EXTRA_TYPE_CHECKING()
         static_assert(__type_check_arguments<__tfx_seq_t, _Receiver>());
-#endif
+#  endif
 
         if constexpr (__next_connectable<__tfx_seq_t, _Receiver>)
         {
@@ -976,21 +981,21 @@ namespace experimental::execution
   }
 
 ////////////////////////////////////////////////////////////////////////////////
-#define STDEXEC_ERROR_ENABLE_SEQUENCE_SENDER_IS_FALSE                                              \
+#  define STDEXEC_ERROR_ENABLE_SEQUENCE_SENDER_IS_FALSE                                              \
   "\n"                                                                                             \
   "\n"                                                                                             \
   "Trying to compute the sequences's item types resulted in an error. See\n"                       \
   "the rest of the compiler diagnostic for clues. Look for the string \"_ERROR_\".\n"
 
 ////////////////////////////////////////////////////////////////////////////////
-#define STDEXEC_ERROR_GET_ITEM_TYPES_RETURNED_AN_ERROR                                             \
+#  define STDEXEC_ERROR_GET_ITEM_TYPES_RETURNED_AN_ERROR                                             \
   "\n"                                                                                             \
   "\n"                                                                                             \
   "Trying to compute the sequences's item types resulted in an error. See\n"                       \
   "the rest of the compiler diagnostic for clues. Look for the string \"_ERROR_\".\n"
 
 ////////////////////////////////////////////////////////////////////////////////
-#define STDEXEC_ERROR_GET_ITEM_TYPES_HAS_INVALID_RETURN_TYPE                                       \
+#  define STDEXEC_ERROR_GET_ITEM_TYPES_HAS_INVALID_RETURN_TYPE                                       \
   "\n"                                                                                             \
   "\n"                                                                                             \
   "The member function `get_item_types` of the sequence returned an\n"                             \
@@ -1152,3 +1157,4 @@ namespace experimental::execution
 namespace exec = experimental::execution;
 
 STDEXEC_PRAGMA_POP()
+#endif

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -19,7 +19,7 @@
 
 #include "../stdexec/__detail/__config.hpp"
 
-#if STDEXEC_USE_MODULES()
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
 import std;
 import stdexec;
 #else
@@ -37,17 +37,19 @@ import stdexec;
 #  include "../stdexec/__detail/__type_traits.hpp"
 #  include "../stdexec/__detail/__variant.hpp"
 
-#  include <compare>
-#  include <condition_variable>
-#  include <cstdint>
-#  include <exception>
-#  include <limits>
-#  include <mutex>
-#  include <random>
-#  include <span>
-#  include <thread>
-#  include <type_traits>
-#  include <vector>
+#  if !STDEXEC_USE_MODULES()
+#    include <compare>
+#    include <condition_variable>
+#    include <cstdint>
+#    include <exception>
+#    include <limits>
+#    include <mutex>
+#    include <random>
+#    include <span>
+#    include <thread>
+#    include <type_traits>
+#    include <vector>
+#  endif
 #endif
 
 #include "detail/atomic_intrusive_queue.hpp"
@@ -1839,4 +1841,5 @@ namespace experimental::execution
 
 }  // namespace experimental::execution
 
+STDEXEC_MODULE_EXPORT
 namespace exec = experimental::execution;

--- a/include/exec/trampoline_scheduler.hpp
+++ b/include/exec/trampoline_scheduler.hpp
@@ -20,7 +20,7 @@
 
 #include "completion_behavior.hpp"
 
-#if STDEXEC_USE_MODULES()
+#if STDEXEC_USE_MODULES() && !defined(STDEXEC_IN_MODULE_PURVIEW)
 import std;
 import stdexec;
 #else
@@ -32,9 +32,10 @@ import stdexec;
 #  include "../stdexec/__detail/__receivers.hpp"
 #  include "../stdexec/stop_token.hpp"
 
-#  include <cstddef>
-#  include <utility>
-#endif
+#  if !STDEXEC_USE_MODULES()
+#    include <cstddef>
+#    include <utility>
+#  endif
 
 namespace experimental::execution
 {
@@ -292,15 +293,15 @@ namespace experimental::execution
       while (__head_ != nullptr)
       {
         // pop the head of the list
-#if STDEXEC_NVHPC()
+#  if STDEXEC_NVHPC()
         // there appears to be a codegen bug in nvhpc where the optimizer does not see the
         // assign to __head_ that happens in the std::exchange call below, causing it to
         // erroneously optimize away the `if (__head_ != nullptr)` check later on.
         _Operation* __op = __head_;
         __head_          = __head_->__next_;
-#else
+#  else
         _Operation* __op = std::exchange(__head_, __head_->__next_);
-#endif
+#  endif
         __op->__next_ = nullptr;
         __op->__prev_ = nullptr;
         if (__head_ != nullptr)
@@ -328,3 +329,4 @@ namespace experimental::execution
 }  // namespace experimental::execution
 
 namespace exec = experimental::execution;
+#endif

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -603,8 +603,11 @@ namespace STDEXEC
 // Some compilers turn on pack indexing in pre-C++26 code. We want to use it if it is
 // available. Pack indexing is disabled for clang < 20 because of:
 // https://github.com/llvm/llvm-project/issues/116105
+// Pack indexing is disabled for clang < 24 when modules are enabled because of:
+// https://github.com/llvm/llvm-project/issues/214780
 #if defined(__cpp_pack_indexing) && !STDEXEC_NVCC()                                                \
-  && !(STDEXEC_CLANG() && STDEXEC_CLANG_VERSION < 2000)
+  && !(STDEXEC_CLANG() && STDEXEC_CLANG_VERSION < 2000)                                            \
+  && !(STDEXEC_CLANG() && STDEXEC_CLANG_VERSION < 2400 && STDEXEC_USE_MODULES())
 #  define STDEXEC_NO_STDCPP_PACK_INDEXING() 0
 #else  // ^^^ has pack indexing ^^^ / vvv no pack indexing vvv
 #  define STDEXEC_NO_STDCPP_PACK_INDEXING() 1

--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -972,9 +972,10 @@ namespace STDEXEC
 #define STDEXEC_MODULE_EXPORT_META      STDEXEC_MODULE_EXPORT
 #define STDEXEC_MODULE_EXPORT_AUTHORING STDEXEC_MODULE_EXPORT
 
-STDEXEC_MODULE_EXPORT
+#if !STDEXEC_USE_MODULES()
 namespace STDEXEC
 {
   namespace parallel_scheduler_replacement
   {}
 }  // namespace STDEXEC
+#endif

--- a/include/stdexec/__detail/__parallel_scheduler.hpp
+++ b/include/stdexec/__detail/__parallel_scheduler.hpp
@@ -811,7 +811,7 @@ namespace STDEXEC
 
 #  include "__epilogue.hpp"
 
-#  if defined(STDEXEC_PARALLEL_SCHEDULER_HEADER_ONLY)
+#  if defined(STDEXEC_PARALLEL_SCHEDULER_HEADER_ONLY) || STDEXEC_USE_MODULES()
 #    define STDEXEC_PARALLEL_SCHEDULER_INLINE inline
 #    include "__parallel_scheduler_default_impl_entry.hpp"
 #  elif defined(STDEXEC_SYSTEM_CONTEXT_HEADER_ONLY)

--- a/include/stdexec/__detail/__parallel_scheduler_backend.hpp
+++ b/include/stdexec/__detail/__parallel_scheduler_backend.hpp
@@ -58,6 +58,7 @@ namespace STDEXEC
   {
     /// Interface for completing a sender operation. Backend will call frontend though
     /// this interface for completing the `schedule` and `schedule_bulk` operations.
+    STDEXEC_MODULE_EXPORT_AUTHORING
     class receiver_proxy
     {
      public:
@@ -83,6 +84,7 @@ namespace STDEXEC
 
     inline constexpr receiver_proxy::~receiver_proxy() = default;
 
+    STDEXEC_MODULE_EXPORT_AUTHORING
     struct bulk_item_receiver_proxy : receiver_proxy
     {
       virtual constexpr void execute(size_t, size_t) noexcept = 0;
@@ -141,6 +143,7 @@ namespace STDEXEC
       }
     };
 
+    STDEXEC_MODULE_EXPORT_AUTHORING
     struct parallel_scheduler_backend : __any::__iabstract<__iparallel_scheduler_backend>
     {};
   }  // namespace parallel_scheduler_replacement

--- a/include/stdexec/__detail/__parallel_scheduler_default_impl.hpp
+++ b/include/stdexec/__detail/__parallel_scheduler_default_impl.hpp
@@ -400,10 +400,13 @@ namespace STDEXEC::__parallel_scheduler_default_impl
   };
 
 #  if STDEXEC_ENABLE_LIBDISPATCH
+  STDEXEC_MODULE_EXPORT_AUTHORING
   using __parallel_scheduler_backend_impl = __generic_impl<exec::libdispatch_queue>;
 #  elif STDEXEC_ENABLE_WINDOWS_THREAD_POOL
+  STDEXEC_MODULE_EXPORT_AUTHORING
   using __parallel_scheduler_backend_impl = __generic_impl<exec::windows_thread_pool>;
 #  else
+  STDEXEC_MODULE_EXPORT_AUTHORING
   using __parallel_scheduler_backend_impl = __generic_impl<exec::static_thread_pool>;
 #  endif
 

--- a/include/stdexec/__detail/__parallel_scheduler_default_impl_entry.hpp
+++ b/include/stdexec/__detail/__parallel_scheduler_default_impl_entry.hpp
@@ -39,12 +39,13 @@ import stdexec;
 
 #  include "__prologue.hpp"
 
-STDEXEC_MODULE_EXPORT namespace STDEXEC::parallel_scheduler_replacement
+STDEXEC_MODULE_EXPORT
+namespace STDEXEC::parallel_scheduler_replacement
 {
   /// Get the backend for the parallel scheduler.
   /// Users might replace this function.
-  STDEXEC_MODULE_EXPORT STDEXEC_PARALLEL_SCHEDULER_INLINE auto query_parallel_scheduler_backend()
-    -> std::shared_ptr<parallel_scheduler_backend>
+  STDEXEC_PARALLEL_SCHEDULER_INLINE auto
+  query_parallel_scheduler_backend() -> std::shared_ptr<parallel_scheduler_backend>
   {
     return STDEXEC::__parallel_scheduler_default_impl::__parallel_scheduler_backend_singleton
       .__get_current_instance();
@@ -53,7 +54,7 @@ STDEXEC_MODULE_EXPORT namespace STDEXEC::parallel_scheduler_replacement
   /// Set a factory for the parallel scheduler backend.
   /// Can be used to replace the parallel scheduler at runtime.
   /// NOT TO SPEC
-  STDEXEC_MODULE_EXPORT extern STDEXEC_PARALLEL_SCHEDULER_INLINE  //
+  extern STDEXEC_PARALLEL_SCHEDULER_INLINE  //
     auto set_parallel_scheduler_backend(__parallel_scheduler_backend_factory_t __new_factory)
       -> __parallel_scheduler_backend_factory_t
   {

--- a/include/stdexec/__detail/__parallel_scheduler_replacement_api.hpp
+++ b/include/stdexec/__detail/__parallel_scheduler_replacement_api.hpp
@@ -37,16 +37,19 @@ namespace STDEXEC::parallel_scheduler_replacement
 {
   /// Get the backend for the parallel scheduler.
   /// Users might replace this function.
+  STDEXEC_MODULE_EXPORT
   STDEXEC_ATTRIBUTE(weak)
   auto query_parallel_scheduler_backend() -> std::shared_ptr<parallel_scheduler_backend>;
 
   /// The type of a factory that can create `parallel_scheduler_backend` instances.
   /// NOT TO SPEC
+  STDEXEC_MODULE_EXPORT_AUTHORING
   using __parallel_scheduler_backend_factory_t = std::shared_ptr<parallel_scheduler_backend> (*)();
 
   /// Set a factory for the parallel scheduler backend.
   /// Can be used to replace the parallel scheduler at runtime.
   /// NOT TO SPEC
+  STDEXEC_MODULE_EXPORT
   [[deprecated("Replacing the parallel scheduler backend at runtime is not recommended and may "
                "lead to unexpected behavior. Use weak linking to replace the parallel scheduler at "
                "compile time instead.")]]

--- a/include/stdexec/__detail/__task.hpp
+++ b/include/stdexec/__detail/__task.hpp
@@ -48,6 +48,7 @@ namespace STDEXEC
 #  if !STDEXEC_NO_STDCPP_COROUTINES()
   ////////////////////////////////////////////////////////////////////////////////
   // STDEXEC::with_error
+  STDEXEC_MODULE_EXPORT
   template <class _Error>
   struct with_error
   {
@@ -60,6 +61,7 @@ namespace STDEXEC
 
   ////////////////////////////////////////////////////////////////////////////////
   // STDEXEC::with_stopped
+  STDEXEC_MODULE_EXPORT
   struct with_stopped
   {};
 

--- a/include/stdexec/__detail/__typeinfo.hpp
+++ b/include/stdexec/__detail/__typeinfo.hpp
@@ -187,6 +187,7 @@ namespace STDEXEC
 
   //////////////////////////////////////////////////////////////////////////////////////////
   // __type_index
+  STDEXEC_MODULE_EXPORT_AUTHORING
   struct __type_index
   {
     __type_index() = default;

--- a/include/stdexec/__detail/__variant.hpp
+++ b/include/stdexec/__detail/__variant.hpp
@@ -74,6 +74,7 @@ namespace STDEXEC
     }
   };
 
+  STDEXEC_MODULE_EXPORT_AUTHORING
   inline constexpr __visit_t __visit{};
 
   namespace __var

--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -289,6 +289,7 @@ namespace STDEXEC
   //!
   //! @see stdexec::when_all      — without the scheduler transfer
   //! @see stdexec::continues_on  — the underlying transfer primitive
+  STDEXEC_MODULE_EXPORT_AUTHORING
   struct transfer_when_all_t
   {
     //! @brief Compose @c __sndrs... and deliver the combined completion on
@@ -335,6 +336,7 @@ namespace STDEXEC
   //!
   //! @see stdexec::when_all_with_variant
   //! @see stdexec::transfer_when_all
+  STDEXEC_MODULE_EXPORT_AUTHORING
   struct transfer_when_all_with_variant_t
   {
     //! @brief Compose @c __sndrs... (each wrapped in @c into_variant) and
@@ -398,6 +400,7 @@ namespace STDEXEC
   //!             <tt>when_all_with_variant(...) | continues_on(sch)</tt> instead.
   //!
   //! @hideinitializer
+  STDEXEC_MODULE_EXPORT_AUTHORING
   inline constexpr transfer_when_all_with_variant_t transfer_when_all_with_variant{};
 
   namespace __when_all
@@ -704,7 +707,10 @@ namespace STDEXEC
     };
 
     template <class _Receiver>
-    static constexpr auto __mk_state_fn(_Receiver&& __rcvr) noexcept
+#  if !STDEXEC_USE_MODULES()
+    static
+#  endif
+      constexpr auto __mk_state_fn(_Receiver&& __rcvr) noexcept
     {
       return [&]<class... _Child>(__ignore, __ignore, _Child&&...) noexcept
         requires(__max1_sender<_Child, __env_t<env_of_t<_Receiver>, _Child...>> && ...)

--- a/modules/stdexec.cppm
+++ b/modules/stdexec.cppm
@@ -6,9 +6,19 @@ module;
 #include <cstdio>
 #include <cstdlib>
 
-export module stdexec;
+#if __has_include(<dispatch/dispatch.h>)
+#  include <dispatch/dispatch.h>
+#endif
 
 #define STDEXEC_IN_MODULE_PURVIEW
+
+#include <stdexec/__detail/__config.hpp>
+
+#if STDEXEC_ENABLE_NUMA
+#  include <numa.h>
+#endif
+
+export module stdexec;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,15 +35,19 @@ set(stdexec_test_sources
     stdexec/algos/adaptors/test_let_stopped.cpp
     stdexec/algos/adaptors/test_let_value.cpp
     stdexec/algos/adaptors/test_sequence.cpp
+    stdexec/algos/adaptors/test_spawn_future.cpp
     stdexec/algos/adaptors/test_starts_on.cpp
     stdexec/algos/adaptors/test_stop_when.cpp
     stdexec/algos/adaptors/test_stopped_as_error.cpp
     stdexec/algos/adaptors/test_stopped_as_optional.cpp
     stdexec/algos/adaptors/test_then.cpp
+    stdexec/algos/adaptors/test_transfer_when_all.cpp
     stdexec/algos/adaptors/test_upon_error.cpp
     stdexec/algos/adaptors/test_upon_stopped.cpp
+    stdexec/algos/adaptors/test_when_all.cpp
     stdexec/algos/adaptors/test_write_env.cpp
     stdexec/algos/consumers/test_spawn.cpp
+    stdexec/algos/consumers/test_sync_wait.cpp
     stdexec/algos/factories/test_just.cpp
     stdexec/algos/factories/test_just_stopped.cpp
     stdexec/algos/factories/test_read.cpp
@@ -75,6 +79,8 @@ set(stdexec_test_sources
     stdexec/queries/test_forwarding_queries.cpp
     stdexec/queries/test_get_completion_behavior.cpp
     stdexec/queries/test_get_forward_progress_guarantee.cpp
+    stdexec/schedulers/test_task_scheduler.cpp
+    stdexec/types/test_counting_scopes.cpp
     )
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
@@ -83,15 +89,9 @@ if(NOT STDEXEC_BUILD_MODULES)
     stdexec/algos/adaptors/test_on.cpp
     stdexec/algos/adaptors/test_on2.cpp
     stdexec/algos/adaptors/test_on3.cpp
-    stdexec/algos/adaptors/test_spawn_future.cpp
-    stdexec/algos/adaptors/test_transfer_when_all.cpp
-    stdexec/algos/adaptors/test_when_all.cpp
     stdexec/algos/factories/test_just_error.cpp
-    stdexec/algos/consumers/test_sync_wait.cpp
     stdexec/detail/test_any_allocator.cpp
     stdexec/schedulers/test_parallel_scheduler.cpp
-    stdexec/schedulers/test_task_scheduler.cpp
-    stdexec/types/test_counting_scopes.cpp
     stdexec/types/test_task.cpp)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,6 @@ set(stdexec_test_sources
     stdexec/algos/adaptors/test_continues_on.cpp
     stdexec/algos/adaptors/test_finally.cpp
     stdexec/algos/adaptors/test_into_variant.cpp
-    stdexec/algos/adaptors/test_let_error.cpp
     stdexec/algos/adaptors/test_sequence.cpp
     stdexec/algos/adaptors/test_spawn_future.cpp
     stdexec/algos/adaptors/test_starts_on.cpp
@@ -75,7 +74,6 @@ set(stdexec_test_sources
     stdexec/queries/test_forwarding_queries.cpp
     stdexec/queries/test_get_completion_behavior.cpp
     stdexec/queries/test_get_forward_progress_guarantee.cpp
-    stdexec/schedulers/test_parallel_scheduler.cpp
     stdexec/schedulers/test_task_scheduler.cpp
     stdexec/types/test_counting_scopes.cpp
     stdexec/types/test_task.cpp
@@ -84,6 +82,7 @@ set(stdexec_test_sources
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
   list(APPEND stdexec_test_sources
+    stdexec/algos/adaptors/test_let_error.cpp
     stdexec/algos/adaptors/test_let_stopped.cpp
     stdexec/algos/adaptors/test_let_value.cpp
     stdexec/algos/adaptors/test_on.cpp
@@ -94,6 +93,7 @@ if(NOT STDEXEC_BUILD_MODULES)
     stdexec/cpos/test_cpo_bulk.cpp
     stdexec/cpos/test_cpo_upon_error.cpp
     stdexec/detail/test_any_allocator.cpp
+    stdexec/schedulers/test_parallel_scheduler.cpp
     )
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,10 +80,12 @@ set(stdexec_test_sources
     stdexec/queries/test_forwarding_queries.cpp
     stdexec/queries/test_get_completion_behavior.cpp
     stdexec/queries/test_get_forward_progress_guarantee.cpp
+    stdexec/schedulers/test_parallel_scheduler.cpp
     stdexec/schedulers/test_task_scheduler.cpp
     stdexec/types/test_counting_scopes.cpp
     stdexec/types/test_task.cpp
     )
+
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
   list(APPEND stdexec_test_sources
@@ -92,7 +94,6 @@ if(NOT STDEXEC_BUILD_MODULES)
     stdexec/algos/adaptors/test_on3.cpp
     stdexec/algos/factories/test_just_error.cpp
     stdexec/detail/test_any_allocator.cpp
-    stdexec/schedulers/test_parallel_scheduler.cpp
     )
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,8 +33,6 @@ set(stdexec_test_sources
     stdexec/algos/adaptors/test_finally.cpp
     stdexec/algos/adaptors/test_into_variant.cpp
     stdexec/algos/adaptors/test_let_error.cpp
-    stdexec/algos/adaptors/test_let_stopped.cpp
-    stdexec/algos/adaptors/test_let_value.cpp
     stdexec/algos/adaptors/test_sequence.cpp
     stdexec/algos/adaptors/test_spawn_future.cpp
     stdexec/algos/adaptors/test_starts_on.cpp
@@ -45,7 +43,6 @@ set(stdexec_test_sources
     stdexec/algos/adaptors/test_transfer_when_all.cpp
     stdexec/algos/adaptors/test_upon_error.cpp
     stdexec/algos/adaptors/test_upon_stopped.cpp
-    stdexec/algos/adaptors/test_when_all.cpp
     stdexec/algos/adaptors/test_write_env.cpp
     stdexec/algos/consumers/test_spawn.cpp
     stdexec/algos/consumers/test_sync_wait.cpp
@@ -62,13 +59,11 @@ set(stdexec_test_sources
     stdexec/concepts/test_concepts_scope_token.cpp
     stdexec/concepts/test_concepts_sender.cpp
     stdexec/concepts/test_concepts_stop_tokens.cpp
-    stdexec/cpos/test_cpo_bulk.cpp
     stdexec/cpos/test_cpo_connect.cpp
     stdexec/cpos/test_cpo_connect_awaitable.cpp
     stdexec/cpos/test_cpo_receiver.cpp
     stdexec/cpos/test_cpo_schedule.cpp
     stdexec/cpos/test_cpo_start.cpp
-    stdexec/cpos/test_cpo_upon_error.cpp
     stdexec/cpos/test_cpo_upon_stopped.cpp
     stdexec/detail/test_any.cpp
     stdexec/detail/test_common_domain.cpp
@@ -89,10 +84,15 @@ set(stdexec_test_sources
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
   list(APPEND stdexec_test_sources
+    stdexec/algos/adaptors/test_let_stopped.cpp
+    stdexec/algos/adaptors/test_let_value.cpp
     stdexec/algos/adaptors/test_on.cpp
     stdexec/algos/adaptors/test_on2.cpp
     stdexec/algos/adaptors/test_on3.cpp
+    stdexec/algos/adaptors/test_when_all.cpp
     stdexec/algos/factories/test_just_error.cpp
+    stdexec/cpos/test_cpo_bulk.cpp
+    stdexec/cpos/test_cpo_upon_error.cpp
     stdexec/detail/test_any_allocator.cpp
     )
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,13 +28,18 @@ endfunction()
 set(stdexec_test_sources
     test_main.cpp
     stdexec/algos/adaptors/test_associate.cpp
+    stdexec/algos/adaptors/test_bulk.cpp
     stdexec/algos/adaptors/test_continues_on.cpp
     stdexec/algos/adaptors/test_finally.cpp
     stdexec/algos/adaptors/test_into_variant.cpp
     stdexec/algos/adaptors/test_let_error.cpp
+    stdexec/algos/adaptors/test_let_stopped.cpp
+    stdexec/algos/adaptors/test_let_value.cpp
     stdexec/algos/adaptors/test_sequence.cpp
+    stdexec/algos/adaptors/test_spawn_future.cpp
     stdexec/algos/adaptors/test_starts_on.cpp
     stdexec/algos/adaptors/test_stop_when.cpp
+    stdexec/algos/adaptors/test_stopped_as_error.cpp
     stdexec/algos/adaptors/test_stopped_as_optional.cpp
     stdexec/algos/adaptors/test_then.cpp
     stdexec/algos/adaptors/test_upon_error.cpp
@@ -72,18 +77,14 @@ set(stdexec_test_sources
     stdexec/queries/test_forwarding_queries.cpp
     stdexec/queries/test_get_completion_behavior.cpp
     stdexec/queries/test_get_forward_progress_guarantee.cpp
+    stdexec/types/test_task.cpp
     )
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
   list(APPEND stdexec_test_sources
-    stdexec/algos/adaptors/test_bulk.cpp
-    stdexec/algos/adaptors/test_let_stopped.cpp
-    stdexec/algos/adaptors/test_let_value.cpp
     stdexec/algos/adaptors/test_on.cpp
     stdexec/algos/adaptors/test_on2.cpp
     stdexec/algos/adaptors/test_on3.cpp
-    stdexec/algos/adaptors/test_spawn_future.cpp
-    stdexec/algos/adaptors/test_stopped_as_error.cpp
     stdexec/algos/adaptors/test_transfer_when_all.cpp
     stdexec/algos/adaptors/test_when_all.cpp
     stdexec/algos/factories/test_just_error.cpp
@@ -91,8 +92,7 @@ if(NOT STDEXEC_BUILD_MODULES)
     stdexec/detail/test_any_allocator.cpp
     stdexec/schedulers/test_parallel_scheduler.cpp
     stdexec/schedulers/test_task_scheduler.cpp
-    stdexec/types/test_counting_scopes.cpp
-    stdexec/types/test_task.cpp)
+    stdexec/types/test_counting_scopes.cpp)
 endif()
 
 add_library(common_test_settings INTERFACE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,7 @@ set(stdexec_test_sources
     stdexec/queries/test_get_forward_progress_guarantee.cpp
     stdexec/schedulers/test_task_scheduler.cpp
     stdexec/types/test_counting_scopes.cpp
+    stdexec/types/test_task.cpp
     )
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
@@ -92,7 +93,7 @@ if(NOT STDEXEC_BUILD_MODULES)
     stdexec/algos/factories/test_just_error.cpp
     stdexec/detail/test_any_allocator.cpp
     stdexec/schedulers/test_parallel_scheduler.cpp
-    stdexec/types/test_task.cpp)
+    )
 endif()
 
 add_library(common_test_settings INTERFACE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,6 @@ endfunction()
 set(stdexec_test_sources
     test_main.cpp
     stdexec/algos/adaptors/test_associate.cpp
-    stdexec/algos/adaptors/test_bulk.cpp
     stdexec/algos/adaptors/test_continues_on.cpp
     stdexec/algos/adaptors/test_finally.cpp
     stdexec/algos/adaptors/test_into_variant.cpp
@@ -36,7 +35,6 @@ set(stdexec_test_sources
     stdexec/algos/adaptors/test_let_stopped.cpp
     stdexec/algos/adaptors/test_let_value.cpp
     stdexec/algos/adaptors/test_sequence.cpp
-    stdexec/algos/adaptors/test_spawn_future.cpp
     stdexec/algos/adaptors/test_starts_on.cpp
     stdexec/algos/adaptors/test_stop_when.cpp
     stdexec/algos/adaptors/test_stopped_as_error.cpp
@@ -77,14 +75,15 @@ set(stdexec_test_sources
     stdexec/queries/test_forwarding_queries.cpp
     stdexec/queries/test_get_completion_behavior.cpp
     stdexec/queries/test_get_forward_progress_guarantee.cpp
-    stdexec/types/test_task.cpp
     )
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
   list(APPEND stdexec_test_sources
+    stdexec/algos/adaptors/test_bulk.cpp
     stdexec/algos/adaptors/test_on.cpp
     stdexec/algos/adaptors/test_on2.cpp
     stdexec/algos/adaptors/test_on3.cpp
+    stdexec/algos/adaptors/test_spawn_future.cpp
     stdexec/algos/adaptors/test_transfer_when_all.cpp
     stdexec/algos/adaptors/test_when_all.cpp
     stdexec/algos/factories/test_just_error.cpp
@@ -92,7 +91,8 @@ if(NOT STDEXEC_BUILD_MODULES)
     stdexec/detail/test_any_allocator.cpp
     stdexec/schedulers/test_parallel_scheduler.cpp
     stdexec/schedulers/test_task_scheduler.cpp
-    stdexec/types/test_counting_scopes.cpp)
+    stdexec/types/test_counting_scopes.cpp
+    stdexec/types/test_task.cpp)
 endif()
 
 add_library(common_test_settings INTERFACE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ endfunction()
 set(stdexec_test_sources
     test_main.cpp
     stdexec/algos/adaptors/test_associate.cpp
+    stdexec/algos/adaptors/test_bulk.cpp
     stdexec/algos/adaptors/test_continues_on.cpp
     stdexec/algos/adaptors/test_finally.cpp
     stdexec/algos/adaptors/test_into_variant.cpp
@@ -85,7 +86,6 @@ set(stdexec_test_sources
 if(NOT STDEXEC_BUILD_MODULES)
   # these tests don't build in modules mode, yet
   list(APPEND stdexec_test_sources
-    stdexec/algos/adaptors/test_bulk.cpp
     stdexec/algos/adaptors/test_on.cpp
     stdexec/algos/adaptors/test_on2.cpp
     stdexec/algos/adaptors/test_on3.cpp

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -74,8 +74,7 @@ if(STDEXEC_BUILD_MODULES)
   # these are the only files that build right now...
   add_executable(test.exec
       ../test_main.cpp
-      async_scope/test_empty.cpp
-      async_scope/test_spawn.cpp)
+      async_scope/test_empty.cpp)
   set_target_properties(test.exec PROPERTIES CXX_MODULE_STD ON)
 else()
   add_executable(test.exec ${exec_test_sources})

--- a/test/exec/asio/CMakeLists.txt
+++ b/test/exec/asio/CMakeLists.txt
@@ -16,13 +16,15 @@
 
 set(asioexec_test_sources
     ../../test_main.cpp
-    test_completion_token.cpp
     test_use_sender.cpp
 )
 
 if(NOT STDEXEC_BUILD_MODULES)
     # this test doesn't build with modules, yet
-    list(APPEND asioexec_test_sources test_asio_thread_pool.cpp)
+    list(APPEND
+      asioexec_test_sources
+      test_asio_thread_pool.cpp
+      test_completion_token.cpp)
 endif()
 
 add_executable(test.asioexec ${asioexec_test_sources})


### PR DESCRIPTION
This diff adds to the modular build the rest of the tests in `test.stdexec` that don't cause Clang 22.1.6 to ICE in the rapidsai container that CI uses to run the modularized tests. I'm working on understanding why the excluded tests cause the ICE.

This PR leaves the modular build of `test.stdexec` reporting 3135 assertions in 483 test cases.