### PR TITLE
fix(exec): ignore sender cvref-qualification when computing sender attributes

### DIFF
--- a/include/nvexec/stream/let_xxx.cuh
+++ b/include/nvexec/stream/let_xxx.cuh
@@ -72,8 +72,7 @@ namespace nv::execution::_strm
     inline constexpr auto _mk_sch_env =
       []<class CvSender, class Receiver, class SetTag>(CvSender&& sndr, Receiver&& rcvr, SetTag)
     {
-      using cv_fn = __copy_cvref_fn<CvSender>;
-      return __mk_secondary_env_t<SetTag>()(cv_fn{}, sndr, STDEXEC::get_env(rcvr));
+      return __mk_secondary_env_t<SetTag>()(sndr, STDEXEC::get_env(rcvr));
     };
 
     template <class CvSender, class Receiver, class SetTag>

--- a/include/stdexec/__detail/__finally.hpp
+++ b/include/stdexec/__detail/__finally.hpp
@@ -225,7 +225,6 @@ namespace STDEXEC
       using __env2_t            = __final::__env2_t<_CvInitialSender, env_of_t<_Receiver>>;
       using __base_t            = __final_opstate_t<_CvInitialSender, _CvFinalSender, _Receiver>;
       using __initial_results_t = __base_t::__results_t;
-      using __cv_fn             = __copy_cvref_fn<_CvInitialSender>;
 
       constexpr explicit __opstate(_CvInitialSender&& __initial,
                                    _CvFinalSender&&   __final,
@@ -233,7 +232,7 @@ namespace STDEXEC
         : __base_t(&__cleanup_initial_opstate,
                    static_cast<_CvFinalSender&&>(__final),
                    static_cast<_Receiver&&>(__rcvr),
-                   __mk_secondary_env_t{}(__cv_fn{}, __initial, get_env(__rcvr)))
+                   __mk_secondary_env_t{}(__initial, STDEXEC::get_env(__rcvr)))
       {
         __initial_opstate_.__emplace_from(STDEXEC::connect,
                                           static_cast<_CvInitialSender&&>(__initial),

--- a/include/stdexec/__detail/__let.hpp
+++ b/include/stdexec/__detail/__let.hpp
@@ -169,16 +169,15 @@ namespace STDEXEC
       using __env2_t        = _Env2;
       using __second_rcvr_t = __rcvr_env<_Receiver, _Env2>;
 
-      template <class _CvFn, class _Sender>
+      template <class _Sender>
       constexpr explicit __opstate_base(_SetTag,
-                                        _CvFn           __cv,
                                         _Sender const & __sndr,
                                         _Fun            __fn,
                                         _Receiver&&     __rcvr) noexcept
         : __rcvr_(static_cast<_Receiver&&>(__rcvr))
         , __fn_(STDEXEC::__allocator_aware_forward(static_cast<_Fun&&>(__fn), __rcvr_))
         // TODO(ericniebler): this needs a fallback:
-        , __env2_(__mk_secondary_env_t<_SetTag>()(__cv, __sndr, STDEXEC::get_env(__rcvr_)))
+        , __env2_(__mk_secondary_env_t<_SetTag>()(__sndr, STDEXEC::get_env(__rcvr_)))
       {}
 
       STDEXEC_IMMOVABLE(__opstate_base);
@@ -305,7 +304,6 @@ namespace STDEXEC
         noexcept(__nothrow_connectable<_CvChild, __first_rcvr_t>
                  && __nothrow_move_constructible<_Fun>)
         : __opstate::__opstate_base(_SetTag(),
-                                    __copy_cvref_fn<_CvChild>{},
                                     __child,
                                     static_cast<_Fun&&>(__fn),
                                     static_cast<_Receiver&&>(__rcvr))

--- a/include/stdexec/__detail/__schedulers.hpp
+++ b/include/stdexec/__detail/__schedulers.hpp
@@ -617,38 +617,6 @@ namespace STDEXEC
     }
   }
 
