### PR TITLE
Fix nvexec upon_error move-only callable forwarding

### DIFF
--- a/include/nvexec/stream/common.cuh
+++ b/include/nvexec/stream/common.cuh
@@ -663,7 +663,7 @@ namespace nv::execution
 
       opstate_base(OuterReceiver rcvr, context ctx)
         : ctx_(ctx)
-        , rcvr_(rcvr)
+        , rcvr_(static_cast<OuterReceiver&&>(rcvr))
         , stream_provider_(borrows_stream, ctx)
       {}
 

--- a/include/nvexec/stream/upon_error.cuh
+++ b/include/nvexec/stream/upon_error.cuh
@@ -172,7 +172,7 @@ namespace nv::execution::_strm
         static_cast<Self&&>(self).sndr_,
         static_cast<Receiver&&>(rcvr),
         [&](_strm::opstate_base<Receiver>& stream_provider) -> receiver_t<Receiver>
-        { return receiver_t<Receiver>(self.fun_, stream_provider); });
+        { return receiver_t<Receiver>(static_cast<Self&&>(self).fun_, stream_provider); });
     }
     STDEXEC_EXPLICIT_THIS_END(connect)
 

--- a/test/nvexec/upon_error.cpp
+++ b/test/nvexec/upon_error.cpp
@@ -1,6 +1,8 @@
 #include <stdexec/execution.hpp>
 #include <test_common/catch2.hpp>
 
+#include <type_traits>
+
 #include "common.cuh"
 #include "nvexec/stream_context.cuh"
 
@@ -11,6 +13,23 @@ using nvexec::is_on_gpu;
 namespace
 {
 
+  struct move_only_error_handler
+  {
+    move_only_error_handler()                                = default;
+    move_only_error_handler(move_only_error_handler const &) = delete;
+
+    STDEXEC_ATTRIBUTE(host, device)
+    move_only_error_handler(move_only_error_handler &&) = default;
+
+    STDEXEC_ATTRIBUTE(host, device) auto operator()(int error) const -> int
+    {
+      return error;
+    }
+  };
+
+  static_assert(std::is_trivially_copyable_v<move_only_error_handler>);
+  static_assert(!std::is_copy_constructible_v<move_only_error_handler>);
+
   TEST_CASE("nvexec upon_error returns a sender", "[cuda][stream][adaptors][upon_error]")
   {
     nvexec::stream_context stream_ctx{};
@@ -19,6 +38,18 @@ namespace
              | ex::upon_error([](int) {});
     STATIC_REQUIRE(ex::sender<decltype(snd)>);
     (void) snd;
+  }
+
+  TEST_CASE("nvexec upon_error supports move-only function objects",
+            "[cuda][stream][adaptors][upon_error]")
+  {
+    nvexec::stream_context stream_ctx{};
+
+    auto snd = ex::just_error(42) | ex::continues_on(stream_ctx.get_scheduler())
+             | ex::upon_error(move_only_error_handler{});
+    auto const [result] = STDEXEC::sync_wait(std::move(snd)).value();
+
+    REQUIRE(result == 42);
   }
 
   TEST_CASE("nvexec upon_error executes on GPU", "[cuda][stream][adaptors][upon_error]")


### PR DESCRIPTION
## Summary

- forward the callable according to the sender value category when connecting `nvexec::upon_error`
- add coverage for a trivially copyable, move-only GPU callable

## Why

Connecting a consumed `upon_error` sender read `self.fun_` as an lvalue, so receiver construction tried to copy the callable. `upon_error` accepts movable function objects, and `nvexec::then` already forwards its stored callable in the same path.