### PR TITLE
Fix nvexec when_all completion environment

### DIFF
--- a/include/nvexec/stream/when_all.cuh
+++ b/include/nvexec/stream/when_all.cuh
@@ -202,7 +202,7 @@ namespace nv::execution::_strm
       using when_all_sender_t = __copy_cvref_t<CvReceiver, when_all_sender>;
       using receiver_t        = __decay_t<CvReceiver>;
       using sender_t          = __m_at_c<Index, Senders...>;
-      using completions_t     = when_all_sender::_completions_t<env_of_t<receiver_t>, CvReceiver>;
+      using completions_t     = when_all_sender::_completions_t<CvReceiver, env_of_t<receiver_t>>;
       using local_env_t =
         STDEXEC::env<STDEXEC::prop<get_stop_token_t, inplace_stop_token>, env_of_t<receiver_t>>;
       using env_t = make_terminal_stream_env_t<local_env_t>;
@@ -290,7 +290,7 @@ namespace nv::execution::_strm
       friend struct receiver;
 
       using _env_t              = env_of_t<_receiver_t>;
-      using _completions_t      = when_all_sender::_completions_t<_env_t, CvReceiver>;
+      using _completions_t      = when_all_sender::_completions_t<CvReceiver, _env_t>;
       using _indices_t          = __indices_for<Senders...>;
       using _stream_providers_t = std::array<stream_provider, sizeof...(Senders)>;
       using _stop_callback_t =

--- a/test/nvexec/when_all.cpp
+++ b/test/nvexec/when_all.cpp
@@ -11,6 +11,14 @@ using nvexec::is_on_gpu;
 
 namespace
 {
+  inline constexpr struct value_query_t : ex::forwarding_query_t
+  {
+    template <class Env>
+    auto operator()(Env const & env) const noexcept -> decltype(env.query(*this))
+    {
+      return env.query(*this);
+    }
+  } value_query;
 
   TEST_CASE("nvexec when_all returns a sender", "[cuda][stream][adaptors][when_all]")
   {
@@ -63,6 +71,19 @@ namespace
 
     REQUIRE(v1 == 24);
     REQUIRE(v2 == 42);
+  }
+
+  TEST_CASE("nvexec when_all supports environment-dependent senders",
+            "[cuda][stream][adaptors][when_all]")
+  {
+    nvexec::stream_context stream_ctx{};
+
+    auto child = ex::read_env(value_query) | ex::continues_on(stream_ctx.get_scheduler());
+    auto snd   = ex::when_all(std::move(child)) | ex::write_env(ex::prop{value_query, 42});
+
+    auto [value] = STDEXEC::sync_wait(std::move(snd)).value();
+
+    REQUIRE(value == 42);
   }
 
   TEST_CASE("nvexec when_all with many senders", "[cuda][stream][adaptors][when_all]")


### PR DESCRIPTION
## Summary

- pass cvref and environment arguments to the internal completion calculation in the right order
- add an environment-dependent sender regression test

## Testing

- `git diff --check`