### PR TITLE
Include __just.hpp from __when_all.hpp

### DIFF
--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -33,6 +33,7 @@ import stdexec;
 #  include "__domain.hpp"
 #  include "__env.hpp"
 #  include "__into_variant.hpp"
+#  include "__just.hpp"
 #  include "__meta.hpp"
 #  include "__optional.hpp"
 #  include "__schedulers.hpp"


### PR DESCRIPTION
While analysing stdexec's internal dependency structure, I discovered that `__when_all.hpp` depends on `stdexec::just` but doesn't incude `__just.hpp`, breaking self-containment. This diff fixes that.