### PR TITLE
Fix read_with_default receiver move exception specification

### DIFF
--- a/include/exec/env.hpp
+++ b/include/exec/env.hpp
@@ -135,7 +135,7 @@ namespace experimental::execution
     struct __opstate
     {
       constexpr explicit __opstate(_Default&& __default, _Receiver&& __rcvr)
-        noexcept(__nothrow_move_constructible<_Default>)
+        noexcept(__nothrow_move_constructible<_Default> && __nothrow_move_constructible<_Receiver>)
         : __default_(static_cast<_Default&&>(__default))
         , __rcvr_(static_cast<_Receiver&&>(__rcvr))
       {}

--- a/test/exec/test_env.cpp
+++ b/test/exec/test_env.cpp
@@ -32,6 +32,9 @@ namespace
   struct default_move_error
   {};
 
+  struct receiver_move_error
+  {};
+
   struct throwing_default
   {
     explicit throwing_default(bool* throw_on_move) noexcept
@@ -67,6 +70,40 @@ namespace
     {
       return {};
     }
+  };
+
+  struct throwing_receiver
+  {
+    using receiver_concept = STDEXEC::receiver_tag;
+
+    explicit throwing_receiver(bool* throw_on_move) noexcept
+      : throw_on_move_{throw_on_move}
+    {}
+
+    throwing_receiver(throwing_receiver const &) noexcept = default;
+
+    throwing_receiver(throwing_receiver&& other)
+      : throw_on_move_{other.throw_on_move_}
+    {
+      if (*throw_on_move_)
+      {
+        throw receiver_move_error{};
+      }
+    }
+
+    template <class _Value>
+    void set_value(_Value&&) noexcept
+    {}
+
+    void set_error(std::exception_ptr) noexcept {}
+    void set_stopped() noexcept {}
+
+    auto get_env() const noexcept -> STDEXEC::env<>
+    {
+      return {};
+    }
+
+    bool* throw_on_move_;
   };
 #endif  // !STDEXEC_NO_STDCPP_EXCEPTIONS()
 
@@ -113,6 +150,17 @@ namespace
 
     STATIC_REQUIRE_FALSE(noexcept(std::move(sndr).connect(read_with_default_receiver{})));
     CHECK_THROWS_AS(std::move(sndr).connect(read_with_default_receiver{}), default_move_error);
+  }
+
+  TEST_CASE("read_with_default connect propagates receiver move exceptions", "[env]")
+  {
+    bool              throw_on_move = false;
+    auto              sndr          = exec::read_with_default(missing_query{}, 42);
+    throwing_receiver rcvr{&throw_on_move};
+    throw_on_move = true;
+
+    STATIC_REQUIRE_FALSE(noexcept(std::move(sndr).connect(rcvr)));
+    CHECK_THROWS_AS(std::move(sndr).connect(rcvr), receiver_move_error);
   }
 #endif  // !STDEXEC_NO_STDCPP_EXCEPTIONS()
 


### PR DESCRIPTION
## Summary

- **Include the receiver move** in the `read_with_default` operation state `noexcept` condition.
- **Add a regression test** for a receiver whose move constructor throws during `connect`.

## Testing

- `cmake -S . -B build -DSTDEXEC_BUILD_TESTS=ON -DSTDEXEC_BUILD_EXAMPLES=OFF -DSTDEXEC_BUILD_RELACY_TESTS=OFF`
- `cmake --build build --target test.exec --parallel 4`
- `build/test/exec/test.exec "read_with_default*"`
- `build/test/exec/test.exec`
- Clang 21 `clang-format --dry-run --Werror` on the changed files