### PR TITLE
Fix merge_each move-only sender forwarding

### DIFF
--- a/include/exec/sequence/merge_each.hpp
+++ b/include/exec/sequence/merge_each.hpp
@@ -1145,7 +1145,7 @@ namespace experimental::execution
                                               _NestedSequenceSender>) -> next_sender auto
       {
         return __next_sequence_sender_t<_NestedSequenceSender>{__op_,
-                                                               static_cast<_NestedSequenceSender>(
+                                                               static_cast<_NestedSequenceSender&&>(
                                                                  __nested_sequence)};
       }
 

--- a/test/exec/sequence/test_merge_each.cpp
+++ b/test/exec/sequence/test_merge_each.cpp
@@ -204,13 +204,28 @@ namespace
   template <ex::sender Sender>
   struct as_sequence_t : Sender
   {
-    using sender_concept = sequence_sender_tag;
-    using item_types     = exec::item_types<Sender>;
-    auto subscribe(auto receiver)
+    using sender_concept        = sequence_sender_tag;
+    using completion_signatures = ex::completion_signatures<ex::set_value_t(), ex::set_stopped_t()>;
+    using item_types            = exec::item_types<Sender>;
+    auto subscribe(auto receiver) &&
     {
-      return connect(set_next(receiver, *static_cast<Sender*>(this)), receiver);
+      return ex::connect(exec::set_next(receiver, static_cast<Sender&&>(*this)), receiver);
     }
   };
+
+  TEST_CASE("merge_each - accepts a move-only nested sequence sender",
+            "[sequence_senders][merge_each]")
+  {
+    using item_sender_t = decltype(fallible_just{empty_sequence()});
+
+    STATIC_REQUIRE_FALSE(std::copy_constructible<item_sender_t>);
+
+    auto sequences = as_sequence_t<item_sender_t>{fallible_just{empty_sequence()}};
+    auto merged    = merge_each(std::move(sequences));
+
+    [[maybe_unused]]
+    auto op = subscribe(std::move(merged), null_receiver{});
+  }
 
   TEST_CASE("merge_each - merge two sequence senders of no elements",
             "[sequence_senders][merge_each][empty_sequence]")


### PR DESCRIPTION
## Summary

- preserve the value category of nested sequence senders in `merge_each`
- allow move-only senders to pass through the `set_next` path
- add a regression that constructs a subscription with a non-copyable sender

The sender is received as a forwarding reference, but the named parameter was cast to `_NestedSequenceSender`. For an rvalue move-only sender, that attempted to copy from the named lvalue. Casting to `_NestedSequenceSender&&` forwards it into the returned sender instead.

## Testing

- `ctest --test-dir build --output-on-failure -j8`
- full `test.exec` run with exceptions disabled