-  namespace __detail
-  {
-    template <class... _SetTags>
-    struct __mk_secondary_env_impl
-    {
-      template <class _CvFn, sender _Sender, class _Env>
-      constexpr auto operator()(_CvFn, _Sender const &__sndr, _Env const &__env) const noexcept
-      {
-        using __domain_t = __make_domain_t<__completion_domain_of_t<_SetTags, _Sender, _Env>...>;
-        // We can only know the scheduler that the secondary sender is started on if there
-        // is exactly one kind of completion that starts the secondary sender.
-        STDEXEC_CONSTEXPR_LOCAL bool __has_completion_scheduler =
-          sizeof...(_SetTags) == 1
-          && (__has_completion_scheduler_for<_SetTags, __mcall1<_CvFn, _Sender>, _Env> || ...);
-
-        if constexpr (__has_completion_scheduler)
-        {
-          auto __sch = (get_completion_scheduler<_SetTags>(get_env(__sndr), __fwd_env(__env)), ...);
-          return STDEXEC::__mk_sch_env(__sch, __fwd_env(__env));
-        }
-        else if constexpr (__not_same_as<__domain_t, indeterminate_domain<>>)
-        {
-          return __env::cprop<get_domain_t, __domain_t{}>();
-        }
-        else
-        {
-          return env{};
-        }
-      }
-    };
-  }  // namespace __detail
-
   //! This environment is for when one sender is started from the completion of another
   //! sender. In that case, the completion scheduler/domain for the first sender should
   //! be used as the scheduler/domain for the second sender.
@@ -667,23 +635,55 @@ namespace STDEXEC
   template <class... _SetTags>
   struct __mk_secondary_env_t
   {
+   private:
+    template <class... _SetTags2>
+    struct __impl
+    {
+      template <sender _Sender, class _Env>
+      constexpr auto operator()(_Sender const &__sndr, _Env const &__env) const noexcept
+      {
+        using __domain_t =
+          __detail::__make_domain_t<__completion_domain_of_t<_SetTags2, _Sender, _Env>...>;
+        // We can only know the scheduler that the secondary sender is started on if there
+        // is exactly one kind of completion that starts the secondary sender.
+        STDEXEC_CONSTEXPR_LOCAL bool __has_completion_scheduler =
+          sizeof...(_SetTags2) == 1
+          && (__has_completion_scheduler_for<_SetTags2, _Sender, _Env> || ...);
+
+        if constexpr (__has_completion_scheduler)
+        {
+          auto __sch = (get_completion_scheduler<_SetTags2>(get_env(__sndr), __fwd_env(__env)),
+                        ...);
+          return STDEXEC::__mk_sch_env(__sch, __fwd_env(__env));
+        }
+        else if constexpr (__not_same_as<__domain_t, indeterminate_domain<>>)
+        {
+          return __env::cprop<get_domain_t, __domain_t{}>();
+        }
+        else
+        {
+          return env{};
+        }
+      }
+    };
+
+   public:
     template <class _Sender, class _Env>
     using __impl_t =
       __minvoke<__mremove_if<__mbind_back_q<__never_sends_t, _Sender, __fwd_env_t<_Env const &>>,
-                             __qq<__detail::__mk_secondary_env_impl>>,
+                             __qq<__impl>>,
                 _SetTags...>;
 
-    template <class _CvFn, class _Sender, class _Env>
-    constexpr auto operator()(_CvFn __cv, _Sender const &__sndr, _Env const &__env) const noexcept
-      -> __call_result_t<__impl_t<_Sender, _Env>, _CvFn, _Sender const &, _Env const &>
+    template <class _Sender, class _Env>
+    constexpr auto operator()(_Sender const &__sndr, _Env const &__env) const noexcept
+      -> __call_result_t<__impl_t<_Sender, _Env>, _Sender const &, _Env const &>
     {
-      return __impl_t<_Sender, _Env>()(__cv, __sndr, __env);
+      return __impl_t<_Sender, _Env>()(__sndr, __env);
     }
   };
 
   template <class _CvSender, class _Env, class... _SetTags>
