### PR TITLE
Fix schedule_all move-only range support

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -1652,7 +1652,7 @@ namespace experimental::execution
       struct opstate_base_with_receiver : opstate_base<Range>
       {
         explicit opstate_base_with_receiver(Range range, _static_thread_pool& pool, Receiver rcvr)
-          : opstate_base<Range>{range, pool}
+          : opstate_base<Range>{std::move(range), pool}
           , rcvr_(static_cast<Receiver&&>(rcvr))
         {}
 

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -31,12 +31,38 @@
 #include <stdexcept>
 #include <thread>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 namespace ex = STDEXEC;
 
 namespace
 {
   thread_local int current_numa_node = -1;
+
+  struct move_only_range
+  {
+    explicit move_only_range(std::vector<int> values)
+      : values_(std::move(values))
+    {}
+
+    move_only_range(move_only_range&&) noexcept                    = default;
+    move_only_range(move_only_range const &)                       = delete;
+    auto operator=(move_only_range&&) noexcept -> move_only_range& = default;
+    auto operator=(move_only_range const &) -> move_only_range&    = delete;
+
+    auto begin() noexcept
+    {
+      return values_.begin();
+    }
+
+    auto end() noexcept
+    {
+      return values_.end();
+    }
+
+   private:
+    std::vector<int> values_;
+  };
 
   struct two_node_numa_policy
   {
@@ -174,7 +200,7 @@ TEST_CASE("schedule_all on static_thread_pool accepts move-only ranges",
   exec::static_thread_pool pool{1};
   int                      sum    = 0;
   auto                     sender = exec::schedule_all(pool,
-                                   std::ranges::owning_view<std::vector<int>>{
+                                   move_only_range{
                                      std::vector<int>{1, 2, 3}
   })
               | exec::transform_each(ex::then([&sum](int value) noexcept { sum += value; }))

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -168,6 +168,19 @@ TEST_CASE("schedule_all on static_thread_pool handles empty ranges", "[types][st
   CHECK(ex::sync_wait(std::move(sender)));
 }
 
+TEST_CASE("schedule_all on static_thread_pool accepts move-only ranges",
+          "[types][static_thread_pool]")
+{
+  exec::static_thread_pool pool{1};
+  int                      sum = 0;
+  auto sender = exec::schedule_all(pool, std::views::all(std::vector<int>{1, 2, 3}))
+              | exec::transform_each(ex::then([&sum](int value) noexcept { sum += value; }))
+              | exec::ignore_all_values();
+
+  CHECK(ex::sync_wait(std::move(sender)));
+  CHECK(sum == 6);
+}
+
 #if !STDEXEC_NO_STDCPP_EXCEPTIONS()
 TEST_CASE("schedule_all on static_thread_pool sends errors from set_next",
           "[types][static_thread_pool]")

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -173,7 +173,9 @@ TEST_CASE("schedule_all on static_thread_pool accepts move-only ranges",
 {
   exec::static_thread_pool pool{1};
   int                      sum = 0;
-  auto sender = exec::schedule_all(pool, std::views::all(std::vector<int>{1, 2, 3}))
+  auto sender = exec::schedule_all(
+    pool,
+    std::ranges::owning_view<std::vector<int>>{std::vector<int>{1, 2, 3}})
               | exec::transform_each(ex::then([&sum](int value) noexcept { sum += value; }))
               | exec::ignore_all_values();
 

--- a/test/exec/test_static_thread_pool.cpp
+++ b/test/exec/test_static_thread_pool.cpp
@@ -172,10 +172,11 @@ TEST_CASE("schedule_all on static_thread_pool accepts move-only ranges",
           "[types][static_thread_pool]")
 {
   exec::static_thread_pool pool{1};
-  int                      sum = 0;
-  auto sender = exec::schedule_all(
-    pool,
-    std::ranges::owning_view<std::vector<int>>{std::vector<int>{1, 2, 3}})
+  int                      sum    = 0;
+  auto                     sender = exec::schedule_all(pool,
+                                   std::ranges::owning_view<std::vector<int>>{
+                                     std::vector<int>{1, 2, 3}
+  })
               | exec::transform_each(ex::then([&sum](int value) noexcept { sum += value; }))
               | exec::ignore_all_values();
 


### PR DESCRIPTION
## What changed

- forward the range when building the schedule_all operation state
- add a regression test with a move-only owning_view

## Why

The consuming subscribe() path moves the range, but opstate_base_with_receiver passed its by-value range parameter as an lvalue. That made valid move-only ranges fail to compile.

## Testing

- build/test/exec/test.exec 'schedule_all on static_thread_pool accepts move-only ranges'
- build/test/exec/test.exec