### PR TITLE
let_value, let_error, & let_stopped: Dependent set_error_t(std::excep…

### DIFF
--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -567,6 +567,24 @@ namespace STDEXEC
             }
             else if constexpr (__nothrow_decay_copyable<_Args...>
                                && __nothrow_invocable<_Fun, __decay_t<_Args>&...>
+                               && sizeof...(_Env) == 0)
+            {
+              auto __completions =
+                STDEXEC::get_completion_signatures<__sndr2_t, __env2_t<_Child, _Env>...>();
+              STDEXEC_IF_OK(__completions)
+              {
+                if constexpr (__completions.template __contains<__eptr_sig_t>())
+                {
+                  return __completions;
+                }
+                else
+                {
+                  return STDEXEC::__throw_dependent_sender_error<__sndr2_t>();
+                }
+              }
+            }
+            else if constexpr (__nothrow_decay_copyable<_Args...>
+                               && __nothrow_invocable<_Fun, __decay_t<_Args>&...>
                                && (__nothrow_connectable<__sndr2_t, __rcvr2_t<_Child, _Env>>
                                    || ...))
             {

--- a/test/stdexec/algos/adaptors/test_let_error.cpp
+++ b/test/stdexec/algos/adaptors/test_let_error.cpp
@@ -100,6 +100,16 @@ namespace
     STDEXEC::sync_wait(std::move(snd));
   }
 
+  TEST_CASE("let_error can be followed by upon_error", "[adaptors][let_error]")
+  {
+    auto snd = ex::just_error(2)
+             | ex::let_error([](int n) noexcept { return ex::just_error(n * 10); })
+             | ex::upon_error([](int n) noexcept { return n + 3; });
+    auto opt = ex::sync_wait(std::move(snd));
+    REQUIRE(opt.has_value());
+    CHECK(std::get<0>(*opt) == 23);
+  }
+
 #if !STDEXEC_NO_STDCPP_EXCEPTIONS()
   TEST_CASE("let_error can be used to produce values (error to value)", "[adaptors][let_error]")
   {


### PR DESCRIPTION
…tion_ptr)

let_value, let_error, and let_stopped have three different kinds of completion signatures:

- Those obtained from the sender type returned by the invocable,
- Those passed through from the child sender, and
- Possibly set_error_t(std::exception_ptr)

The latter must be added when:

- Decay-copying the apropos result datums of the child sender can throw,
- Invoking the invocable with any set of decay-copied result datums can throw, or
- Connecting any of the sender types which can be returned by the invocable can throw

Note that if the child of let_value, let_error, or let_stopped is not dependent the apropos result datums can be determined without the context of an environment. This means, in turn, that in such a situation it can be determined, without the context of an environment, whether invocation of the invocable can throw (since the type of the decay- copied result datums with which it will be invoked can be known).

The last of the bullets above, however, presents a problem in an environment-free context. Computing whether or not a sender can be connected without throwing requires the context of an environment (see P3388).

Previously let_value, let_error, and let_stopped unconditionally added set_error_t(std::exception_ptr) in the case where no environment was provided. This created the illusion that the sender was not dependent, and led to compilation failures in situations such as the test added by this commit.

The above might seem to imply that let_value, let_error, and let_stopped are always dependent, but this isn't true. In the case where set_error_t(std::exception_ptr) is already a possible completion signature it doesn't matter whether or not connecting the sender returned by the invocable can throw.

Reified the above: let_value, let_error, and let_stopped indicate they are dependent when the question of whether or not connecting the sender returned by the invocable throws determines the presence of set_error_t(std::exception_ptr), otherwise they can advertise non- dependent completion signatures.

Fixes #2197.