-  using __secondary_env_t =
-    __call_result_t<__mk_secondary_env_t<_SetTags...>, __copy_cvref_fn<_CvSender>, _CvSender, _Env>;
+  using __secondary_env_t = __call_result_t<__mk_secondary_env_t<_SetTags...>, _CvSender, _Env>;
 
   //////////////////////////////////////////////////////////////////////////////////////////
   // __infallible_scheduler

--- a/include/stdexec/__detail/__sequence.hpp
+++ b/include/stdexec/__detail/__sequence.hpp
@@ -69,41 +69,41 @@ namespace STDEXEC
     struct __attrs<> : __just::__attrs<set_value_t>
     {};
 
-    template <class _CvSender>
-    struct __attrs<_CvSender>
+    template <class _Sender>
+    struct __attrs<_Sender>
     {
       template <class _Query, class... _Args>
-        requires __queryable_with<env_of_t<_CvSender>, _Query, _Args...>
+        requires __queryable_with<env_of_t<_Sender>, _Query, _Args...>
       STDEXEC_ATTRIBUTE(nodiscard, always_inline, host, device)
       constexpr auto operator()(_Query, _Args &&...__args) const
-        noexcept(__nothrow_queryable_with<env_of_t<_CvSender>, _Query, _Args...>)
-          -> __query_result_t<env_of_t<_CvSender>, _Query, _Args...>
+        noexcept(__nothrow_queryable_with<env_of_t<_Sender>, _Query, _Args...>)
+          -> __query_result_t<env_of_t<_Sender>, _Query, _Args...>
       {
         return __query<_Query>()(STDEXEC::get_env(__sndr_), static_cast<_Args &&>(__args)...);
       }
 
-      _CvSender __sndr_;
+      _Sender __sndr_;
     };
 
