### PR TITLE
Fix nvexec scheduler equality across stream priorities

### DIFF
--- a/include/nvexec/multi_gpu_context.cuh
+++ b/include/nvexec/multi_gpu_context.cuh
@@ -38,7 +38,7 @@ namespace nv::execution
 
       auto operator==(multi_gpu_stream_scheduler const & other) const noexcept -> bool
       {
-        return ctx_.hub_ == other.ctx_.hub_;
+        return ctx_.hub_ == other.ctx_.hub_ && ctx_.priority_ == other.ctx_.priority_;
       }
 
       [[nodiscard]]

--- a/include/nvexec/stream_context.cuh
+++ b/include/nvexec/stream_context.cuh
@@ -75,7 +75,7 @@ namespace nv::execution
 
       auto operator==(stream_scheduler const & other) const noexcept -> bool
       {
-        return ctx_.hub_ == other.ctx_.hub_;
+        return ctx_.hub_ == other.ctx_.hub_ && ctx_.priority_ == other.ctx_.priority_;
       }
 
       STDEXEC_ATTRIBUTE(nodiscard, host, device) auto schedule() const noexcept

--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -25,6 +25,7 @@ set(nvexec_test_sources
     split.cpp
     upon_stopped.cpp
     transfer.cpp
+    scheduler.cpp
     launch.cpp
     let_error.cpp
     let_stopped.cpp

--- a/test/nvexec/scheduler.cpp
+++ b/test/nvexec/scheduler.cpp
@@ -38,8 +38,5 @@ namespace
     CHECK_FALSE(high == normal);
     CHECK_FALSE(normal == low);
     CHECK_FALSE(high == low);
-
-    nvexec::multi_gpu_stream_context other_stream_ctx{};
-    CHECK_FALSE(high == other_stream_ctx.get_scheduler(nvexec::stream_priority::high));
   }
 }  // namespace

--- a/test/nvexec/scheduler.cpp
+++ b/test/nvexec/scheduler.cpp
@@ -1,0 +1,45 @@
+#include <test_common/catch2.hpp>
+
+#include "nvexec/multi_gpu_context.cuh"
+#include "nvexec/stream_context.cuh"
+
+namespace
+{
+  TEST_CASE("nvexec stream scheduler equality includes priority", "[cuda][stream][scheduler]")
+  {
+    nvexec::stream_context stream_ctx{};
+
+    auto high   = stream_ctx.get_scheduler(nvexec::stream_priority::high);
+    auto normal = stream_ctx.get_scheduler(nvexec::stream_priority::normal);
+    auto low    = stream_ctx.get_scheduler(nvexec::stream_priority::low);
+
+    CHECK(high == stream_ctx.get_scheduler(nvexec::stream_priority::high));
+    CHECK(normal == stream_ctx.get_scheduler(nvexec::stream_priority::normal));
+    CHECK(low == stream_ctx.get_scheduler(nvexec::stream_priority::low));
+    CHECK_FALSE(high == normal);
+    CHECK_FALSE(normal == low);
+    CHECK_FALSE(high == low);
+
+    nvexec::stream_context other_stream_ctx{};
+    CHECK_FALSE(high == other_stream_ctx.get_scheduler(nvexec::stream_priority::high));
+  }
+
+  TEST_CASE("nvexec multi-GPU scheduler equality includes priority", "[cuda][stream][scheduler]")
+  {
+    nvexec::multi_gpu_stream_context stream_ctx{};
+
+    auto high   = stream_ctx.get_scheduler(nvexec::stream_priority::high);
+    auto normal = stream_ctx.get_scheduler(nvexec::stream_priority::normal);
+    auto low    = stream_ctx.get_scheduler(nvexec::stream_priority::low);
+
+    CHECK(high == stream_ctx.get_scheduler(nvexec::stream_priority::high));
+    CHECK(normal == stream_ctx.get_scheduler(nvexec::stream_priority::normal));
+    CHECK(low == stream_ctx.get_scheduler(nvexec::stream_priority::low));
+    CHECK_FALSE(high == normal);
+    CHECK_FALSE(normal == low);
+    CHECK_FALSE(high == low);
+
+    nvexec::multi_gpu_stream_context other_stream_ctx{};
+    CHECK_FALSE(high == other_stream_ctx.get_scheduler(nvexec::stream_priority::high));
+  }
+}  // namespace


### PR DESCRIPTION
## Summary

- include stream priority when comparing stream schedulers
- apply the same check to multi-GPU stream schedulers
- add regression coverage for equal resources, different priorities, and different contexts
- avoid constructing a second multi-GPU context in the regression test

Schedulers with the same hub but different priorities use different stream pools. They should not compare equal.

Tests:
- `cmake --build build-cuda --target test.nvexec -j 8`
- `./build-cuda/test/nvexec/test.nvexec --reporter compact`
