### PR TITLE
Avoid redundant bulk remote queue notifications

### DIFF
--- a/include/exec/static_thread_pool.hpp
+++ b/include/exec/static_thread_pool.hpp
@@ -930,8 +930,10 @@ namespace experimental::execution
       for (std::uint32_t i = 0; i < tasks.size(); ++i)
       {
         std::uint32_t index = i % this->available_parallelism();
-        queue.queues_[index].push_front(&tasks[i]);
-        thread_states_[index]->notify();
+        if (queue.queues_[index].push_front(&tasks[i]))
+        {
+          thread_states_[index]->notify();
+        }
       }
       // At this point the calling thread can exit and the pool will take over.
       // Ultimately, the last completing thread passes the result forward.


### PR DESCRIPTION
## Summary

- Check the result of `push_front()` in the static thread pool bulk enqueue path.
- Notify a worker only when its submitter queue changes from empty to non-empty.
- This is a follow-up to #2178. The single-task paths were optimized there, while the bulk paths were left unchanged.

## Benchmark

Focused sender-level `schedule | bulk` benchmark on Apple arm64 with AppleClang 21, `-O3`, 100,000 bulk operations per producer, and the median of 5 runs after 1 warmup. Each cell is end-to-end throughput in Mops/s: `main -> patch (change)`.

| Workers / agents | 1 producer | 2 producers | 4 producers | 8 producers |
| --- | ---: | ---: | ---: | ---: |
| 2 / 2 | 5.84 -> 6.59 (+13%) | 5.78 -> 5.76 (0%) | 4.64 -> 5.36 (+15%) | 4.09 -> 4.47 (+9%) |
| 4 / 4 | 3.39 -> 3.59 (+6%) | 2.98 -> 3.41 (+15%) | 2.77 -> 3.04 (+10%) | 2.50 -> 2.76 (+10%) |
| 8 / 8 | 1.84 -> 2.22 (+21%) | 1.81 -> 1.99 (+10%) | 1.67 -> 2.05 (+22%) | 1.65 -> 1.85 (+12%) |

I also checked smaller bulk operations with one agent per submission:

| Workers / agents | 2 producers | 4 producers | 8 producers |
| --- | ---: | ---: | ---: |
| 2 / 1 | 5.59 -> 6.56 (+17%) | 5.71 -> 5.76 (+1%) | 4.46 -> 4.82 (+8%) |
| 4 / 1 | 4.79 -> 5.51 (+15%) | 4.45 -> 4.92 (+10%) | 4.33 -> 4.65 (+7%) |
| 8 / 1 | 4.98 -> 5.20 (+4%) | 3.98 -> 4.08 (+3%) | 3.36 -> 3.34 (-1%) |

The gains are largest when several producers share worker queues.

## Testing

- `git diff --check`
- Static thread pool tests: 9 test cases, 18 assertions
- Full `test.exec`: 336 test cases, 3,343 assertions