### PR TITLE
Preserve NVTX names for lvalue senders

### DIFF
--- a/include/nvexec/nvtx.cuh
+++ b/include/nvexec/nvtx.cuh
@@ -110,7 +110,7 @@ namespace nv::execution
           static_cast<Self&&>(self).sndr_,
           static_cast<Receiver&&>(rcvr),
           [&](_strm::opstate_base<Receiver>& stream_provider) -> receiver_t<Receiver>
-          { return receiver_t<Receiver>(stream_provider, std::move(self.name_)); });
+          { return receiver_t<Receiver>(stream_provider, static_cast<Self&&>(self).name_); });
       }
       STDEXEC_EXPLICIT_THIS_END(connect)
 

--- a/test/nvexec/CMakeLists.txt
+++ b/test/nvexec/CMakeLists.txt
@@ -32,6 +32,7 @@ set(nvexec_test_sources
     let_value.cpp
     test_main.cpp
     then.cpp
+    nvtx.cpp
     reduce.cpp
     repeat_n.cpp
     split.cpp

--- a/test/nvexec/nvtx.cpp
+++ b/test/nvexec/nvtx.cpp
@@ -1,0 +1,20 @@
+#include <nvexec/nvtx.cuh>
+#include <nvexec/stream_context.cuh>
+#include <stdexec/execution.hpp>
+#include <test_common/catch2.hpp>
+
+namespace ex = STDEXEC;
+
+namespace
+{
+  TEST_CASE("nvexec nvtx preserves names for lvalue senders", "[cuda][stream][nvtx]")
+  {
+    nvexec::stream_context stream_ctx{};
+    auto                   snd = ex::schedule(stream_ctx.get_scheduler())
+                 | nvexec::nvtx::push("test");
+
+    ex::sync_wait(snd);
+
+    CHECK(snd.name_ == "test");
+  }
+}  // namespace

--- a/test/nvexec/nvtx.cpp
+++ b/test/nvexec/nvtx.cpp
@@ -10,8 +10,7 @@ namespace
   TEST_CASE("nvexec nvtx preserves names for lvalue senders", "[cuda][stream][nvtx]")
   {
     nvexec::stream_context stream_ctx{};
-    auto                   snd = ex::schedule(stream_ctx.get_scheduler())
-                 | nvexec::nvtx::push("test");
+    auto snd = ex::schedule(stream_ctx.get_scheduler()) | nvexec::nvtx::push("test");
 
     ex::sync_wait(snd);
 


### PR DESCRIPTION
## What changed

- forward the NVTX name using the sender cvref
- add a regression test for connecting an lvalue sender

## Why

The child sender already preserves the value category, but the NVTX name was always moved. Connecting an lvalue sender could consume its name.

## Testing

- build/test/exec/test.exec
- added the CUDA regression to test.nvexec