### PR TITLE
Make exec::without conditionally noexcept

### DIFF
--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -61,16 +61,20 @@ namespace experimental::execution
     struct __without_t
     {
       template <class _Env, class _Query>
-      constexpr auto operator()(_Env&& __env, _Query) const noexcept
+        requires STDEXEC::__queryable_with<_Env, _Query>
+      constexpr auto operator()(_Env&& __env, _Query) const
+        noexcept(STDEXEC::__nothrow_constructible_from<__without<_Env, _Query>, _Env>)
+          -> __without<_Env, _Query>
       {
-        if constexpr (STDEXEC::__queryable_with<_Env, _Query>)
-        {
-          return __without<_Env, _Query>{static_cast<_Env&&>(__env)};
-        }
-        else
-        {
-          return static_cast<_Env&&>(__env);
-        }
+        return __without<_Env, _Query>{static_cast<_Env&&>(__env)};
+      }
+
+      template <class _Env, class _Query>
+        requires(!STDEXEC::__queryable_with<_Env, _Query>)
+      constexpr auto operator()(_Env&& __env, _Query) const
+        noexcept(STDEXEC::__nothrow_constructible_from<_Env, _Env>) -> _Env
+      {
+        return static_cast<_Env&&>(__env);
       }
     };
 

--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -70,9 +70,8 @@ namespace experimental::execution
       }
 
       template <class _Env, class _Query>
-        requires(!STDEXEC::__queryable_with<_Env, _Query>)
       constexpr auto operator()(_Env&& __env, _Query) const
-        noexcept(STDEXEC::__nothrow_constructible_from<_Env, _Env>) -> _Env
+        noexcept(STDEXEC::__nothrow_move_constructible<_Env>) -> _Env
       {
         return static_cast<_Env&&>(__env);
       }

--- a/test/exec/test_env.cpp
+++ b/test/exec/test_env.cpp
@@ -18,6 +18,9 @@
 #include <stdexec/execution.hpp>
 #include <test_common/catch2.hpp>
 
+#include <type_traits>
+#include <utility>
+
 namespace
 {
   // Two dummy properties:
@@ -52,5 +55,98 @@ namespace
     auto e4 = exec::without(e3, foo);
     STATIC_REQUIRE(!std::invocable<Foo, decltype(e4)>);
     CHECK(bar(e4) == 43);
+  }
+
+  TEST_CASE("without propagates environment move exceptions", "[env]")
+  {
+    struct missing_query : STDEXEC::__query<missing_query>
+    {
+      using STDEXEC::__query<missing_query>::operator();
+    };
+
+    struct without_move_error
+    {};
+
+    struct throwing_env
+    {
+      explicit throwing_env(bool* throw_on_move) noexcept
+        : throw_on_move_{throw_on_move}
+      {}
+
+      throwing_env(throwing_env const & other) noexcept
+        : throw_on_move_{other.throw_on_move_}
+      {}
+
+      throwing_env(throwing_env&& other)
+        : throw_on_move_{other.throw_on_move_}
+      {
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+        if (*throw_on_move_)
+        {
+          throw without_move_error{};
+        }
+#endif
+      }
+
+      int query(Foo) const noexcept
+      {
+        return 42;
+      }
+
+      bool* throw_on_move_;
+    };
+
+    bool         throw_on_move = false;
+    throwing_env missing_env{&throw_on_move};
+    throwing_env queried_env{&throw_on_move};
+
+    STATIC_REQUIRE_FALSE(noexcept(exec::without(std::move(missing_env), missing_query{})));
+    STATIC_REQUIRE_FALSE(noexcept(exec::without(std::move(queried_env), foo)));
+    STATIC_REQUIRE(noexcept(exec::without(missing_env, missing_query{})));
+    STATIC_REQUIRE(noexcept(exec::without(queried_env, foo)));
+
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+    throw_on_move = true;
+    CHECK_THROWS_AS(exec::without(std::move(missing_env), missing_query{}), without_move_error);
+    CHECK_THROWS_AS(exec::without(std::move(queried_env), foo), without_move_error);
+#endif
+
+    struct throwing_copy_error
+    {};
+
+    struct throwing_copy_env
+    {
+      explicit throwing_copy_env(bool* throw_on_copy) noexcept
+        : throw_on_copy_{throw_on_copy}
+      {}
+
+      throwing_copy_env(throwing_copy_env const & other)
+        : throw_on_copy_{other.throw_on_copy_}
+      {
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+        if (*throw_on_copy_)
+        {
+          throw throwing_copy_error{};
+        }
+#endif
+      }
+
+      throwing_copy_env(throwing_copy_env&&) noexcept = default;
+
+      bool* throw_on_copy_;
+    };
+
+    bool              throw_on_copy = false;
+    throwing_copy_env copy_env{&throw_on_copy};
+
+    STATIC_REQUIRE(
+      std::is_same_v<decltype(exec::without(copy_env, missing_query{})), throwing_copy_env&>);
+    STATIC_REQUIRE(noexcept(exec::without(copy_env, missing_query{})));
+
+#if !STDEXEC_NO_STDCPP_EXCEPTIONS()
+    throw_on_copy = true;
+    auto&& result = exec::without(copy_env, missing_query{});
+    CHECK(&result == &copy_env);
+#endif
   }
 }  // namespace


### PR DESCRIPTION
## What changed

- Make `exec::without` derive its exception specification from the selected return object construction.
- Keep lvalue environments nothrow when `without` only stores a reference.
- Add regressions for throwing rvalue environment moves in both queryable and missing-query paths.

## Why

`exec::without` was unconditionally `noexcept`, even though it can move an rvalue environment into its return object. A throwing move could terminate instead of propagating the exception.

## Testing

- `build/test/exec/test.exec [env]`
- `ctest --test-dir build --output-on-failure -j 8`

All 953 configured tests passed.