### PR TITLE
Preserve libdispatch bulk child sender value category

### DIFF
--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -537,8 +537,8 @@ namespace experimental::execution
 
       bulk_op_state(libdispatch_queue &queue, Shape shape, Fun fun, CvSender &&sndr, Receiver rcvr)
         : shared_state_(std::move(rcvr), shape, fun)
-        , inner_op_{STDEXEC::connect(static_cast<CvSender &&>(sndr),
-                                     bulk_rcvr{shared_state_, queue})}
+        , inner_op_{
+            STDEXEC::connect(static_cast<CvSender &&>(sndr), bulk_rcvr{shared_state_, queue})}
       {}
 
       void start() & noexcept

--- a/include/exec/libdispatch_queue.hpp
+++ b/include/exec/libdispatch_queue.hpp
@@ -537,7 +537,8 @@ namespace experimental::execution
 
       bulk_op_state(libdispatch_queue &queue, Shape shape, Fun fun, CvSender &&sndr, Receiver rcvr)
         : shared_state_(std::move(rcvr), shape, fun)
-        , inner_op_{STDEXEC::connect(std::move(sndr), bulk_rcvr{shared_state_, queue})}
+        , inner_op_{STDEXEC::connect(static_cast<CvSender &&>(sndr),
+                                     bulk_rcvr{shared_state_, queue})}
       {}
 
       void start() & noexcept

--- a/test/exec/test_libdispatch.cpp
+++ b/test/exec/test_libdispatch.cpp
@@ -25,6 +25,42 @@
 
 namespace
 {
+  struct lvalue_connect_sender
+  {
+    using sender_concept = STDEXEC::sender_tag;
+
+    template <class, class...>
+    static consteval auto get_completion_signatures()
+      -> STDEXEC::completion_signatures<STDEXEC::set_value_t(int)>
+    {
+      return {};
+    }
+
+    auto get_env() const noexcept -> STDEXEC::env<>
+    {
+      return {};
+    }
+
+    template <STDEXEC::receiver Receiver>
+    struct operation
+    {
+      using operation_state_concept = STDEXEC::operation_state_tag;
+
+      Receiver receiver_;
+
+      void start() & noexcept
+      {
+        STDEXEC::set_value(std::move(receiver_), 42);
+      }
+    };
+
+    template <STDEXEC::receiver Receiver>
+    auto connect(Receiver receiver) & noexcept -> operation<Receiver>
+    {
+      return {std::move(receiver)};
+    }
+  };
+
   TEST_CASE("libdispatch queue should be able to process tasks")
   {
     exec::libdispatch_queue queue;
@@ -200,5 +236,18 @@ namespace
     REQUIRE(result.has_value());
     CHECK(seen == 42);
     CHECK_FALSE(value.moved_from);
+  }
+
+  TEST_CASE("libdispatch bulk connects an lvalue child sender as an lvalue")
+  {
+    exec::libdispatch_queue queue;
+    auto                    fun = [](int, int &) noexcept {};
+    using sender_t = exec::__libdispatch::bulk_sender<lvalue_connect_sender, int, decltype(fun)>;
+
+    sender_t sender{queue, lvalue_connect_sender{}, 0, std::move(fun)};
+    auto     result = STDEXEC::sync_wait(sender);
+
+    REQUIRE(result.has_value());
+    CHECK(std::get<0>(*result) == 42);
   }
 }  // namespace

--- a/test/exec/test_libdispatch.cpp
+++ b/test/exec/test_libdispatch.cpp
@@ -30,8 +30,8 @@ namespace
     using sender_concept = STDEXEC::sender_tag;
 
     template <class, class...>
-    static consteval auto get_completion_signatures()
-      -> STDEXEC::completion_signatures<STDEXEC::set_value_t(int)>
+    static consteval auto
+    get_completion_signatures() -> STDEXEC::completion_signatures<STDEXEC::set_value_t(int)>
     {
       return {};
     }


### PR DESCRIPTION
## What

- Preserve the child sender cvref when libdispatch bulk connects it.
- Add a regression for a child sender that is only connectable as an lvalue.

## Why

`bulk_op_state` computes `inner_op_state` from `CvSender`, but used `std::move(sndr)` when connecting it. For an lvalue bulk sender, that turned a valid `Sender&` connection into an rvalue connection.

## Test

- `ctest --test-dir build --output-on-failure -j 8`
- All 948 tests passed.