-    template <sender _CvSender1, class _CvSender2>
-    struct __attrs<_CvSender1, _CvSender2>
+    template <sender _Sender1, class _Sender2>
+    struct __attrs<_Sender1, _Sender2>
     {
      private:
-      using __joined_t = env<env_of_t<_CvSender2>, env_of_t<_CvSender1>>;
+      using __joined_t = env<env_of_t<_Sender2>, env_of_t<_Sender1>>;
 
       // The env to use when querying _CvSender2:
       template <class _Env>
-      using __env2_t = __secondary_env_t<_CvSender1 const &, _Env, set_value_t>;
+      using __env2_t = __secondary_env_t<_Sender1, _Env, set_value_t>;
 
       template <class _Env>
       constexpr auto __mk_env2(_Env &__env) const noexcept -> __env2_t<_Env>
       {
-        return __mk_env2_t()(__cp{}, __sndr1_, __env);
+        return __mk_env2_t()(__sndr1_, __env);
       }
 
      public:
       template <class... _Env>
-        requires __has_completion_scheduler_for<set_value_t, _CvSender2, __env2_t<_Env>...>
+        requires __has_completion_scheduler_for<set_value_t, _Sender2, __env2_t<_Env>...>
       [[nodiscard]]
       constexpr auto query(get_completion_scheduler_t<set_value_t>, _Env &&...__env) const noexcept
       {
@@ -114,12 +114,12 @@ namespace STDEXEC
       // We only know the error or stopped completion scheduler if exactly one of the two
       // senders knows its error/stopped completion scheduler.
       template <__one_of<set_error_t, set_stopped_t> _Tag, class... _Env>
-        requires(__has_completion_scheduler_for<_Tag, _CvSender1, __fwd_env_t<_Env>...>
-                 != __has_completion_scheduler_for<_Tag, _CvSender2, __env2_t<_Env>...>)
+        requires(__has_completion_scheduler_for<_Tag, _Sender1, __fwd_env_t<_Env>...>
+                 != __has_completion_scheduler_for<_Tag, _Sender2, __env2_t<_Env>...>)
       [[nodiscard]]
       constexpr auto query(get_completion_scheduler_t<_Tag>, _Env &&...__env) const noexcept
       {
-        if constexpr (__has_completion_scheduler_for<_Tag, _CvSender2, __env2_t<_Env>...>)
+        if constexpr (__has_completion_scheduler_for<_Tag, _Sender2, __env2_t<_Env>...>)
         {
           return STDEXEC::get_completion_scheduler<_Tag>(STDEXEC::get_env(__sndr2_),
                                                          __mk_env2(__env)...);
@@ -138,7 +138,7 @@ namespace STDEXEC
       constexpr auto query(get_completion_domain_t<set_value_t>, _Env &&...) const noexcept
       {
         using __domain_t =
-          __completion_domain_t<set_value_t, env_of_t<_CvSender2>, __env2_t<_Env>...>;
+          __completion_domain_t<set_value_t, env_of_t<_Sender2>, __env2_t<_Env>...>;
         return __domain_t();
       }
 
@@ -149,8 +149,8 @@ namespace STDEXEC
       constexpr auto query(get_completion_domain_t<_Tag>, _Env &&...) const noexcept
       {
         using __domain_t =
-          __common_domain_t<__completion_domain_t<_Tag, env_of_t<_CvSender1>, __fwd_env_t<_Env>...>,
-                            __completion_domain_t<_Tag, env_of_t<_CvSender2>, __env2_t<_Env>...>>;
+          __common_domain_t<__completion_domain_t<_Tag, env_of_t<_Sender1>, __fwd_env_t<_Env>...>,
+                            __completion_domain_t<_Tag, env_of_t<_Sender2>, __env2_t<_Env>...>>;
         return __domain_t();
       }
 
@@ -161,8 +161,8 @@ namespace STDEXEC
       constexpr auto query(__get_completion_behavior_t<_Tag>, _Env &&...) const noexcept
       {
         return __completion_behavior::__common(
-          STDEXEC::__get_completion_behavior<_Tag, _CvSender1, __fwd_env_t<_Env>...>(),
-          STDEXEC::__get_completion_behavior<_Tag, _CvSender2, __env2_t<_Env>...>());
+          STDEXEC::__get_completion_behavior<_Tag, _Sender1, __fwd_env_t<_Env>...>(),
+          STDEXEC::__get_completion_behavior<_Tag, _Sender2, __env2_t<_Env>...>());
       }
 
       // For queries that are not related to completion schedulers, domains, or behaviors,
@@ -178,13 +178,12 @@ namespace STDEXEC
                                  static_cast<_Args &&>(__args)...);
       }
 
-      _CvSender1 __sndr1_;
-      _CvSender2 __sndr2_;
+      _Sender1 __sndr1_;
+      _Sender2 __sndr2_;
     };
 
     template <class _Child1, class _Child2, class... _Rest>
