### PR TITLE
Preserve nvexec repeat_n child errors

### DIFF
--- a/include/nvexec/stream/repeat_n.cuh
+++ b/include/nvexec/stream/repeat_n.cuh
@@ -155,7 +155,7 @@ namespace nv::execution::_strm
       using sender_concept = STDEXEC::sender_tag;
 
       template <class...>
-      using _set_value_t = STDEXEC::completion_signatures<STDEXEC::set_value_t()>;
+      using _set_value_t = STDEXEC::completion_signatures<>;
 
       template <class Error>
       using _set_error_t =

--- a/include/nvexec/stream/repeat_n.cuh
+++ b/include/nvexec/stream/repeat_n.cuh
@@ -154,13 +154,26 @@ namespace nv::execution::_strm
     {
       using sender_concept = STDEXEC::sender_tag;
 
-      template <class>
-      static consteval auto get_completion_signatures()
+      template <class...>
+      using _set_value_t = STDEXEC::completion_signatures<STDEXEC::set_value_t()>;
+
+      template <class Error>
+      using _set_error_t =
+        STDEXEC::completion_signatures<STDEXEC::set_error_t(STDEXEC::__decay_t<Error>)>;
+
+      template <class Env>
+      using completions_t = STDEXEC::__transform_completion_signatures_t<
+        STDEXEC::__completion_signatures_of_t<CvSender, Env>,
+        STDEXEC::completion_signatures<STDEXEC::set_value_t(),
+                                       STDEXEC::set_error_t(std::exception_ptr),
+                                       STDEXEC::set_error_t(cudaError_t)>,
+        _set_value_t,
+        _set_error_t>;
+
+      template <class Env>
+      static consteval auto get_completion_signatures() -> completions_t<Env>
       {
-        return STDEXEC::completion_signatures<STDEXEC::set_value_t(),
-                                              STDEXEC::set_stopped_t(),
-                                              STDEXEC::set_error_t(std::exception_ptr),
-                                              STDEXEC::set_error_t(cudaError_t)>();
+        return {};
       }
 
       explicit sender(CvSender&& sndr, std::size_t count)

--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -32,6 +32,7 @@ set(nvexec_test_sources
     test_main.cpp
     then.cpp
     reduce.cpp
+    repeat_n.cpp
     split.cpp
     start_detached.cpp
     transfer.cpp

--- a/test/nvexec/repeat_n.cpp
+++ b/test/nvexec/repeat_n.cpp
@@ -1,0 +1,23 @@
+#include <stdexec/execution.hpp>
+#include <test_common/catch2.hpp>
+#include <test_common/type_helpers.hpp>
+
+#include "nvexec/stream_context.cuh"
+
+namespace ex = STDEXEC;
+
+namespace
+{
+  struct custom_error
+  {};
+
+  TEST_CASE("nvexec repeat_n preserves child errors", "[cuda][stream][adaptors][repeat_n]")
+  {
+    nvexec::stream_context stream_ctx{};
+
+    auto snd = ex::just_error(custom_error{}) | ex::continues_on(stream_ctx.get_scheduler())
+             | exec::repeat_n(1);
+
+    check_err_types<ex::__mset<custom_error, std::exception_ptr, cudaError_t>>(snd);
+  }
+}  // namespace


### PR DESCRIPTION
## Summary

- derive `repeat_n` completions from its child sender
- preserve and decay child error types while keeping the existing CUDA and exception paths
- add coverage with a custom child error

## Testing

- `git diff --check`