### PR TITLE
Avoid RMWs when polling empty remote queues

### DIFF
--- a/examples/benchmark/common.hpp
+++ b/examples/benchmark/common.hpp
@@ -23,7 +23,6 @@
 #include <barrier>
 #include <chrono>
 #include <cmath>
-#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -121,10 +120,6 @@ void my_main(int argc, char** argv, exec::numa_policy policy = exec::get_numa_po
     nthreads = std::atoi(argv[1]);
   }
   std::size_t total_scheds = 10'000'000;
-  if (argc > 2)
-  {
-    total_scheds = static_cast<std::size_t>(std::strtoull(argv[2], nullptr, 10));
-  }
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
   std::vector<std::unique_ptr<char, numa_deleter>> buffers;
 #endif

--- a/examples/benchmark/common.hpp
+++ b/examples/benchmark/common.hpp
@@ -23,6 +23,7 @@
 #include <barrier>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -120,6 +121,10 @@ void my_main(int argc, char** argv, exec::numa_policy policy = exec::get_numa_po
     nthreads = std::atoi(argv[1]);
   }
   std::size_t total_scheds = 10'000'000;
+  if (argc > 2)
+  {
+    total_scheds = static_cast<std::size_t>(std::strtoull(argv[2], nullptr, 10));
+  }
 #ifndef STDEXEC_NO_MONOTONIC_BUFFER_RESOURCE
   std::vector<std::unique_ptr<char, numa_deleter>> buffers;
 #endif

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -165,8 +165,8 @@ namespace experimental::execution
         }
       }
 
-      auto pop_all_reversed(std::size_t tid, bool force) noexcept
-        -> __intrusive_queue<&task_base::next_>
+      auto
+      pop_all_reversed(std::size_t tid, bool force) noexcept -> __intrusive_queue<&task_base::next_>
       {
         remote_queue*                        head = head_.load(__std::memory_order_acquire);
         __intrusive_queue<&task_base::next_> tasks{};
@@ -975,13 +975,12 @@ namespace experimental::execution
       tmp.clear();
     }
 
