### PR TITLE
Fix iterate subscribe exception specification

### DIFF
--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -178,7 +178,12 @@ namespace experimental::execution
     struct __subscribe_fn
     {
       template <class _Range>
-      constexpr auto operator()(__ignore, _Range&& __range) noexcept
+      constexpr auto operator()(__ignore, _Range&& __range) noexcept(
+        noexcept(std::ranges::begin(static_cast<_Range&&>(__range)))
+        && noexcept(std::ranges::end(static_cast<_Range&&>(__range)))
+        && __nothrow_move_constructible<std::ranges::iterator_t<_Range>,
+                                        std::ranges::sentinel_t<_Range>,
+                                        _Receiver>)
       {
         return __operation{std::ranges::begin(static_cast<_Range&&>(__range)),
                            std::ranges::end(static_cast<_Range&&>(__range)),

--- a/include/exec/sequence/iterate.hpp
+++ b/include/exec/sequence/iterate.hpp
@@ -178,12 +178,12 @@ namespace experimental::execution
     struct __subscribe_fn
     {
       template <class _Range>
-      constexpr auto operator()(__ignore, _Range&& __range) noexcept(
-        noexcept(std::ranges::begin(static_cast<_Range&&>(__range)))
-        && noexcept(std::ranges::end(static_cast<_Range&&>(__range)))
-        && __nothrow_move_constructible<std::ranges::iterator_t<_Range>,
-                                        std::ranges::sentinel_t<_Range>,
-                                        _Receiver>)
+      constexpr auto operator()(__ignore, _Range&& __range)
+        noexcept(noexcept(std::ranges::begin(static_cast<_Range&&>(__range)))
+                 && noexcept(std::ranges::end(static_cast<_Range&&>(__range)))
+                 && __nothrow_move_constructible<std::ranges::iterator_t<_Range>,
+                                                 std::ranges::sentinel_t<_Range>,
+                                                 _Receiver>)
       {
         return __operation{std::ranges::begin(static_cast<_Range&&>(__range)),
                            std::ranges::end(static_cast<_Range&&>(__range)),

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -25,6 +25,26 @@
 namespace
 {
 
+  struct begin_error
+  {};
+
+  struct begin_throws_range
+  {
+    using iterator = std::array<int, 1>::iterator;
+
+    iterator begin()
+    {
+      throw begin_error{};
+    }
+
+    iterator end() noexcept
+    {
+      return values.end();
+    }
+
+    std::array<int, 1> values{0};
+  };
+
   template <class Receiver>
   struct sum_item_rcvr
   {
@@ -138,6 +158,15 @@ namespace
     auto op   = exec::subscribe(iterate, sum_receiver<Env>{.sum_ = sum, .env_ = env});
     STDEXEC::start(op);
     CHECK(sum == (42 + 43 + 44 + 1));
+  }
+
+  TEST_CASE("iterate - subscribe propagates begin exceptions", "[sequence_senders][iterate]")
+  {
+    auto iterate = exec::iterate(begin_throws_range{});
+    int  sum     = 0;
+
+    STATIC_REQUIRE_FALSE(noexcept(exec::subscribe(iterate, sum_receiver<>{.sum_ = sum})));
+    CHECK_THROWS_AS(exec::subscribe(iterate, sum_receiver<>{.sum_ = sum}), begin_error);
   }
 
 }  // namespace

--- a/test/exec/sequence/test_iterate.cpp
+++ b/test/exec/sequence/test_iterate.cpp
@@ -25,6 +25,7 @@
 namespace
 {
 
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
   struct begin_error
   {};
 
@@ -44,6 +45,7 @@ namespace
 
     std::array<int, 1> values{0};
   };
+#endif  // !STDEXEC_NO_STDCPP_EXCEPTIONS()
 
   template <class Receiver>
   struct sum_item_rcvr
@@ -160,6 +162,7 @@ namespace
     CHECK(sum == (42 + 43 + 44 + 1));
   }
 
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
   TEST_CASE("iterate - subscribe propagates begin exceptions", "[sequence_senders][iterate]")
   {
     auto iterate = exec::iterate(begin_throws_range{});
@@ -168,5 +171,6 @@ namespace
     STATIC_REQUIRE_FALSE(noexcept(exec::subscribe(iterate, sum_receiver<>{.sum_ = sum})));
     CHECK_THROWS_AS(exec::subscribe(iterate, sum_receiver<>{.sum_ = sum}), begin_error);
   }
+#endif  // !STDEXEC_NO_STDCPP_EXCEPTIONS()
 
 }  // namespace


### PR DESCRIPTION
## What

- Make `iterate` report when range access or operation-state construction can throw during `subscribe`.
- Add a regression for a range whose `begin()` throws.

## Why

`iterate_t::subscribe()` derives its exception specification from an internal helper, but that helper was unconditionally `noexcept` even though it calls `ranges::begin()` and `ranges::end()`. A throwing range could therefore terminate instead of propagating the subscription exception.

## Test

- `ctest --test-dir build --output-on-failure -j 8`
- All 948 tests passed.