### PR TITLE
Fix just_from submit exception specification

### DIFF
--- a/include/exec/just_from.hpp
+++ b/include/exec/just_from.hpp
@@ -172,7 +172,7 @@ namespace experimental::execution
 
       template <class Rcvr>
       STDEXEC_ATTRIBUTE(host, device)
-      auto submit(Rcvr rcvr) && noexcept -> void
+      auto submit(Rcvr rcvr) && noexcept(STDEXEC::__nothrow_decay_copyable<Rcvr, Fn>) -> void
       {
         auto op = static_cast<_sndr_base&&>(*this).connect(static_cast<Rcvr&&>(rcvr));
         STDEXEC::start(op);
@@ -180,7 +180,8 @@ namespace experimental::execution
 
       template <class Rcvr>
       STDEXEC_ATTRIBUTE(host, device)
-      auto submit(Rcvr rcvr) const & noexcept -> void
+      auto submit(Rcvr rcvr) const & noexcept(STDEXEC::__nothrow_decay_copyable<Rcvr, Fn const &>)
+        -> void
       {
         auto op = this->connect(static_cast<Rcvr&&>(rcvr));
         STDEXEC::start(op);

--- a/include/exec/just_from.hpp
+++ b/include/exec/just_from.hpp
@@ -30,9 +30,9 @@ namespace experimental::execution
 
   namespace detail
   {
-    auto _just_from(just_from_t*) -> STDEXEC::set_value_t;
-    auto _just_from(just_error_from_t*) -> STDEXEC::set_error_t;
-    auto _just_from(just_stopped_from_t*) -> STDEXEC::set_stopped_t;
+    auto _just_from(just_from_t *) -> STDEXEC::set_value_t;
+    auto _just_from(just_error_from_t *) -> STDEXEC::set_error_t;
+    auto _just_from(just_stopped_from_t *) -> STDEXEC::set_stopped_t;
   }  // namespace detail
 
   template <class JustTag>
@@ -40,7 +40,7 @@ namespace experimental::execution
   {  // NOLINT(bugprone-crtp-constructor-accessibility)
    private:
     friend JustTag;
-    using _set_tag_t = decltype(detail::_just_from(static_cast<JustTag*>(nullptr)));
+    using _set_tag_t = decltype(detail::_just_from(static_cast<JustTag *>(nullptr)));
 
     using _diag_t = STDEXEC::__if_c<STDEXEC_IS_SAME(_set_tag_t, STDEXEC::set_error_t),
                                     AN_ERROR_COMPLETION_MUST_HAVE_EXACTLY_ONE_ERROR_ARGUMENT,
@@ -54,11 +54,11 @@ namespace experimental::execution
     struct _probe_fn
     {
       template <class... Ts>
-      auto operator()(Ts&&... ts) const noexcept -> _error_t<Ts...>;
+      auto operator()(Ts &&...ts) const noexcept -> _error_t<Ts...>;
 
       template <class... Ts>
         requires STDEXEC::__cmplsigs::__is_compl_sig<_set_tag_t(Ts...)>
-      auto operator()(Ts&&...) const noexcept -> STDEXEC::completion_signatures<_set_tag_t(Ts...)>
+      auto operator()(Ts &&...) const noexcept -> STDEXEC::completion_signatures<_set_tag_t(Ts...)>
       {
         return {};
       }
@@ -67,13 +67,13 @@ namespace experimental::execution
     template <class Rcvr>
     struct _complete_fn
     {
-      Rcvr& _rcvr;
+      Rcvr &_rcvr;
 
       template <class... Ts>
       STDEXEC_ATTRIBUTE(always_inline, host, device)
-      void operator()(Ts&&... ts) const noexcept
+      void operator()(Ts &&...ts) const noexcept
       {
-        _set_tag_t()(static_cast<Rcvr&&>(_rcvr), static_cast<Ts&&>(ts)...);
+        _set_tag_t()(static_cast<Rcvr &&>(_rcvr), static_cast<Ts &&>(ts)...);
       }
     };
 
@@ -89,17 +89,17 @@ namespace experimental::execution
       {
         if constexpr (STDEXEC::__nothrow_callable<Fn, _complete_fn<Rcvr>>)
         {
-          static_cast<Fn&&>(_fn)(_complete_fn<Rcvr>{_rcvr});
+          static_cast<Fn &&>(_fn)(_complete_fn<Rcvr>{_rcvr});
         }
         else
         {
           STDEXEC_TRY
           {
-            static_cast<Fn&&>(_fn)(_complete_fn<Rcvr>{_rcvr});
+            static_cast<Fn &&>(_fn)(_complete_fn<Rcvr>{_rcvr});
           }
           STDEXEC_CATCH_ALL
           {
-            STDEXEC::set_error(static_cast<Rcvr&&>(_rcvr), std::current_exception());
+            STDEXEC::set_error(static_cast<Rcvr &&>(_rcvr), std::current_exception());
           }
         }
       }
@@ -149,7 +149,7 @@ namespace experimental::execution
       auto connect(Rcvr rcvr) && noexcept(STDEXEC::__nothrow_decay_copyable<Rcvr, Fn>)
         -> _opstate<Rcvr, Fn>
       {
-        return _opstate<Rcvr, Fn>{static_cast<Rcvr&&>(rcvr), static_cast<Fn&&>(_fn)};
+        return _opstate<Rcvr, Fn>{static_cast<Rcvr &&>(rcvr), static_cast<Fn &&>(_fn)};
       }
 
       template <class Rcvr>
@@ -157,7 +157,7 @@ namespace experimental::execution
       auto connect(Rcvr rcvr) const & noexcept(STDEXEC::__nothrow_decay_copyable<Rcvr, Fn const &>)
         -> _opstate<Rcvr, Fn>
       {
-        return _opstate<Rcvr, Fn>{static_cast<Rcvr&&>(rcvr), _fn};
+        return _opstate<Rcvr, Fn>{static_cast<Rcvr &&>(rcvr), _fn};
       }
 
       [[nodiscard]]
@@ -172,18 +172,17 @@ namespace experimental::execution
 
       template <class Rcvr>
       STDEXEC_ATTRIBUTE(host, device)
-      auto submit(Rcvr rcvr) && noexcept(STDEXEC::__nothrow_decay_copyable<Rcvr, Fn>) -> void
+      auto submit(Rcvr rcvr) && noexcept(STDEXEC::__nothrow_decay_copyable<Fn>) -> void
       {
-        auto op = static_cast<_sndr_base&&>(*this).connect(static_cast<Rcvr&&>(rcvr));
+        auto op = static_cast<_sndr_base &&>(*this).connect(static_cast<Rcvr &&>(rcvr));
         STDEXEC::start(op);
       }
 
       template <class Rcvr>
       STDEXEC_ATTRIBUTE(host, device)
-      auto submit(Rcvr rcvr) const & noexcept(STDEXEC::__nothrow_decay_copyable<Rcvr, Fn const &>)
-        -> void
+      auto submit(Rcvr rcvr) const & noexcept(STDEXEC::__nothrow_decay_copyable<Fn const &>) -> void
       {
-        auto op = this->connect(static_cast<Rcvr&&>(rcvr));
+        auto op = this->connect(static_cast<Rcvr &&>(rcvr));
         STDEXEC::start(op);
       }
     };
@@ -204,7 +203,7 @@ namespace experimental::execution
                       "must return an instance of a specialization of " STDEXEC_PP_STRINGIZE(
                         STDEXEC) "::completion_signatures<>.");
         return _sndr<Fn>{
-          {{}, static_cast<Fn&&>(fn)}
+          {{}, static_cast<Fn &&>(fn)}
         };
       }
       else

--- a/test/exec/test_just_from.cpp
+++ b/test/exec/test_just_from.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "exec/just_from.hpp"
+#include "test_common/receivers.hpp"
 #include "test_common/tuple.hpp"
 #include "test_common/type_helpers.hpp"
 
@@ -26,13 +27,19 @@ namespace
 
   struct throwing_move_callable
   {
-    throwing_move_callable()                                        = default;
-    throwing_move_callable(throwing_move_callable const &) noexcept = default;
-    throwing_move_callable(throwing_move_callable &&other) noexcept(false)
+    explicit throwing_move_callable(bool& should_throw) noexcept
+      : should_throw_(&should_throw)
+    {}
+
+    throwing_move_callable(throwing_move_callable const &other) noexcept
+      : should_throw_(other.should_throw_)
+    {}
+
+    throwing_move_callable(throwing_move_callable&& other) noexcept(false)
       : should_throw_(other.should_throw_)
     {
 #if !STDEXEC_NO_STDCPP_EXCEPTIONS()
-      if (should_throw_)
+      if (*should_throw_)
       {
         throw 42;
       }
@@ -45,7 +52,7 @@ namespace
       return sink();
     }
 
-    bool should_throw_{false};
+    bool* should_throw_;
   };
 
   TEST_CASE("just_from is a sender", "[just_from]")
@@ -94,12 +101,27 @@ namespace
     };
     STATIC_REQUIRE(noexcept(exec::just_from(nothrow_fn)));
 
