### PR TITLE
Fix __receiver_proxy_base start_scheduler_t query.

### DIFF
--- a/include/stdexec/__detail/__task_scheduler.hpp
+++ b/include/stdexec/__detail/__task_scheduler.hpp
@@ -848,9 +848,8 @@ namespace STDEXEC
       {
         if constexpr (__callable<get_start_scheduler_t, env_of_t<_Rcvr>>)
         {
-          if constexpr (__std::constructible_from<
-                          task_scheduler,
-                          __call_result_t<get_start_scheduler_t, env_of_t<_Rcvr>>>)
+          using __sched_t = __call_result_t<get_start_scheduler_t, env_of_t<_Rcvr>>;
+          if constexpr (__std::constructible_from<task_scheduler, __sched_t>)
           {
             auto& __val = *static_cast<std::optional<task_scheduler>*>(__dest);
             __val.emplace(get_start_scheduler(get_env(__rcvr_)));

--- a/include/stdexec/__detail/__task_scheduler.hpp
+++ b/include/stdexec/__detail/__task_scheduler.hpp
@@ -846,14 +846,15 @@ namespace STDEXEC
     {
       if (__value_type == __mtypeid<task_scheduler>)
       {
-        auto& __val = *static_cast<std::optional<task_scheduler>*>(__dest);
         if constexpr (__callable<get_start_scheduler_t, env_of_t<_Rcvr>>)
         {
-          __val.emplace(get_start_scheduler(get_env(__rcvr_)));
-        }
-        else
-        {
-          __val.emplace(inline_scheduler{});
+          if constexpr (__std::constructible_from<
+                          task_scheduler,
+                          __call_result_t<get_start_scheduler_t, env_of_t<_Rcvr>>>)
+          {
+            auto& __val = *static_cast<std::optional<task_scheduler>*>(__dest);
+            __val.emplace(get_start_scheduler(get_env(__rcvr_)));
+          }
         }
       }
     }

--- a/test/stdexec/schedulers/test_parallel_scheduler.cpp
+++ b/test/stdexec/schedulers/test_parallel_scheduler.cpp
@@ -94,6 +94,13 @@ TEST_CASE("trivial schedule task on parallel scheduler", "[scheduler][parallel_s
   ex::sync_wait(ex::schedule(sched));
 }
 
+TEST_CASE("can schedule from parallel scheduler to parallel scheduler",
+          "[scheduler][parallel_scheduler]")
+{
+  auto sched = ex::get_parallel_scheduler();
+  ex::sync_wait(ex::starts_on(sched, ex::starts_on(sched, ex::just())));
+}
+
 TEST_CASE("simple schedule task on parallel scheduler", "[scheduler][parallel_scheduler]")
 {
   std::thread::id             this_id = std::this_thread::get_id();


### PR DESCRIPTION
## Current behaviour

When start scheduler is queried, __receiver_proxy_base does:

  1. If the requested scheduler type is not `task_scheduler`, we just declare
    that there is no start scheduler, and the query returns `nullopt`.
  2. Otherwise, the user is explicitly querying a start scheduler as `task_scheduler`.  
      1. If there do exists a start scheduler, we give you the `task_scheduler` constructed
       from the start scheduler. And if the constructor throws, `std::terminate()` is automatically invoked as querying is noexcept.  
      2. Otherwise, there is no start scheduler, but we still give you a `task_scheduler` created with `inline_scheduler`. Again, `std::terminate()` on exception.

## There is one problem I encountered currently

This code does not compile:

```c++
namespace ex = STDEXEC;
auto sched = ex::get_parallel_scheduler();
ex::sync_wait(ex::starts_on(sched,ex::starts_on(sched,ex::just())));
```

That is `parallel_scheduler` being the start scheduler
which does not satisfies `task_scheduler` constructor's constraints, caused compilation failure.

`task_scheduler` is not named `any_scheduler`, which means some scheduler types can not be used to construct a `task_scheduler`, but 2.1 does not check that.

## Fixes in this PR

1. If the start scheduler can not be used to construct a `task_scheduler`, and the user is explicitly requesting
a `task_scheduler`, then there is no such start scheduler of the requested type.

2. According to the specification of [`receiver_proxy::try_query`](https://eel.is/c++draft/exec.parschedrepl.recvproxy):

    Returns: Let env be the environment of the receiver represented by *this. If
        - Query is not a member of an implementation-defined set of supported queries; or
        - P is not a member of an implementation-defined set of supported result types for Query; or
        - the expression q(env) is not well-formed,
    then returns nullopt. Otherwise, if q(env) has type cv P, then returns q(env). Otherwise, returns an implementation-defined value of type optional\<P\>.

    1. Current implementation returns `inline_scheduler` when `q(env)`is not well-formed, which should be `nullopt` according to the standard.
    2. When the start scheduler's type is not `task_scheduler`, return an implementation-defined value of type `optional<task_scheduler>`:

        * If constructible as `task_scheduler`, return constructed `task_scheduler`.
        * Otherwise, return nullopt.
