### PR TITLE
Fix nvexec sync_wait scheduler query

### DIFF
--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -36,7 +36,7 @@ namespace nv::execution::_strm
     struct env
     {
       template <
-        __one_of<get_start_scheduler_t, get_start_scheduler_t, get_delegation_scheduler_t> _Query>
+        __one_of<get_scheduler_t, get_start_scheduler_t, get_delegation_scheduler_t> _Query>
       [[nodiscard]]
       constexpr auto query(_Query) const noexcept -> run_loop::scheduler
       {

--- a/include/nvexec/stream/sync_wait.cuh
+++ b/include/nvexec/stream/sync_wait.cuh
@@ -35,8 +35,7 @@ namespace nv::execution::_strm
   {
     struct env
     {
-      template <
-        __one_of<get_scheduler_t, get_start_scheduler_t, get_delegation_scheduler_t> _Query>
+      template <__one_of<get_scheduler_t, get_start_scheduler_t, get_delegation_scheduler_t> _Query>
       [[nodiscard]]
       constexpr auto query(_Query) const noexcept -> run_loop::scheduler
       {

--- a/test/nvexec/continues_on.cpp
+++ b/test/nvexec/continues_on.cpp
@@ -32,4 +32,15 @@ namespace
 
     STDEXEC::sync_wait(std::move(sndr));
   }
+
+  TEST_CASE("nvexec sync_wait provides a scheduler", "[cuda][stream][sync_wait]")
+  {
+    nvexec::stream_context ctx;
+
+    auto sndr = STDEXEC::get_scheduler() | STDEXEC::continues_on(ctx.get_scheduler());
+
+    auto result = STDEXEC::sync_wait(std::move(sndr));
+
+    REQUIRE(result.has_value());
+  }
 }  // namespace


### PR DESCRIPTION
## Summary

- restore the missing `get_scheduler_t` query in the nvexec `sync_wait` environment
- add a regression test that reads the scheduler through a stream-completing sender

## Testing

- `git diff --check`