### PR TITLE
Do not invoke bulk_chunked for zero shape

### DIFF
--- a/include/stdexec/__detail/__bulk.hpp
+++ b/include/stdexec/__detail/__bulk.hpp
@@ -283,8 +283,7 @@ namespace STDEXEC
           {
             if (__shape_t{} < __state.__data_.__shape_)
             {
-              __state.__data_.__fun_(
-                __shape_t(), __shape_t(__state.__data_.__shape_), __args...);
+              __state.__data_.__fun_(__shape_t(), __shape_t(__state.__data_.__shape_), __args...);
             }
             STDEXEC::set_value(static_cast<_State&&>(__state).__rcvr_,
                                static_cast<_Args&&>(__args)...);

--- a/include/stdexec/__detail/__bulk.hpp
+++ b/include/stdexec/__detail/__bulk.hpp
@@ -281,7 +281,11 @@ namespace STDEXEC
 
           STDEXEC_TRY
           {
-            __state.__data_.__fun_(__shape_t(), __shape_t(__state.__data_.__shape_), __args...);
+            if (__shape_t{} < __state.__data_.__shape_)
+            {
+              __state.__data_.__fun_(
+                __shape_t(), __shape_t(__state.__data_.__shape_), __args...);
+            }
             STDEXEC::set_value(static_cast<_State&&>(__state).__rcvr_,
                                static_cast<_Args&&>(__args)...);
           }

--- a/test/stdexec/algos/adaptors/test_bulk.cpp
+++ b/test/stdexec/algos/adaptors/test_bulk.cpp
@@ -701,6 +701,26 @@ namespace
     ex::start(op);
   }
 
+  TEST_CASE("bulk_chunked function is not called with a zero shape", "[adaptors][bulk]")
+  {
+    int called{};
+
+    auto snd = ex::just() | ex::bulk_chunked(ex::seq, 0, [&called](int, int) { called++; });
+    ex::sync_wait(std::move(snd));
+
+    CHECK(called == 0);
+  }
+
+  TEST_CASE("bulk_chunked function is not called with a negative shape", "[adaptors][bulk]")
+  {
+    int called{};
+
+    auto snd = ex::just() | ex::bulk_chunked(ex::seq, -1, [&called](int, int) { called++; });
+    ex::sync_wait(std::move(snd));
+
+    CHECK(called == 0);
+  }
+
   TEST_CASE("bulk_unchunked function in not called on stop", "[adaptors][bulk]")
   {
     constexpr int n = 2;


### PR DESCRIPTION
## What changed

`bulk_chunked` currently calls the function once with `(0, 0)` when the shape is zero. `exec.bulk` requires each chunk to satisfy `b < e`, so an empty shape has no valid chunk.

- **Skip the callback when `shape <= 0`.**
- **Still forward the value completion.**
- Add regressions for zero and signed negative shapes.

The exposition-only default implementation in the same section currently calls `f(0, shape, args...)` unconditionally. That looks inconsistent with the non-empty chunk requirement. This change follows the behavioral requirement.

## Test

- `build/test/test.stdexec "[adaptors][bulk]"` (363 assertions, 59 test cases)
- `ctest --test-dir build --output-on-failure` (953 passed)

See [exec.bulk](https://eel.is/c%2B%2Bdraft/exec.bulk).