### PR TITLE
fix(exec): any_sender completion signatures for sequence with 3+ senders

### DIFF
--- a/include/stdexec/__detail/__sequence.hpp
+++ b/include/stdexec/__detail/__sequence.hpp
@@ -183,7 +183,7 @@ namespace STDEXEC
     };
 
     template <class _Child1, class _Child2, class... _Rest>
-    struct __attrs<_Child1, _Child2, _Rest...> : __attrs<__sndr<_Child1, _Child2>, _Rest...>
+    struct __attrs<_Child1, _Child2, _Rest...> : __attrs<__sndr<__decay_t<_Child1>, __decay_t<_Child2>>, __decay_t<_Rest>...>
     {};
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -379,17 +379,25 @@ namespace STDEXEC
       {
         using __cv_sender1_t = __copy_cvref_t<_Self, _Sender1>;
 
+        // If the first sender is a nested sequence (held by const& in attrs),
+        // decay it for completion signature queries since it's not the "true"
+        // first sender that gets connected directly (see line 328).
+        using __sender1_for_completions_t =
+          __if_c<__is_instance_of<__decay_t<__cv_sender1_t>, __seq::__sndr>,
+                 __decay_t<__cv_sender1_t>,
+                 __cv_sender1_t>;
+
         if constexpr (!__decay_copyable<_Self>)
         {
           return STDEXEC::__throw_compile_time_error<_SENDER_TYPE_IS_NOT_DECAY_COPYABLE_,
                                                      _WITH_PRETTY_SENDER_<_Self>>();
         }
-        else if constexpr (!__sends<set_value_t, __cv_sender1_t, __fwd_env_t<_Env>...>)
+        else if constexpr (!__sends<set_value_t, __sender1_for_completions_t, __fwd_env_t<_Env>...>)
         {
           // If the first sender has no set_value completions, then the second sender will
           // never be started, so just return the (error and stopped) completions of the
           // first sender.
-          return STDEXEC::get_completion_signatures<__cv_sender1_t, __fwd_env_t<_Env>...>();
+          return STDEXEC::get_completion_signatures<__sender1_for_completions_t, __fwd_env_t<_Env>...>();
         }
         else
         {
@@ -398,7 +406,7 @@ namespace STDEXEC
 
           auto __completions1 =  //
             STDEXEC::__transform_completion_signatures(
-              STDEXEC::get_completion_signatures<__cv_sender1_t, __fwd_env_t<_Env>...>(),
+              STDEXEC::get_completion_signatures<__sender1_for_completions_t, __fwd_env_t<_Env>...>(),
               __eat_value_signatures<_Self>{});
 
           auto __completions2 =

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -58,6 +58,7 @@ set(exec_test_sources
     sequence/test_iterate.cpp
     sequence/test_transform_each.cpp
     sequence/test_merge.cpp
+    sequence/test_sequence_any_sender.cpp
     # These tests cause Microsoft's compiler to run out of memory
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:sequence/test_merge_each.cpp>
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:sequence/test_merge_each_threaded.cpp>

--- a/test/exec/sequence/test_sequence_any_sender.cpp
+++ b/test/exec/sequence/test_sequence_any_sender.cpp
@@ -1,0 +1,71 @@
+/*
+ * Test for PR #2223: any_sender completion signatures for sequence with 3+ senders
+ * Fixes #2101
+ */
+#include <exec/any_sender_of.hpp>
+#include <exec/sequence.hpp>
+#include <stdexec/execution.hpp>
+
+#include <catch2/catch_all.hpp>
+
+namespace ex = STDEXEC;
+
+TEST_CASE("sequence with 3 any_sender works - PR #2223", "[sequence][any_sender]")
+{
+    // Test case from issue #2101: sequence with 3+ any_sender
+    // sequence requires all but the last sender to be void senders
+    using SigsVoid = ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+    using SigsInt = ex::completion_signatures<ex::set_value_t(int), ex::set_error_t(std::exception_ptr)>;
+    
+    using AnySenderVoid = exec::any_receiver_ref<SigsVoid>::any_sender<>;
+    using AnySenderInt = exec::any_receiver_ref<SigsInt>::any_sender<>;
+
+    // Create 2 void any_senders and 1 int any_sender
+    AnySenderVoid s1 = ex::just();
+    AnySenderVoid s2 = ex::just();
+    AnySenderInt s3 = ex::just(42);
+
+    // This should work now (was failing before the fix)
+    auto seq = exec::sequence(std::move(s1), std::move(s2), std::move(s3));
+
+    // Run it
+    auto [a] = *ex::sync_wait(std::move(seq));
+    CHECK(a == 42);
+}
+
+TEST_CASE("sequence with 4 any_sender works", "[sequence][any_sender]")
+{
+    using SigsVoid = ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+    using SigsInt = ex::completion_signatures<ex::set_value_t(int), ex::set_error_t(std::exception_ptr)>;
+    
+    using AnySenderVoid = exec::any_receiver_ref<SigsVoid>::any_sender<>;
+    using AnySenderInt = exec::any_receiver_ref<SigsInt>::any_sender<>;
+
+    AnySenderVoid s1 = ex::just();
+    AnySenderVoid s2 = ex::just();
+    AnySenderVoid s3 = ex::just();
+    AnySenderInt s4 = ex::just(42);
+
+    auto seq = exec::sequence(std::move(s1), std::move(s2), std::move(s3), std::move(s4));
+
+    auto [a] = *ex::sync_wait(std::move(seq));
+    CHECK(a == 42);
+}
+
+TEST_CASE("sequence with mixed senders including any_sender works", "[sequence][any_sender]")
+{
+    using SigsVoid = ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+    using SigsInt = ex::completion_signatures<ex::set_value_t(int), ex::set_error_t(std::exception_ptr)>;
+    
+    using AnySenderVoid = exec::any_receiver_ref<SigsVoid>::any_sender<>;
+    using AnySenderInt = exec::any_receiver_ref<SigsInt>::any_sender<>;
+
+    AnySenderVoid s1 = ex::just();
+    auto s2 = ex::just();  // regular sender
+    AnySenderInt s3 = ex::just(42);
+
+    auto seq = exec::sequence(std::move(s1), std::move(s2), std::move(s3));
+
+    auto [a] = *ex::sync_wait(std::move(seq));
+    CHECK(a == 42);
+}


### PR DESCRIPTION
When exec::sequence has 3+ senders, it recursively computes completion signatures by peeling off the first sender and querying the tail as a sub-sequence (__seq::__sndr). This tail holds child senders by const&. The get_completion_signatures discovery machinery passes the sender type un-decayed (as const any_sender&), but any_sender's constraint std::derived_from<Self, _interface_> fails because reference types are never derived_from anything.

Fix by decaying Self before the derived_from check in _isender::_interface_::get_completion_signatures().

Fixes #2101