### PR TITLE
get_completion_signatures_type

### DIFF
--- a/include/stdexec/__detail/__config.hpp
+++ b/include/stdexec/__detail/__config.hpp
@@ -617,6 +617,12 @@ namespace STDEXEC
 #  define STDEXEC_NO_STDCPP_PACK_INDEXING() 1
 #endif  // no pack indexing
 
+#if __cpp_impl_reflection >= 202506L && __cpp_lib_reflection >= 202506L
+#  define STDEXEC_NO_STDCPP_REFLECTION() 0
+#else
+#  define STDEXEC_NO_STDCPP_REFLECTION() 1
+#endif
+
 #if STDEXEC_HAS_FEATURE(thread_sanitizer) || defined(__SANITIZE_THREAD__)
 #  define STDEXEC_TSAN() 1
 #else

--- a/include/stdexec/__detail/__get_completion_signatures.hpp
+++ b/include/stdexec/__detail/__get_completion_signatures.hpp
@@ -35,6 +35,10 @@ import stdexec;
 #  include "__tag_invoke.hpp"
 #  include "__tuple.hpp"  // IWYU pragma: keep for __tuple
 
+#  if !STDEXEC_NO_STDCPP_REFLECTION()
+#    include <meta>
+#  endif
+
 #  include "__prologue.hpp"
 
 namespace STDEXEC
@@ -61,6 +65,16 @@ namespace STDEXEC
   STDEXEC_PRAGMA_IGNORE_MSVC(4913)
 
   struct _A_GET_COMPLETION_SIGNATURES_CUSTOMIZATION_RETURNED_A_TYPE_THAT_IS_NOT_A_COMPLETION_SIGNATURES_SPECIALIZATION;
+
+#  if !STDEXEC_NO_STDCPP_REFLECTION()
+  STDEXEC_MODULE_EXPORT
+  template <class _Sender>
+  consteval std::meta::info get_completion_signatures_type();
+
+  STDEXEC_MODULE_EXPORT
+  template <class _Sender, class _Env>
+  consteval std::meta::info get_completion_signatures_type();
+#  endif
 
   namespace __cmplsigs
   {
@@ -162,6 +176,28 @@ namespace STDEXEC
     template <class _Sender, class... _Env>
     concept __with_co_await = __awaitable<_Sender, __detail::__promise<_Env>...>;
 
+#  if !STDEXEC_NO_STDCPP_REFLECTION()
+    template <class _Sender, class... _Env>
+    concept __has_get_completion_signatures_type = requires {
+      {
+        STDEXEC_REMOVE_REFERENCE(_Sender)
+        ::template get_completion_signatures_type<_Sender, _Env...>()
+      } -> __std::same_as<std::meta::info>;
+    };
+
+    template <class _Sender, class... _Env>
+    consteval bool __nothrow_get_completion_signatures_type() noexcept
+    try
+    {
+      (void) STDEXEC::get_completion_signatures_type<_Sender, _Env...>();
+      return true;
+    }
+    catch (...)
+    {
+      return false;
+    }
+#  endif
+
     template <class _Sender, class _Env>
     concept __with = __with_legacy_static_member<_Sender, _Env>              //
                   || __with_legacy_member<_Sender, _Env>                     //
@@ -170,7 +206,11 @@ namespace STDEXEC
                   || __with_consteval_static_member<_Sender>                 //
                   || __with_legacy_tag_invoke<_Sender, _Env>                 //
                   || __with_legacy_non_dependent_tag_invoke<_Sender, _Env>   //
-                  || __with_co_await<_Sender, _Env>;
+                  || __with_co_await<_Sender, _Env>
+#  if !STDEXEC_NO_STDCPP_REFLECTION()
+                  || __has_get_completion_signatures_type<_Sender, _Env>
+#  endif
+      ;
   }  // namespace __cmplsigs
 
   template <class _Sender, class _Env>
