### PR TITLE
Fix nvexec launch error signature

### DIFF
--- a/include/nvexec/stream/launch.cuh
+++ b/include/nvexec/stream/launch.cuh
@@ -119,7 +119,7 @@ namespace nv::execution
       template <class Fun, class CvSender, class... Env>
       using completions_t =
         __transform_completion_signatures_t<__completion_signatures_of_t<CvSender, Env...>,
-                                            completion_signatures<set_error_t(std::exception_ptr)>,
+                                            completion_signatures<set_error_t(cudaError_t)>,
                                             __mbind_front_q<_set_value_t, Fun>::template __f>;
     }  // namespace _launch
 

--- a/test/nvexec/launch.cpp
+++ b/test/nvexec/launch.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <stdexec/execution.hpp>
 #include <test_common/catch2.hpp>
+#include <test_common/type_helpers.hpp>
 
 #include "common.cuh"
 #include "nvexec/stream_context.cuh"
@@ -48,6 +49,16 @@ namespace
       std::iota(input.begin(), input.end(), 1);
       std::ranges::transform(input, input.begin(), [](int i) { return i * scaling; });
       return std::accumulate(input.begin(), input.end(), 0);
+    }
+
+    TEST_CASE("nvexec launch advertises CUDA launch errors", "[cuda][stream][adaptors][launch]")
+    {
+      nvexec::stream_context stream{};
+
+      auto snd = STDEXEC::just() | STDEXEC::continues_on(stream.get_scheduler())
+               | nvexec::launch([](cudaStream_t) {});
+
+      check_err_types<ex::__mset<cudaError_t>>(snd);
     }
 
     TEST_CASE("nvexec launch executes on GPU", "[cuda][stream][adaptors][launch]")


### PR DESCRIPTION
## Summary

- advertise `cudaError_t` for CUDA launch failures instead of `std::exception_ptr`
- add coverage for the launch sender error types

## Testing

- `git diff --check`