### PR TITLE
Avoid redundant single-task remote queue notifications

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -890,8 +890,10 @@ namespace experimental::execution
       }
 
       std::size_t const thread_index = random_thread_index_with_constraints(constraints);
-      queue.queues_[thread_index].push_front(task);
-      thread_states_[thread_index]->notify();
+      if (queue.queues_[thread_index].push_front(task))
+      {
+        thread_states_[thread_index]->notify();
+      }
     }
 
     inline void _static_thread_pool::enqueue(remote_queue& queue,
@@ -899,8 +901,10 @@ namespace experimental::execution
                                              std::size_t   thread_index) noexcept
     {
       thread_index %= thread_count_;
-      queue.queues_[thread_index].push_front(task);
-      thread_states_[thread_index]->notify();
+      if (queue.queues_[thread_index].push_front(task))
+      {
+        thread_states_[thread_index]->notify();
+      }
     }
 
     template <std::derived_from<task_base> Task>


### PR DESCRIPTION
## Summary

Notify a static thread pool worker only when a single-task remote enqueue transitions its submitter's target queue from empty to non-empty.

`push_front()` reports whether its successful CAS performed the empty-to-non-empty transition. The producer that performs that transition is responsible for notifying the worker. Further single-task submissions can skip the worker-state exchange until the worker drains that queue.

This change is limited to the two single-task remote enqueue paths. The bulk enqueue paths are unchanged.

This matters when multiple threads submit to the same worker. Their per-submitter remote queues avoid contention on the queue heads, but the unconditional notification made every submitter contend on the same worker-state cache line.

## Benchmark

Apple Silicon, AppleClang 21, `-O3`, 1.6 million tasks submitted to one worker from eight producer threads:

| | Before | After |
|---|---:|---:|
| Submission time | 108.0 ms | 16.9 ms |
| End-to-end time | 164.0 ms | 71.8 ms |

The submission portion was 6.38x faster. The effect scales with producer contention; the single-producer case was effectively unchanged.

## Correctness

The queue CAS determines who wins the producer/consumer race. If the consumer clears the queue first, the producer retries against `nullptr`, performs a new empty-to-non-empty transition, and notifies. If the producer inserts first, the consumer takes the queued task. The worker state protocol then either prevents sleeping or wakes an already sleeping worker.

I also ran a stress test with 12 million tasks across 3,000 active-draining and idle-transition rounds, plus a clean ThreadSanitizer run.

## Tests

- static thread pool tests: 6 test cases, 12 assertions
- full `test.exec`: 324 test cases, 3,292 assertions