@@ -354,7 +394,26 @@ namespace STDEXEC
   template <class _Sender>
   consteval auto get_completion_signatures()
   {
-    return __cmplsigs::__get_completion_signatures_helper<_Sender>();
+#  if !STDEXEC_NO_STDCPP_REFLECTION()
+    if constexpr (__cmplsigs::__has_get_completion_signatures_type<_Sender>)
+    {
+      if constexpr (__cmplsigs::__nothrow_get_completion_signatures_type<_Sender>())
+      {
+        constexpr std::meta::info __completions =
+          STDEXEC::get_completion_signatures_type<_Sender>();
+        return typename[:__completions:]{};
+      }
+      else
+      {
+        (void) STDEXEC::get_completion_signatures_type<_Sender>();
+        return completion_signatures<>{};
+      }
+    }
+    else
+#  endif
+    {
+      return __cmplsigs::__get_completion_signatures_helper<_Sender>();
+    }
   }
 
   //! @brief Overload of @ref get_completion_signatures that takes an
@@ -377,8 +436,62 @@ namespace STDEXEC
   {
     using __new_sndr_t = transform_sender_result_t<_Sender, _Env>;
     static_assert(!__merror<__new_sndr_t>);
-    return __cmplsigs::__get_completion_signatures_helper<__new_sndr_t, _Env>();
+#  if !STDEXEC_NO_STDCPP_REFLECTION()
+    if constexpr (__cmplsigs::__has_get_completion_signatures_type<__new_sndr_t, _Env>)
+    {
+      if constexpr (__cmplsigs::__nothrow_get_completion_signatures_type<_Sender, _Env>())
+      {
+        constexpr std::meta::info __completions =
+          STDEXEC::get_completion_signatures_type<_Sender, _Env>();
+        return typename[:__completions:]{};
+      }
+      else
+      {
+        (void) STDEXEC::get_completion_signatures_type<_Sender, _Env>();
+        return completion_signatures<>{};
+      }
+    }
+    else
+#  endif
+    {
+      return __cmplsigs::__get_completion_signatures_helper<__new_sndr_t, _Env>();
+    }
   }