-    struct __attrs<_Child1, _Child2, _Rest...>
-      : __attrs<__sndr<__decay_t<_Child1>, __decay_t<_Child2>>, __decay_t<_Rest>...>
+    struct __attrs<_Child1, _Child2, _Rest...> : __attrs<__sndr<_Child1, _Child2>, _Rest...>
     {};
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -278,11 +277,9 @@ namespace STDEXEC
     template <class _CvSender1, class _Sender2, class _Receiver>
     struct __opstate final : __state<_Receiver, __env2_t<_CvSender1, env_of_t<_Receiver>>>
     {
-      using __cv_fn = __copy_cvref_fn<_CvSender1>;
-
       constexpr explicit __opstate(_CvSender1 &&__sndr1, _Sender2 __sndr2, _Receiver __rcvr)
         noexcept(__nothrow_constructible)
-        : __opstate(__sndr1, __sndr2, __rcvr, __mk_env2_t()(__cv_fn{}, __sndr1, get_env(__rcvr)))
+        : __opstate(__sndr1, __sndr2, __rcvr, __mk_env2_t()(__sndr1, get_env(__rcvr)))
       {}
 
       STDEXEC_IMMOVABLE(__opstate);
@@ -370,7 +367,7 @@ namespace STDEXEC
       using __env2_t = __join_env_t<__seq::__env2_t<__copy_cvref_t<_Self, _Sender1>, _Env> const &,
                                     __fwd_env_t<_Env>>;
 
-      using __attrs_t = __attrs<_Sender1 const &, _Sender2 const &>;
+      using __attrs_t = __attrs<_Sender1, _Sender2>;
 
       template <class _Self, class... _Env>
         requires(sizeof...(_Env) != 0)  //
@@ -379,26 +376,18 @@ namespace STDEXEC
       static consteval auto get_completion_signatures()
       {
         using __cv_sender1_t = __copy_cvref_t<_Self, _Sender1>;
-        // Decay the first sender type for completion-signature queries.
-        // When __sequence recursively nests (__seq::__sndr held by const& in
-        // __attrs), __copy_cvref_t can propagate a reference qualifier into
-        // _Sender1. Reference types never satisfy derived_from, which breaks
-        // type-erased senders (e.g. any_sender). Completion signatures are
-        // pure type information and don't depend on value category, so
-        // decaying is safe here. The connect path still uses __cv_sender1_t.
-        using __sig_sender1_t = __decay_t<__cv_sender1_t>;
 
         if constexpr (!__decay_copyable<_Self>)
         {
           return STDEXEC::__throw_compile_time_error<_SENDER_TYPE_IS_NOT_DECAY_COPYABLE_,
                                                      _WITH_PRETTY_SENDER_<_Self>>();
         }
-        else if constexpr (!__sends<set_value_t, __sig_sender1_t, __fwd_env_t<_Env>...>)
+        else if constexpr (!__sends<set_value_t, __cv_sender1_t, __fwd_env_t<_Env>...>)
         {
           // If the first sender has no set_value completions, then the second sender will
           // never be started, so just return the (error and stopped) completions of the
           // first sender.
-          return STDEXEC::get_completion_signatures<__sig_sender1_t, __fwd_env_t<_Env>...>();
+          return STDEXEC::get_completion_signatures<__cv_sender1_t, __fwd_env_t<_Env>...>();
         }
         else
         {
@@ -407,7 +396,7 @@ namespace STDEXEC
 
           auto __completions1 =  //
             STDEXEC::__transform_completion_signatures(
-              STDEXEC::get_completion_signatures<__sig_sender1_t, __fwd_env_t<_Env>...>(),
+              STDEXEC::get_completion_signatures<__cv_sender1_t, __fwd_env_t<_Env>...>(),
               __eat_value_signatures<_Self>{});
 
           auto __completions2 =
@@ -452,11 +441,10 @@ namespace STDEXEC
 
     struct __impls : __sexpr_defaults
     {
-      static constexpr auto __get_attrs =                                   //
-        []<class... _Child>(auto, auto, _Child const &...__child) noexcept  //
-        -> __attrs<_Child const &...>
+      static constexpr auto __get_attrs =  //
+        []<class... _Child>(auto, auto, _Child const &...__child) noexcept -> __attrs<_Child...>
       {
-        return __attrs<_Child const &...>{__child...};
+        return __attrs<_Child...>{__child...};
       };
 
       template <class _Self>

--- a/include/stdexec/__detail/__sequence.hpp
+++ b/include/stdexec/__detail/__sequence.hpp
@@ -183,7 +183,8 @@ namespace STDEXEC
     };
 
     template <class _Child1, class _Child2, class... _Rest>
-    struct __attrs<_Child1, _Child2, _Rest...> : __attrs<__sndr<_Child1, _Child2>, _Rest...>
+    struct __attrs<_Child1, _Child2, _Rest...>
+      : __attrs<__sndr<__decay_t<_Child1>, __decay_t<_Child2>>, __decay_t<_Rest>...>
     {};
 
     //////////////////////////////////////////////////////////////////////////////////////
@@ -378,18 +379,26 @@ namespace STDEXEC
       static consteval auto get_completion_signatures()
       {
         using __cv_sender1_t = __copy_cvref_t<_Self, _Sender1>;
+        // Decay the first sender type for completion-signature queries.
+        // When __sequence recursively nests (__seq::__sndr held by const& in
+        // __attrs), __copy_cvref_t can propagate a reference qualifier into
+        // _Sender1. Reference types never satisfy derived_from, which breaks
+        // type-erased senders (e.g. any_sender). Completion signatures are
+        // pure type information and don't depend on value category, so
+        // decaying is safe here. The connect path still uses __cv_sender1_t.
+        using __sig_sender1_t = __decay_t<__cv_sender1_t>;
 
         if constexpr (!__decay_copyable<_Self>)
         {
           return STDEXEC::__throw_compile_time_error<_SENDER_TYPE_IS_NOT_DECAY_COPYABLE_,
                                                      _WITH_PRETTY_SENDER_<_Self>>();
         }
-        else if constexpr (!__sends<set_value_t, __cv_sender1_t, __fwd_env_t<_Env>...>)
+        else if constexpr (!__sends<set_value_t, __sig_sender1_t, __fwd_env_t<_Env>...>)
         {
           // If the first sender has no set_value completions, then the second sender will
           // never be started, so just return the (error and stopped) completions of the
           // first sender.
-          return STDEXEC::get_completion_signatures<__cv_sender1_t, __fwd_env_t<_Env>...>();
+          return STDEXEC::get_completion_signatures<__sig_sender1_t, __fwd_env_t<_Env>...>();
         }
         else
         {
@@ -398,7 +407,7 @@ namespace STDEXEC
 
           auto __completions1 =  //
             STDEXEC::__transform_completion_signatures(
-              STDEXEC::get_completion_signatures<__cv_sender1_t, __fwd_env_t<_Env>...>(),
+              STDEXEC::get_completion_signatures<__sig_sender1_t, __fwd_env_t<_Env>...>(),
               __eat_value_signatures<_Self>{});
 
           auto __completions2 =

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -58,6 +58,7 @@ set(exec_test_sources
     sequence/test_iterate.cpp
     sequence/test_transform_each.cpp
     sequence/test_merge.cpp
+    sequence/test_sequence_any_sender.cpp
     # These tests cause Microsoft's compiler to run out of memory
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:sequence/test_merge_each.cpp>
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:sequence/test_merge_each_threaded.cpp>

--- a/test/exec/sequence/test_sequence_any_sender.cpp
+++ b/test/exec/sequence/test_sequence_any_sender.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression test for issue #2101:
+// exec::any_sender fails get_completion_signatures inside a sequence of 3+ senders.
+// The root cause is that the recursive completion-signature computation in
+// __seq::__sndr passes the first sender type through __copy_cvref_t, which
+// can produce a reference type. any_sender's get_completion_signatures
+// constraint (derived_from<Self, interface>) then fails for reference types.
+
+#include <exec/sequence.hpp>
+#include <exec/any_sender_of.hpp>
+#include <stdexec/execution.hpp>
+
+#include <test_common/catch2.hpp>
+
+#include <exception>
+
+namespace ex = STDEXEC;
+
+TEST_CASE("sequence with 3 any_senders compiles and runs", "[sequence][any_sender]")
+{
+  // all but the last sender must be void senders
+  using SigsVoid =
+    ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+  using SigsInt =
+    ex::completion_signatures<ex::set_value_t(int), ex::set_error_t(std::exception_ptr)>;
+
+  using AnyVoid = exec::any_sender<exec::any_receiver<SigsVoid, exec::queries<>>>;
+  using AnyInt  = exec::any_sender<exec::any_receiver<SigsInt, exec::queries<>>>;
+
+  AnyVoid s1 = ex::just();
+  AnyVoid s2 = ex::just();
+  AnyInt  s3 = ex::just(42);
+
+  // Before the fix this would fail to compile with:
+  //   "no matching function for call to 'get_completion_signatures'"
+  auto seq = exec::sequence(std::move(s1), std::move(s2), std::move(s3));
+
+  auto [result] = *ex::sync_wait(std::move(seq));
+  CHECK(result == 42);
+}
+
+TEST_CASE("sequence with 4 any_senders compiles and runs", "[sequence][any_sender]")
+{
+  using SigsVoid =
+    ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+  using SigsInt =
+    ex::completion_signatures<ex::set_value_t(int), ex::set_error_t(std::exception_ptr)>;
+
+  using AnyVoid = exec::any_sender<exec::any_receiver<SigsVoid, exec::queries<>>>;
+  using AnyInt  = exec::any_sender<exec::any_receiver<SigsInt, exec::queries<>>>;
+
+  AnyVoid s1 = ex::just();
+  AnyVoid s2 = ex::just();
+  AnyVoid s3 = ex::just();
+  AnyInt  s4 = ex::just(42);
+
+  auto seq = exec::sequence(std::move(s1), std::move(s2), std::move(s3), std::move(s4));
+
+  auto [result] = *ex::sync_wait(std::move(seq));
+  CHECK(result == 42);
+}
+
+TEST_CASE(
+  "sequence with mixed concrete and any_senders compiles and runs",
+  "[sequence][any_sender]")
+{
+  using SigsVoid =
+    ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
+  using SigsInt =
+    ex::completion_signatures<ex::set_value_t(int), ex::set_error_t(std::exception_ptr)>;
+
+  using AnyVoid = exec::any_sender<exec::any_receiver<SigsVoid, exec::queries<>>>;
+  using AnyInt  = exec::any_sender<exec::any_receiver<SigsInt, exec::queries<>>>;
+
+  AnyVoid s1 = ex::just();
+  auto    s2 = ex::just(); // concrete sender
+  AnyInt  s3 = ex::just(42);
+
+  auto seq = exec::sequence(std::move(s1), std::move(s2), std::move(s3));
+
+  auto [result] = *ex::sync_wait(std::move(seq));
+  CHECK(result == 42);
+}

--- a/test/exec/sequence/test_sequence_any_sender.cpp
+++ b/test/exec/sequence/test_sequence_any_sender.cpp
@@ -21,8 +21,8 @@
 // can produce a reference type. any_sender's get_completion_signatures
 // constraint (derived_from<Self, interface>) then fails for reference types.
 
-#include <exec/sequence.hpp>
 #include <exec/any_sender_of.hpp>
+#include <exec/sequence.hpp>
 #include <stdexec/execution.hpp>
 
 #include <test_common/catch2.hpp>
@@ -75,9 +75,8 @@ TEST_CASE("sequence with 4 any_senders compiles and runs", "[sequence][any_sende
   CHECK(result == 42);
 }
 
-TEST_CASE(
-  "sequence with mixed concrete and any_senders compiles and runs",
-  "[sequence][any_sender]")
+TEST_CASE("sequence with mixed concrete and any_senders compiles and runs",
+          "[sequence][any_sender]")
 {
   using SigsVoid =
     ex::completion_signatures<ex::set_value_t(), ex::set_error_t(std::exception_ptr)>;
@@ -88,7 +87,7 @@ TEST_CASE(
   using AnyInt  = exec::any_sender<exec::any_receiver<SigsInt, exec::queries<>>>;
 
   AnyVoid s1 = ex::just();
-  auto    s2 = ex::just(); // concrete sender
+  auto    s2 = ex::just();  // concrete sender
   AnyInt  s3 = ex::just(42);
 
   auto seq = exec::sequence(std::move(s1), std::move(s2), std::move(s3));


### PR DESCRIPTION
Fixes #2101 (supersedes #2223 and the earlier approach in this PR).

When exec::sequence has 3+ senders, the recursive __seq::__sndr nesting stores intermediate types by const& in __attrs. This causes __copy_cvref_t to propagate reference qualifiers into the sender type passed to get_completion_signatures. Reference types never satisfy derived_from, which breaks type-erased senders (e.g. any_sender).

Root cause

The __attrs 3+ children specialization creates intermediate __seq::__sndr types with the raw (possibly reference) child types. When get_completion_signatures is called on these intermediate types, __copy_cvref_t<_Self, _Sender1> produces a reference type, and derived_from fails because reference types can't derive from anything.

Fix (2 targeted changes in __sequence.hpp only)

Decay child types in __attrs 3+ children specialization to prevent intermediate __seq::__sndr types with reference types.
Use __decay_t<__cv_sender1_t> for completion-signature queries only; the connect path still uses the cvref-qualified type.
No changes to any_sender_of.hpp — its derived_from constraint is correct.
