### PR TITLE
Fix nvexec launch move-only callable forwarding

### DIFF
--- a/include/nvexec/stream/launch.cuh
+++ b/include/nvexec/stream/launch.cuh
@@ -141,7 +141,10 @@ namespace nv::execution
           static_cast<Self&&>(self).sndr_,
           static_cast<Receiver&&>(rcvr),
           [&](_strm::opstate_base<Receiver>& stream_provider) -> receiver_t<Receiver>
-          { return receiver_t<Receiver>(stream_provider, self.fun_, self.params_); });
+          {
+            return receiver_t<Receiver>(
+              stream_provider, static_cast<Self&&>(self).fun_, self.params_);
+          });
       }
       STDEXEC_EXPLICIT_THIS_END(connect)
 

--- a/include/nvexec/stream/launch.cuh
+++ b/include/nvexec/stream/launch.cuh
@@ -142,8 +142,9 @@ namespace nv::execution
           static_cast<Receiver&&>(rcvr),
           [&](_strm::opstate_base<Receiver>& stream_provider) -> receiver_t<Receiver>
           {
-            return receiver_t<Receiver>(
-              stream_provider, static_cast<Self&&>(self).fun_, self.params_);
+            return receiver_t<Receiver>(stream_provider,
+                                        static_cast<Self&&>(self).fun_,
+                                        self.params_);
           });
       }
       STDEXEC_EXPLICIT_THIS_END(connect)

--- a/test/nvexec/launch.cpp
+++ b/test/nvexec/launch.cpp
@@ -54,11 +54,11 @@ namespace
 
     struct move_only_launch_handler
     {
-      move_only_launch_handler()                                  = default;
+      move_only_launch_handler()                                 = default;
       move_only_launch_handler(move_only_launch_handler const &) = delete;
 
       STDEXEC_ATTRIBUTE(host, device)
-      move_only_launch_handler(move_only_launch_handler &&) = default;
+      move_only_launch_handler(move_only_launch_handler&&) = default;
 
       STDEXEC_ATTRIBUTE(host, device) void operator()(cudaStream_t) const {}
     };

--- a/test/nvexec/launch.cpp
+++ b/test/nvexec/launch.cpp
@@ -18,6 +18,8 @@
 #include <test_common/catch2.hpp>
 #include <test_common/type_helpers.hpp>
 
+#include <type_traits>
+
 #include "common.cuh"
 #include "nvexec/stream_context.cuh"
 
@@ -48,6 +50,31 @@ namespace
       std::iota(input.begin(), input.end(), 1);
       std::ranges::transform(input, input.begin(), [](int i) { return i * scaling; });
       return std::accumulate(input.begin(), input.end(), 0);
+    }
+
+    struct move_only_launch_handler
+    {
+      move_only_launch_handler()                                  = default;
+      move_only_launch_handler(move_only_launch_handler const &) = delete;
+
+      STDEXEC_ATTRIBUTE(host, device)
+      move_only_launch_handler(move_only_launch_handler &&) = default;
+
+      STDEXEC_ATTRIBUTE(host, device) void operator()(cudaStream_t) const {}
+    };
+
+    static_assert(std::is_trivially_copyable_v<move_only_launch_handler>);
+    static_assert(!std::is_copy_constructible_v<move_only_launch_handler>);
+
+    TEST_CASE("nvexec launch supports move-only function objects",
+              "[cuda][stream][adaptors][launch]")
+    {
+      nvexec::stream_context stream_ctx{};
+
+      auto snd = STDEXEC::just() | STDEXEC::continues_on(stream_ctx.get_scheduler())
+               | nvexec::launch(move_only_launch_handler{});
+
+      REQUIRE(STDEXEC::sync_wait(std::move(snd)).has_value());
     }
 
     TEST_CASE("nvexec launch advertises CUDA launch errors", "[cuda][stream][adaptors][launch]")


### PR DESCRIPTION
## What changed

- Forward the stored launch callable with the sender's value category.
- Add coverage for a trivially copyable callable that cannot be copied.

## Why

nvexec::launch accepts movable callables, but connect() passed the stored callable as an lvalue. Consuming a sender with a move-only callable therefore tried to copy it.

## Testing

- git diff --check
- Standalone C++ syntax check for the move-only callable
- CUDA coverage is included for GPU CI