+
+#  if !STDEXEC_NO_STDCPP_REFLECTION()
+  STDEXEC_MODULE_EXPORT
+  template <class _Sender>
+  consteval std::meta::info get_completion_signatures_type()
+  {
+    if constexpr (__cmplsigs::__has_get_completion_signatures_type<_Sender>)
+    {
+      return STDEXEC_REMOVE_REFERENCE(_Sender)::template get_completion_signatures_type<_Sender>();
+    }
+    else
+    {
+      auto __completions = STDEXEC::get_completion_signatures<_Sender>();
+      return ^^decltype(__completions);
+    }
+  }
+
+  STDEXEC_MODULE_EXPORT
+  template <class _Sender, class _Env>
+  consteval std::meta::info get_completion_signatures_type()
+  {
+    using __new_sndr_t = transform_sender_result_t<_Sender, _Env>;
+    static_assert(!__merror<__new_sndr_t>);
+    if constexpr (__cmplsigs::__has_get_completion_signatures_type<__new_sndr_t, _Env>)
+    {
+      return STDEXEC_REMOVE_REFERENCE(
+        __new_sndr_t)::template get_completion_signatures_type<__new_sndr_t, _Env>();
+    }
+    else
+    {
+      auto __completions = STDEXEC::get_completion_signatures<_Sender, _Env>();
+      return ^^decltype(__completions);
+    }
+  }
+#  endif
 
   // Legacy interface:
   STDEXEC_MODULE_EXPORT_AUTHORING

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,7 @@ set(stdexec_test_sources
     stdexec/detail/test_common_domain.cpp
     stdexec/detail/test_completion_signatures.cpp
     stdexec/detail/test_demangle.cpp
+    stdexec/detail/test_get_completion_signatures.cpp
     stdexec/detail/test_intrusive_mpsc_queue.cpp
     stdexec/detail/test_utility.cpp
     stdexec/queries/test_env.cpp

--- a/test/stdexec/detail/test_get_completion_signatures.cpp
+++ b/test/stdexec/detail/test_get_completion_signatures.cpp
@@ -1,0 +1,248 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ * Licensed under the Apache License, Version 2.0 with LLVM Exceptions (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <catch2/catch_all.hpp>
+
+#include <stdexec/execution.hpp>
+
+#if !STDEXEC_NO_STDCPP_REFLECTION()
+#  include <meta>
+#endif
+
+namespace ex = STDEXEC;
+
+namespace
+{
+  using independent_completions = ex::completion_signatures<ex::set_value_t(int)>;
+  using dependent_completions   = ex::completion_signatures<ex::set_value_t(double)>;
+
+  struct test_sender
+  {
+    using sender_concept = ex::sender_tag;
+
+    template <class, class... Env>
+    static consteval auto get_completion_signatures() noexcept
+    {
+      if constexpr (sizeof...(Env) == 0)
+      {
+        return independent_completions{};
+      }
+      else
+      {
+        return dependent_completions{};
+      }
+    }
+  };
+
+#if !STDEXEC_NO_STDCPP_REFLECTION()
+  template <class Sender, class... Env>
+  consteval bool completion_signature_protocols_agree()
+  {
+    return std::meta::is_same_type(ex::get_completion_signatures_type<Sender, Env...>(),
+                                   ^^decltype(ex::get_completion_signatures<Sender, Env...>()));
+  }
+
+  template <class Sender, class... Env>
+  consteval bool get_completion_signatures_type_throws() noexcept
+  try
+  {
+    (void) ex::get_completion_signatures_type<Sender, Env...>();
+    return false;
+  }
+  catch (...)
+  {
+    return true;
+  }
+
+  struct throwing_legacy_test_sender
+  {
+    using sender_concept = ex::sender_tag;
+
+    template <class, class...>
+    static consteval auto get_completion_signatures()
+    {
+      throw std::meta::exception("Unable to compute completion signatures.",
+                                 ^^throwing_legacy_test_sender);
+      return ex::completion_signatures<>{};
+    }
+  };
+
+  struct reflection_test_sender
+  {
+    using sender_concept = ex::sender_tag;
+
+    template <class, class... Env>
+    static consteval std::meta::info get_completion_signatures_type() noexcept
+    {
+      if constexpr (sizeof...(Env) == 0)
+      {
+        return ^^independent_completions;
+      }
+      else
+      {
+        return ^^dependent_completions;
+      }
+    }
+  };
+
+  struct transformed_reflection_test_sender
+  {
+    using sender_concept = ex::sender_tag;
+
+    template <class, class>
+    static consteval std::meta::info get_completion_signatures_type() noexcept
+    {
+      return ^^dependent_completions;
+    }
+  };
+
+  struct throwing_reflection_test_sender
+  {
+    using sender_concept = ex::sender_tag;
+
+    template <class, class...>
+    static consteval std::meta::info get_completion_signatures_type()
+    {
+      throw std::meta::exception("Unable to compute completion signatures.",
+                                 ^^throwing_reflection_test_sender);
+    }
+  };
+
+  struct reflection_test_domain
+  {
+    template <class Env>
+    auto transform_sender(ex::start_t, reflection_test_sender, Env const &) const
+      -> transformed_reflection_test_sender
+    {
+      return {};
+    }
+  };
+
+  using reflection_test_env = ex::prop<ex::get_domain_t, reflection_test_domain>;
+
+  struct throwing_reflection_test_domain
+  {
+    template <class Env>
+    auto transform_sender(ex::start_t, reflection_test_sender, Env const &) const
+      -> throwing_reflection_test_sender
+    {
+      return {};
+    }
+  };
+
+  using throwing_reflection_test_env = ex::prop<ex::get_domain_t, throwing_reflection_test_domain>;
+#endif
+
+  TEST_CASE("get_completion_signatures queries a sender without an environment",
+            "[detail][get_completion_signatures]")
+  {
+    STATIC_REQUIRE(std::same_as<decltype(ex::get_completion_signatures<test_sender>()),
+                                independent_completions>);
+#if !STDEXEC_NO_STDCPP_REFLECTION()
+    STATIC_REQUIRE(completion_signature_protocols_agree<test_sender>());
+#endif
+  }
+
+  TEST_CASE("get_completion_signatures queries a sender in an environment",
+            "[detail][get_completion_signatures]")
+  {
+    STATIC_REQUIRE(std::same_as<decltype(ex::get_completion_signatures<test_sender, ex::env<>>()),
+                                dependent_completions>);
+#if !STDEXEC_NO_STDCPP_REFLECTION()
+    STATIC_REQUIRE(completion_signature_protocols_agree<test_sender, ex::env<>>());
+#endif
+  }
+
+  TEST_CASE("get_completion_signatures supports the legacy function-call interface",
+            "[detail][get_completion_signatures]")
+  {
+    STATIC_REQUIRE(std::same_as<decltype(ex::get_completion_signatures(test_sender{}, ex::env<>{})),
+                                dependent_completions>);
+#if !STDEXEC_NO_STDCPP_REFLECTION()
+    STATIC_REQUIRE(completion_signature_protocols_agree<test_sender, ex::env<>>());
+#endif
+  }
+
+#if !STDEXEC_NO_STDCPP_REFLECTION()
+  TEST_CASE("get_completion_signatures_type reflects the legacy query result",
+            "[detail][get_completion_signatures_type][reflection]")
+  {
+    STATIC_REQUIRE(std::meta::is_same_type(ex::get_completion_signatures_type<test_sender>(),
+                                           ^^independent_completions));
+    STATIC_REQUIRE(
+      std::meta::is_same_type(ex::get_completion_signatures_type<test_sender, ex::env<>>(),
+                              ^^dependent_completions));
+    STATIC_REQUIRE(completion_signature_protocols_agree<test_sender>());
+    STATIC_REQUIRE(completion_signature_protocols_agree<test_sender, ex::env<>>());
+  }
+
+  TEST_CASE("get_completion_signatures_type invokes the legacy query",
+            "[detail][get_completion_signatures_type][reflection]")
+  {
+    STATIC_REQUIRE(get_completion_signatures_type_throws<throwing_legacy_test_sender>());
+    STATIC_REQUIRE(get_completion_signatures_type_throws<throwing_legacy_test_sender, ex::env<>>());
+  }
+
+  TEST_CASE("detect whether get_completion_signatures_type throws",
+            "[detail][get_completion_signatures_type][reflection]")
+  {
+    STATIC_REQUIRE(
+      ex::__cmplsigs::__nothrow_get_completion_signatures_type<reflection_test_sender>());
+    STATIC_REQUIRE_FALSE(
+      ex::__cmplsigs::__nothrow_get_completion_signatures_type<throwing_reflection_test_sender>());
+    STATIC_REQUIRE_FALSE(
+      ex::__cmplsigs::__nothrow_get_completion_signatures_type<reflection_test_sender,
+                                                               throwing_reflection_test_env>());
+    STATIC_REQUIRE(
+      std::same_as<decltype(ex::get_completion_signatures<throwing_reflection_test_sender>()),
+                   ex::completion_signatures<>>);
+    STATIC_REQUIRE(
+      std::same_as<decltype(ex::get_completion_signatures<reflection_test_sender,
+                                                          throwing_reflection_test_env>()),
+                   ex::completion_signatures<>>);
+  }
+
+  TEST_CASE("get_completion_signatures_type queries a reflection-native sender without an "
+            "environment",
+            "[detail][get_completion_signatures_type][reflection]")
+  {
+    STATIC_REQUIRE(
+      std::meta::is_same_type(ex::get_completion_signatures_type<reflection_test_sender>(),
+                              ^^independent_completions));
+    STATIC_REQUIRE(completion_signature_protocols_agree<reflection_test_sender>());
+  }
+
+  TEST_CASE("get_completion_signatures_type queries a reflection-native sender in an environment",
+            "[detail][get_completion_signatures_type][reflection]")
+  {
+    STATIC_REQUIRE(std::meta::is_same_type(
+      ex::get_completion_signatures_type<reflection_test_sender, ex::env<>>(),
+      ^^dependent_completions));
+    STATIC_REQUIRE(completion_signature_protocols_agree<reflection_test_sender, ex::env<>>());
+  }
+
+  TEST_CASE("get_completion_signatures_type queries the transformed sender",
+            "[detail][get_completion_signatures_type][reflection]")
+  {
+    STATIC_REQUIRE(std::meta::is_same_type(
+      ex::get_completion_signatures_type<reflection_test_sender, reflection_test_env>(),
+      ^^dependent_completions));
+    STATIC_REQUIRE(
+      completion_signature_protocols_agree<reflection_test_sender, reflection_test_env>());
+  }
+#endif
+}  // namespace


### PR DESCRIPTION
get_completion_signatures attempts to leverage compile-time exceptions to report errors. It does this by:

- Throwing an exception when it cannot synthesize completion signatures (definitionally this happens at compile time because it's consteval), and
- Reporting that it returns completion_signatures<> in situations wherein it would throw an exception

The latter is reflective of a tension: get_completion_signatures "knows" it will throw an exception when the return type is computed, but that exception is not surfaced until and unless the function is invoked. This creates the opportunity for very interesting bugs, for example decltype( get_completion_signatures<...>()) is, in a vacuum, likely to be a bug because this doesn't actually evaluate the expression and therefore any exception is not thrown.

The solution is complete surrender to the invocation of functions at compile time (rather than exposing information via channels which can be interrogated via an unevaluated context): Reflection.

Added get_completion_signatures_type which returns std::meta::info and provides a reflection-first way to access completion signatures computation. In addition to ameliorating the above-described tension in the design of get_completion_signatures this new function allows for better ergonomics in reflection-first uses.

When attempting to use reflection to aid in the computation of a certain asynchronous operation's completion signatures one needs to, in general:

- Obtain the completion signatures of one or more child operations
- Examine and manipulate those completion signatures
- Yield the final completion signatures

With get_completion_signatures this becomes awkward. The way to "lift" the completion signatures into the reflection domain is via ^^decltype( get_completion_signatures<...>()), which is pathological as discussed above. In order to expose the needed interface (i.e. a static, consteval member function get_completion_signatures which returns an instance of an instantiation of the completion_signatures class template) one needs to splice a reflection, but one can't splice a reflection unless that reflection is constexpr, but initialization of constexpr variables needs to be done by a constant expression which can't propagate exceptions thereby ruining the entire error reporting mechanism of get_completion_signatures.

To make the above concrete consider:

```c++
  template<typename Self, typename Env>
  static consteval auto get_completion_signatures() {
    auto sigs = get_completion_signatures<...>();
    auto meta = ^^decltype(sigs);
    auto final_sigs = /* depends on meta */;
    return typename [:final_sigs:]{};
  }
```

This doesn't compile because final_sigs isn't a constant expression. If we try to adapt:

```c++
  template<typename Self, typename Env>
  static consteval auto get_completion_signatures() {
    auto sigs = get_completion_signatures<...>();
    constexpr auto meta = ^^decltype(sigs);
    constexpr auto final_sigs = /* depends on meta */;
    return typename [:final_sigs:]{};
  }
```

Then any operation in the synthesis of final_sigs which throws an exception fails compilation rather than being propagated. Intuitively we can understand why this is the case: The return type of the function depends thereupon, a problem get_completion_signatures works around by coalescing to the dummy type completion_signatures<>.

Also note again that in both of the above examples:

```c++
  auto sigs = get_completion_signatures<...>();
  constexpr auto meta = ^^decltype(sigs);
```

Is fragile. It seems as though it could be rewritten as:

```c++
  constexpr auto meta = ^^decltype(get_completion_signatures<...>());
```

But that would introduce a subtle bug: get_completion_signatures would not actually be evaluated.

get_completion_signatures_type ameliorates the above. The problematic member function can be written as:

```c++
  template<typename Self, typename Env>
  static consteval std::meta::info get_completion_signatures_type() {
    auto meta = get_completion_signatures_type<...>();
    auto final_sigs = /* depends on meta */;
    return final_sigs;
  }
```