-    inline auto
-    _static_thread_pool::thread_state::try_remote(bool force)
+    inline auto _static_thread_pool::thread_state::try_remote(bool force)
       -> _static_thread_pool::thread_state::pop_result
     {
       pop_result                           result{.task = nullptr, .queue_index = index_};
-      __intrusive_queue<&task_base::next_> remotes =
-        pool_->remotes_.pop_all_reversed(index_, force);
+      __intrusive_queue<&task_base::next_> remotes = pool_->remotes_.pop_all_reversed(index_,
+                                                                                      force);
       pending_queue_.append(std::move(remotes));
       if (!pending_queue_.empty())
       {

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -139,6 +139,12 @@ namespace experimental::execution
       std::size_t index_{(std::numeric_limits<std::size_t>::max)()};
     };
 
+    enum class remote_poll_mode
+    {
+      speculative,
+      before_sleep
+    };
+
     struct remote_queue_list
     {
      private:
@@ -166,14 +172,15 @@ namespace experimental::execution
       }
 
       auto
-      pop_all_reversed(std::size_t tid, bool force) noexcept -> __intrusive_queue<&task_base::next_>
+      pop_all_reversed(std::size_t tid, remote_poll_mode mode) noexcept
+        -> __intrusive_queue<&task_base::next_>
       {
         remote_queue*                        head = head_.load(__std::memory_order_acquire);
         __intrusive_queue<&task_base::next_> tasks{};
         while (head != nullptr)
         {
           auto& queue = head->queues_[tid];
-          if (force || !queue.empty())
+          if (mode == remote_poll_mode::before_sleep || !queue.empty())
           {
             tasks.append(queue.pop_all_reversed());
           }
@@ -650,7 +657,7 @@ namespace experimental::execution
         };
 
         auto try_pop() -> pop_result;
-        auto try_remote(bool force = false) -> pop_result;
+        auto try_remote(remote_poll_mode mode) -> pop_result;
         auto try_steal(std::span<workstealing_victim> victims) -> pop_result;
         auto try_steal_near() -> pop_result;
         auto try_steal_any() -> pop_result;
@@ -975,12 +982,12 @@ namespace experimental::execution
       tmp.clear();
     }
 
-    inline auto _static_thread_pool::thread_state::try_remote(bool force)
+    inline auto _static_thread_pool::thread_state::try_remote(remote_poll_mode mode)
       -> _static_thread_pool::thread_state::pop_result
     {
       pop_result                           result{.task = nullptr, .queue_index = index_};
       __intrusive_queue<&task_base::next_> remotes = pool_->remotes_.pop_all_reversed(index_,
-                                                                                      force);
+                                                                                      mode);
       pending_queue_.append(std::move(remotes));
       if (!pending_queue_.empty())
       {
@@ -1000,7 +1007,7 @@ namespace experimental::execution
       {
         return result;
       }
-      return try_remote();
+      return try_remote(remote_poll_mode::speculative);
     }
 
     inline auto _static_thread_pool::thread_state::try_steal(std::span<workstealing_victim> victims)
@@ -1138,7 +1145,10 @@ namespace experimental::execution
                                          __std::memory_order_relaxed,
                                          __std::memory_order_relaxed))
         {
-          result = try_remote(true);
+          // The relaxed empty probe is safe during normal polling, but the
+          // running-to-sleeping boundary must perform the CAS dequeue so work
+          // published before the transition cannot be missed.
+          result = try_remote(remote_poll_mode::before_sleep);
           if (result.task)
           {
             state expected_sleeping = state::sleeping;

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1134,11 +1134,19 @@ namespace experimental::execution
           return result;
         }
         state expected = state::running;
-        if (state_.compare_exchange_weak(expected, state::sleeping, __std::memory_order_relaxed))
+        if (state_.compare_exchange_weak(expected,
+                                         state::sleeping,
+                                         __std::memory_order_relaxed,
+                                         __std::memory_order_acquire))
         {
           result = try_remote(true);
           if (result.task)
           {
+            state expected_sleeping = state::sleeping;
+            state_.compare_exchange_strong(expected_sleeping,
+                                           state::running,
+                                           __std::memory_order_relaxed,
+                                           __std::memory_order_relaxed);
             return result;
           }
           set_sleeping();
@@ -1158,7 +1166,7 @@ namespace experimental::execution
 
     inline auto _static_thread_pool::thread_state::notify() -> bool
     {
-      if (state_.exchange(state::notified, __std::memory_order_relaxed) == state::sleeping)
+      if (state_.exchange(state::notified, __std::memory_order_release) == state::sleeping)
       {
         {
           std::lock_guard lock{mut_};

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -165,14 +165,15 @@ namespace experimental::execution
         }
       }
 
-      auto pop_all_reversed(std::size_t tid) noexcept -> __intrusive_queue<&task_base::next_>
+      auto pop_all_reversed(std::size_t tid, bool force) noexcept
+        -> __intrusive_queue<&task_base::next_>
       {
         remote_queue*                        head = head_.load(__std::memory_order_acquire);
         __intrusive_queue<&task_base::next_> tasks{};
         while (head != nullptr)
         {
           auto& queue = head->queues_[tid];
-          if (!queue.empty())
+          if (force || !queue.empty())
           {
             tasks.append(queue.pop_all_reversed());
           }
@@ -649,7 +650,7 @@ namespace experimental::execution
         };
 
         auto try_pop() -> pop_result;
-        auto try_remote() -> pop_result;
+        auto try_remote(bool force = false) -> pop_result;
         auto try_steal(std::span<workstealing_victim> victims) -> pop_result;
         auto try_steal_near() -> pop_result;
         auto try_steal_any() -> pop_result;
@@ -975,10 +976,12 @@ namespace experimental::execution
     }
 
     inline auto
-    _static_thread_pool::thread_state::try_remote() -> _static_thread_pool::thread_state::pop_result
+    _static_thread_pool::thread_state::try_remote(bool force)
+      -> _static_thread_pool::thread_state::pop_result
     {
       pop_result                           result{.task = nullptr, .queue_index = index_};
-      __intrusive_queue<&task_base::next_> remotes = pool_->remotes_.pop_all_reversed(index_);
+      __intrusive_queue<&task_base::next_> remotes =
+        pool_->remotes_.pop_all_reversed(index_, force);
       pending_queue_.append(std::move(remotes));
       if (!pending_queue_.empty())
       {
@@ -1133,7 +1136,7 @@ namespace experimental::execution
         state expected = state::running;
         if (state_.compare_exchange_weak(expected, state::sleeping, __std::memory_order_relaxed))
         {
-          result = try_remote();
+          result = try_remote(true);
           if (result.task)
           {
             return result;

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -171,8 +171,7 @@ namespace experimental::execution
         }
       }
 
-      auto
-      pop_all_reversed(std::size_t tid, remote_poll_mode mode) noexcept
+      auto pop_all_reversed(std::size_t tid, remote_poll_mode mode) noexcept
         -> __intrusive_queue<&task_base::next_>
       {
         remote_queue*                        head = head_.load(__std::memory_order_acquire);
@@ -986,8 +985,7 @@ namespace experimental::execution
       -> _static_thread_pool::thread_state::pop_result
     {
       pop_result                           result{.task = nullptr, .queue_index = index_};
-      __intrusive_queue<&task_base::next_> remotes = pool_->remotes_.pop_all_reversed(index_,
-                                                                                      mode);
+      __intrusive_queue<&task_base::next_> remotes = pool_->remotes_.pop_all_reversed(index_, mode);
       pending_queue_.append(std::move(remotes));
       if (!pending_queue_.empty())
       {

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -171,7 +171,11 @@ namespace experimental::execution
         __intrusive_queue<&task_base::next_> tasks{};
         while (head != nullptr)
         {
-          tasks.append(head->queues_[tid].pop_all_reversed());
+          auto& queue = head->queues_[tid];
+          if (!queue.empty())
+          {
+            tasks.append(queue.pop_all_reversed());
+          }
           head = head->next_;
         }
         return tasks;

--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1137,7 +1137,7 @@ namespace experimental::execution
         if (state_.compare_exchange_weak(expected,
                                          state::sleeping,
                                          __std::memory_order_relaxed,
-                                         __std::memory_order_acquire))
+                                         __std::memory_order_relaxed))
         {
           result = try_remote(true);
           if (result.task)
@@ -1158,7 +1158,7 @@ namespace experimental::execution
         {
           lock.unlock();
         }
-        state_.store(state::running, __std::memory_order_relaxed);
+        state_.exchange(state::running, __std::memory_order_acquire);
         result = try_pop();
       }
       return result;

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -16,17 +16,21 @@
 
 #include <exec/sequence/ignore_all_values.hpp>
 #include <exec/sequence/transform_each.hpp>
+#include <exec/start_detached.hpp>
 #include <exec/static_thread_pool.hpp>
 #include <stdexec/execution.hpp>
 #include <test_common/catch2.hpp>  // IWYU pragma: keep
 
 #include <atomic>
+#include <chrono>
 #include <exception>
+#include <latch>
 #include <mutex>
 #include <ranges>
 #include <stdexcept>
 #include <thread>
 #include <unordered_set>
+#include <vector>
 namespace ex = STDEXEC;
 
 namespace
@@ -228,4 +232,87 @@ TEST_CASE("bulk on static_thread_pool executes on multiple threads, take 2",
                          });
   ex::sync_wait(std::move(sender));
   REQUIRE(thread_ids.size() == num_of_threads);
+}
+
+TEST_CASE("static_thread_pool drains remote work after idle transitions",
+          "[types][static_thread_pool][stress]")
+{
+  constexpr std::size_t num_producers = 4;
+  constexpr std::size_t rounds        = 10'000;
+
+  std::latch                         ready{num_producers};
+  std::atomic<bool>                  start{false};
+  std::atomic<bool>                  stop{false};
+  std::vector<std::atomic<std::size_t>> completed(num_producers);
+  std::vector<std::thread>                producers;
+  producers.reserve(num_producers);
+  for (auto& count: completed)
+  {
+    count.store(0, std::memory_order_relaxed);
+  }
+
+  exec::static_thread_pool pool{1};
+  auto                     scheduler = pool.get_scheduler();
+
+  for (std::size_t producer = 0; producer < num_producers; ++producer)
+  {
+    producers.emplace_back([&, producer]
+    {
+      ready.count_down();
+      while (!start.load(std::memory_order_acquire))
+      {
+        std::this_thread::yield();
+      }
+
+      auto* const producer_completed = &completed[producer];
+      std::size_t expected            = 0;
+      for (std::size_t round = 0; round < rounds && !stop.load(std::memory_order_relaxed);
+           ++round)
+      {
+        std::size_t const batch_size = (round % 4 == 0) ? 2 : 1;
+        expected += batch_size;
+        for (std::size_t i = 0; i < batch_size; ++i)
+        {
+          exec::start_detached(
+            ex::schedule(scheduler)
+            | ex::then([producer_completed]
+                       { producer_completed->fetch_add(1, std::memory_order_relaxed); }));
+        }
+
+        while (!stop.load(std::memory_order_relaxed)
+               && producer_completed->load(std::memory_order_relaxed) < expected)
+        {
+          std::this_thread::yield();
+        }
+        std::this_thread::yield();
+      }
+    });
+  }
+
+  ready.wait();
+  start.store(true, std::memory_order_release);
+
+  auto const expected = num_producers * rounds + num_producers * ((rounds + 3) / 4);
+  auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  auto       completed_total = [&]
+  {
+    std::size_t result = 0;
+    for (auto const& count: completed)
+    {
+      result += count.load(std::memory_order_relaxed);
+    }
+    return result;
+  };
+
+  while (completed_total() < expected && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::yield();
+  }
+  stop.store(true, std::memory_order_release);
+  for (auto& producer: producers)
+  {
+    producer.join();
+  }
+
+  CHECK(completed_total() == expected);
 }

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -26,6 +26,7 @@
 #include <exception>
 #include <latch>
 #include <mutex>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <thread>
@@ -234,86 +235,106 @@ TEST_CASE("bulk on static_thread_pool executes on multiple threads, take 2",
   REQUIRE(thread_ids.size() == num_of_threads);
 }
 
-TEST_CASE("static_thread_pool drains remote work after idle transitions",
-          "[types][static_thread_pool][stress]")
+namespace
 {
-  constexpr std::size_t num_producers = 4;
-  constexpr std::size_t rounds        = 10'000;
-
-  std::latch                            ready{num_producers};
-  std::atomic<bool>                     start{false};
-  std::atomic<bool>                     stop{false};
-  std::vector<std::atomic<std::size_t>> completed(num_producers);
-  std::vector<std::thread>              producers;
-  producers.reserve(num_producers);
-  for (auto& count: completed)
+  void run_remote_poll_stress(bool separate_schedulers)
   {
-    count.store(0, std::memory_order_relaxed);
-  }
+    constexpr std::size_t num_producers = 4;
+    constexpr std::size_t rounds        = 10'000;
 
-  exec::static_thread_pool pool{1};
-  auto                     scheduler = pool.get_scheduler();
+    std::latch                            ready{num_producers};
+    std::atomic<bool>                     start{false};
+    std::atomic<bool>                     stop{false};
+    std::vector<std::atomic<std::size_t>> completed(num_producers);
+    std::vector<std::thread>              producers;
+    producers.reserve(num_producers);
+    for (auto& count: completed)
+    {
+      count.store(0, std::memory_order_relaxed);
+    }
 
-  for (std::size_t producer = 0; producer < num_producers; ++producer)
-  {
-    producers.emplace_back(
-      [&, producer]
-      {
-        ready.count_down();
-        while (!start.load(std::memory_order_acquire))
+    exec::static_thread_pool pool{1};
+    using scheduler_t = decltype(pool.get_scheduler());
+    std::optional<scheduler_t> shared_scheduler;
+    if (!separate_schedulers)
+    {
+      shared_scheduler.emplace(pool.get_scheduler());
+    }
+
+    for (std::size_t producer = 0; producer < num_producers; ++producer)
+    {
+      producers.emplace_back(
+        [&, producer]
         {
-          std::this_thread::yield();
-        }
-
-        auto* const producer_completed = &completed[producer];
-        std::size_t expected           = 0;
-        for (std::size_t round = 0; round < rounds && !stop.load(std::memory_order_relaxed);
-             ++round)
-        {
-          std::size_t const batch_size = (round % 4 == 0) ? 2 : 1;
-          expected += batch_size;
-          for (std::size_t i = 0; i < batch_size; ++i)
-          {
-            exec::start_detached(
-              ex::schedule(scheduler)
-              | ex::then([producer_completed]
-                         { producer_completed->fetch_add(1, std::memory_order_relaxed); }));
-          }
-
-          while (!stop.load(std::memory_order_relaxed)
-                 && producer_completed->load(std::memory_order_relaxed) < expected)
+          auto scheduler = separate_schedulers ? pool.get_scheduler() : *shared_scheduler;
+          ready.count_down();
+          while (!start.load(std::memory_order_acquire))
           {
             std::this_thread::yield();
           }
-          std::this_thread::yield();
-        }
-      });
-  }
 
-  ready.wait();
-  start.store(true, std::memory_order_release);
+          auto* const producer_completed = &completed[producer];
+          std::size_t expected           = 0;
+          for (std::size_t round = 0; round < rounds && !stop.load(std::memory_order_relaxed);
+               ++round)
+          {
+            std::size_t const batch_size = (round % 4 == 0) ? 2 : 1;
+            expected += batch_size;
+            for (std::size_t i = 0; i < batch_size; ++i)
+            {
+              exec::start_detached(
+                ex::schedule(scheduler)
+                | ex::then([producer_completed]
+                           { producer_completed->fetch_add(1, std::memory_order_relaxed); }));
+            }
 
-  auto const expected        = num_producers * rounds + num_producers * ((rounds + 3) / 4);
-  auto const deadline        = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-  auto       completed_total = [&]
-  {
-    std::size_t result = 0;
-    for (auto const & count: completed)
-    {
-      result += count.load(std::memory_order_relaxed);
+            while (!stop.load(std::memory_order_relaxed)
+                   && producer_completed->load(std::memory_order_relaxed) < expected)
+            {
+              std::this_thread::yield();
+            }
+            std::this_thread::yield();
+          }
+        });
     }
-    return result;
-  };
 
-  while (completed_total() < expected && std::chrono::steady_clock::now() < deadline)
-  {
-    std::this_thread::yield();
-  }
-  stop.store(true, std::memory_order_release);
-  for (auto& producer: producers)
-  {
-    producer.join();
-  }
+    ready.wait();
+    start.store(true, std::memory_order_release);
 
-  CHECK(completed_total() == expected);
+    auto const expected        = num_producers * rounds + num_producers * ((rounds + 3) / 4);
+    auto const deadline        = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    auto       completed_total = [&]
+    {
+      std::size_t result = 0;
+      for (auto const & count: completed)
+      {
+        result += count.load(std::memory_order_relaxed);
+      }
+      return result;
+    };
+
+    while (completed_total() < expected && std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::yield();
+    }
+    stop.store(true, std::memory_order_release);
+    for (auto& producer: producers)
+    {
+      producer.join();
+    }
+
+    CHECK(completed_total() == expected);
+  }
+}  // namespace
+
+TEST_CASE("static_thread_pool drains remote work from a shared scheduler",
+          "[types][static_thread_pool][stress]")
+{
+  run_remote_poll_stress(false);
+}
+
+TEST_CASE("static_thread_pool drains remote work from producer schedulers",
+          "[types][static_thread_pool][stress]")
+{
+  run_remote_poll_stress(true);
 }

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -240,11 +240,11 @@ TEST_CASE("static_thread_pool drains remote work after idle transitions",
   constexpr std::size_t num_producers = 4;
   constexpr std::size_t rounds        = 10'000;
 
-  std::latch                         ready{num_producers};
-  std::atomic<bool>                  start{false};
-  std::atomic<bool>                  stop{false};
+  std::latch                            ready{num_producers};
+  std::atomic<bool>                     start{false};
+  std::atomic<bool>                     stop{false};
   std::vector<std::atomic<std::size_t>> completed(num_producers);
-  std::vector<std::thread>                producers;
+  std::vector<std::thread>              producers;
   producers.reserve(num_producers);
   for (auto& count: completed)
   {
@@ -256,48 +256,49 @@ TEST_CASE("static_thread_pool drains remote work after idle transitions",
 
   for (std::size_t producer = 0; producer < num_producers; ++producer)
   {
-    producers.emplace_back([&, producer]
-    {
-      ready.count_down();
-      while (!start.load(std::memory_order_acquire))
+    producers.emplace_back(
+      [&, producer]
       {
-        std::this_thread::yield();
-      }
-
-      auto* const producer_completed = &completed[producer];
-      std::size_t expected            = 0;
-      for (std::size_t round = 0; round < rounds && !stop.load(std::memory_order_relaxed);
-           ++round)
-      {
-        std::size_t const batch_size = (round % 4 == 0) ? 2 : 1;
-        expected += batch_size;
-        for (std::size_t i = 0; i < batch_size; ++i)
-        {
-          exec::start_detached(
-            ex::schedule(scheduler)
-            | ex::then([producer_completed]
-                       { producer_completed->fetch_add(1, std::memory_order_relaxed); }));
-        }
-
-        while (!stop.load(std::memory_order_relaxed)
-               && producer_completed->load(std::memory_order_relaxed) < expected)
+        ready.count_down();
+        while (!start.load(std::memory_order_acquire))
         {
           std::this_thread::yield();
         }
-        std::this_thread::yield();
-      }
-    });
+
+        auto* const producer_completed = &completed[producer];
+        std::size_t expected           = 0;
+        for (std::size_t round = 0; round < rounds && !stop.load(std::memory_order_relaxed);
+             ++round)
+        {
+          std::size_t const batch_size = (round % 4 == 0) ? 2 : 1;
+          expected += batch_size;
+          for (std::size_t i = 0; i < batch_size; ++i)
+          {
+            exec::start_detached(
+              ex::schedule(scheduler)
+              | ex::then([producer_completed]
+                         { producer_completed->fetch_add(1, std::memory_order_relaxed); }));
+          }
+
+          while (!stop.load(std::memory_order_relaxed)
+                 && producer_completed->load(std::memory_order_relaxed) < expected)
+          {
+            std::this_thread::yield();
+          }
+          std::this_thread::yield();
+        }
+      });
   }
 
   ready.wait();
   start.store(true, std::memory_order_release);
 
-  auto const expected = num_producers * rounds + num_producers * ((rounds + 3) / 4);
-  auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  auto const expected        = num_producers * rounds + num_producers * ((rounds + 3) / 4);
+  auto const deadline        = std::chrono::steady_clock::now() + std::chrono::seconds(10);
   auto       completed_total = [&]
   {
     std::size_t result = 0;
-    for (auto const& count: completed)
+    for (auto const & count: completed)
     {
       result += count.load(std::memory_order_relaxed);
     }

--- a/test/rrd/CMakeLists.txt
+++ b/test/rrd/CMakeLists.txt
@@ -54,7 +54,7 @@ function(add_relacy_test target_name)
 endfunction()
 
 set(relacy_tests async_scope bwos_lifo_queue intrusive_mpsc_queue split
-                 sync_wait)
+                 static_thread_pool_remote_poll sync_wait)
 
 foreach(test ${relacy_tests})
   add_relacy_test(${test})

--- a/test/rrd/static_thread_pool_remote_poll.cpp
+++ b/test/rrd/static_thread_pool_remote_poll.cpp
@@ -2,8 +2,8 @@
  * Copyright (c) 2026 NVIDIA Corporation
  *
  * Licensed under the Apache License Version 2.0 with LLVM Exceptions
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
  *
  *   https://llvm.org/LICENSE.txt
  *
@@ -18,9 +18,15 @@
 
 #include <atomic>
 
-struct remote_queue_node
+struct task_node
 {
-  remote_queue_node* next_ = nullptr;
+  task_node* next_ = nullptr;
+};
+
+struct remote_queue
+{
+  remote_queue*           next_ = nullptr;
+  std::atomic<task_node*> head_{nullptr};
 };
 
 struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote_poll, 3>
@@ -29,31 +35,68 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
   static constexpr int sleeping = 1;
   static constexpr int notified = 2;
 
-  std::atomic<int>                state_{running};
-  std::atomic<remote_queue_node*> head_{nullptr};
-  std::atomic<bool>               first_notification_published_{false};
-  remote_queue_node               first_{};
-  remote_queue_node               second_{};
-  bool                            worker_would_sleep_ = false;
+  enum class remote_poll_mode
+  {
+    speculative,
+    before_sleep
+  };
+
+  struct poll_result
+  {
+    bool any    = false;
+    bool second = false;
+  };
+
+  std::atomic<int>           state_{running};
+  std::atomic<remote_queue*> remote_head_{nullptr};
+  std::atomic<bool>          first_notification_published_{false};
+  remote_queue               first_queue_{};
+  remote_queue               second_queue_{};
+  task_node                  first_task_{};
+  task_node                  first_extra_task_{};
+  task_node                  second_task_{};
+  bool                       worker_would_sleep_ = false;
 
   void before()
   {
     state_.store(running, std::memory_order_relaxed);
-    head_.store(nullptr, std::memory_order_relaxed);
+    remote_head_.store(nullptr, std::memory_order_relaxed);
     first_notification_published_.store(false, std::memory_order_relaxed);
-    first_.next_        = nullptr;
-    second_.next_       = nullptr;
-    worker_would_sleep_ = false;
+    first_queue_.next_  = nullptr;
+    second_queue_.next_ = nullptr;
+    first_queue_.head_.store(nullptr, std::memory_order_relaxed);
+    second_queue_.head_.store(nullptr, std::memory_order_relaxed);
+    first_task_.next_       = nullptr;
+    first_extra_task_.next_ = nullptr;
+    second_task_.next_      = nullptr;
+    worker_would_sleep_     = false;
   }
 
-  void publish(remote_queue_node& node)
+  void publish_remote_queue(remote_queue& queue)
   {
-    auto* old_head = head_.load(std::memory_order_relaxed);
+    auto* old_head = remote_head_.load(std::memory_order_acquire);
     do
     {
-      node.next_ = old_head;
+      queue.next_ = old_head;
     }
-    while (!head_.compare_exchange_weak(old_head, &node, std::memory_order_acq_rel));
+    while (!remote_head_.compare_exchange_weak(old_head,
+                                               &queue,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_acquire));
+  }
+
+  auto push(remote_queue& queue, task_node& task) -> bool
+  {
+    auto* old_head = queue.head_.load(std::memory_order_relaxed);
+    do
+    {
+      task.next_ = old_head;
+    }
+    while (!queue.head_.compare_exchange_weak(old_head,
+                                              &task,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire));
+    return old_head == nullptr;
   }
 
   void notify()
@@ -61,23 +104,61 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
     state_.exchange(notified, std::memory_order_release);
   }
 
-  auto sees_second_node() -> bool
+  void enqueue(remote_queue& queue, task_node& task)
   {
-    for (auto* node = head_.load(std::memory_order_acquire); node != nullptr; node = node->next_)
+    bool const was_empty = push(queue, task);
+    if (was_empty)
     {
-      if (node == &second_)
-      {
-        return true;
-      }
+      notify();
     }
-    return false;
+  }
+
+  auto drain(remote_queue& queue) -> task_node*
+  {
+    auto* old_head = queue.head_.load(std::memory_order_relaxed);
+    while (!queue.head_.compare_exchange_weak(old_head,
+                                              nullptr,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire))
+    {
+    }
+    return old_head;
+  }
+
+  auto poll_remote(remote_poll_mode mode) -> poll_result
+  {
+    poll_result result{};
+    auto*       queue = remote_head_.load(std::memory_order_acquire);
+    while (queue != nullptr)
+    {
+      if (mode == remote_poll_mode::before_sleep
+          || queue->head_.load(std::memory_order_relaxed) != nullptr)
+      {
+        for (auto* task = drain(*queue); task != nullptr; task = task->next_)
+        {
+          result.any    = true;
+          result.second = result.second || task == &second_task_;
+        }
+      }
+      queue = queue->next_;
+    }
+    return result;
   }
 
   void worker_poll()
   {
-    if (sees_second_node())
+    auto result = poll_remote(remote_poll_mode::speculative);
+    if (result.second)
     {
       return;
+    }
+    if (result.any)
+    {
+      result = poll_remote(remote_poll_mode::speculative);
+      if (result.second)
+      {
+        return;
+      }
     }
 
     int expected = running;
@@ -86,12 +167,19 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
                                       std::memory_order_relaxed,
                                       std::memory_order_relaxed))
     {
-      // This acquire RMW must consume a preceding notification or leave a
-      // later notification visible to the next sleep transition.
       state_.exchange(running, std::memory_order_acquire);
-      if (sees_second_node())
+      result = poll_remote(remote_poll_mode::speculative);
+      if (result.second)
       {
         return;
+      }
+      if (result.any)
+      {
+        result = poll_remote(remote_poll_mode::speculative);
+        if (result.second)
+        {
+          return;
+        }
       }
 
       expected = running;
@@ -104,7 +192,8 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
       }
     }
 
-    if (sees_second_node())
+    result = poll_remote(remote_poll_mode::before_sleep);
+    if (result.any)
     {
       int expected_sleeping = sleeping;
       state_.compare_exchange_strong(expected_sleeping,
@@ -121,8 +210,9 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
   {
     if (thread_id == 0)
     {
-      publish(first_);
-      notify();
+      publish_remote_queue(first_queue_);
+      enqueue(first_queue_, first_task_);
+      enqueue(first_queue_, first_extra_task_);
       first_notification_published_.store(true, std::memory_order_release);
     }
     else if (thread_id == 1)
@@ -130,8 +220,8 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
       while (!first_notification_published_.load(std::memory_order_acquire))
       {
       }
-      publish(second_);
-      notify();
+      publish_remote_queue(second_queue_);
+      enqueue(second_queue_, second_task_);
     }
     else
     {

--- a/test/rrd/static_thread_pool_remote_poll.cpp
+++ b/test/rrd/static_thread_pool_remote_poll.cpp
@@ -34,7 +34,7 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
   std::atomic<bool>               first_notification_published_{false};
   remote_queue_node               first_{};
   remote_queue_node               second_{};
-  bool                             worker_would_sleep_ = false;
+  bool                            worker_would_sleep_ = false;
 
   void before()
   {
@@ -63,8 +63,7 @@ struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote
 
   auto sees_second_node() -> bool
   {
-    for (auto* node = head_.load(std::memory_order_acquire); node != nullptr;
-         node       = node->next_)
+    for (auto* node = head_.load(std::memory_order_acquire); node != nullptr; node = node->next_)
     {
       if (node == &second_)
       {

--- a/test/rrd/static_thread_pool_remote_poll.cpp
+++ b/test/rrd/static_thread_pool_remote_poll.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdexec_relacy.hpp>
+
+#include <atomic>
+
+struct remote_queue_node
+{
+  remote_queue_node* next_ = nullptr;
+};
+
+struct static_thread_pool_remote_poll : rl::test_suite<static_thread_pool_remote_poll, 3>
+{
+  static constexpr int running  = 0;
+  static constexpr int sleeping = 1;
+  static constexpr int notified = 2;
+
+  std::atomic<int>                state_{running};
+  std::atomic<remote_queue_node*> head_{nullptr};
+  std::atomic<bool>               first_notification_published_{false};
+  remote_queue_node               first_{};
+  remote_queue_node               second_{};
+  bool                             worker_would_sleep_ = false;
+
+  void before()
+  {
+    state_.store(running, std::memory_order_relaxed);
+    head_.store(nullptr, std::memory_order_relaxed);
+    first_notification_published_.store(false, std::memory_order_relaxed);
+    first_.next_        = nullptr;
+    second_.next_       = nullptr;
+    worker_would_sleep_ = false;
+  }
+
+  void publish(remote_queue_node& node)
+  {
+    auto* old_head = head_.load(std::memory_order_relaxed);
+    do
+    {
+      node.next_ = old_head;
+    }
+    while (!head_.compare_exchange_weak(old_head, &node, std::memory_order_acq_rel));
+  }
+
+  void notify()
+  {
+    state_.exchange(notified, std::memory_order_release);
+  }
+
+  auto sees_second_node() -> bool
+  {
+    for (auto* node = head_.load(std::memory_order_acquire); node != nullptr;
+         node       = node->next_)
+    {
+      if (node == &second_)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void worker_poll()
+  {
+    if (sees_second_node())
+    {
+      return;
+    }
+
+    int expected = running;
+    if (!state_.compare_exchange_weak(expected,
+                                      sleeping,
+                                      std::memory_order_relaxed,
+                                      std::memory_order_relaxed))
+    {
+      // This acquire RMW must consume a preceding notification or leave a
+      // later notification visible to the next sleep transition.
+      state_.exchange(running, std::memory_order_acquire);
+      if (sees_second_node())
+      {
+        return;
+      }
+
+      expected = running;
+      if (!state_.compare_exchange_weak(expected,
+                                        sleeping,
+                                        std::memory_order_relaxed,
+                                        std::memory_order_relaxed))
+      {
+        return;
+      }
+    }
+
+    if (sees_second_node())
+    {
+      int expected_sleeping = sleeping;
+      state_.compare_exchange_strong(expected_sleeping,
+                                     running,
+                                     std::memory_order_relaxed,
+                                     std::memory_order_relaxed);
+      return;
+    }
+
+    worker_would_sleep_ = true;
+  }
+
+  void thread(unsigned thread_id)
+  {
+    if (thread_id == 0)
+    {
+      publish(first_);
+      notify();
+      first_notification_published_.store(true, std::memory_order_release);
+    }
+    else if (thread_id == 1)
+    {
+      while (!first_notification_published_.load(std::memory_order_acquire))
+      {
+      }
+      publish(second_);
+      notify();
+    }
+    else
+    {
+      worker_poll();
+    }
+  }
+
+  void after()
+  {
+    if (worker_would_sleep_)
+    {
+      RL_ASSERT(state_.load(std::memory_order_acquire) != sleeping);
+    }
+  }
+};
+
+auto main() -> int
+{
+  rl::test_params p;
+  p.iteration_count       = 50000;
+  p.execution_depth_limit = 10000;
+  p.search_type           = rl::random_scheduler_type;
+  return rl::simulate<static_thread_pool_remote_poll>(p) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- skip the CAS dequeue for remote queue shards observed empty
- keep the CAS path for nonempty shards
- force the dequeue before a worker goes to sleep
- keep this scoped to static_thread_pool remote polling
- cover shared and per-thread producer schedulers in tests

Each worker walks every producer shard when checking for remote work. The current empty path performs a compare-exchange from null to null on every shard, taking exclusive ownership of cache lines only to discover that no work is present.

Before sleeping, the worker still does a real dequeue across the remote queues. This keeps the empty check as a speculative optimization while retaining the sleep-boundary safety check.

## Benchmark on current HEAD

Equivalent isolated empty remote-queue-list polling on an Apple M1 Pro, optimized build. The isolated numbers were measured before the test and benchmark cleanup commits. The production polling path is unchanged by those cleanup commits. The baseline forces the existing CAS dequeue for every shard; this branch first probes empty() and only dequeues nonempty shards. Values are median nanoseconds per complete list poll.

| Dormant producer shards | Current | This branch | Speedup |
| ---: | ---: | ---: | ---: |
| 0 | 7.03 ns | 0.99 ns | 7.1x |
| 8 | 21.33 ns | 4.68 ns | 4.6x |
| 32 | 79.22 ns | 25.18 ns | 3.1x |
| 128 | 298.36 ns | 154.67 ns | 1.9x |

## End-to-end benchmark rerun

Reran `build/examples/example.benchmark.static_thread_pool` on an Apple M1 Pro with the Release build.

- Base: `origin/main` at `3a836a97`
- PR: `16f3342f`
- Command: `./build/examples/example.benchmark.static_thread_pool <threads>`
- 10,000,000 schedules per round
- 100 rounds with one warmup round

| Workers / producer threads | origin/main | This branch | Change |
| ---: | ---: | ---: | ---: |
| 1 | 19.2M schedules/s | 20.3M schedules/s | +5.7% |
| 4 | 13.5M schedules/s | 14.0M schedules/s | +3.7% |

This is a steady-state scheduling benchmark. It does not measure enqueue-to-start latency or repeated sleep/wake bursts.

## Testing

- `cmake --build build --target test.exec -j2`
- `ctest --test-dir build -R 'static_thread_pool' --output-on-failure` (14/14 passed)
- Relacy remote-poll model: 50,000 iterations under x86_64 emulation
- Stress coverage for both a shared scheduler and per-thread producer schedulers

