### PR TITLE
Fix missing trailing return type in `__when_all_impl::__get_env`

### DIFF
--- a/include/stdexec/__detail/__when_all.hpp
+++ b/include/stdexec/__detail/__when_all.hpp
@@ -766,6 +766,9 @@ namespace STDEXEC
       }
 
       static constexpr auto __get_env = []<class _State>(__ignore, _State const & __state) noexcept
+        -> __if_c<_State::__uses_stop_source,
+                  __stoppable_env_t<env_of_t<typename _State::__receiver_t const &>>,
+                  env_of_t<typename _State::__receiver_t const &>>
       {
         if constexpr (_State::__uses_stop_source)
         {


### PR DESCRIPTION
In #2124, the trailing return type was removed from `__when_all_impl::__get_env`. This forces early instantiation of downstream `get_env`, which in turn may cause compilation errors when downstream types are still incomplete. This PR restores the trailing return type.

@RobertLeahy 