### PR TITLE
Fix __let.hpp __let_t<Tag> get_completion_signatures() computation.

### DIFF
--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -625,7 +625,7 @@ namespace STDEXEC
         using __child_t    = __child_of<_CvSender>;
         auto __completions = STDEXEC::get_completion_signatures<__child_t, _Env...>();
 
-        if constexpr (STDEXEC::sender_in<__child_t, _Env...>)
+        STDEXEC_IF_OK(__completions)
         {
           auto __transform = __get_transform_fn<__fn_t<_CvSender>, __child_t, _Env...>();
           if constexpr (!__decay_copyable<_CvSender>)
@@ -645,10 +645,6 @@ namespace STDEXEC
           {
             return STDEXEC::__transform_completion_signatures(__completions, {}, {}, __transform);
           }
-        }
-        else
-        {
-          return __completions;
         }
       }
 

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -624,23 +624,31 @@ namespace STDEXEC
         static_assert(__sender_for<_CvSender, _LetTag>);
         using __child_t    = __child_of<_CvSender>;
         auto __completions = STDEXEC::get_completion_signatures<__child_t, _Env...>();
-        auto __transform   = __get_transform_fn<__fn_t<_CvSender>, __child_t, _Env...>();
-        if constexpr (!__decay_copyable<_CvSender>)
+
+        if constexpr (STDEXEC::sender_in<__child_t, _Env...>)
         {
-          return STDEXEC::__throw_compile_time_error<_SENDER_TYPE_IS_NOT_DECAY_COPYABLE_,
-                                                     _WITH_PRETTY_SENDER_<_CvSender>>();
-        }
-        else if constexpr (__t<_LetTag>() == STDEXEC::set_value)
-        {
-          return STDEXEC::__transform_completion_signatures(__completions, __transform);
-        }
-        else if constexpr (__t<_LetTag>() == STDEXEC::set_error)
-        {
-          return STDEXEC::__transform_completion_signatures(__completions, {}, __transform);
+          auto __transform = __get_transform_fn<__fn_t<_CvSender>, __child_t, _Env...>();
+          if constexpr (!__decay_copyable<_CvSender>)
+          {
+            return STDEXEC::__throw_compile_time_error<_SENDER_TYPE_IS_NOT_DECAY_COPYABLE_,
+                                                       _WITH_PRETTY_SENDER_<_CvSender>>();
+          }
+          else if constexpr (__t<_LetTag>() == STDEXEC::set_value)
+          {
+            return STDEXEC::__transform_completion_signatures(__completions, __transform);
+          }
+          else if constexpr (__t<_LetTag>() == STDEXEC::set_error)
+          {
+            return STDEXEC::__transform_completion_signatures(__completions, {}, __transform);
+          }
+          else
+          {
+            return STDEXEC::__transform_completion_signatures(__completions, {}, {}, __transform);
+          }
         }
         else
         {
-          return STDEXEC::__transform_completion_signatures(__completions, {}, {}, __transform);
+          return __completions;
         }
       }
 


### PR DESCRIPTION
__get_transform_fn actually requires __child_t a sender_in<_Env...>.