### PR TITLE
Fix nvexec bulk callable forwarding

### DIFF
--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -138,7 +138,8 @@ namespace nv::execution::_strm
         static_cast<Receiver&&>(rcvr),
         [&](_strm::opstate_base<Receiver>& stream_provider) -> receiver_t<Receiver>
         {
-          return receiver_t<Receiver>(self.shape_, static_cast<Fun&&>(self.fun_), stream_provider);
+          return receiver_t<Receiver>(
+            self.shape_, static_cast<Self&&>(self).fun_, stream_provider);
         });
     }
     STDEXEC_EXPLICIT_THIS_END(connect)

--- a/include/nvexec/stream/bulk.cuh
+++ b/include/nvexec/stream/bulk.cuh
@@ -138,8 +138,7 @@ namespace nv::execution::_strm
         static_cast<Receiver&&>(rcvr),
         [&](_strm::opstate_base<Receiver>& stream_provider) -> receiver_t<Receiver>
         {
-          return receiver_t<Receiver>(
-            self.shape_, static_cast<Self&&>(self).fun_, stream_provider);
+          return receiver_t<Receiver>(self.shape_, static_cast<Self&&>(self).fun_, stream_provider);
         });
     }
     STDEXEC_EXPLICIT_THIS_END(connect)

--- a/test/nvexec/bulk.cpp
+++ b/test/nvexec/bulk.cpp
@@ -21,6 +21,15 @@ namespace
     (void) snd;
   }
 
+  TEST_CASE("nvexec bulk supports const lvalue senders", "[cuda][stream][adaptors][bulk]")
+  {
+    nvexec::stream_context stream_ctx{};
+    auto const snd = ex::schedule(stream_ctx.get_scheduler())
+                   | ex::bulk(ex::par, 1, [](int) {});
+
+    REQUIRE(STDEXEC::sync_wait(snd).has_value());
+  }
+
   TEST_CASE("nvexec bulk executes on GPU", "[cuda][stream][adaptors][bulk]")
   {
     nvexec::stream_context stream_ctx{};

--- a/test/nvexec/bulk.cpp
+++ b/test/nvexec/bulk.cpp
@@ -24,8 +24,7 @@ namespace
   TEST_CASE("nvexec bulk supports const lvalue senders", "[cuda][stream][adaptors][bulk]")
   {
     nvexec::stream_context stream_ctx{};
-    auto const snd = ex::schedule(stream_ctx.get_scheduler())
-                   | ex::bulk(ex::par, 1, [](int) {});
+    auto const snd = ex::schedule(stream_ctx.get_scheduler()) | ex::bulk(ex::par, 1, [](int) {});
 
     REQUIRE(STDEXEC::sync_wait(snd).has_value());
   }


### PR DESCRIPTION
## What changed

- Preserve the callable's cvref when connecting the single-GPU nvexec bulk sender.
- Add coverage for running a const lvalue bulk sender.

## Why

bulk_sender::connect() always cast the stored callable to Fun&&. That can move from an lvalue sender and makes const lvalue senders fail to compile. The sender's value category should decide whether the callable is moved or copied.

## Testing

- git diff --check
- CUDA regression test added for GPU CI