### PR TITLE
Fix constrained worker selection

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -853,8 +853,8 @@ namespace experimental::execution
     {
       thread_local std::uint64_t start_index{std::uint64_t(std::random_device{}())};
       start_index += 1;
-      std::size_t target_index = start_index % thread_count_;
-      std::size_t n_threads    = num_threads(constraints);
+      std::size_t const n_threads = num_threads(constraints);
+      std::size_t target_index    = start_index % (n_threads == 0 ? thread_count_ : n_threads);
       if (n_threads != 0)
       {
         for (std::size_t node_index = 0; node_index < numa_.num_nodes(); ++node_index)

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -853,8 +853,8 @@ namespace experimental::execution
     {
       thread_local std::uint64_t start_index{std::uint64_t(std::random_device{}())};
       start_index += 1;
-      std::size_t const n_threads = num_threads(constraints);
-      std::size_t target_index    = start_index % (n_threads == 0 ? thread_count_ : n_threads);
+      std::size_t const n_threads    = num_threads(constraints);
+      std::size_t       target_index = start_index % (n_threads == 0 ? thread_count_ : n_threads);
       if (n_threads != 0)
       {
         for (std::size_t node_index = 0; node_index < numa_.num_nodes(); ++node_index)

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -102,9 +102,8 @@ TEST_CASE("constrained static_thread_pool scheduler selects eligible workers",
           "[types][static_thread_pool]")
 {
   constexpr std::size_t const num_of_threads = 4;
-  exec::static_thread_pool    pool{
-    num_of_threads, {}, exec::numa_policy{two_node_numa_policy{}}};
-  exec::nodemask constraints{};
+  exec::static_thread_pool    pool{num_of_threads, {}, exec::numa_policy{two_node_numa_policy{}}};
+  exec::nodemask              constraints{};
   constraints.set(0);
   auto scheduler = pool.get_constrained_scheduler(&constraints);
 

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -31,6 +31,35 @@ namespace ex = STDEXEC;
 
 namespace
 {
+  thread_local int current_numa_node = -1;
+
+  struct two_node_numa_policy
+  {
+    [[nodiscard]]
+    constexpr auto num_nodes() const noexcept -> std::size_t
+    {
+      return 2;
+    }
+
+    [[nodiscard]]
+    constexpr auto num_cpus(int) const noexcept -> std::size_t
+    {
+      return 2;
+    }
+
+    auto bind_to_node(int node) const noexcept -> int
+    {
+      current_numa_node = node;
+      return 0;
+    }
+
+    [[nodiscard]]
+    constexpr auto thread_index_to_node(std::size_t index) const noexcept -> int
+    {
+      return index < 2 ? 1 : 0;
+    }
+  };
+
 #if !STDEXEC_NO_STDCPP_EXCEPTIONS()
   struct throwing_set_next_receiver
   {
@@ -68,6 +97,25 @@ namespace
   };
 #endif
 }  // namespace
+
+TEST_CASE("constrained static_thread_pool scheduler selects eligible workers",
+          "[types][static_thread_pool]")
+{
+  constexpr std::size_t const num_of_threads = 4;
+  exec::static_thread_pool    pool{
+    num_of_threads, {}, exec::numa_policy{two_node_numa_policy{}}};
+  exec::nodemask constraints{};
+  constraints.set(0);
+  auto scheduler = pool.get_constrained_scheduler(&constraints);
+
+  for (std::size_t i = 0; i < num_of_threads; ++i)
+  {
+    auto [node] = ex::sync_wait(ex::schedule(scheduler)
+                                | ex::then([]() noexcept { return current_numa_node; }))
+                    .value();
+    CHECK(node == 0);
+  }
+}
 
 TEST_CASE("static_thread_pool::get_scheduler_on_thread Test start on a specific thread",
           "[types][static_thread_pool]")


### PR DESCRIPTION
## Summary

- select the round-robin target from the eligible worker count
- preserve the existing fallback when no pool workers match the mask
- add a regression test with a synthetic two-node NUMA policy

The constrained selection path reduced its target modulo the full pool size before walking only the eligible workers. When the eligible set was smaller than the pool, indices beyond that set fell through the traversal and were returned as raw worker indices, allowing work to be queued on an excluded node.

The regression test uses four workers split across two synthetic nodes. Before this change, two of four consecutive submissions ran on the excluded node.

## Testing

- full test.exec suite: 3,302 assertions in 327 test cases
- full test.exec suite with -fno-exceptions: 3,244 assertions in 309 test cases
- regression test repeated 100 times