### PR TITLE
Fix read_with_default connect noexcept

### DIFF
--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -177,7 +177,10 @@ namespace experimental::execution
 
       template <__decays_to<__sender> _Self, class _Receiver>
       constexpr STDEXEC_EXPLICIT_THIS_BEGIN(auto connect)(this _Self&& __self, _Receiver __rcvr)
-        noexcept(std::is_nothrow_move_constructible_v<_Receiver>)
+        noexcept(__nothrow_constructible_from<
+          __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>,
+          __default_t<env_of_t<_Receiver>>,
+          _Receiver>)
           -> __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>
       {
         using __opstate_t = __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>;

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -177,10 +177,11 @@ namespace experimental::execution
 
       template <__decays_to<__sender> _Self, class _Receiver>
       constexpr STDEXEC_EXPLICIT_THIS_BEGIN(auto connect)(this _Self&& __self, _Receiver __rcvr)
-        noexcept(__nothrow_constructible_from<
-          __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>,
-          __default_t<env_of_t<_Receiver>>,
-          _Receiver>)
+        noexcept(
+          __nothrow_constructible_from<
+            __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>,
+            __default_t<env_of_t<_Receiver>>,
+            _Receiver>)
           -> __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>
       {
         using __opstate_t = __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>;

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -177,12 +177,10 @@ namespace experimental::execution
 
       template <__decays_to<__sender> _Self, class _Receiver>
       constexpr STDEXEC_EXPLICIT_THIS_BEGIN(auto connect)(this _Self&& __self, _Receiver __rcvr)
-        noexcept(
-          __nothrow_constructible_from<
-            __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>,
-            __default_t<env_of_t<_Receiver>>,
-            _Receiver>)
-          -> __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>
+        noexcept(__nothrow_constructible_from<
+                 __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>,
+                 __default_t<env_of_t<_Receiver>>,
+                 _Receiver>) -> __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>
       {
         using __opstate_t = __opstate<_Query, __default_t<env_of_t<_Receiver>>, _Receiver>;
         return __opstate_t{static_cast<_Self&&>(__self).__default_,

--- a/test/exec/test_env.cpp
+++ b/test/exec/test_env.cpp
@@ -34,7 +34,7 @@ namespace
       : throw_on_move_{throw_on_move}
     {}
 
-    throwing_default(throwing_default const&) noexcept = default;
+    throwing_default(throwing_default const &) noexcept = default;
 
     throwing_default(throwing_default&& other)
       : throw_on_move_{other.throw_on_move_}
@@ -102,7 +102,7 @@ namespace
   TEST_CASE("read_with_default connect propagates default move exceptions", "[env]")
   {
     bool throw_on_move = false;
-    auto sndr = exec::read_with_default(missing_query{}, throwing_default{&throw_on_move});
+    auto sndr     = exec::read_with_default(missing_query{}, throwing_default{&throw_on_move});
     throw_on_move = true;
 
     STATIC_REQUIRE_FALSE(noexcept(std::move(sndr).connect(read_with_default_receiver{})));

--- a/test/exec/test_env.cpp
+++ b/test/exec/test_env.cpp
@@ -20,6 +20,51 @@
 
 namespace
 {
+  struct missing_query : STDEXEC::__query<missing_query>
+  {
+    using STDEXEC::__query<missing_query>::operator();
+  };
+
+  struct default_move_error
+  {};
+
+  struct throwing_default
+  {
+    explicit throwing_default(bool* throw_on_move) noexcept
+      : throw_on_move_{throw_on_move}
+    {}
+
+    throwing_default(throwing_default const&) noexcept = default;
+
+    throwing_default(throwing_default&& other)
+      : throw_on_move_{other.throw_on_move_}
+    {
+      if (*throw_on_move_)
+      {
+        throw default_move_error{};
+      }
+    }
+
+    bool* throw_on_move_;
+  };
+
+  struct read_with_default_receiver
+  {
+    using receiver_concept = STDEXEC::receiver_tag;
+
+    template <class _Value>
+    void set_value(_Value&&) noexcept
+    {}
+
+    void set_error(std::exception_ptr) noexcept {}
+    void set_stopped() noexcept {}
+
+    auto get_env() const noexcept -> STDEXEC::env<>
+    {
+      return {};
+    }
+  };
+
   // Two dummy properties:
   constexpr struct Foo
     : STDEXEC::__query<Foo>
@@ -52,5 +97,15 @@ namespace
     auto e4 = exec::without(e3, foo);
     STATIC_REQUIRE(!std::invocable<Foo, decltype(e4)>);
     CHECK(bar(e4) == 43);
+  }
+
+  TEST_CASE("read_with_default connect propagates default move exceptions", "[env]")
+  {
+    bool throw_on_move = false;
+    auto sndr = exec::read_with_default(missing_query{}, throwing_default{&throw_on_move});
+    throw_on_move = true;
+
+    STATIC_REQUIRE_FALSE(noexcept(std::move(sndr).connect(read_with_default_receiver{})));
+    CHECK_THROWS_AS(std::move(sndr).connect(read_with_default_receiver{}), default_move_error);
   }
 }  // namespace

--- a/test/exec/test_env.cpp
+++ b/test/exec/test_env.cpp
@@ -20,6 +20,7 @@
 
 namespace
 {
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
   struct missing_query : STDEXEC::__query<missing_query>
   {
     using STDEXEC::__query<missing_query>::operator();
@@ -64,6 +65,7 @@ namespace
       return {};
     }
   };
+#endif  // !STDEXEC_NO_STDCPP_EXCEPTIONS()
 
   // Two dummy properties:
   constexpr struct Foo
@@ -99,6 +101,7 @@ namespace
     CHECK(bar(e4) == 43);
   }
 
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
   TEST_CASE("read_with_default connect propagates default move exceptions", "[env]")
   {
     bool throw_on_move = false;
@@ -108,4 +111,5 @@ namespace
     STATIC_REQUIRE_FALSE(noexcept(std::move(sndr).connect(read_with_default_receiver{})));
     CHECK_THROWS_AS(std::move(sndr).connect(read_with_default_receiver{}), default_move_error);
   }
+#endif  // !STDEXEC_NO_STDCPP_EXCEPTIONS()
 }  // namespace

--- a/test/exec/test_env.cpp
+++ b/test/exec/test_env.cpp
@@ -102,8 +102,8 @@ namespace
   TEST_CASE("read_with_default connect propagates default move exceptions", "[env]")
   {
     bool throw_on_move = false;
-    auto sndr     = exec::read_with_default(missing_query{}, throwing_default{&throw_on_move});
-    throw_on_move = true;
+    auto sndr          = exec::read_with_default(missing_query{}, throwing_default{&throw_on_move});
+    throw_on_move      = true;
 
     STATIC_REQUIRE_FALSE(noexcept(std::move(sndr).connect(read_with_default_receiver{})));
     CHECK_THROWS_AS(std::move(sndr).connect(read_with_default_receiver{}), default_move_error);


### PR DESCRIPTION
## What changed

- Make `read_with_default` member `connect()` derive its exception specification from constructing the returned operation state.
- Add a regression for a default value whose move throws during `connect()`.

## Why

The operation state already accounts for a potentially throwing default move, but `connect()` only considered moving the receiver.

## Testing

- `build/test/exec/test.exec` (3345 assertions passed)
- `ctest --test-dir build --output-on-failure -j 8` (948 passed)