-    throwing_move_callable fn;
+    bool                   should_throw = false;
+    throwing_move_callable fn{should_throw};
     STATIC_REQUIRE_FALSE(noexcept(exec::just_from(fn)));
 
 #if !STDEXEC_NO_STDCPP_EXCEPTIONS()
-    fn.should_throw_ = true;
+    should_throw = true;
     CHECK_THROWS_AS(exec::just_from(fn), int);
+#endif
+  }
+
+  TEST_CASE("just_from submit is conditionally noexcept", "[just_from]")
+  {
+    bool should_throw = false;
+    auto s            = exec::just_from(throwing_move_callable{should_throw});
+
+    STATIC_REQUIRE_FALSE(noexcept(static_cast<decltype(s)&&>(s).submit(empty_recv::recv0{})));
+    STATIC_REQUIRE(noexcept(s.submit(empty_recv::recv0{})));
+
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+    should_throw = true;
+    CHECK_THROWS_AS(static_cast<decltype(s)&&>(s).submit(empty_recv::recv0{}), int);
 #endif
   }
 

--- a/test/exec/test_just_from.cpp
+++ b/test/exec/test_just_from.cpp
@@ -31,7 +31,7 @@ namespace
       : should_throw_(&should_throw)
     {}
 
-    throwing_move_callable(throwing_move_callable const &other) noexcept
+    throwing_move_callable(throwing_move_callable const & other) noexcept
       : should_throw_(other.should_throw_)
     {}
 
@@ -163,7 +163,7 @@ namespace
     global_int = 42;
     auto s     = exec::just_from([](auto sink) noexcept { return sink(global_int); })
            | ex::then(
-               [](int &i) noexcept
+               [](int& i) noexcept
                {
                  CHECK(&i == &global_int);
                  return std::ref(i);


### PR DESCRIPTION
## What changed

- Make both `just_from::submit()` overloads conditionally `noexcept`.
- Add coverage for a callable that throws while being moved during `submit()`.

## Why

`submit()` calls `connect()`, but both overloads were unconditionally `noexcept`. A throwing callable move could therefore terminate instead of propagating the exception.

## Testing

- `build/test/exec/test.exec [just_from]`
- `ctest --test-dir build --output-on-failure -j 8`

All 953 configured tests passed.